### PR TITLE
[EJIT] Discard note and comment sections in object file

### DIFF
--- a/ejit_test/lipo/merge.ld
+++ b/ejit_test/lipo/merge.ld
@@ -15,6 +15,8 @@ SECTIONS
     *(.rela.debug*)           /*  debug relocations (not needed)     */
     *(.rela.llvm_addrsig*)    /*  address-significance relocs        */
     *(*.llvm_addrsig*)        /*  any leftover addrsig sections      */
+    *(.comment .comment.*)    /*  compiler name and version string   */
+    *(.note .note.*)          /*  build environment info             */
   }
 
   /* ── code ─────────────────────────────────────────────────────────── */
@@ -44,8 +46,6 @@ SECTIONS
 
   /* ── misc known sections ──────────────────────────────────────────── */
   .interp         : { *(.interp) }
-  .note           : { *(.note .note.*) }
-  .comment        : { *(.comment .comment.*) }
   .llvm_addrsig   : { *(.llvm_addrsig) }
   .llvm.call_graph_profile : { *(.llvm.call_graph_profile) }
   .cg_profile      : { *(.cg_profile) }


### PR DESCRIPTION
We currently have such info:
```
wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ objdump -s -j .comment ejit_test/lipo/ejit.o
objdump: ejit_test/lipo/ejit.o: no group info for section '.text'
objdump: ejit_test/lipo/ejit.o: no group info for section '.rodata'
objdump: ejit_test/lipo/ejit.o: no group info for section '.data'
objdump: ejit_test/lipo/ejit.o: no group info for section '.bss'
objdump: ejit_test/lipo/ejit.o: no group info for section '.init_array'

ejit_test/lipo/ejit.o:     file format elf64-littleaarch64

Contents of section .comment:
 0000 636c616e 67207665 7273696f 6e203231  clang version 21
 0010 2e312e38 20286874 7470733a 2f2f6769  .1.8 (https://gi
 0020 74687562 2e636f6d 2f646f6e 676a6961  thub.com/dongjia
 0030 6e716961 6e67322f 6c6c766d 2d70726f  nqiang2/llvm-pro
 0040 6a656374 2e676974 20316635 61663863  ject.git 1f5af8c
 0050 36316466 39376330 32393166 39356662  61df97c0291f95fb
 0060 64336332 62663265 38393762 64333361  d3c2bf2e897bd33a
 0070 31290000 5562756e 74752063 6c616e67  1)..Ubuntu clang
 0080 20766572 73696f6e 2031382e 312e3320   version 18.1.3
 0090 28317562 756e7475 312900             (1ubuntu1).
```

A similar case with `.note`. These sections are not useful during linking and we can get rid of them, shaves off a few bytes.