### PR TITLE
[EJIT] Remove remaining GlobalISel dependencies when EJIT_TRIM_LLVM_BACKEND is enabled

### DIFF
--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -161,9 +161,11 @@ static cl::opt<cl::boolOrDefault>
 EnableFastISelOption("fast-isel", cl::Hidden,
   cl::desc("Enable the \"fast\" instruction selector"));
 
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 static cl::opt<cl::boolOrDefault> EnableGlobalISelOption(
     "global-isel", cl::Hidden,
     cl::desc("Enable the \"global\" instruction selector"));
+#endif
 
 // FIXME: remove this after switching to NPM or GlobalISel, whichever gets there
 //        first...
@@ -171,6 +173,7 @@ static cl::opt<bool>
     PrintAfterISel("print-after-isel", cl::init(false), cl::Hidden,
                    cl::desc("Print machine instrs after ISel"));
 
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 static cl::opt<GlobalISelAbortMode> EnableGlobalISelAbort(
     "global-isel-abort", cl::Hidden,
     cl::desc("Enable abort calls when \"global\" instruction selection "
@@ -180,6 +183,7 @@ static cl::opt<GlobalISelAbortMode> EnableGlobalISelAbort(
         clEnumValN(GlobalISelAbortMode::Enable, "1", "Enable the abort"),
         clEnumValN(GlobalISelAbortMode::DisableWithDiag, "2",
                    "Disable the abort but emit a diagnostic on failure")));
+#endif
 
 // Disable MIRProfileLoader before RegAlloc. This is for for debugging and
 // tuning purpose.
@@ -487,8 +491,10 @@ CGPassBuilderOption llvm::getCGPassBuilderOption() {
     Opt.Option = Option;
 
   SET_OPTION(EnableFastISelOption)
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   SET_OPTION(EnableGlobalISelAbort)
   SET_OPTION(EnableGlobalISelOption)
+#endif
   SET_OPTION(EnableIPRA)
   SET_OPTION(OptimizeRegAlloc)
   SET_OPTION(VerifyMachineCode)
@@ -609,8 +615,10 @@ TargetPassConfig::TargetPassConfig(TargetMachine &TM, PassManagerBase &PM)
   if (TM.Options.EnableIPRA)
     setRequiresCodeGenSCCOrder();
 
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   if (EnableGlobalISelAbort.getNumOccurrences())
     TM.Options.GlobalISelAbort = EnableGlobalISelAbort;
+#endif
 
   setStartStopPasses();
 }
@@ -978,15 +986,21 @@ bool TargetPassConfig::addCoreISelPasses() {
   TM->setO0WantsFastISel(EnableFastISelOption != cl::BOU_FALSE);
 
   // Determine an instruction selector.
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   enum class SelectorType { SelectionDAG, FastISel, GlobalISel };
+#else
+  enum class SelectorType { SelectionDAG, FastISel };
+#endif
   SelectorType Selector;
 
   if (EnableFastISelOption == cl::BOU_TRUE)
     Selector = SelectorType::FastISel;
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   else if (EnableGlobalISelOption == cl::BOU_TRUE ||
            (TM->Options.EnableGlobalISel &&
             EnableGlobalISelOption != cl::BOU_FALSE))
     Selector = SelectorType::GlobalISel;
+#endif
   else if (TM->getOptLevel() == CodeGenOptLevel::None &&
            TM->getO0WantsFastISel())
     Selector = SelectorType::FastISel;
@@ -997,9 +1011,11 @@ bool TargetPassConfig::addCoreISelPasses() {
   if (Selector == SelectorType::FastISel) {
     TM->setFastISel(true);
     TM->setGlobalISel(false);
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   } else if (Selector == SelectorType::GlobalISel) {
     TM->setFastISel(false);
     TM->setGlobalISel(true);
+#endif
   }
 
   // FIXME: Injecting into the DAGISel pipeline seems to cause issues with
@@ -1012,6 +1028,7 @@ bool TargetPassConfig::addCoreISelPasses() {
   //        and -run-pass seem to be unaffected. The majority of GlobalISel
   //        testing uses -run-pass so this probably isn't too bad.
   SaveAndRestore SavedDebugifyIsSafe(DebugifyIsSafe);
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   if (Selector != SelectorType::GlobalISel || !isGlobalISelAbortEnabled())
     DebugifyIsSafe = false;
 
@@ -1044,12 +1061,20 @@ bool TargetPassConfig::addCoreISelPasses() {
   if (Selector == SelectorType::GlobalISel)
     addPass(createResetMachineFunctionPass(
         reportDiagnosticWhenGlobalISelFallback(), isGlobalISelAbortEnabled()));
+#else
+  DebugifyIsSafe = false;
+#endif
 
   // Run the SDAG InstSelector, providing a fallback path when we do not want to
   // abort on not-yet-supported input.
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   if (Selector != SelectorType::GlobalISel || !isGlobalISelAbortEnabled())
     if (addInstSelector())
       return true;
+#else
+  if (addInstSelector())
+    return true;
+#endif
 
   // Expand pseudo-instructions emitted by ISel. Don't run the verifier before
   // FinalizeISel.

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -10,6 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined(EJIT_TRIM_LLVM_BACKEND) && !defined(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+#define EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#endif
+
 #include "AArch64ISelLowering.h"
 #include "AArch64CallingConvention.h"
 #include "AArch64ExpandImm.h"
@@ -40,7 +44,9 @@
 #include "llvm/CodeGen/Analysis.h"
 #include "llvm/CodeGen/CallingConvLower.h"
 #include "llvm/CodeGen/ComplexDeinterleavingPass.h"
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 #include "llvm/CodeGen/GlobalISel/Utils.h"
+#endif
 #include "llvm/CodeGen/ISDOpcodes.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
@@ -148,10 +154,12 @@ static cl::opt<unsigned> MaxXors("aarch64-max-xors", cl::init(16), cl::Hidden,
 // scalable vector types for all instruction, even if SVE is not yet supported
 // with some instructions.
 // See [AArch64TargetLowering::fallbackToDAGISel] for implementation details.
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 cl::opt<bool> EnableSVEGISel(
     "aarch64-enable-gisel-sve", cl::Hidden,
     cl::desc("Enable / disable SVE scalable vectors in Global ISel"),
     cl::init(false));
+#endif
 
 // TODO: This option should be removed once we switch to always using PTRADD in
 // the SelectionDAG.
@@ -27122,6 +27130,7 @@ bool AArch64TargetLowering::mayBeEmittedAsTailCall(const CallInst *CI) const {
 bool AArch64TargetLowering::isIndexingLegal(MachineInstr &MI, Register Base,
                                             Register Offset, bool IsPre,
                                             MachineRegisterInfo &MRI) const {
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   auto CstOffset = getIConstantVRegVal(Offset, MRI);
   if (!CstOffset || CstOffset->isZero())
     return false;
@@ -27130,6 +27139,9 @@ bool AArch64TargetLowering::isIndexingLegal(MachineInstr &MI, Register Base,
   // immediate offset. Our CstOffset is a G_PTR_ADD offset so it already
   // encodes the sign/indexing direction.
   return isInt<9>(CstOffset->getSExtValue());
+#else
+  return false;
+#endif
 }
 
 bool AArch64TargetLowering::getIndexedAddressParts(SDNode *N, SDNode *Op,
@@ -28678,6 +28690,7 @@ bool AArch64TargetLowering::shouldLocalize(
 }
 
 bool AArch64TargetLowering::fallBackToDAGISel(const Instruction &Inst) const {
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   // Fallback for scalable vectors.
   // Note that if EnableSVEGISel is true, we allow scalable vector types for
   // all instructions, regardless of whether they are actually supported.
@@ -28705,6 +28718,9 @@ bool AArch64TargetLowering::fallBackToDAGISel(const Instruction &Inst) const {
       return true;
   }
   return false;
+#else
+  return false;
+#endif
 }
 
 // Return the largest legal scalable vector type that matches VT's element type.

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -398,8 +398,8 @@ AArch64Subtarget::AArch64Subtarget(const Triple &TT, StringRef CPU,
 
 #ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   CallLoweringInfo.reset(new AArch64CallLowering(*getTargetLowering()));
-#endif
   InlineAsmLoweringInfo.reset(new InlineAsmLowering(getTargetLowering()));
+#endif
 #ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   Legalizer.reset(new AArch64LegalizerInfo(*this));
 
@@ -450,9 +450,11 @@ const CallLowering *AArch64Subtarget::getCallLowering() const {
 }
 #endif
 
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 const InlineAsmLowering *AArch64Subtarget::getInlineAsmLowering() const {
   return InlineAsmLoweringInfo.get();
 }
+#endif
 
 #ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 InstructionSelector *AArch64Subtarget::getInstructionSelector() const {
@@ -468,6 +470,9 @@ const RegisterBankInfo *AArch64Subtarget::getRegBankInfo() const {
 }
 #else  // EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL — stub: GlobalISel is excluded
 const CallLowering *AArch64Subtarget::getCallLowering() const {
+  return nullptr;
+}
+const InlineAsmLowering *AArch64Subtarget::getInlineAsmLowering() const {
   return nullptr;
 }
 InstructionSelector *AArch64Subtarget::getInstructionSelector() const {

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -103,7 +103,9 @@ protected:
 
   /// GlobalISel related APIs.
   std::unique_ptr<CallLowering> CallLoweringInfo;
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   std::unique_ptr<InlineAsmLowering> InlineAsmLoweringInfo;
+#endif
   std::unique_ptr<InstructionSelector> InstSelector;
   std::unique_ptr<LegalizerInfo> Legalizer;
   std::unique_ptr<RegisterBankInfo> RegBankInfo;


### PR DESCRIPTION
There are still a couple of GlobalISel objects being linked into the final merged object when `EJIT_TRIM_LLVM_BACKEND` is enabled.

Using a grep on the static library archive after extract, we currently have:
```
> wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ ar t ejit_test/lipo/libejit_lipo_aarch64.a | grep GlobalISel
libLLVMGlobalISel__GISelChangeObserver.cpp.o
libLLVMGlobalISel__GISelValueTracking.cpp.o
libLLVMGlobalISel__InlineAsmLowering.cpp.o
libLLVMGlobalISel__LostDebugLocObserver.cpp.o
libLLVMGlobalISel__MachineFloatingPointPredicateUtils.cpp.o
libLLVMGlobalISel__MachineIRBuilder.cpp.o
libLLVMGlobalISel__Utils.cpp.o
````

This PR removes all of these unused objects and reduces the size of the final merged object file by ~20KB.
