### PR TITLE
[EJIT] Introduce EJIT_DISABLE_SVE to disable SVE when necessary

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -570,6 +570,11 @@ if(EJIT_FREESTANDING)
   add_definitions(-DEJIT_FREESTANDING)
 endif()
 
+option(EJIT_DISABLE_SVE "Disable AArch64 SVE code generation. Use to reduce binary size." OFF)
+if(EJIT_DISABLE_SVE)
+  add_definitions(-DEJIT_DISABLE_SVE)
+endif()
+
 set(LLVM_TARGETS_TO_BUILD "all"
     CACHE STRING "Semicolon-separated list of targets to build, or \"all\".")
 

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -256,6 +256,8 @@ LLVMInitializeAArch64Target() {
 #ifndef EJIT_TRIM_LLVM_BACKEND
   initializeSMEABIPass(PR);
   initializeSMEPeepholeOptPass(PR);
+#endif
+#ifndef EJIT_DISABLE_SVE
   initializeSVEIntrinsicOptsPass(PR);
 #endif
   initializeAArch64SpeculationHardeningPass(PR);
@@ -642,7 +644,7 @@ void AArch64PassConfig::addIRPasses() {
   addPass(createAtomicExpandLegacyPass());
 
   // Expand any SVE vector library calls that we can't code generate directly.
-#ifndef EJIT_TRIM_LLVM_BACKEND
+#ifndef EJIT_DISABLE_SVE
   if (EnableSVEIntrinsicOpts &&
       TM->getOptLevel() != CodeGenOptLevel::None)
     addPass(createSVEIntrinsicOptsPass());

--- a/llvm/lib/Target/AArch64/CMakeLists.txt
+++ b/llvm/lib/Target/AArch64/CMakeLists.txt
@@ -78,11 +78,16 @@ set(AARCH64_CODEGEN_SOURCES
   AArch64TargetTransformInfo.cpp
   )
 
+if(NOT EJIT_DISABLE_SVE)
+  list(APPEND AARCH64_CODEGEN_SOURCES
+    SVEIntrinsicOpts.cpp
+  )
+endif()
+
 if(NOT EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL AND NOT EJIT_TRIM_LLVM_BACKEND)
   list(APPEND AARCH64_CODEGEN_SOURCES
     SMEABIPass.cpp
     SMEPeepholeOpt.cpp
-    SVEIntrinsicOpts.cpp
     AArch64AdvSIMDScalarPass.cpp
     AArch64SIMDInstrOpt.cpp
     )


### PR DESCRIPTION
Previously, these were guarded with `EJIT_TRIM_LLVM_BACKEND`, but we may need SVE enabled during execution. So, this introduces a new flag `EJIT_DISABLE_SVE`, so we disable it if absolutely necessary.