### PR TITLE
[EmbeddedJIT] Fix failure for ejit_jit_verify_test on AArch64

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -155,6 +155,21 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   if (!ModuleOrErr)
     return ModuleOrErr.takeError();
 
+  Triple TT((*ModuleOrErr)->getTargetTriple());
+  if (TT.isAArch64() && TT.isOSBinFormatELF()) {
+    // These declarations resolve to process addresses, not co-located JIT
+    // storage. Clearing dso_local forces AArch64 PIC codegen to use GOT/PLT
+    // style indirection instead of near-page ADRP relocations.
+    for (Function &F : (*ModuleOrErr)->functions()) {
+      if (F.isDeclaration() && !F.isIntrinsic())
+        F.setDSOLocal(false);
+    }
+    for (GlobalVariable &GV : (*ModuleOrErr)->globals()) {
+      if (GV.isDeclaration())
+        GV.setDSOLocal(false);
+    }
+  }
+
   // Collect global variable addresses from the registry for symbols
   // that appear as external declarations in the bitcode module.
   orc::SymbolMap globalSymbols;


### PR DESCRIPTION
On AArch64, `ejit_jit_verify_test` fails currently with a Page 21 out of range error when declarations are not close. We can set `dso_local` as false on AArch64 to avoid this failure, so AArch64 PIC codegen doesn't make use of near-page ADRP relocations.

The current failing AArch64 test can be reproduced using:
`build.sh --run --lipo ejit_jit_verify_test`

with this error:
```
  Compiling ejit_jit_verify_test.c ...
  Linking ejit_jit_verify_test (aarch64) ...
  OK: /home/wilson/ejit/llvm-project/ejit_test/out/ejit_jit_verify_test

=== Running Tests ===
  Running ejit_jit_verify_test 0 1 5 ...
  FAIL (exit code 1)
  stats: entries=1 hits=0 misses=4
  FAIL: JIT entries increased (>=3, actual 1)
  OK:   JIT misses increased (>=3, actual 4)

--- 验证 5: Deactivate 后重新激活应触发新编译 ---
  OK:   jit_cell_check(0) after type change = 999 (expected 999)
  stats: misses 4 -> 5
  OK:   New miss after deactivate/re-activate (misses increased)

=== Result: 4 failures ===

=== Done ===
```