### PR TITLE
[EJIT] Remove EJitLogger from EJIT_SOURCES when EJIT_FREESTANDING is enabled

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -61,7 +61,6 @@ set(EJIT_SOURCES
   EJitCache.cpp
   EJitRuntimeState.cpp
   EJitModuleLoader.cpp
-  EJitLogger.cpp
   EJitRegistrationStore.cpp
   EJitStructFieldPass.cpp
   EJitOptimizer.cpp
@@ -71,6 +70,7 @@ set(EJIT_SOURCES
 # Async/sync compiler — excluded in freestanding mode (single-threaded, no std::thread)
 if(NOT EJIT_FREESTANDING)
   list(APPEND EJIT_SOURCES
+    EJitLogger.cpp
     EJitSyncCompiler.cpp
     EJitAsyncCompiler.cpp
   )


### PR DESCRIPTION
EJitLogger doesn't need to be built as it is unused when `EJIT_FREESTANDING` is enabled. Guards have already been placed around its usages appropriately, so the tests will pass fine and we won't link an unused object file.