### PR TITLE
[EJIT] Remove EJitRegistration from EJIT_SOURCES in CMakeLists

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -54,7 +54,6 @@ endforeach()
 set(EJIT_SOURCES
   EJit.cpp
   EJitRuntime.cpp
-  EJitRegistration.cpp
   EJitRegistryTable.c
   EJitOrcEngine.cpp
   EJitCompileDriver.cpp


### PR DESCRIPTION
<img width="1114" height="50" alt="image" src="https://github.com/user-attachments/assets/a0823c4a-6e70-47c8-a7f3-cf6e8fad1d6f" />

[EJitRegistration](https://github.com/dongjianqiang2/llvm-project/blob/ejit_dev_spec4/llvm/lib/ExecutionEngine/EJIT/EJitRegistration.cpp) is empty, and all the logic is contained and implemented in EJitRuntime. It is redundant in the final merged object file.