### PR TITLE
[EJIT] Trim X86 dependencies when building for AArch64

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -557,6 +557,11 @@ set(LLVM_TARGETS_WITH_JIT X86 PowerPC AArch64 ARM Mips SystemZ)
 option(EJIT_TRIM_LLVM_BACKEND "Trim LLVM backend pieces used by EJIT: disable heavyweight debug info, GlobalISel, and optional AArch64 SME/SVE passes" OFF)
 if(EJIT_TRIM_LLVM_BACKEND)
   add_definitions(-DEJIT_TRIM_LLVM_BACKEND)
+  # When trimming for AArch64, exclude non-AArch64 JITLink/ELF backends.
+  # On X86 builds keep the X86 ELF dispatch intact.
+  if(LLVM_TARGETS_TO_BUILD STREQUAL "AArch64")
+    add_definitions(-DEJIT_TRIM_JITLINK_AARCH64_ONLY)
+  endif()
 endif()
 
 option(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL "Trim backend for bare-metal: exclude non-ELF formats, non-AArch64 targets, DWARF/CFI" OFF)

--- a/llvm/lib/ExecutionEngine/JITLink/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/JITLink/CMakeLists.txt
@@ -1,4 +1,5 @@
-if(NOT EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+# COFFOptions tablegen is needed unless this is an AArch64-only EJIT build.
+if(NOT (EJIT_TRIM_LLVM_BACKEND AND LLVM_TARGETS_TO_BUILD STREQUAL "AArch64"))
   set(LLVM_TARGET_DEFINITIONS COFFOptions.td)
   tablegen(LLVM COFFOptions.inc -gen-opt-parser-defs)
   add_public_tablegen_target(JITLinkTableGen)
@@ -27,13 +28,15 @@ set(JITLINK_MACHO_COFF
   COFF.cpp  COFFDirectiveParser.cpp  COFFLinkGraphBuilder.cpp  COFF_x86_64.cpp
   )
 
-# ELF arches not needed by EJIT (keep only current target's arch)
+# ELF backends for non-AArch64/non-x86 arches — excluded in AArch64 EJIT builds,
+# included in normal and X86 EJIT builds.
 set(JITLINK_ELF_OTHER
   ELF_aarch32.cpp  ELF_loongarch.cpp  ELF_ppc64.cpp
   ELF_riscv.cpp
   )
 
-# Bloat — not needed by any EJIT arch
+# XCOFF format and non-AArch64/non-x86 arch helpers — excluded in AArch64 EJIT
+# builds, included in normal and X86 EJIT builds.
 set(JITLINK_BLOAT
   XCOFF.cpp  XCOFF_ppc64.cpp  XCOFFLinkGraphBuilder.cpp
   # Arch support (non-AArch64, non-x86)
@@ -47,21 +50,17 @@ set(JITLINK_ARCH_X86
 
 set(JITLINK_DEPENDS intrinsics_gen)
 
-if(NOT EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
-  # Normal build: include everything
+if(EJIT_TRIM_LLVM_BACKEND AND LLVM_TARGETS_TO_BUILD STREQUAL "AArch64")
+  # AArch64 with EJIT_TRIM_LLVM_BACKEND: ELF only, AArch64 only.  aarch32.cpp
+  # needed by LinkGraphLinkingLayer.cpp (hasTargetFlags).
+  list(APPEND JITLINK_SOURCES aarch32.cpp)
+else()
+  # Normal build, X86 EJIT, or EXPERIMENTAL: include all format/arch backends.
   list(APPEND JITLINK_SOURCES ${JITLINK_MACHO_COFF})
   list(APPEND JITLINK_SOURCES ${JITLINK_ELF_OTHER})
   list(APPEND JITLINK_SOURCES ${JITLINK_BLOAT})
   list(APPEND JITLINK_SOURCES ${JITLINK_ARCH_X86})
   list(APPEND JITLINK_DEPENDS JITLinkTableGen)
-elseif(LLVM_TARGETS_TO_BUILD STREQUAL "AArch64")
-  # AArch64 bare-metal: ELF only, AArch64 only.  Include aarch32 to
-  # satisfy extern declarations transitively included via ELF_aarch32.h.
-  list(APPEND JITLINK_SOURCES aarch32.cpp)
-else()
-  # x86 bare-metal: ELF + MachO + COFF, x86 arch support
-  list(APPEND JITLINK_SOURCES ${JITLINK_MACHO_COFF})
-  list(APPEND JITLINK_SOURCES ${JITLINK_ARCH_X86})
 endif()
 
 add_llvm_component_library(LLVMJITLink

--- a/llvm/lib/ExecutionEngine/JITLink/ELF.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF.cpp
@@ -12,6 +12,12 @@
 
 #include "llvm/ExecutionEngine/JITLink/ELF.h"
 
+// On AArch64-only EJIT builds, restrict ELF dispatch to AArch64.
+// On X86 builds with EJIT_TRIM_LLVM_BACKEND, X86 ELF dispatch must remain.
+#if defined(EJIT_TRIM_JITLINK_AARCH64_ONLY) && !defined(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+#define EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#endif
+
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/ExecutionEngine/JITLink/ELF_aarch32.h"
 #include "llvm/ExecutionEngine/JITLink/ELF_aarch64.h"
@@ -78,7 +84,9 @@ createLinkGraphFromELFObject(MemoryBufferRef ObjectBuffer,
   if (memcmp(Buffer.data(), ELF::ElfMagic, strlen(ELF::ElfMagic)) != 0)
     return make_error<JITLinkError>("ELF magic not valid");
 
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   uint8_t DataEncoding = Buffer.data()[ELF::EI_DATA];
+#endif
   Expected<uint16_t> TargetMachineArch = readTargetMachineArch(Buffer);
   if (!TargetMachineArch)
     return TargetMachineArch.takeError();

--- a/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/JITLink.cpp
@@ -8,6 +8,12 @@
 
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 
+// On AArch64-only EJIT builds, restrict JITLink dispatch to AArch64/ELF.
+// On X86 builds with EJIT_TRIM_LLVM_BACKEND, full dispatch must remain.
+#if defined(EJIT_TRIM_JITLINK_AARCH64_ONLY) && !defined(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+#define EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#endif
+
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/BinaryFormat/Magic.h"
 #ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL

--- a/llvm/lib/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/Orc/CMakeLists.txt
@@ -6,11 +6,9 @@ if( CMAKE_HOST_UNIX AND HAVE_LIBRT )
   set(rt_lib rt)
 endif()
 
-add_llvm_component_library(LLVMOrcJIT
+# OrcJIT sources always included
+set(ORCJIT_SOURCES
   AbsoluteSymbols.cpp
-  COFF.cpp
-  COFFVCRuntimeSupport.cpp
-  COFFPlatform.cpp
   CompileOnDemandLayer.cpp
   CompileUtils.cpp
   Core.cpp
@@ -41,8 +39,6 @@ add_llvm_component_library(LLVMOrcJIT
   LoadLinkableFile.cpp
   LookupAndRecordAddrs.cpp
   LLJIT.cpp
-  MachO.cpp
-  MachOPlatform.cpp
   MapperJITLinkMemoryManager.cpp
   MemoryMapper.cpp
   ELFNixPlatform.cpp
@@ -64,6 +60,25 @@ add_llvm_component_library(LLVMOrcJIT
   RedirectionManager.cpp
   JITLinkRedirectableSymbolManager.cpp
   ReOptimizeLayer.cpp
+)
+
+# COFF/MachO platform support — not needed for Linux/ELF targets.
+# Excluded under EJIT_TRIM_LLVM_BACKEND (AArch64 ELF only) and EXPERIMENTAL.
+if(NOT EJIT_TRIM_LLVM_BACKEND AND NOT EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+  list(APPEND ORCJIT_SOURCES
+    COFF.cpp
+    COFFVCRuntimeSupport.cpp
+    COFFPlatform.cpp
+    MachO.cpp
+    MachOPlatform.cpp
+  )
+endif()
+
+add_llvm_component_library(LLVMOrcJIT
+  ${ORCJIT_SOURCES}
+
+  PARTIAL_SOURCES_INTENDED
+
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/ExecutionEngine/Orc
 

--- a/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LLJIT.cpp
@@ -8,6 +8,12 @@
 
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 
+// EJIT_TRIM_LLVM_BACKEND: exclude COFF/MachO platform support (Linux ELF only).
+// Use the same code paths as EXPERIMENTAL for this file.
+#if defined(EJIT_TRIM_LLVM_BACKEND) && !defined(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+#define EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#endif
+
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_THREADS
 #ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
@@ -11,6 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/RuntimeDyld.h"
+
+// EJIT_TRIM_LLVM_BACKEND: exclude COFF/MachO RuntimeDyld paths (Linux ELF only).
+#if defined(EJIT_TRIM_LLVM_BACKEND) && !defined(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+#define EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#endif
+
 #ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 #include "RuntimeDyldCOFF.h"
 #endif


### PR DESCRIPTION
We still have some x86 dependencies being linked although we are testing on aarch64. Some of the deps we currently have:

<img width="1096" height="158" alt="image" src="https://github.com/user-attachments/assets/b92dd56e-6789-406b-98af-38240a87cc0c" />


Specifically, this removes non-elf JITLink/OrcJIT backends (COFF, MachO, XCOFF) and their associated OrcJIT platforms and RuntimeDyld paths. These are now guarded under `EJIT_TRIM_LLVM_BACKEND`.

I've cross-tested on x86 to check that no x86 dependencies are incorrectly removed. 

This trims the size of the final object file to ~32MB.

```
[1/4] Building symbol index ...
       92631 symbols indexed
[2/4] Generating linker map ...
[3/4] Extracting .o files + tracing dependencies ...
       iteration 1: +255 .o
       iteration 2: +110 .o
       iteration 3: +74 .o
       iteration 4: +24 .o
       iteration 5: +8 .o
[4/4] Building /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64.a ...
       908 .o files, 89 MB
       (from 36 .a = 117 MB)
       output: /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64.a
[1/3] Extracting .o from input .a ...
       908 .o files, 80 MB
[2/3] Running ld -r --gc-sections ...
       80 MB -> 53 MB (gc-sections)
       note: GNU objcopy cannot handle this ELF (>65280sections from ld -r).  Build llvm-objcopy to enable $x/$d stripping.  The $x/$d symbols are harmless ARM mapping metadata.
[3/3] Building /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64_gc.a ...
       53 MB
       output: /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64_gc.a
[merge] ld -r -T merge.ld -> ejit_test/lipo/ejit.o ...
       32 MB
       output: ejit_test/lipo/ejit.o
```