### PR TITLE
[lit] Report invalid regexes as expression parse errors

### DIFF
--- a/llvm/utils/lit/lit/BooleanExpression.py
+++ b/llvm/utils/lit/lit/BooleanExpression.py
@@ -30,6 +30,10 @@ class BooleanExpression:
         try:
             parser = BooleanExpression(string, set(variables))
             return parser.parseAll()
+        except re.error as e:
+            raise ValueError(
+                "invalid regex in boolean expression: %s\nin expression: %r" % (e, string)
+            )
         except ValueError as e:
             raise ValueError(str(e) + ("\nin expression: %r" % string))
 
@@ -244,6 +248,12 @@ class TestBooleanExpression(unittest.TestCase):
         self.assertTrue(BooleanExpression.evaluate("(false && false) || true", {}))
         self.assertFalse(BooleanExpression.evaluate("false && (false || true)", {}))
 
+    def test_invalid_regex_reports_expression(self):
+        with self.assertRaises(ValueError) as ctx:
+            BooleanExpression.evaluate("{{(}}", {})
+
+        self.assertIn("invalid regex in boolean expression", str(ctx.exception))
+        self.assertIn("in expression: '{{(}}'", str(ctx.exception))
     # Evaluate boolean expression `expr`.
     # Fail if it does not throw a ValueError containing the text `error`.
     def checkException(self, expr, error):


### PR DESCRIPTION
### Motivation
- The boolean-expression parser exposed raw `re.error` exceptions for malformed braced regex fragments, which lacked the usual `in expression: ...` context and was inconsistent with other parse errors.

### Description
- Catch `re.error` in `BooleanExpression.evaluate` and convert it to a `ValueError` that includes the original expression using the existing `in expression: %r` style. 
- Add `test_invalid_regex_reports_expression` to `llvm/utils/lit/lit/BooleanExpression.py` to verify malformed regexes such as `{{(}}` surface a user-facing parse error. 
- Changes made in `llvm/utils/lit/lit/BooleanExpression.py`.

### Testing
- Ran `python3 -m unittest llvm/utils/lit/lit/BooleanExpression.py`, which executed 5 tests and completed successfully (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d50f32d4832381f4c37469c1852c)