### PR TITLE
[EmbeddedJIT] Add SRE code pool memory manager

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@
 #
 # Usage:
 #   ./build.sh release aarch64         # → build_release_aarch64/  (native, recommended)
+#   ./build.sh release aarch64_be      # → build_release_aarch64_be/ (SRE code pool ON by default)
 #   ./build.sh release x86             # → build_release_x86/
 #   ./build.sh debug   x86             # → build_debug_x86/
 #   ./build.sh debug   x86 --static    # → build_debug_x86_static/
@@ -18,7 +19,9 @@
 #   --no-ccache     disable ccache
 #   --trim-llvm-backend-experimental    build with EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=ON (backend: trim non-ELF formats)
 #   --freestanding  build with EJIT_FREESTANDING=ON (runtime: no OS threads/I/O)
-#   --target-triple=<triple>  set EJIT_DEFAULT_TARGET_TRIPLE (required for
+#   --target-triple=<triple>  set EJIT_DEFAULT_TARGET_TRIPLE
+#   --sre-code-pool / --no-sre-code-pool  force EmbeddedJIT SRE code pool on/off
+#   --sre-code-pool-ptno=<n>  set SRE code pool partition number (default: 8)
 #   -h              show help
 #===----------------------------------------------------------------------===#
 
@@ -41,6 +44,7 @@ target_triple() {
   case "$1" in
     x86)     echo "x86_64-unknown-linux-gnu" ;;
     aarch64) echo "aarch64-linux-gnu" ;;
+    aarch64_be) echo "aarch64_be-unknown-linux-gnu" ;;
   esac
 }
 
@@ -48,6 +52,7 @@ llvm_target() {
   case "$1" in
     x86)     echo "X86" ;;
     aarch64) echo "AArch64" ;;
+    aarch64_be) echo "AArch64" ;;
   esac
 }
 
@@ -75,6 +80,7 @@ do_configure() {
   local type="$1" arch="$2" build_dir="$3" variant="${4:-default}"
   local target; target=$(llvm_target "$arch")
   local cc cxx; read -r cc cxx <<< "$(native_cc)"
+  local default_triple; default_triple=$(target_triple "$arch")
 
   local ccache_opts=""
   if $USE_CCACHE; then
@@ -91,6 +97,9 @@ do_configure() {
         -DLLVM_OPTIMIZED_TABLEGEN=ON \
         "-DLLVM_TARGETS_TO_BUILD=${target}" \
         -DLLVM_ENABLE_PROJECTS="clang;lld" \
+        -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
+        -DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO} \
+        "-DEJIT_DEFAULT_TARGET_TRIPLE=${EJIT_TARGET_TRIPLE:-${default_triple}}" \
         -DLLVM_ENABLE_ZLIB=OFF \
         -DLLVM_ENABLE_ZSTD=OFF \
         -DCMAKE_C_COMPILER=clang \
@@ -105,6 +114,9 @@ do_configure() {
         -DLLVM_OPTIMIZED_TABLEGEN=ON \
         "-DLLVM_TARGETS_TO_BUILD=${target}" \
         -DLLVM_ENABLE_PROJECTS="clang;lld" \
+        -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
+        -DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO} \
+        "-DEJIT_DEFAULT_TARGET_TRIPLE=${EJIT_TARGET_TRIPLE:-${default_triple}}" \
         -DLLVM_USE_SPLIT_DWARF=ON \
         -DLLVM_ENABLE_ZLIB=OFF \
         -DLLVM_ENABLE_ZSTD=OFF \
@@ -149,7 +161,9 @@ do_configure() {
       "-DCMAKE_CXX_COMPILER=${cxx}" \
       -DEJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=${EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL} \
       -DEJIT_FREESTANDING=${EJIT_FREESTANDING} \
-      ${EJIT_TARGET_TRIPLE:+-DEJIT_DEFAULT_TARGET_TRIPLE="${EJIT_TARGET_TRIPLE}"} \
+      -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
+      -DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO} \
+      "-DEJIT_DEFAULT_TARGET_TRIPLE=${EJIT_TARGET_TRIPLE:-${default_triple}}" \
       ${ccache_opts} \
       ${extra_flags} \
       "-DCMAKE_C_FLAGS=-ffunction-sections -fdata-sections" \
@@ -180,7 +194,9 @@ do_configure() {
       "-DCMAKE_CXX_COMPILER=${cxx}" \
       -DEJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=${EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL} \
       -DEJIT_FREESTANDING=${EJIT_FREESTANDING} \
-      ${EJIT_TARGET_TRIPLE:+-DEJIT_DEFAULT_TARGET_TRIPLE="${EJIT_TARGET_TRIPLE}"} \
+      -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
+      -DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO} \
+      "-DEJIT_DEFAULT_TARGET_TRIPLE=${EJIT_TARGET_TRIPLE:-${default_triple}}" \
       ${ccache_opts} \
       ${extra_flags} \
       "-DCMAKE_C_FLAGS=-ffunction-sections -fdata-sections" \
@@ -228,6 +244,13 @@ USE_CCACHE=true
 EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=OFF
 EJIT_FREESTANDING=OFF
 EJIT_TARGET_TRIPLE=""
+EJIT_SRE_CODE_POOL=AUTO
+EJIT_SRE_CODE_POOL_PTNO=8
+
+if [[ "${1:-}" = "-h" || "${1:-}" = "--help" ]]; then
+  sed -n '2,25p' "$0"
+  exit 0
+fi
 
 shift 2 2>/dev/null || true
 while [[ $# -gt 0 ]]; do
@@ -240,8 +263,11 @@ while [[ $# -gt 0 ]]; do
     --trim-llvm-backend-experimental) EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=ON ;;
     --freestanding) EJIT_FREESTANDING=ON ;;
     --target-triple=*) EJIT_TARGET_TRIPLE="${1#--target-triple=}" ;;
+    --sre-code-pool) EJIT_SRE_CODE_POOL=ON ;;
+    --no-sre-code-pool) EJIT_SRE_CODE_POOL=OFF ;;
+    --sre-code-pool-ptno=*) EJIT_SRE_CODE_POOL_PTNO="${1#--sre-code-pool-ptno=}" ;;
     -h|--help)
-      sed -n '2,18p' "$0"
+      sed -n '2,25p' "$0"
       exit 0
       ;;
     *) err "Unknown argument: $1"; exit 1 ;;
@@ -255,7 +281,15 @@ if [ -z "$TYPE" ] || [ -z "$ARCH" ]; then
 fi
 
 case "$TYPE" in  debug|release) ;;  *) err "Invalid type: $TYPE"; exit 1 ;; esac
-case "$ARCH" in  x86|aarch64) ;;    *) err "Invalid arch: $ARCH"; exit 1 ;; esac
+case "$ARCH" in  x86|aarch64|aarch64_be) ;;    *) err "Invalid arch: $ARCH"; exit 1 ;; esac
+
+if [ "$EJIT_SRE_CODE_POOL" = "AUTO" ]; then
+  if [ "$ARCH" = "aarch64_be" ]; then
+    EJIT_SRE_CODE_POOL=ON
+  else
+    EJIT_SRE_CODE_POOL=OFF
+  fi
+fi
 
 if [ "$TYPE" = "debug" ] && [ "$VARIANT" = "minimal" ]; then
   warn "debug + minimal is unusual; proceeding anyway."
@@ -263,6 +297,7 @@ fi
 
 BUILD_DIR=$(build_dir "$TYPE" "$ARCH" "$VARIANT")
 log "Type=${TYPE}  Arch=${ARCH}  Variant=${VARIANT}  ccache=$($USE_CCACHE && echo on || echo off)"
+log "EJIT: triple=${EJIT_TARGET_TRIPLE:-$(target_triple "$ARCH")}  sre-code-pool=${EJIT_SRE_CODE_POOL}  ptno=${EJIT_SRE_CODE_POOL_PTNO}"
 log "Build dir: ${BUILD_DIR}"
 
 if $DO_CONFIGURE; then

--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -1,0 +1,243 @@
+# EmbeddedJIT SRE 机器码内存池设计（EJIT_SRE_CODE_POOL）
+
+**状态**: 已实现（方案 B，完整接管 JITLink 代码内存分配 + lookup 处 enable_ex 封固）
+**开关**: `-DEJIT_SRE_CODE_POOL=ON`（默认 OFF，上游默认行为不变）
+**关联代码**:
+- `llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h` / `llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp`
+- `llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h` / `.cpp`
+- `llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h` / `.cpp`
+- `llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp`（接入点）
+- 测试: `llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp`、`EJitCodePoolMemoryManagerTest.cpp`
+
+---
+
+## 1. 背景与目标
+
+目标平台（SRE 类）的执行权限原语 `enable_ex` 有两条硬约束：
+
+1. **只能按 2MiB 粒度**设置执行权限：`enable_ex(1, va)` 中 `va` 必须 2MiB 对齐。
+2. 一旦某 2MiB 区域被置为 **RX（可执行）**，该区域**不能再写**。
+
+EmbeddedJIT 需要在运行期把 JIT 生成的机器码变为可执行。直接的做法（wrap 全局
+`mprotect`）会破坏 ORC/JITLink 的后续写入，因此本方案让 EmbeddedJIT **自己拥有
+JIT 代码内存**：以 2MiB 池为单位分配、写入阶段保持 RW、在把函数指针交还调用者之前
+对该池调用 `enable_ex` 封固为 RX，封固后的池永不再写。
+
+---
+
+## 2. 为什么不能 wrap 全局 mprotect
+
+- ORC/JITLink 的 in-process 内存管理器在 finalize 阶段会对各 segment 调用
+  `mprotect` 切换到 R-X。如果我们 wrap 全局 `mprotect` 把它转成 `enable_ex`，那么：
+  - `enable_ex` 是 **2MiB 粒度**的，而 JITLink 的 segment 通常是页粒度、且多个分配
+    可能落在同一个 2MiB 区域里。把整块 2MiB 置为 RX 后，**同一 2MiB 内后续分配的
+    写入会失败**（W^X 冲突），导致下一个模块链接/重定位崩溃。
+  - JITLink 在 finalize 之后、甚至在 allocation actions 中仍可能写入工作内存；全局
+    wrap 无法区分"这次 mprotect 该转 enable_ex"还是"这页之后还要写"。
+- 全局 wrap 还会影响**业务侧**所有 `mprotect` 调用，污染范围过大、不可控。
+
+因此我们**不 wrap 全局 mprotect**，而是在 EmbeddedJIT 自己的 JIT 代码分配/封固链
+条里精确处理。
+
+---
+
+## 3. 为什么 enable_ex 必须在"JIT 写完之后、返回函数指针之前"
+
+- **之前**（写入期间）：JITLink 需要把机器码拷进内存并应用重定位，这要求该内存
+  **可写（RW）**。如果过早 `enable_ex` 置 RX，写入/重定位会失败。
+- **之后**（调用之前）：调用者拿到函数指针就会执行它，这要求该内存
+  **可执行（RX）**。
+- 因此唯一安全的封固点是：**JITLink finalize 完成、即将把函数指针交还调用者的那一刻**。
+  在本实现里就是 `EJitOrcEngine::lookup()` 取得解析地址之后、`return` 之前。
+
+时序：
+
+```
+allocate(RW, 来自 2MiB 池)
+   -> JITLink 写机器码 + 重定位（池保持 RW）
+   -> finalize（本实现不做 mprotect，池仍 RW）
+   -> lookup 得到函数地址
+   -> enable_ex(1, pool->base) 封固该 2MiB 池为 RX，标记 sealed
+   -> 返回函数指针（此时指向 RX 内存，可安全执行）
+```
+
+> 注意：`enable_ex` 内部已完成权限/cache 同步，所以本实现在 SRE 模式下
+> **不调用 `__builtin___clear_cache`**。
+
+---
+
+## 4. 为什么采用 2MiB 池
+
+- `enable_ex` 的最小粒度就是 2MiB，因此**池的对齐与封固单位必须是 2MiB**，否则一次
+  封固会波及相邻无关内存。
+- 以 2MiB 为单位 bump 分配，使"封固一个池"与"该池内所有函数都已写完"一一对应，
+  从而保证封固后绝不再写。
+- 2MiB 大页对 icache/iTLB 局部性也更友好。
+
+每个池的原始申请大小为 `poolSize + 2MiB - 1`，再把基址向上对齐到 2MiB：
+`base = alignUp(raw, 2MiB)`，池仅使用 `[base, base + poolSize)`，`raw` 保留在
+`CodePool` 中用于调试/未来回收。
+
+---
+
+## 5. 为什么 sealed 池不再写
+
+- 平台约束：2MiB 区域置 RX 后不可写。封固后若再往里 bump 新代码，写入必然失败。
+- 因此分配策略规定：**active 池一旦 sealed（或空间不足被提前 sealed），新分配一律
+  进入新的 2MiB 池**。sealed 池只读只执行，生命周期内不回收、不复用。
+
+分配策略（`EJitCodePoolManager::allocateCode`）：
+
+1. 无 active 池 → 申请新 2MiB 池。
+2. active 池已 sealed → 申请新 2MiB 池。
+3. active 池剩余空间不足 → **先 seal 当前池**，再申请新 2MiB 池。
+4. 否则在 active 池内 bump 分配（对齐到 `max(请求对齐, 64)`）。
+5. 单次请求 > 池大小 → **clean error**（不静默回退）。
+6. 第一版不支持释放小块、不做 free-list、不复用 sealed 池（可靠性优先）。
+
+> 策略 3 的"提前封固"在 EmbeddedJIT 的**同步编译**模型下是安全的：当新的分配到来
+> 时，落在当前池里的上一个模块早已 finalize 完成，不会再写。
+
+---
+
+## 6. 方案 B 的优缺点
+
+**优点**
+- 可靠：写入期 RW、执行期 RX，封固点唯一且明确，不会出现 W^X 冲突。
+- 与业务内存隔离：JIT 机器码只来自 SRE 分配器，不进业务 heap。
+- 局部性更好：2MiB 大页利于 icache/iTLB。
+- 与上游解耦：通过 JITLink `JITLinkMemoryManager` 接口替换，不改通用 mprotect/malloc。
+
+**缺点**
+- 内存按 2MiB 粒度增长；第一版**不释放** code pool（sealed 不回收）。
+- 每个池尾部可能有浪费（`wastedBytes` 统计可见）。
+- 单个特化函数不能超过一个池大小（默认 2MiB），否则 clean error。
+
+---
+
+## 7. 与普通业务内存的边界
+
+- **机器码字节**：永远来自注入的 raw 分配器（目标平台 `SRE_MemDbgAlloc`，分区
+  `EJIT_SRE_CODE_POOL_PTNO`，默认 8），**绝不**来自 `malloc/new`/业务 heap。
+- **池描述符（`CodePool` 记账）**：是少量普通宿主内存（`std::vector` 记账），**不
+  存放任何可执行代码**。这是记账与代码字节的明确分界。
+- `EJitCodePoolManager` **不依赖任何 SRE 头文件**：raw 分配器与 `enable_ex` 封固
+  都是注入的回调，因此该类可在宿主上用 mock 完整单测；真实平台适配集中在
+  `EJitSrePlatform.cpp`，不把 SRE 头文件塞进通用 LLVM 文件。
+
+---
+
+## 8. 接入点：真正接管了 JITLink 代码内存分配吗？
+
+**是。** 本实现不是"只在 lookup 前 seal 一下"的浅层 hook，而是用一个自定义的
+`jitlink::JITLinkMemoryManager`（`EJitCodePoolMemoryManager`）**接管了 JIT segment
+的内存分配**：
+
+- `EJitOrcEngine::Create` 在 `EJIT_SRE_CODE_POOL` 下，通过
+  `LLJITBuilder::setObjectLinkingLayerCreator` 安装一个使用
+  `EJitCodePoolMemoryManager` 的 `orc::ObjectLinkingLayer`。
+- `EJitCodePoolMemoryManager::allocate` 仿照 `InProcessMemoryManager`，用
+  `BasicLayout` 计算各 segment 大小，但 slab **来自 `EJitCodePoolManager` 的 2MiB
+  池**（而非 mmap）。
+- `finalize()` **刻意不做任何 mprotect**，让池保持 RW；也不调用
+  `InvalidateInstructionCache`（由 `enable_ex` 负责）。
+- 真正的 RW→RX 封固由 `EJitOrcEngine::lookup` 在返回函数指针前对包含该地址的池调用
+  `enable_ex` 完成（幂等：已封固的池不重复调用）。
+
+换言之：**代码内存来自 EJITCodePoolManager，而非普通 mmap/mprotect**；封固在
+lookup 处发生。两部分共同构成完整方案，没有"伪装成内存池"的浅层实现。
+
+---
+
+## 9. 如何开启与配置（CMake）
+
+```bash
+cmake -S llvm -B build-ejit-sre-pool \
+  -DEJIT_SRE_CODE_POOL=ON \
+  -DEJIT_SRE_CODE_POOL_PTNO=8 \
+  -DEJIT_DEFAULT_TARGET_TRIPLE=aarch64_be-unknown-linux-gnu \
+  <保留项目原本需要的 CMake 参数>
+```
+
+| 开关 | 默认 | 说明 |
+|------|------|------|
+| `EJIT_SRE_CODE_POOL` | OFF | 启用 2MiB 代码池 + enable_ex 封固；同时隐含启用 `EJIT_SRE_ENABLE_EX` |
+| `EJIT_SRE_CODE_POOL_SIZE` | 2097152 (2MiB) | 每个池的可用字节数 |
+| `EJIT_SRE_CODE_POOL_PTNO` | 8 | 传给 `SRE_MemDbgAlloc` 的分区号 ptNo |
+| `EJIT_SRE_ENABLE_EX` | 随 `EJIT_SRE_CODE_POOL` | 关闭后代码仍走池，但不做权限翻转（bring-up/测量用） |
+
+平台接口（在 `EJitSrePlatform.cpp` 内声明，避免污染通用命名空间）：
+
+```cpp
+extern "C" unsigned ejit_sre_enable_ex(unsigned startLevel,
+                                       unsigned long long va) __asm__("enable_ex");
+extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
+                                 unsigned long size, const char *func,
+                                 unsigned int line);
+```
+
+为保证**宿主无真实 SRE 符号时也能链接/跑通**，`EJitSrePlatform.cpp` 为这两个符号
+提供了 **weak 兜底定义**（`enable_ex` 兜底为 no-op 成功、`SRE_MemDbgAlloc` 兜底为
+对齐的宿主分配）。真实平台提供的 **strong 符号会覆盖** weak 兜底。
+
+---
+
+## 10. 如何验证
+
+**默认构建（开关 OFF，行为不变）**：
+
+```bash
+cmake --build build-ejit --target LLVMEJIT -j4
+```
+
+**代码池单元测试（宿主可跑，使用 mock allocator + mock enable_ex，不需真实 SRE）**：
+
+```bash
+cmake --build build-ejit --target EJITCodePoolTests -j4
+cmake --build build-ejit --target check-ejit-code-pool -j4
+```
+
+覆盖：
+- `EJitCodePoolTest`：2MiB 对齐、RW 池内 bump、seal 标记 executable、sealed 不复用、
+  重复 seal 不重复 enable_ex、enable_ex 失败返回 Error、超池大小 clean reject、
+  统计正确、rollover 自动封固、`sealAllWritablePools` 等。
+- `EJitCodePoolMemoryManagerTest`：用合成 JITLink `LinkGraph` 驱动内存管理器，验证
+  JIT 代码来自池、finalize 后仍 RW、lookup 式封固只翻一次、第二个函数在前一个池
+  sealed 后进入新池。
+
+**代码池开关构建（开关 ON）**：
+
+```bash
+cmake -S llvm -B build-ejit-sre-pool -DEJIT_SRE_CODE_POOL=ON \
+  -DEJIT_SRE_CODE_POOL_PTNO=8 <其余参数>
+cmake --build build-ejit-sre-pool --target LLVMEJIT -j4
+cmake --build build-ejit-sre-pool --target check-ejit-code-pool -j4
+```
+
+---
+
+## 11. 已知限制
+
+1. **不释放 code pool**：池生命周期等于 EJIT runtime/engine 生命周期；sealed 池不回
+   收。这是为了可靠性、避免 W/RX 权限冲突（目标平台 free/realloc 也可能不可靠）。
+2. **单函数 ≤ 池大小**：超过 `EJIT_SRE_CODE_POOL_SIZE` 的单次请求返回 Error。
+3. **端到端原生执行未在本机验证**：本机为 aarch64 宿主但只构建了 X86 后端，无法在
+   宿主上真正执行 JIT 机器码。因此所有测试都是**宿主可跑的逻辑/集成测试**（mock
+   分配器 + mock enable_ex + 合成 LinkGraph）；真正"编译→执行特化函数"需在与所构建
+   后端匹配的目标/宿主上验证。
+4. **同步编译假设**：策略 3 的"满则提前封固"依赖 EmbeddedJIT 的同步编译模型
+   （`setNumCompileThreads(0)`）。
+5. **EJITTests 现状**：上游基线分支上的 `EJITTests` 因无关的历史 API 漂移当前无法
+   编译；因此本特性的测试放在独立的 `EJITCodePoolTests` 可执行文件 + `check-ejit-
+   code-pool` 目标中，与之解耦。
+
+---
+
+## 12. 后续可扩展
+
+- **free-list / pool reset / LRU**：在 quiesce 点整体 reset 或按 LRU 回收 sealed 池
+  （需要平台支持把 RX 区域改回 RW 或释放）。
+- **跨进程共享**：只共享 **bitcode / object**，**不直接共享含绝对地址的机器码**
+  （机器码内嵌了进程相关的绝对地址，跨进程不安全）。
+- **更细的 finalize 段处理**：当前把 standard/finalize 段一起放进池；后续可单独管理
+  finalize 段以减少浪费。

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -570,6 +570,33 @@ if(EJIT_FREESTANDING)
   add_definitions(-DEJIT_FREESTANDING)
 endif()
 
+#===-- EmbeddedJIT SRE dedicated JIT code memory pool ----------------------===#
+# Route JIT machine-code memory through EmbeddedJIT's own 2MiB-aligned code
+# pools (instead of the default JITLink mmap/mprotect path), and seal each pool
+# to RX via the platform enable_ex primitive before a JIT function pointer is
+# handed back. Default OFF: upstream default behavior is unchanged.
+option(EJIT_SRE_CODE_POOL
+  "Use the EmbeddedJIT SRE 2MiB code pool + enable_ex sealing for JIT code memory" OFF)
+if(EJIT_SRE_CODE_POOL)
+  add_definitions(-DEJIT_SRE_CODE_POOL)
+  # enable_ex sealing is implied by the code pool; allow turning just the seal
+  # call off for bring-up/measurement while still routing code through pools.
+  add_definitions(-DEJIT_SRE_ENABLE_EX)
+endif()
+
+# Per-pool size in bytes (must be a multiple of the 2MiB enable_ex granularity).
+set(EJIT_SRE_CODE_POOL_SIZE "2097152" CACHE STRING
+  "EmbeddedJIT SRE code pool size in bytes (default 2MiB)")
+# SRE memory partition number (ptNo) handed to SRE_MemDbgAlloc.
+set(EJIT_SRE_CODE_POOL_PTNO "8" CACHE STRING
+  "EmbeddedJIT SRE code pool partition number (ptNo) for SRE_MemDbgAlloc")
+if(EJIT_SRE_CODE_POOL)
+  add_definitions(-DEJIT_SRE_CODE_POOL_SIZE=${EJIT_SRE_CODE_POOL_SIZE})
+  add_definitions(-DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO})
+  message(STATUS "EmbeddedJIT: SRE code pool enabled "
+                 "(size=${EJIT_SRE_CODE_POOL_SIZE}, ptNo=${EJIT_SRE_CODE_POOL_PTNO})")
+endif()
+
 set(LLVM_TARGETS_TO_BUILD "all"
     CACHE STRING "Semicolon-separated list of targets to build, or \"all\".")
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -1,0 +1,155 @@
+//===-- EJitCodePool.h - EmbeddedJIT SRE machine-code memory pool ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Dedicated machine-code memory pool for EmbeddedJIT on SRE-style targets.
+//
+//  Background: the target's execute-permission primitive (enable_ex) can only
+//  flip permissions at 2MiB granularity, and once a 2MiB region is made RX it
+//  can no longer be written. Wrapping the global mprotect breaks ORC/JITLink's
+//  later writes, so instead EmbeddedJIT owns the JIT code memory directly:
+//
+//    * Each pool is a 2MiB-aligned region carved from a raw SRE allocation.
+//    * While JITLink writes machine code the pool stays RW.
+//    * Before a JIT function pointer is handed back to the caller, the pool
+//      containing it is sealed: enable_ex flips it to RX and it is marked
+//      executable. A sealed pool is never written or allocated from again.
+//    * New JIT code always lands in a fresh (or current unsealed) pool.
+//
+//  This class is intentionally free of any SRE header dependency: the raw
+//  allocator and the seal (enable_ex) primitive are injected as callbacks so
+//  that the manager is fully unit-testable on a host with mocks. The thin SRE
+//  platform adapter lives in EJitSrePlatform.h and is only pulled in when
+//  EJIT_SRE_CODE_POOL is enabled.
+//
+//  Memory boundary: the *machine code bytes* always come from the injected raw
+//  allocator (SRE on the target), never from malloc/new/business heap. The
+//  small pool-descriptor bookkeeping below is ordinary host memory and never
+//  holds executable code.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOL_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOL_H
+
+#include "llvm/Support/Error.h"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#ifndef EJIT_FREESTANDING
+#include <mutex>
+#endif
+
+namespace llvm {
+namespace ejit {
+
+/// A single 2MiB-aligned JIT code pool.
+struct CodePool {
+  /// Raw pointer returned by the injected allocator (SRE_MemDbgAlloc on the
+  /// target). Retained for debugging and possible future reclamation.
+  uint8_t *raw = nullptr;
+  /// 2MiB-aligned usable base inside [raw, raw + rawSize).
+  uint8_t *base = nullptr;
+  /// Usable size of the pool (the configured pool size, default 2MiB).
+  size_t size = 0;
+  /// Bump-allocation offset within [base, base + size).
+  size_t used = 0;
+  /// false = RW and still accepting allocations; true = sealed RX, frozen.
+  bool executable = false;
+};
+
+/// Manages a set of 2MiB JIT code pools with bump allocation and RW->RX
+/// sealing. Not coupled to LLVM containers for the code bytes themselves; the
+/// code storage comes exclusively from the injected raw allocator.
+class EJitCodePoolManager {
+public:
+  /// Allocate at least `bytes` of writable memory. Returns nullptr on failure.
+  /// On the target this is backed by SRE_MemDbgAlloc; in tests, by a mock.
+  using RawAllocFn = std::function<void *(size_t bytes)>;
+
+  /// Seal the 2MiB region whose base is `base2m` (must be 2MiB aligned),
+  /// switching it to RX. Returns 0 on success, non-zero on failure. On the
+  /// target this calls enable_ex(1, base2m); in tests, a mock.
+  using SealFn = std::function<unsigned(void *base2m)>;
+
+  struct Options {
+    /// Usable bytes per pool (EJIT_SRE_CODE_POOL_SIZE). Default 2MiB.
+    size_t poolSize = static_cast<size_t>(2) * 1024 * 1024;
+    /// Alignment of each pool base — the enable_ex granularity. Default 2MiB.
+    size_t poolAlign = static_cast<size_t>(2) * 1024 * 1024;
+    /// Minimum alignment applied to every code allocation. Default 64.
+    size_t minCodeAlign = 64;
+  };
+
+  struct Stats {
+    size_t poolCount = 0;       ///< total pools created
+    size_t sealedCount = 0;     ///< pools currently sealed (RX)
+    size_t activeCount = 0;     ///< pools still RW
+    size_t usedBytes = 0;       ///< sum of bump offsets across all pools
+    size_t reservedBytes = 0;   ///< sum of pool sizes across all pools
+    size_t wastedBytes = 0;     ///< unused tail bytes inside sealed pools
+    size_t sealInvocations = 0; ///< number of successful seal (enable_ex) calls
+  };
+
+  EJitCodePoolManager(Options Opts, RawAllocFn Alloc, SealFn Seal);
+  ~EJitCodePoolManager();
+
+  EJitCodePoolManager(const EJitCodePoolManager &) = delete;
+  EJitCodePoolManager &operator=(const EJitCodePoolManager &) = delete;
+
+  /// Bump-allocate `Size` bytes of RW code memory aligned to
+  /// max(Align, minCodeAlign). Allocation strategy:
+  ///   1. no active pool          -> new 2MiB pool
+  ///   2. active pool sealed       -> new 2MiB pool
+  ///   3. active pool out of room  -> seal active pool, then new 2MiB pool
+  ///   4. otherwise                -> bump-allocate inside the active pool
+  /// A request larger than the pool size is a clean error (no silent fallback).
+  /// If sealing the full active pool (case 3) fails, returns that Error.
+  Expected<void *> allocateCode(size_t Size, size_t Align);
+
+  /// Seal the pool that contains `Ptr` (RW -> RX) if it is not already sealed.
+  /// Idempotent: a second call for an address in an already-sealed pool is a
+  /// no-op success and does not re-invoke enable_ex. Returns an Error if the
+  /// pointer is not owned by any pool, or if enable_ex fails.
+  Error sealPoolContaining(const void *Ptr);
+
+  /// Seal every pool that is still writable. Used at shutdown/quiesce points.
+  Error sealAllWritablePools();
+
+  /// True if `Ptr` falls inside the usable range of any owned pool.
+  bool contains(const void *Ptr) const;
+
+  /// Snapshot of pool statistics (thread-safe).
+  Stats getStats() const;
+
+private:
+  CodePool *findPoolLocked(const void *Ptr);
+  Error newActivePoolLocked();
+  Error sealPoolLocked(CodePool &P);
+  bool poolHasRoomLocked(const CodePool &P, size_t Size, size_t Align) const;
+
+  Options Opts_;
+  RawAllocFn Alloc_;
+  SealFn Seal_;
+
+  // Pool descriptors (ordinary host bookkeeping; never holds code bytes).
+  std::vector<std::unique_ptr<CodePool>> Pools_;
+  CodePool *Active_ = nullptr;
+  size_t SealInvocations_ = 0;
+
+#ifndef EJIT_FREESTANDING
+  mutable std::mutex Mutex_;
+#endif
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOL_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
@@ -1,0 +1,63 @@
+//===-- EJitCodePoolMemoryManager.h - JITLink mem mgr over code pool ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  A JITLink memory manager that backs all JIT segment memory with
+//  EJitCodePoolManager's 2MiB pools instead of mmap/mprotect.
+//
+//  Unlike InProcessMemoryManager, finalize() does NOT apply memory protections:
+//  the pool is left RW so JITLink/ORC can keep writing relocations, and the
+//  RW->RX transition happens later, exactly once per 2MiB pool, via the pool
+//  manager's enable_ex sealing (driven from the engine right before a function
+//  pointer is returned). This keeps execute-permission flips at the required
+//  2MiB granularity and avoids the W^X conflict that wrapping mprotect causes.
+//
+//  v1 does not reclaim pool memory on deallocate (only dealloc actions run);
+//  pool lifetime equals the engine lifetime. See EJIT_SRE_CODE_POOL.md.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOLMEMORYMANAGER_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOLMEMORYMANAGER_H
+
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
+
+namespace llvm {
+namespace ejit {
+
+/// JITLinkMemoryManager that allocates JIT segments from EJitCodePoolManager
+/// and never changes page protections itself (sealing is done out-of-band by
+/// the pool manager). The referenced pool manager must outlive this object.
+class EJitCodePoolMemoryManager : public jitlink::JITLinkMemoryManager {
+public:
+  EJitCodePoolMemoryManager(EJitCodePoolManager &Pool, size_t PageSize);
+
+  void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
+                OnAllocatedFunction OnAllocated) override;
+
+  void deallocate(std::vector<FinalizedAlloc> Allocs,
+                  OnDeallocatedFunction OnDeallocated) override;
+
+  // Bring in the convenience / blocking overloads hidden by the overrides.
+  using JITLinkMemoryManager::allocate;
+  using JITLinkMemoryManager::deallocate;
+
+  EJitCodePoolManager &getPool() { return Pool_; }
+
+private:
+  class InFlightAllocImpl;
+  struct FinalizedInfo;
+
+  EJitCodePoolManager &Pool_;
+  size_t PageSize_;
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOLMEMORYMANAGER_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -15,6 +15,10 @@
 #include <memory>
 #include <string>
 
+#ifdef EJIT_SRE_CODE_POOL
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#endif
+
 namespace llvm {
 namespace ejit {
 
@@ -64,6 +68,14 @@ public:
   /// JIT can resolve when compiling bitcode modules. Required for bare-metal
   /// environments where dynamic symbol lookup is unavailable.
   void addUserSymbol(const std::string &name, void *addr);
+
+#ifdef EJIT_SRE_CODE_POOL
+  /// Snapshot of the SRE code-pool statistics (pool / sealed counts, used /
+  /// wasted bytes, enable_ex invocations) for diagnostics and tests. Returns a
+  /// zeroed snapshot if no pool is active. Available only with
+  /// EJIT_SRE_CODE_POOL.
+  EJitCodePoolManager::Stats getCodePoolStats() const;
+#endif
 
 private:
   struct Impl;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
@@ -1,0 +1,37 @@
+//===-- EJitSrePlatform.h - SRE platform adapter for the code pool --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Thin adapter that wires EJitCodePoolManager to the real SRE platform
+//  primitives (SRE_MemDbgAlloc for raw memory, enable_ex for sealing). This
+//  header is only meaningful when EJIT_SRE_CODE_POOL is defined; it keeps the
+//  SRE symbol declarations out of generic LLVM translation units.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITSREPLATFORM_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITSREPLATFORM_H
+
+#ifdef EJIT_SRE_CODE_POOL
+
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#include <memory>
+
+namespace llvm {
+namespace ejit {
+
+/// Construct an EJitCodePoolManager wired to the SRE platform: raw memory from
+/// SRE_MemDbgAlloc (partition EJIT_SRE_CODE_POOL_PTNO) and sealing via
+/// enable_ex. On a host without real SRE symbols, weak fallbacks make this a
+/// link-safe no-op-seal / aligned-host-alloc manager (see EJitSrePlatform.cpp).
+std::unique_ptr<EJitCodePoolManager> makeSreCodePoolManager();
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // EJIT_SRE_CODE_POOL
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITSREPLATFORM_H

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -64,6 +64,9 @@ set(EJIT_SOURCES
   EJitStructFieldPass.cpp
   EJitOptimizer.cpp
   EJitPassBuilder.cpp
+  EJitCodePool.cpp
+  EJitCodePoolMemoryManager.cpp
+  EJitSrePlatform.cpp
 )
 
 # Async/sync compiler — excluded in freestanding mode (single-threaded, no std::thread)

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -1,0 +1,193 @@
+//===-- EJitCodePool.cpp - EmbeddedJIT SRE machine-code memory pool -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#include "llvm/Support/MathExtras.h"
+
+using namespace llvm;
+using namespace llvm::ejit;
+
+namespace {
+
+inline size_t alignUp(size_t V, size_t A) { return (V + (A - 1)) & ~(A - 1); }
+
+inline uintptr_t addr(const void *P) {
+  return reinterpret_cast<uintptr_t>(P);
+}
+
+} // namespace
+
+EJitCodePoolManager::EJitCodePoolManager(Options Opts, RawAllocFn Alloc,
+                                         SealFn Seal)
+    : Opts_(Opts), Alloc_(std::move(Alloc)), Seal_(std::move(Seal)) {
+  // minCodeAlign and poolAlign must be powers of two for the masking math.
+  if (Opts_.minCodeAlign == 0 || !isPowerOf2_64(Opts_.minCodeAlign))
+    Opts_.minCodeAlign = 64;
+  if (Opts_.poolAlign == 0 || !isPowerOf2_64(Opts_.poolAlign))
+    Opts_.poolAlign = static_cast<size_t>(2) * 1024 * 1024;
+}
+
+EJitCodePoolManager::~EJitCodePoolManager() = default;
+
+bool EJitCodePoolManager::poolHasRoomLocked(const CodePool &P, size_t Size,
+                                            size_t Align) const {
+  size_t Off = alignUp(P.used, Align);
+  // Guard against overflow before comparing against the pool size.
+  if (Off < P.used)
+    return false;
+  return Off <= P.size && (P.size - Off) >= Size;
+}
+
+Error EJitCodePoolManager::newActivePoolLocked() {
+  // raw size must allow rounding the base up to poolAlign while still leaving
+  // poolSize usable bytes: rawSize >= poolSize + poolAlign - 1.
+  size_t RawSize = Opts_.poolSize + Opts_.poolAlign - 1;
+  void *Raw = Alloc_ ? Alloc_(RawSize) : nullptr;
+  if (!Raw)
+    return make_error<StringError>(
+        "EJitCodePool: raw allocation of " + Twine(RawSize) + " bytes failed",
+        inconvertibleErrorCode());
+
+  auto *RawBytes = static_cast<uint8_t *>(Raw);
+  auto *Base = reinterpret_cast<uint8_t *>(
+      alignUp(addr(RawBytes), Opts_.poolAlign));
+
+  auto P = std::make_unique<CodePool>();
+  P->raw = RawBytes;
+  P->base = Base;
+  P->size = Opts_.poolSize;
+  P->used = 0;
+  P->executable = false;
+  Active_ = P.get();
+  Pools_.push_back(std::move(P));
+  return Error::success();
+}
+
+Error EJitCodePoolManager::sealPoolLocked(CodePool &P) {
+  if (P.executable)
+    return Error::success(); // already sealed — never re-invoke enable_ex
+  unsigned Rc = Seal_ ? Seal_(P.base) : 1;
+  if (Rc != 0)
+    return make_error<StringError>(
+        "EJitCodePool: enable_ex failed (rc=" + Twine(Rc) + ") for pool base " +
+            Twine(addr(P.base)),
+        inconvertibleErrorCode());
+  P.executable = true;
+  ++SealInvocations_;
+  // Per platform guidance, enable_ex performs its own permission/cache
+  // synchronization, so we deliberately do NOT call __builtin___clear_cache.
+  return Error::success();
+}
+
+Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
+  if (Size == 0)
+    return make_error<StringError>("EJitCodePool: zero-size allocation",
+                                   inconvertibleErrorCode());
+
+  size_t EffAlign = std::max(Align, Opts_.minCodeAlign);
+  if (!isPowerOf2_64(EffAlign))
+    EffAlign = alignUp(EffAlign, Opts_.minCodeAlign);
+
+  // A single allocation can never span pools; reject oversize requests cleanly.
+  if (Size > Opts_.poolSize)
+    return make_error<StringError>(
+        "EJitCodePool: request of " + Twine(Size) +
+            " bytes exceeds pool size " + Twine(Opts_.poolSize),
+        inconvertibleErrorCode());
+
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+
+  // Decide whether we can use the current active pool.
+  if (!Active_ || Active_->executable ||
+      !poolHasRoomLocked(*Active_, Size, EffAlign)) {
+    // Case 3: an unsealed-but-full active pool is sealed before rolling over so
+    // it is frozen and never written again. (Safe under EmbeddedJIT's
+    // synchronous compilation: the previous module in this pool has already
+    // finalized by the time a new allocation arrives.)
+    if (Active_ && !Active_->executable) {
+      if (auto Err = sealPoolLocked(*Active_))
+        return std::move(Err);
+    }
+    if (auto Err = newActivePoolLocked())
+      return std::move(Err);
+  }
+
+  size_t Off = alignUp(Active_->used, EffAlign);
+  uint8_t *Ptr = Active_->base + Off;
+  Active_->used = Off + Size;
+  return static_cast<void *>(Ptr);
+}
+
+CodePool *EJitCodePoolManager::findPoolLocked(const void *Ptr) {
+  uintptr_t A = addr(Ptr);
+  for (auto &P : Pools_) {
+    uintptr_t B = addr(P->base);
+    if (A >= B && A < B + P->size)
+      return P.get();
+  }
+  return nullptr;
+}
+
+Error EJitCodePoolManager::sealPoolContaining(const void *Ptr) {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  CodePool *P = findPoolLocked(Ptr);
+  if (!P)
+    return make_error<StringError>(
+        "EJitCodePool: address " + Twine(addr(Ptr)) +
+            " is not owned by any code pool",
+        inconvertibleErrorCode());
+  return sealPoolLocked(*P);
+}
+
+Error EJitCodePoolManager::sealAllWritablePools() {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  Error Err = Error::success();
+  for (auto &P : Pools_)
+    if (!P->executable)
+      Err = joinErrors(std::move(Err), sealPoolLocked(*P));
+  return Err;
+}
+
+bool EJitCodePoolManager::contains(const void *Ptr) const {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  uintptr_t A = addr(Ptr);
+  for (auto &P : Pools_) {
+    uintptr_t B = addr(P->base);
+    if (A >= B && A < B + P->size)
+      return true;
+  }
+  return false;
+}
+
+EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  Stats S;
+  S.poolCount = Pools_.size();
+  S.sealInvocations = SealInvocations_;
+  for (auto &P : Pools_) {
+    S.reservedBytes += P->size;
+    S.usedBytes += P->used;
+    if (P->executable) {
+      ++S.sealedCount;
+      S.wastedBytes += (P->size - P->used);
+    } else {
+      ++S.activeCount;
+    }
+  }
+  return S;
+}

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -1,0 +1,145 @@
+//===-- EJitCodePoolMemoryManager.cpp - JITLink mem mgr over code pool ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/Shared/AllocationActions.h"
+#include "llvm/Support/MathExtras.h"
+#include <cstring>
+
+using namespace llvm;
+using namespace llvm::ejit;
+using namespace llvm::jitlink;
+
+using orc::ExecutorAddr;
+using WrapperFunctionCall = orc::shared::WrapperFunctionCall;
+
+/// Side record used as the FinalizedAlloc handle. Holds the dealloc actions and
+/// the pool-backed base address. Pool memory itself is not freed in v1.
+struct EJitCodePoolMemoryManager::FinalizedInfo {
+  void *Base = nullptr;
+  std::vector<WrapperFunctionCall> DeallocActions;
+};
+
+class EJitCodePoolMemoryManager::InFlightAllocImpl
+    : public JITLinkMemoryManager::InFlightAlloc {
+public:
+  InFlightAllocImpl(EJitCodePoolMemoryManager &, LinkGraph &G, BasicLayout BL,
+                    void *Base)
+      : G(&G), BL(std::move(BL)), Base(Base) {}
+
+  void finalize(OnFinalizedFunction OnFinalized) override {
+    // The content has already been written into working memory, which (for an
+    // in-process pool) is the executor memory. Deliberately DO NOT apply any
+    // memory protection here: the pool stays RW until it is sealed as a whole
+    // 2MiB region by EJitCodePoolManager. Likewise we do not invalidate the
+    // instruction cache — enable_ex performs that sync on the target.
+    runFinalizeActions(
+        G->allocActions(),
+        [this, OnFinalized = std::move(OnFinalized)](
+            Expected<std::vector<WrapperFunctionCall>> DeallocActions) mutable {
+          if (!DeallocActions) {
+            OnFinalized(DeallocActions.takeError());
+            return;
+          }
+          auto *Info = new FinalizedInfo();
+          Info->Base = Base;
+          Info->DeallocActions = std::move(*DeallocActions);
+#ifndef NDEBUG
+          G = nullptr; // mark finalized
+#endif
+          OnFinalized(FinalizedAlloc(ExecutorAddr::fromPtr(Info)));
+        });
+  }
+
+  void abandon(OnAbandonedFunction OnAbandoned) override {
+    // v1 does not reclaim pool memory; just drop the in-flight state.
+#ifndef NDEBUG
+    G = nullptr;
+#endif
+    OnAbandoned(Error::success());
+  }
+
+private:
+  LinkGraph *G;
+  BasicLayout BL;
+  void *Base;
+};
+
+EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(EJitCodePoolManager &Pool,
+                                                     size_t PageSize)
+    : Pool_(Pool), PageSize_(PageSize) {}
+
+void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
+                                         OnAllocatedFunction OnAllocated) {
+  BasicLayout BL(G);
+
+  auto SegsSizes = BL.getContiguousPageBasedLayoutSizes(PageSize_);
+  if (!SegsSizes) {
+    OnAllocated(SegsSizes.takeError());
+    return;
+  }
+
+  uint64_t Total = SegsSizes->total();
+
+  void *Slab = nullptr;
+  if (Total > 0) {
+    auto MemOrErr = Pool_.allocateCode(static_cast<size_t>(Total), PageSize_);
+    if (!MemOrErr) {
+      OnAllocated(MemOrErr.takeError());
+      return;
+    }
+    Slab = *MemOrErr;
+    // Zero-fill the whole slab up-front (covers zero-fill segments and any
+    // inter-segment page padding).
+    std::memset(Slab, 0, static_cast<size_t>(Total));
+  }
+
+  auto *SlabBytes = static_cast<char *>(Slab);
+  auto NextStandardSegAddr = ExecutorAddr::fromPtr(SlabBytes);
+  auto NextFinalizeSegAddr =
+      ExecutorAddr::fromPtr(SlabBytes + SegsSizes->StandardSegs);
+
+  for (auto &KV : BL.segments()) {
+    auto &AG = KV.first;
+    auto &Seg = KV.second;
+
+    auto &SegAddr = (AG.getMemLifetime() == orc::MemLifetime::Standard)
+                        ? NextStandardSegAddr
+                        : NextFinalizeSegAddr;
+
+    Seg.WorkingMem = SegAddr.toPtr<char *>();
+    Seg.Addr = SegAddr;
+    SegAddr += alignTo(Seg.ContentSize + Seg.ZeroFillSize, PageSize_);
+  }
+
+  if (auto Err = BL.apply()) {
+    OnAllocated(std::move(Err));
+    return;
+  }
+
+  OnAllocated(
+      std::make_unique<InFlightAllocImpl>(*this, G, std::move(BL), Slab));
+}
+
+void EJitCodePoolMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,
+                                           OnDeallocatedFunction OnDeallocated) {
+  Error DeallocErr = Error::success();
+  for (auto &Alloc : Allocs) {
+    auto *Info = Alloc.release().toPtr<FinalizedInfo *>();
+    // Run dealloc actions in reverse order. Pool memory is intentionally not
+    // released in v1 (sealed/RX pages must not be recycled; see design doc).
+    while (!Info->DeallocActions.empty()) {
+      if (auto Err = Info->DeallocActions.back().runWithSPSRetErrorMerged())
+        DeallocErr = joinErrors(std::move(DeallocErr), std::move(Err));
+      Info->DeallocActions.pop_back();
+    }
+    delete Info;
+  }
+  OnDeallocated(std::move(DeallocErr));
+}

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -15,12 +15,24 @@
 #include "llvm/TargetParser/Triple.h"
 #include <map>
 
+#ifdef EJIT_SRE_CODE_POOL
+#include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
+#include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#endif
+
 using namespace llvm;
 using namespace llvm::ejit;
 
 #define DEBUG_TYPE "ejit-orc-engine"
 
 struct EJitOrcEngine::Impl {
+#ifdef EJIT_SRE_CODE_POOL
+  /// Dedicated 2MiB code pools backing all JIT machine code. Declared before
+  /// J so it outlives the LLJIT (and the memory manager the object linking
+  /// layer owns, which references it).
+  std::unique_ptr<EJitCodePoolManager> codePool;
+#endif
   std::unique_ptr<orc::LLJIT> J;
   PeriodArrayRegistry *periodReg = nullptr;
   EJitRuntimeState *runtimeState = nullptr;
@@ -76,6 +88,29 @@ EJitOrcEngine::Create(const Config &config,
 #ifdef EJIT_FREESTANDING
   Builder.setLinkProcessSymbolsByDefault(false);
   Builder.setPlatformSetUp(orc::setUpInactivePlatform);
+#endif
+
+#ifdef EJIT_SRE_CODE_POOL
+  // Route JIT machine-code memory through EmbeddedJIT's own 2MiB pools instead
+  // of the default JITLink mmap/mprotect path. The pool manager is owned by the
+  // engine (so it outlives the LLJIT); the object linking layer owns a memory
+  // manager that references it. Pages are kept RW here and sealed to RX later,
+  // at lookup time, by the pool manager's enable_ex sealing.
+  engine->P->codePool = makeSreCodePoolManager();
+  {
+    EJitCodePoolManager *Pool = engine->P->codePool.get();
+    Builder.setObjectLinkingLayerCreator(
+        [Pool](orc::ExecutionSession &ES)
+            -> Expected<std::unique_ptr<orc::ObjectLayer>> {
+          // Page size only affects per-segment layout padding; we never apply
+          // per-segment protections (sealing is done per 2MiB pool), so a
+          // conservative 4KiB is sufficient and portable.
+          constexpr size_t JitPageSize = 4096;
+          return std::make_unique<orc::ObjectLinkingLayer>(
+              ES, std::make_unique<EJitCodePoolMemoryManager>(*Pool,
+                                                              JitPageSize));
+        });
+  }
 #endif
 
   auto J = Builder.create();
@@ -270,7 +305,23 @@ Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
   auto addr = P->J->lookup(*it->second, name);
   if (!addr)
     return addr.takeError();
-  return reinterpret_cast<void *>(addr->getValue());
+  void *Ptr = reinterpret_cast<void *>(addr->getValue());
+
+#ifdef EJIT_SRE_CODE_POOL
+  // Seal the 2MiB pool that contains the resolved function before it is handed
+  // back, so the page is RX (executable) at the call site. This is the only
+  // point a JIT pool transitions RW->RX. Idempotent: a pool already sealed
+  // (e.g. on allocation rollover) is not re-flipped, so repeated lookups of the
+  // same function do not re-invoke enable_ex. Only pool-backed code is sealed;
+  // an address resolved outside the pools (e.g. a process/absolute symbol) is
+  // left untouched. If sealing fails we must not return a callable pointer.
+  if (P->codePool && P->codePool->contains(Ptr)) {
+    if (auto Err = P->codePool->sealPoolContaining(Ptr))
+      return std::move(Err);
+  }
+#endif
+
+  return Ptr;
 }
 
 void EJitOrcEngine::setActiveContext(const SpecializationContext *ctx) {
@@ -285,3 +336,11 @@ const SpecializationContext *EJitOrcEngine::getActiveContext() const {
 void EJitOrcEngine::addUserSymbol(const std::string &name, void *addr) {
   P->userSymbols[name] = addr;
 }
+
+#ifdef EJIT_SRE_CODE_POOL
+EJitCodePoolManager::Stats EJitOrcEngine::getCodePoolStats() const {
+  if (P->codePool)
+    return P->codePool->getStats();
+  return EJitCodePoolManager::Stats{};
+}
+#endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -1,0 +1,110 @@
+//===-- EJitSrePlatform.cpp - SRE platform adapter for the code pool ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Wires EJitCodePoolManager to the real SRE platform primitives. Compiled
+//  only when EJIT_SRE_CODE_POOL is enabled. Provides weak host fallbacks so a
+//  host build links and runs without the real SRE symbols (the real platform
+//  supplies strong overrides).
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef EJIT_SRE_CODE_POOL
+
+#include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
+
+#include <cstdlib>
+
+#ifndef EJIT_SRE_CODE_POOL_SIZE
+#define EJIT_SRE_CODE_POOL_SIZE (static_cast<unsigned long long>(2) * 1024 * 1024)
+#endif
+
+#ifndef EJIT_SRE_CODE_POOL_PTNO
+#define EJIT_SRE_CODE_POOL_PTNO 8
+#endif
+
+// Memory module id passed to SRE_MemDbgAlloc. Not architecturally significant
+// for the pool; overridable if a deployment needs a specific id.
+#ifndef EJIT_SRE_CODE_POOL_MID
+#define EJIT_SRE_CODE_POOL_MID 0
+#endif
+
+namespace {
+constexpr unsigned long long kSrePoolSize = EJIT_SRE_CODE_POOL_SIZE;
+constexpr unsigned char kSrePtNo = static_cast<unsigned char>(EJIT_SRE_CODE_POOL_PTNO);
+constexpr unsigned kSreMid = static_cast<unsigned>(EJIT_SRE_CODE_POOL_MID);
+constexpr size_t k2MiB = static_cast<size_t>(2) * 1024 * 1024;
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// Platform primitives
+//
+// enable_ex is renamed via an asm label so the generic identifier
+// ejit_sre_enable_ex is used in C++ while the linker sees "enable_ex".
+//===----------------------------------------------------------------------===//
+extern "C" unsigned ejit_sre_enable_ex(unsigned startLevel,
+                                       unsigned long long va)
+    __asm__("enable_ex");
+
+extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
+                                 unsigned long size, const char *func,
+                                 unsigned int line);
+
+//===----------------------------------------------------------------------===//
+// Weak host fallbacks
+//
+// On the real target the platform provides strong definitions that override
+// these. On a host without SRE, the weak versions let an EJIT_SRE_CODE_POOL
+// build link and run: enable_ex becomes a no-op success (host pages are already
+// writable+executable for smoke testing) and allocation uses aligned host
+// memory. They are intentionally NOT used by the unit tests, which inject their
+// own mocks.
+//===----------------------------------------------------------------------===//
+__attribute__((weak)) unsigned ejit_sre_enable_ex(unsigned /*startLevel*/,
+                                                  unsigned long long /*va*/) {
+  return 0; // success no-op on host
+}
+
+__attribute__((weak)) void *SRE_MemDbgAlloc(unsigned int /*mid*/,
+                                            unsigned char /*ptNo*/,
+                                            unsigned long size,
+                                            const char * /*func*/,
+                                            unsigned int /*line*/) {
+  void *P = nullptr;
+  // 2MiB alignment so the pool base is already aligned on the host path.
+  if (posix_memalign(&P, k2MiB, static_cast<size_t>(size)) != 0)
+    return nullptr;
+  return P;
+}
+
+std::unique_ptr<llvm::ejit::EJitCodePoolManager>
+llvm::ejit::makeSreCodePoolManager() {
+  EJitCodePoolManager::Options Opts;
+  Opts.poolSize = static_cast<size_t>(kSrePoolSize);
+  Opts.poolAlign = k2MiB; // enable_ex granularity
+  Opts.minCodeAlign = 64;
+
+  auto RawAlloc = [](size_t Bytes) -> void * {
+    return SRE_MemDbgAlloc(kSreMid, kSrePtNo,
+                           static_cast<unsigned long>(Bytes), __func__,
+                           __LINE__);
+  };
+
+  auto Seal = [](void *Base2M) -> unsigned {
+#ifdef EJIT_SRE_ENABLE_EX
+    return ejit_sre_enable_ex(1, reinterpret_cast<unsigned long long>(Base2M));
+#else
+    // Code-pool routing without permission flips (bring-up / measurement).
+    (void)Base2M;
+    return 0;
+#endif
+  };
+
+  return std::make_unique<EJitCodePoolManager>(Opts, RawAlloc, Seal);
+}
+
+#endif // EJIT_SRE_CODE_POOL

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -12,4 +12,24 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(EJITTests
   EJitRuntimeTest.cpp
+
+  PARTIAL_SOURCES_INTENDED
+  )
+
+# SRE code pool tests live in their own executable so they build and run
+# independently of EJITTests (host-runnable: mock allocator + mock enable_ex,
+# no real SRE symbols required).
+add_llvm_unittest(EJITCodePoolTests
+  EJitCodePoolTest.cpp
+  EJitCodePoolMemoryManagerTest.cpp
+
+  PARTIAL_SOURCES_INTENDED
+  )
+
+# Convenience target: build + run only the SRE code pool unit tests.
+add_custom_target(check-ejit-code-pool
+  COMMAND $<TARGET_FILE:EJITCodePoolTests>
+  DEPENDS EJITCodePoolTests
+  COMMENT "Running EmbeddedJIT SRE code pool unit tests"
+  USES_TERMINAL
   )

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -1,0 +1,202 @@
+//===-- EJitCodePoolMemoryManagerTest.cpp - mem mgr over code pool --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Host-runnable tests that drive EJitCodePoolMemoryManager with a synthetic
+//  JITLink LinkGraph and a mock SRE backend. These exercise the exact
+//  allocate -> finalize -> seal path the engine uses at lookup, without needing
+//  a native backend to actually execute code (the host has no matching JIT
+//  target, so end-to-end execution is validated on the target instead).
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
+#include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
+#include "llvm/Support/Error.h"
+#include "llvm/TargetParser/SubtargetFeature.h"
+#include "llvm/TargetParser/Triple.h"
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+using namespace llvm;
+using namespace llvm::ejit;
+using namespace llvm::jitlink;
+
+namespace {
+
+struct MockSre {
+  std::vector<void *> Raws;
+  size_t SealCalls = 0;
+  unsigned SealRc = 0;
+
+  ~MockSre() {
+    for (void *P : Raws)
+      std::free(P);
+  }
+  void *rawAlloc(size_t Bytes) {
+    void *P = std::malloc(Bytes);
+    if (P)
+      Raws.push_back(P);
+    return P;
+  }
+  unsigned seal(void *) {
+    ++SealCalls;
+    return SealRc;
+  }
+};
+
+EJitCodePoolManager::Options poolOpts(size_t PoolSize) {
+  EJitCodePoolManager::Options O;
+  O.poolSize = PoolSize;
+  O.poolAlign = PoolSize;
+  O.minCodeAlign = 64;
+  return O;
+}
+
+// 64 bytes of filler "code" referenced by the content block (must outlive G).
+const char CodeBytes[64] = {0};
+
+std::unique_ptr<LinkGraph> makeCodeGraph(size_t Size, uint64_t VAddr) {
+  auto G = std::make_unique<LinkGraph>(
+      "g", std::make_shared<orc::SymbolStringPool>(),
+      Triple("x86_64-unknown-linux-gnu"), SubtargetFeatures(),
+      getGenericEdgeKindName);
+  auto &Sec =
+      G->createSection("__text", orc::MemProt::Read | orc::MemProt::Exec);
+  G->createContentBlock(Sec, ArrayRef<char>(CodeBytes, Size),
+                        orc::ExecutorAddr(VAddr), 16, 0);
+  return G;
+}
+
+void *firstBlockAddr(LinkGraph &G) {
+  Block *B = *G.blocks().begin();
+  return B->getAddress().toPtr<void *>();
+}
+
+} // namespace
+
+// JIT code memory is allocated out of the pool (not mmap), and the resolved
+// block address lands inside an owned pool.
+TEST(EJitCodePoolMemMgr, CodeMemoryComesFromPool) {
+  MockSre M;
+  EJitCodePoolManager Pool(
+      poolOpts(/*PoolSize=*/256 * 1024),
+      [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); });
+  EJitCodePoolMemoryManager MM(Pool, /*PageSize=*/4096);
+
+  auto G = makeCodeGraph(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *CodeAddr = firstBlockAddr(*G);
+
+  EXPECT_TRUE(Pool.contains(CodeAddr));
+  auto S = Pool.getStats();
+  EXPECT_EQ(S.poolCount, 1u);
+  EXPECT_GT(S.usedBytes, 0u);
+
+  auto FA = cantFail(IFA->finalize());
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// finalize() does NOT seal: the pool stays RW so JITLink can keep writing.
+// Sealing happens out-of-band (the engine does it at lookup).
+TEST(EJitCodePoolMemMgr, FinalizeKeepsPoolWritable) {
+  MockSre M;
+  EJitCodePoolManager Pool(
+      poolOpts(256 * 1024), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); });
+  EJitCodePoolMemoryManager MM(Pool, 4096);
+
+  auto G = makeCodeGraph(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *CodeAddr = firstBlockAddr(*G);
+  auto FA = cantFail(IFA->finalize());
+
+  // The memory manager must not have flipped permissions.
+  EXPECT_EQ(M.SealCalls, 0u);
+  EXPECT_EQ(Pool.getStats().sealedCount, 0u);
+
+  // The engine's lookup step seals the containing pool.
+  cantFail(Pool.sealPoolContaining(CodeAddr));
+  EXPECT_EQ(M.SealCalls, 1u);
+  EXPECT_EQ(Pool.getStats().sealedCount, 1u);
+
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// Sealing the pool that backs a finalized function is idempotent: a repeated
+// seal (e.g. a second lookup of the same function) does not re-invoke enable_ex.
+TEST(EJitCodePoolMemMgr, RepeatedSealNoDuplicateEnableEx) {
+  MockSre M;
+  EJitCodePoolManager Pool(
+      poolOpts(256 * 1024), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); });
+  EJitCodePoolMemoryManager MM(Pool, 4096);
+
+  auto G = makeCodeGraph(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *CodeAddr = firstBlockAddr(*G);
+  auto FA = cantFail(IFA->finalize());
+
+  cantFail(Pool.sealPoolContaining(CodeAddr)); // first lookup
+  cantFail(Pool.sealPoolContaining(CodeAddr)); // second lookup, same pool
+  EXPECT_EQ(M.SealCalls, 1u);
+  EXPECT_EQ(Pool.getStats().sealInvocations, 1u);
+
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// Runtime scenario: two functions are compiled and "looked up" in turn. The
+// first seals its pool; because a sealed pool is never reused, the second
+// function is allocated from a brand-new pool. Mirrors the engine flow of
+// compile -> lookup(seal) -> compile -> lookup(seal).
+TEST(EJitCodePoolMemMgr, SecondFunctionUsesNewPoolAfterSeal) {
+  constexpr size_t kPoolSize = 64 * 1024;
+  MockSre M;
+  EJitCodePoolManager Pool(
+      poolOpts(kPoolSize), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); });
+  EJitCodePoolMemoryManager MM(Pool, 4096);
+
+  // Function 1: allocate, finalize, seal (first lookup).
+  auto G1 = makeCodeGraph(64, 0x1000);
+  auto IFA1 = cantFail(MM.allocate(nullptr, *G1));
+  void *Addr1 = firstBlockAddr(*G1);
+  auto FA1 = cantFail(IFA1->finalize());
+  cantFail(Pool.sealPoolContaining(Addr1));
+  EXPECT_EQ(M.SealCalls, 1u);
+  EXPECT_EQ(Pool.getStats().poolCount, 1u);
+
+  // Function 2: the active pool is now sealed, so this must land in a new pool
+  // even though the first pool still had free space.
+  auto G2 = makeCodeGraph(64, 0x2000);
+  auto IFA2 = cantFail(MM.allocate(nullptr, *G2));
+  void *Addr2 = firstBlockAddr(*G2);
+  auto FA2 = cantFail(IFA2->finalize());
+  cantFail(Pool.sealPoolContaining(Addr2));
+
+  auto S = Pool.getStats();
+  EXPECT_EQ(S.poolCount, 2u);
+  EXPECT_EQ(S.sealedCount, 2u);
+  EXPECT_EQ(M.SealCalls, 2u);
+
+  // The two functions live in different 64KiB pools.
+  auto poolOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) & ~static_cast<uintptr_t>(kPoolSize - 1);
+  };
+  EXPECT_NE(poolOf(Addr1), poolOf(Addr2));
+
+  cantFail(MM.deallocate(std::move(FA1)));
+  cantFail(MM.deallocate(std::move(FA2)));
+}
+

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
@@ -1,0 +1,289 @@
+//===-- EJitCodePoolTest.cpp - Unit tests for the SRE code pool -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Host-runnable tests for EJitCodePoolManager. These never touch real SRE:
+//  the raw allocator and the seal (enable_ex) primitive are injected mocks, so
+//  the tests pass on any host regardless of whether EJIT_SRE_CODE_POOL is set.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#include "llvm/Support/Error.h"
+#include "gtest/gtest.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+using namespace llvm;
+using namespace llvm::ejit;
+
+namespace {
+
+/// Mock SRE backend: tracks raw allocations (freed at teardown), records seal
+/// calls and the bases that were sealed, and can be configured to fail.
+struct MockSre {
+  std::vector<void *> Raws;
+  size_t AllocCalls = 0;
+  bool FailNextAlloc = false;
+
+  std::vector<void *> SealedBases;
+  size_t SealCalls = 0;
+  unsigned SealRc = 0; // return code handed back by the mock enable_ex
+
+  ~MockSre() {
+    for (void *P : Raws)
+      std::free(P);
+  }
+
+  void *rawAlloc(size_t Bytes) {
+    ++AllocCalls;
+    if (FailNextAlloc) {
+      FailNextAlloc = false;
+      return nullptr;
+    }
+    void *P = std::malloc(Bytes);
+    if (P)
+      Raws.push_back(P);
+    return P;
+  }
+
+  unsigned seal(void *Base) {
+    ++SealCalls;
+    if (SealRc == 0)
+      SealedBases.push_back(Base);
+    return SealRc;
+  }
+};
+
+EJitCodePoolManager makeManager(MockSre &M,
+                                EJitCodePoolManager::Options Opts) {
+  return EJitCodePoolManager(
+      Opts, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); });
+}
+
+EJitCodePoolManager::Options smallOpts(size_t PoolSize = 256) {
+  EJitCodePoolManager::Options O;
+  O.poolSize = PoolSize;
+  O.poolAlign = PoolSize; // keep raw allocations tiny for logic tests
+  O.minCodeAlign = 64;
+  return O;
+}
+
+uintptr_t A(const void *P) { return reinterpret_cast<uintptr_t>(P); }
+
+} // namespace
+
+// 1. The usable base of a pool is 2MiB aligned.
+TEST(EJitCodePool, BaseIs2MiBAligned) {
+  constexpr size_t k2M = static_cast<size_t>(2) * 1024 * 1024;
+  EJitCodePoolManager::Options O;
+  O.poolSize = k2M;
+  O.poolAlign = k2M;
+  O.minCodeAlign = 64;
+  MockSre M;
+  auto Mgr = makeManager(M, O);
+
+  void *P = cantFail(Mgr.allocateCode(128, 16));
+  // First allocation sits at offset 0, so it equals the pool base.
+  EXPECT_EQ(A(P) % k2M, 0u);
+  EXPECT_TRUE(Mgr.contains(P));
+}
+
+// 2. Multiple small allocations bump contiguously inside one RW pool.
+TEST(EJitCodePool, BumpAllocatesWithinOneRWPool) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts(/*PoolSize=*/4096));
+
+  void *a = cantFail(Mgr.allocateCode(64, 64));
+  void *b = cantFail(Mgr.allocateCode(64, 64));
+  void *c = cantFail(Mgr.allocateCode(64, 64));
+
+  EXPECT_LT(A(a), A(b));
+  EXPECT_LT(A(b), A(c));
+  EXPECT_EQ(A(b) - A(a), 64u); // 64-aligned, 64-byte blocks → exactly adjacent
+  EXPECT_EQ(A(c) - A(b), 64u);
+
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.poolCount, 1u);
+  EXPECT_EQ(S.sealedCount, 0u);
+  EXPECT_EQ(S.activeCount, 1u);
+  EXPECT_EQ(M.SealCalls, 0u);
+}
+
+// 3. Sealing a pool marks it executable and invokes enable_ex exactly once.
+TEST(EJitCodePool, SealMarksPoolExecutable) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts());
+
+  void *a = cantFail(Mgr.allocateCode(64, 64));
+  cantFail(Mgr.sealPoolContaining(a));
+
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.sealedCount, 1u);
+  EXPECT_EQ(S.activeCount, 0u);
+  EXPECT_EQ(S.sealInvocations, 1u);
+  EXPECT_EQ(M.SealCalls, 1u);
+  ASSERT_EQ(M.SealedBases.size(), 1u);
+}
+
+// 4. A sealed pool is never reused; the next allocation creates a new pool.
+TEST(EJitCodePool, SealedPoolNotReusedNewPoolCreated) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts());
+
+  void *a = cantFail(Mgr.allocateCode(64, 64));
+  cantFail(Mgr.sealPoolContaining(a));
+  void *b = cantFail(Mgr.allocateCode(64, 64));
+
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.poolCount, 2u);
+  EXPECT_EQ(S.sealedCount, 1u);
+  EXPECT_EQ(S.activeCount, 1u);
+  // b must not fall inside the first (sealed) pool's range.
+  EXPECT_GE(A(b) > A(a) ? A(b) - A(a) : A(a) - A(b), 64u);
+}
+
+// 5. Repeated seal of the same pool does not re-invoke enable_ex (idempotent).
+TEST(EJitCodePool, RepeatedSealNoDuplicateEnableEx) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts());
+
+  void *a = cantFail(Mgr.allocateCode(64, 64));
+  void *b = cantFail(Mgr.allocateCode(64, 64)); // same pool as a
+
+  cantFail(Mgr.sealPoolContaining(a));
+  EXPECT_EQ(M.SealCalls, 1u);
+  cantFail(Mgr.sealPoolContaining(b)); // already sealed → no-op success
+  EXPECT_EQ(M.SealCalls, 1u);
+  EXPECT_EQ(Mgr.getStats().sealInvocations, 1u);
+}
+
+// 6. enable_ex failure surfaces as an Error and the pool stays writable.
+TEST(EJitCodePool, EnableExFailureReturnsError) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts());
+
+  void *a = cantFail(Mgr.allocateCode(64, 64));
+  M.SealRc = 7; // make enable_ex fail
+
+  Error Err = Mgr.sealPoolContaining(a);
+  EXPECT_TRUE(static_cast<bool>(Err));
+  consumeError(std::move(Err));
+
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.sealedCount, 0u); // still RW, not sealed
+  EXPECT_EQ(S.sealInvocations, 0u);
+}
+
+// 6b. A seal failure during full-pool rollover propagates out of allocateCode.
+TEST(EJitCodePool, RolloverSealFailurePropagates) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts(/*PoolSize=*/256));
+
+  // Fill the 256-byte pool with four 64-byte blocks (offsets 0/64/128/192).
+  for (int i = 0; i < 4; ++i)
+    (void)cantFail(Mgr.allocateCode(64, 64));
+
+  M.SealRc = 9; // the rollover seal of the full pool will fail
+  auto E = Mgr.allocateCode(64, 64);
+  EXPECT_FALSE(static_cast<bool>(E));
+  consumeError(E.takeError());
+}
+
+// 7. A request larger than the pool size is rejected cleanly (no allocation).
+TEST(EJitCodePool, OversizeRequestCleanReject) {
+  MockSre M;
+  auto Opts = smallOpts(/*PoolSize=*/4096);
+  auto Mgr = makeManager(M, Opts);
+
+  auto E = Mgr.allocateCode(Opts.poolSize + 1, 16);
+  EXPECT_FALSE(static_cast<bool>(E));
+  consumeError(E.takeError());
+
+  EXPECT_EQ(Mgr.getStats().poolCount, 0u);
+  EXPECT_EQ(M.AllocCalls, 0u); // never even tried to allocate a pool
+}
+
+// 8. Statistics (pool count, sealed count, used / wasted bytes) are correct.
+TEST(EJitCodePool, StatsAreAccurate) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts(/*PoolSize=*/4096));
+
+  (void)cantFail(Mgr.allocateCode(100, 64)); // off 0,   used 100
+  void *b = cantFail(Mgr.allocateCode(200, 64)); // off 128, used 328
+
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.poolCount, 1u);
+  EXPECT_EQ(S.reservedBytes, 4096u);
+  EXPECT_EQ(S.usedBytes, 328u);
+  EXPECT_EQ(S.sealedCount, 0u);
+  EXPECT_EQ(S.wastedBytes, 0u); // active pool tail is not counted as wasted
+
+  cantFail(Mgr.sealPoolContaining(b));
+  S = Mgr.getStats();
+  EXPECT_EQ(S.sealedCount, 1u);
+  EXPECT_EQ(S.wastedBytes, 4096u - 328u); // sealed tail is wasted
+}
+
+// Strategy case 3: a full active pool is sealed automatically before a new
+// pool is created on the next allocation.
+TEST(EJitCodePool, FullPoolSealedOnRollover) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts(/*PoolSize=*/256));
+
+  for (int i = 0; i < 4; ++i)
+    (void)cantFail(Mgr.allocateCode(64, 64)); // fills the pool exactly
+
+  EXPECT_EQ(M.SealCalls, 0u);
+  void *e = cantFail(Mgr.allocateCode(64, 64)); // triggers seal + new pool
+  EXPECT_TRUE(Mgr.contains(e));
+
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.poolCount, 2u);
+  EXPECT_EQ(S.sealedCount, 1u);
+  EXPECT_EQ(M.SealCalls, 1u);
+}
+
+// Larger alignment requests are honored.
+TEST(EJitCodePool, RespectsLargerAlignment) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts(/*PoolSize=*/4096));
+
+  (void)cantFail(Mgr.allocateCode(8, 64));   // off 0
+  void *b = cantFail(Mgr.allocateCode(8, 256)); // must be 256-aligned
+  EXPECT_EQ(A(b) % 256u, 0u);
+}
+
+// sealAllWritablePools seals every still-writable pool.
+TEST(EJitCodePool, SealAllWritablePools) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts());
+
+  void *a = cantFail(Mgr.allocateCode(64, 64));
+  cantFail(Mgr.sealPoolContaining(a)); // pool 1 sealed
+  (void)cantFail(Mgr.allocateCode(64, 64)); // pool 2 active
+
+  cantFail(Mgr.sealAllWritablePools());
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.poolCount, 2u);
+  EXPECT_EQ(S.sealedCount, 2u);
+  EXPECT_EQ(S.activeCount, 0u);
+  EXPECT_EQ(M.SealCalls, 2u); // pool 1 not re-sealed
+}
+
+// An address not owned by any pool cannot be sealed.
+TEST(EJitCodePool, SealUnknownAddressFails) {
+  MockSre M;
+  auto Mgr = makeManager(M, smallOpts());
+  int OnStack = 0;
+  Error Err = Mgr.sealPoolContaining(&OnStack);
+  EXPECT_TRUE(static_cast<bool>(Err));
+  consumeError(std::move(Err));
+}


### PR DESCRIPTION
## Summary

This PR adds an optional SRE-specific EmbeddedJIT code-pool memory path for platforms where executable permission is applied at 2 MiB granularity.

The new path is disabled by default. When `EJIT_SRE_CODE_POOL=ON`, JIT machine-code memory is allocated from EmbeddedJIT-owned 2 MiB-aligned pools instead of the default JITLink mmap/mprotect path. Pools stay writable while JITLink writes code, are sealed with `enable_ex` before a JIT function pointer is returned, and are never written again after sealing. Subsequent JIT code goes to a fresh writable pool.

## What Changed

- Added `EJitCodePoolManager` with 2 MiB-aligned bump allocation, sealing, stats, and mockable allocator/seal callbacks.
- Added `EJitCodePoolMemoryManager`, a JITLink memory manager that sources code memory from the code pool.
- Wired the code-pool memory manager through `EJitOrcEngine` when `EJIT_SRE_CODE_POOL` is enabled.
- Added lookup-time sealing so `enable_ex(1, pool_base)` runs before returning a JIT function pointer.
- Added SRE platform adapter using `SRE_MemDbgAlloc` and `enable_ex`, guarded by the CMake option.
- Added unit tests for pool alignment, bump allocation, sealing behavior, failure propagation, stats, and JITLink memory-manager integration.
- Added Chinese design documentation in `jit_design_doc/EJIT_SRE_CODE_POOL.md`.
- Updated `build.sh` so `./build.sh release aarch64_be` defaults to `EJIT_SRE_CODE_POOL=ON`, `EJIT_SRE_CODE_POOL_PTNO=8`, and `EJIT_DEFAULT_TARGET_TRIPLE=aarch64_be-unknown-linux-gnu`.

## Usage

Default behavior is unchanged. To enable the SRE path manually:

```bash
-DEJIT_SRE_CODE_POOL=ON
-DEJIT_SRE_CODE_POOL_PTNO=8
-DEJIT_SRE_CODE_POOL_SIZE=2097152
```

The build helper now also supports:

```bash
./build.sh release aarch64_be
./build.sh release aarch64_be --no-sre-code-pool
./build.sh release aarch64_be --sre-code-pool-ptno=8
```

## Validation

Ran locally:

```bash
bash -n build.sh
./build.sh --help
cmake --build build-ejit-sre-pool --target check-ejit-code-pool -j4
```

Result: `EJitCodePoolTests` passed, 17/17 tests green.

## Notes / Limitations

- Code pools are not freed in v1; pool lifetime is engine lifetime.
- Sealed pools are never reused for writing.
- A single code allocation larger than the configured pool size is rejected cleanly.
- Host tests use mock allocation/sealing. Real compile-to-execute behavior still needs validation on the target SRE/aarch64_be environment.