### PR TITLE
[EJIT] Add EJIT_FREESTANDING guards around logger uses

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -80,7 +80,9 @@ private:
   std::unique_ptr<EJitRuntimeState> runtimeState_;
   std::unique_ptr<EJitModuleLoader> moduleLoader_;
   std::unique_ptr<EJitCache> cache_;
+#ifndef EJIT_FREESTANDING
   std::unique_ptr<EJitLogger> logger_;
+#endif
   std::unique_ptr<EJitCompileDriver> compileDriver_;
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -63,7 +63,9 @@ private:
   PeriodArrayRegistry &periodReg_;
   EJitRuntimeState &runtimeState_;
   EJitModuleLoader &loader_;
+#ifndef EJIT_FREESTANDING
   EJitLogger *logger_;
+#endif
 
   std::unique_ptr<EJitOrcEngine> syncEngine_;
   // Async compiler will be added in EJitAsyncCompiler phase

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -26,12 +26,19 @@ EJit::EJit(const Config &config) : config_(config) {
                                        config.maxCacheSize,
                                        config.maxSingleFuncSize);
 
+#ifndef EJIT_FREESTANDING
   if (config.enableLogger)
     logger_ = std::make_unique<EJitLogger>();
+#endif
 
+#ifndef EJIT_FREESTANDING
+  EJitLogger *logger = logger_.get();
+#else
+  EJitLogger *logger = nullptr;
+#endif
   compileDriver_ = std::make_unique<EJitCompileDriver>(
       config, *cache_, runtimeState_->getRegistry(),
-      *runtimeState_, *moduleLoader_, logger_.get());
+      *runtimeState_, *moduleLoader_, logger);
 
   // Consume registration data from the staging store (constructor path).
   StoredData data = EJitRegistrationStore::instance().consume();
@@ -100,12 +107,16 @@ EJit::EJit(const Config &config) : config_(config) {
       (*engine)->addUserSymbol(sym.name, sym.addr);
     compileDriver_->setSyncEngine(std::move(*engine));
   } else {
+#ifndef EJIT_FREESTANDING
     std::string errStr;
     llvm::handleAllErrors(engine.takeError(),
                           [&](const llvm::ErrorInfoBase &E) { errStr = E.message(); });
     if (logger_)
       logger_->log(ErrorCode::CompilationFailed,
                    "Failed to create OrcJIT engine: " + errStr, "", "");
+#else
+    consumeError(engine.takeError());
+#endif
   }
 }
 
@@ -114,7 +125,9 @@ EJit::~EJit() {
   compileDriver_.reset();
   cache_.reset();
   moduleLoader_.reset();
+#ifndef EJIT_FREESTANDING
   logger_.reset();
+#endif
   runtimeState_.reset();
 }
 
@@ -210,6 +223,9 @@ EJitCache::Stats EJit::getStats() const {
 }
 
 const EJitError *EJit::getLastError() const {
+#ifdef EJIT_FREESTANDING
+  return nullptr;
+#else
   if (!logger_)
     return nullptr;
   // Copy into stable storage so the caller gets a snapshot that won't be
@@ -218,4 +234,5 @@ const EJitError *EJit::getLastError() const {
   if (logger_->copyLastError(lastErr))
     return &lastErr;
   return nullptr;
+#endif
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -1,7 +1,9 @@
 //===-- EJitCompileDriver.cpp - Compilation Scheduler ---------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitCompileDriver.h"
+#ifndef EJIT_FREESTANDING
 #include "llvm/ExecutionEngine/EJIT/EJitLogger.h"
+#endif
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #ifndef EJIT_FREESTANDING
 #include <chrono>
@@ -17,7 +19,11 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
                                      EJitModuleLoader &loader,
                                      EJitLogger *logger)
     : config_(config), cache_(cache), periodReg_(periodReg),
-      runtimeState_(runtimeState), loader_(loader), logger_(logger) {}
+  runtimeState_(runtimeState), loader_(loader)
+#ifndef EJIT_FREESTANDING
+  , logger_(logger)
+#endif
+{}
 
 EJitCompileDriver::~EJitCompileDriver() = default;
 
@@ -46,10 +52,12 @@ void *EJitCompileDriver::getOrCompile(
   // Verify time-window state
   for (unsigned i = 0; i < count; ++i) {
     if (!runtimeState_.isActive(dims[i].first, dims[i].second)) {
+#ifndef EJIT_FREESTANDING
       if (logger_)
         logger_->log(ErrorCode::TimeWindowNotActive,
                      "Time window not active for " + dims[i].first,
                      funcName, std::to_string(cacheKey));
+#endif
       return nullptr;
     }
   }
@@ -57,9 +65,11 @@ void *EJitCompileDriver::getOrCompile(
   // Get bitcode
   auto bitcodeOrErr = loader_.getBitcode(funcName);
   if (!bitcodeOrErr) {
+#ifndef EJIT_FREESTANDING
     if (logger_)
       logger_->log(ErrorCode::BitcodeNotFound,
                    "No bitcode for function", funcName, std::to_string(cacheKey));
+#endif
     return nullptr;
   }
 
@@ -75,10 +85,12 @@ void *EJitCompileDriver::getOrCompile(
 
   // Sync compile
   if (!syncEngine_) {
+#ifndef EJIT_FREESTANDING
     if (logger_)
       logger_->log(ErrorCode::NotActive,
                    "Sync engine not initialized", funcName,
                    std::to_string(cacheKey));
+#endif
     return nullptr;
   }
 
@@ -92,9 +104,13 @@ void *EJitCompileDriver::getOrCompile(
   // symbol renaming (each specialization gets a unique symbol).
   if (auto Err = syncEngine_->loadBitcodeModule(bitcode, cacheKey, funcName)) {
     syncEngine_->setActiveContext(nullptr);
+#ifndef EJIT_FREESTANDING
     if (logger_)
       logger_->log(ErrorCode::CompilationFailed,
                    "Failed to load bitcode module", funcName, std::to_string(cacheKey));
+#else
+    consumeError(std::move(Err));
+#endif
     return nullptr;
   }
 
@@ -102,9 +118,13 @@ void *EJitCompileDriver::getOrCompile(
   syncEngine_->setActiveContext(nullptr);
 
   if (!addrOrErr) {
+#ifndef EJIT_FREESTANDING
     if (logger_)
       logger_->log(ErrorCode::CompilationFailed,
                    "Failed to look up compiled function", funcName, std::to_string(cacheKey));
+#else
+    consumeError(addrOrErr.takeError());
+#endif
     return nullptr;
   }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -31,6 +31,9 @@ static void parseConfig(const ejit_config_t *src, Config &dst) {
   dst.forceStaticRegistry = src->forceStaticRegistry;
   if (src->dumpJITDir && src->dumpJITDir[0])
     dst.dumpJITDir = src->dumpJITDir;
+#ifdef EJIT_FREESTANDING
+  dst.enableLogger = false;
+#endif
 }
 
 extern "C" {


### PR DESCRIPTION
Basically the title. 

This PR adds `EJIT_FREESTANDING` around EJIT logger usages so we don't construct, call or retain logger paths when `EJIT_FREESTANDING` is enabled. It reduces the size of the merged lipo object slightly.
