### PR TITLE
[EmbeddedJIT] Support 4K code-pool sealing

### DIFF
--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -1,7 +1,10 @@
 # EmbeddedJIT SRE 机器码内存池设计（EJIT_SRE_CODE_POOL）
 
-**状态**: 已实现（方案 B，完整接管 JITLink 代码内存分配 + lookup 处 enable_ex 封固）
-**开关**: `-DEJIT_SRE_CODE_POOL=ON`（默认 OFF，上游默认行为不变）
+**状态**: 已实现（方案 B，完整接管 JITLink 代码内存分配；默认 4K 粒度页封固，可回退整 2MiB 池封固）
+**开关**:
+- `-DEJIT_SRE_CODE_POOL=ON`（默认 OFF，上游默认行为不变）
+- `-DEJIT_CODE_POOL_4K_SEAL=ON`（默认 ON，仅在 `EJIT_SRE_CODE_POOL=ON` 时生效；OFF 回退到旧的整 2MiB 池封固）
+
 **关联代码**:
 - `llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h` / `llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp`
 - `llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h` / `.cpp`
@@ -9,19 +12,33 @@
 - `llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp`（接入点）
 - 测试: `llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp`、`EJitCodePoolMemoryManagerTest.cpp`
 
+> **重要更新（4K 粒度执行权限封固）**：目标平台的**真实大页仍然是 2MiB**，但平台新增
+> 了 `split_2m_to_4k(base, size)`，可把一段 2MiB 对齐的 VA 区间**拆成 4K 映射**；其后
+> `enable_ex(1, pageVA)` 即可**按 4K 页**设置执行权限。因此 code pool 仍按 **2MiB 对齐**
+> 申请大池（在池创建时对整池调用一次 `split_2m_to_4k`），但**封固改为 4K 粒度**：只对某
+> 个函数实际写入机器码覆盖到的 4K 页逐页 `enable_ex`，而不是把整个 2MiB 池一次性封固。
+> 详见 [§13](#13-4k-粒度执行权限封固ejit_code_pool_4k_seal)。下面的 §1–§8 描述通用的池
+> 化/接管机制（两种封固模式共用）；§5 的"整池封固"是 `EJIT_CODE_POOL_4K_SEAL=OFF` 的旧
+> 行为。
+
 ---
 
 ## 1. 背景与目标
 
-目标平台（SRE 类）的执行权限原语 `enable_ex` 有两条硬约束：
+目标平台（SRE 类）的执行权限原语有如下约束：
 
-1. **只能按 2MiB 粒度**设置执行权限：`enable_ex(1, va)` 中 `va` 必须 2MiB 对齐。
-2. 一旦某 2MiB 区域被置为 **RX（可执行）**，该区域**不能再写**。
+- `enable_ex(1, va)` 为 `va` **所在的 4K 页**设置执行权限（**新接口**；旧接口按 2MiB
+  粒度）。
+- 真实大页仍是 **2MiB**：必须先用 `split_2m_to_4k(base, size)` 把 2MiB 对齐区间拆成 4K
+  映射，之后才能对其中的 4K 页 `enable_ex`。`base` 必须 2MiB 对齐，`size` 为 2MiB 的整数
+  倍，且 `split_2m_to_4k` 必须在 `enable_ex` 之前调用。
+- 一旦某 4K 页被置为 **RX（可执行）**，该页**不能再写**。
 
 EmbeddedJIT 需要在运行期把 JIT 生成的机器码变为可执行。直接的做法（wrap 全局
 `mprotect`）会破坏 ORC/JITLink 的后续写入，因此本方案让 EmbeddedJIT **自己拥有
-JIT 代码内存**：以 2MiB 池为单位分配、写入阶段保持 RW、在把函数指针交还调用者之前
-对该池调用 `enable_ex` 封固为 RX，封固后的池永不再写。
+JIT 代码内存**：以 2MiB 对齐大池为单位分配、写入阶段保持 RW、在把函数指针交还调用者
+之前对实际写入的 4K 页调用 `enable_ex` 封固为 RX，封固后的页永不再写。
+
 
 ---
 
@@ -137,15 +154,21 @@ allocate(RW, 来自 2MiB 池)
   `LLJITBuilder::setObjectLinkingLayerCreator` 安装一个使用
   `EJitCodePoolMemoryManager` 的 `orc::ObjectLinkingLayer`。
 - `EJitCodePoolMemoryManager::allocate` 仿照 `InProcessMemoryManager`，用
-  `BasicLayout` 计算各 segment 大小，但 slab **来自 `EJitCodePoolManager` 的 2MiB
-  池**（而非 mmap）。
-- `finalize()` **刻意不做任何 mprotect**，让池保持 RW；也不调用
-  `InvalidateInstructionCache`（由 `enable_ex` 负责）。
-- 真正的 RW→RX 封固由 `EJitOrcEngine::lookup` 在返回函数指针前对包含该地址的池调用
-  `enable_ex` 完成（幂等：已封固的池不重复调用）。
+  `BasicLayout` 计算各 segment 大小，但 slab **来自 `EJitCodePoolManager` 的 2MiB 对齐
+  池**（而非 mmap）；**allocate 阶段绝不 `enable_ex`**。
+- `finalize()` **刻意不做任何 mprotect**；也不调用 `InvalidateInstructionCache`（由
+  `enable_ex` 负责）。
+- 真正的 RW→RX 封固时机按模式不同：
+  - **4K 模式（默认）**：在 `finalize()` 中（所有写入/relocation/fixup 完成后）对该
+    allocation 覆盖到的 4K 页逐页 `enable_ex`；任一页失败则 `finalize` 返回 Error，
+    `lookup` 不会拿到可调用指针。见 [§13](#13-4k-粒度执行权限封固ejit_code_pool_4k_seal)。
+  - **整池模式（`EJIT_CODE_POOL_4K_SEAL=OFF`）**：`finalize` 仍保持 RW，封固由
+    `EJitOrcEngine::lookup` 在返回函数指针前对包含该地址的整 2MiB 池调用 `enable_ex`
+    完成（幂等：已封固的池不重复调用）。
 
-换言之：**代码内存来自 EJITCodePoolManager，而非普通 mmap/mprotect**；封固在
-lookup 处发生。两部分共同构成完整方案，没有"伪装成内存池"的浅层实现。
+换言之：**代码内存来自 EJITCodePoolManager，而非普通 mmap/mprotect**；封固在 finalize
+（4K 模式）或 lookup（整池模式）处发生。两部分共同构成完整方案，没有"伪装成内存池"
+的浅层实现。
 
 ---
 
@@ -161,24 +184,49 @@ cmake -S llvm -B build-ejit-sre-pool \
 
 | 开关 | 默认 | 说明 |
 |------|------|------|
-| `EJIT_SRE_CODE_POOL` | OFF | 启用 2MiB 代码池 + enable_ex 封固；同时隐含启用 `EJIT_SRE_ENABLE_EX` |
-| `EJIT_SRE_CODE_POOL_SIZE` | 2097152 (2MiB) | 每个池的可用字节数 |
+| `EJIT_SRE_CODE_POOL` | OFF | 启用 2MiB 对齐代码池 + enable_ex 封固；同时隐含启用 `EJIT_SRE_ENABLE_EX` |
+| `EJIT_CODE_POOL_4K_SEAL` | ON | 仅在 `EJIT_SRE_CODE_POOL=ON` 时生效。开启：池创建时 `split_2m_to_4k`，封固按 **4K 页** `enable_ex`。关闭：回退到整 2MiB 池封固。**唯一新增布尔开关，无新增数值配置**（2MiB/4KiB 为实现内平台常量） |
+| `EJIT_SRE_CODE_POOL_SIZE` | 2097152 (2MiB) | 每个池的可用字节数；4K 模式下向上取整为 2MiB 整数倍 |
 | `EJIT_SRE_CODE_POOL_PTNO` | 8 | 传给 `SRE_MemDbgAlloc` 的分区号 ptNo |
 | `EJIT_SRE_ENABLE_EX` | 随 `EJIT_SRE_CODE_POOL` | 关闭后代码仍走池，但不做权限翻转（bring-up/测量用） |
 
-平台接口（在 `EJitSrePlatform.cpp` 内声明，避免污染通用命名空间）：
+平台接口（在 `EJitSrePlatform.cpp` 内**仅声明、不定义**，避免污染通用命名空间）：
 
 ```cpp
 extern "C" unsigned ejit_sre_enable_ex(unsigned startLevel,
                                        unsigned long long va) __asm__("enable_ex");
+extern "C" unsigned ejit_sre_split_2m_to_4k(unsigned long long va,
+                                            unsigned long long size) __asm__("split_2m_to_4k");
 extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
                                  unsigned long size, const char *func,
                                  unsigned int line);
 ```
 
-为保证**宿主无真实 SRE 符号时也能链接/跑通**，`EJitSrePlatform.cpp` 为这两个符号
-提供了 **weak 兜底定义**（`enable_ex` 兜底为 no-op 成功、`SRE_MemDbgAlloc` 兜底为
-对齐的宿主分配）。真实平台提供的 **strong 符号会覆盖** weak 兜底。
+**EmbeddedJIT runtime 只声明平台符号、不定义平台符号，也不提供 weak 兜底。** 真实平台 /
+业务链接环境**必须提供**这些符号的强定义：
+
+- `enable_ex`
+- `split_2m_to_4k`
+- `SRE_MemDbgAlloc`
+- 若启用平台 taskpool 队列（`EJIT_SRE_TASKPOOL_PLATFORM_QUEUE`），还必须提供
+  `QueueCreate` / `QueueWrite` / `QueueRead`（见 `EJitSreQueue.cpp`）。
+
+**为什么不做 weak 兜底**：
+
+- 在静态包 / 半链接 / 平台 SDK 场景下，weak 本地定义可能**覆盖或与真实平台符号冲突、
+  错误绑定**，造成重复定义或符号归属不清。
+- 平台缺符号时应当**在链接期暴露问题**，而不是被一个静默 no-op 兜底掩盖（no-op 的
+  `enable_ex` 会让"未真正赋予执行权限"的代码看起来成功）。
+
+**host 单测不依赖任何真实平台符号**：`EJitCodePoolManager` 的 raw 分配器、seal、split
+都是**注入的 callback**，单测全部传入 mock；测试也不引用 `makeSreCodePoolManager`，因此
+`EJitSrePlatform.cpp` 的外部引用根本不会被拉进宿主测试链接。默认 host taskpool 测试不
+定义 `EJIT_SRE_TASKPOOL_PLATFORM_QUEUE`，走 mock ring queue。
+
+> **封固 API 边界**：4K 模式只应通过 `sealCodeRange(start, size)` 封固**实际写入机器码的
+> 范围**（由 memory manager 的 finalize 驱动）。`sealPoolContaining` / `sealAllWritablePools`
+> 是**整池封固**语义，仅用于旧整池模式；在 4K 模式下它们会**返回 Error**（裸指针无 size，
+> 无法判断该封几页；整池"全部封固"在 4K 模式也无正确含义），避免误用。
 
 ---
 
@@ -187,47 +235,60 @@ extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
 **默认构建（开关 OFF，行为不变）**：
 
 ```bash
-cmake --build build-ejit --target LLVMEJIT -j4
+cmake --build build-ejit --target LLVMEJIT -j8
 ```
 
-**代码池单元测试（宿主可跑，使用 mock allocator + mock enable_ex，不需真实 SRE）**：
+**代码池单元测试（宿主可跑，使用 mock allocator + mock enable_ex/split_2m_to_4k，不需真实 SRE）**：
 
 ```bash
-cmake --build build-ejit --target EJITCodePoolTests -j4
-cmake --build build-ejit --target check-ejit-code-pool -j4
+cmake --build build-ejit --target EJITCodePoolTests -j8
+cmake --build build-ejit --target check-ejit-code-pool -j8
 ```
 
 覆盖：
-- `EJitCodePoolTest`：2MiB 对齐、RW 池内 bump、seal 标记 executable、sealed 不复用、
-  重复 seal 不重复 enable_ex、enable_ex 失败返回 Error、超池大小 clean reject、
-  统计正确、rollover 自动封固、`sealAllWritablePools` 等。
-- `EJitCodePoolMemoryManagerTest`：用合成 JITLink `LinkGraph` 驱动内存管理器，验证
-  JIT 代码来自池、finalize 后仍 RW、lookup 式封固只翻一次、第二个函数在前一个池
-  sealed 后进入新池。
+- `EJitCodePoolTest`（整池模式）：2MiB 对齐、RW 池内 bump、seal 标记 executable、
+  sealed 不复用、重复 seal 不重复 enable_ex、enable_ex 失败返回 Error、超池大小
+  clean reject、统计正确、rollover 自动封固、`sealAllWritablePools` 等。
+- `EJitCodePoolTest`（4K 模式 `EJitCodePool4K.*`）：故意非 2MiB 对齐 rawBase → 对齐后
+  2MiB 对齐且 usable 不越界、`split_2m_to_4k(alignedBase, usableSize)` 每池只调用一次、
+  小代码只封覆盖到的 4K 页、跨多页循环 enable_ex、某页 enable_ex 失败返回 Error、
+  后续 allocation 落到下一个 4K 页（不落已封页）、split 失败池创建失败、rollover 新池
+  再次 split 且不整池封固、**4K 模式下 `sealPoolContaining` / `sealAllWritablePools`
+  返回 Error 且不 enable_ex**。
+- `EJitCodePoolMemoryManagerTest`（整池 + 4K 模式 `EJitCodePoolMemMgr4K.*`）：用合成
+  JITLink `LinkGraph` 驱动内存管理器，验证 JIT 代码来自池、allocate 阶段不 enable_ex、
+  finalize 只封覆盖到的 4K 页、跨多页 finalize 逐页封固、某页 enable_ex 失败时 finalize
+  返回 Error（不返回函数指针）、第二个函数复用同一 2MiB 池但落在不同 4K 页。
 
-**代码池开关构建（开关 ON）**：
+**代码池开关构建（开关 ON，默认 4K 封固）**：
 
 ```bash
 cmake -S llvm -B build-ejit-sre-pool -DEJIT_SRE_CODE_POOL=ON \
-  -DEJIT_SRE_CODE_POOL_PTNO=8 <其余参数>
-cmake --build build-ejit-sre-pool --target LLVMEJIT -j4
-cmake --build build-ejit-sre-pool --target check-ejit-code-pool -j4
+  -DEJIT_SRE_CODE_POOL_PTNO=8 <其余参数>      # EJIT_CODE_POOL_4K_SEAL 默认 ON
+cmake --build build-ejit-sre-pool --target LLVMEJIT -j8
+cmake --build build-ejit-sre-pool --target check-ejit-code-pool -j8
 ```
 
 ---
 
 ## 11. 已知限制
 
-1. **不释放 code pool**：池生命周期等于 EJIT runtime/engine 生命周期；sealed 池不回
-   收。这是为了可靠性、避免 W/RX 权限冲突（目标平台 free/realloc 也可能不可靠）。
+1. **不释放 code pool（FreeCode 不物理释放）**：池生命周期等于 EJIT runtime/engine
+   生命周期；已封固的页/池不回收。`FreeCode` / `deallocate` 只运行 dealloc actions，
+   **不归还 code pool 物理内存**。这是为了可靠性、避免 W/RX 权限冲突（目标平台
+   free/realloc 也可能不可靠），4K 模式同样如此。
 2. **单函数 ≤ 池大小**：超过 `EJIT_SRE_CODE_POOL_SIZE` 的单次请求返回 Error。
-3. **端到端原生执行未在本机验证**：本机为 aarch64 宿主但只构建了 X86 后端，无法在
+3. **4K 模式每个 allocation 至少占 1 个 4K 页**：v1 为可靠起见，每个 JIT allocation
+   起点 4K 对齐、大小向上取整到 4K，故最小占用 4K（旧的整 2MiB 粒度则最小占用
+   2MiB）。不把多个独立 finalize 的函数塞进同一个 4K 页，避免 RX 后再写。
+4. **端到端原生执行未在本机验证**：本机为 aarch64 宿主但只构建了 X86 后端，无法在
    宿主上真正执行 JIT 机器码。因此所有测试都是**宿主可跑的逻辑/集成测试**（mock
-   分配器 + mock enable_ex + 合成 LinkGraph）；真正"编译→执行特化函数"需在与所构建
-   后端匹配的目标/宿主上验证。
-4. **同步编译假设**：策略 3 的"满则提前封固"依赖 EmbeddedJIT 的同步编译模型
-   （`setNumCompileThreads(0)`）。
-5. **EJITTests 现状**：上游基线分支上的 `EJITTests` 因无关的历史 API 漂移当前无法
+   分配器 + mock enable_ex / split_2m_to_4k + 合成 LinkGraph）；真正"编译→执行特化
+   函数"需在与所构建后端匹配的目标/宿主上验证。
+5. **同步编译假设**：旧整池模式策略 3 的"满则提前封固"、以及 4K 模式"finalize 即封
+   固对应页"都依赖 EmbeddedJIT 的同步编译模型（`setNumCompileThreads(0)`）：一个
+   allocation 一旦 finalize 完成就不再被写。
+6. **EJITTests 现状**：上游基线分支上的 `EJITTests` 因无关的历史 API 漂移当前无法
    编译；因此本特性的测试放在独立的 `EJITCodePoolTests` 可执行文件 + `check-ejit-
    code-pool` 目标中，与之解耦。
 
@@ -241,3 +302,108 @@ cmake --build build-ejit-sre-pool --target check-ejit-code-pool -j4
   （机器码内嵌了进程相关的绝对地址，跨进程不安全）。
 - **更细的 finalize 段处理**：当前把 standard/finalize 段一起放进池；后续可单独管理
   finalize 段以减少浪费。
+
+---
+
+## 13. 4K 粒度执行权限封固（EJIT_CODE_POOL_4K_SEAL）
+
+这是当前**默认**的封固模式（`EJIT_CODE_POOL_4K_SEAL=ON`，仅在 `EJIT_SRE_CODE_POOL=ON`
+时生效）。它适配目标平台**新的 4K 粒度执行权限接口**，在保留大块 code pool 设计的同时
+把封固粒度从整 2MiB 降到 4K。
+
+### 13.1 平台语义
+
+```cpp
+extern "C" unsigned int split_2m_to_4k(unsigned long long va, unsigned long long size);
+extern "C" unsigned int enable_ex(unsigned int startLevel, unsigned long long va);
+```
+
+- **真实大页仍是 2MiB**。`split_2m_to_4k(base, size)` 把一段 **2MiB 对齐**的 VA 区间
+  拆成 **4K 映射**：`base` 必须 2MiB 对齐，`size` 必须是 2MiB 的整数倍。
+- `split_2m_to_4k` **必须在** `enable_ex` **之前**调用。
+- 拆分之后，`enable_ex(1, pageVA)` 对 `pageVA` **所在的 4K 页**设置执行权限。
+- 返回 0 表示成功，非 0 表示失败。
+
+### 13.2 2MiB 对齐大池 + alignment slack
+
+池仍按 2MiB 对齐申请，做法（`EJitCodePoolManager::newActivePoolLocked`，4K 模式）：
+
+```
+requestedSize = poolSize + 2MiB           // 多申请一个大页做对齐 slack
+rawBase       = platform alloc(requestedSize)   // 目标平台 SRE_MemDbgAlloc
+alignedBase   = align_up(rawBase, 2MiB)
+usableSize    = poolSize                   // poolSize 已向上取整到 2MiB 整数倍
+assert(alignedBase + usableSize <= rawBase + requestedSize)   // 不越界检查
+split_2m_to_4k(alignedBase, usableSize)    // 每个池创建时只调用一次
+```
+
+- `poolSize` 若不是 2MiB 整数倍，构造时**向上取整**到 2MiB 整数倍。
+- 2MiB / 4KiB 是**实现内的平台常量**（`EJitSrePlatform.cpp` 的适配器里写死），不做成
+  一堆 CMake 数值配置；`EJitCodePoolManager` 本身把它们作为 `Options` 字段，便于宿主用
+  小数值做单测（与既有 256B 池测试同一思路）。
+- `split_2m_to_4k` 失败 → **池创建失败，返回明确 Error**，不会注册半成品池。每个池
+  **只 split 一次**，绝不在每次函数编译时重复 split。
+
+### 13.3 4K 封固粒度（只封写到的页）
+
+`finalize` 完成（所有写入、relocation、link graph fixup 都已结束）后，对该 allocation
+实际写入机器码覆盖到的 4K 页**逐页**封固（`EJitCodePoolManager::sealCodeRange`）：
+
+```
+pageStart = align_down(codeStart, 4KiB)
+pageEnd   = align_up(codeStart + size, 4KiB)
+for (page = pageStart; page < pageEnd; page += 4KiB)
+    enable_ex(1, page)
+```
+
+- 只封固覆盖到的页：一个 ~100 字节的小函数只 `enable_ex` **1 个 4K 页**，而不是整个
+  2MiB（旧模式 512 个页）。跨多页的代码会循环逐页 `enable_ex`。
+- **任何一页 `enable_ex` 失败 → 返回 Error，绝不返回可调用函数指针。** 封固发生在
+  JITLink memory manager 的 `finalize` 中，失败会让 `finalize`（进而 `lookup`）返回
+  Error。
+- 封固后**不**调用 `__builtin___clear_cache`：`enable_ex` 自身完成权限/cache 同步。
+
+### 13.4 避免写入已 RX 页（分配策略）
+
+采用简单可靠策略（v1）：
+
+- **每个 allocation 起点按 4K 对齐**（`EffAlign = max(reqAlign, 4KiB)`）。
+- **allocation size 向上取整到 4K**：bump 游标推进到 `align_up(off + size, 4KiB)`。
+- finalize 后封固该 allocation 覆盖的页；**后续 allocation 从下一个 4K 页开始**，因此
+  绝不会写入已经 RX 的页。
+- **不在 rollover 时整池封固**：4K 模式下池不再"满则整池 seal"。当前池放不下时直接换
+  新池（旧池已封固的页保持 RX，未用尾部就是闲置 RW，无害）。同一个池可以服务很多
+  4K 函数，**池保持部分可写**。
+
+代价：每个独立 finalize 的函数/section 最少占 1 个 4K 页；不会为了极限省内存把多个独立
+finalize 的函数塞进同一个 4K 页（那样会在某页 RX 后还要写它，违反平台约束）。
+
+### 13.5 内存节省效果
+
+- 旧模式：每个"封固 epoch"烧掉一整个 **2MiB** 池（一个池一旦因 lookup 被整池封固便不再
+  复用，尾部全部浪费）。N 个小函数最坏占 N×2MiB。
+- 4K 模式：每个小函数只占 **4K**（向上取整），且**同一个 2MiB 池可装下最多 512 个**
+  这样的函数后才换池。相对旧模式，封固/占用粒度从 2MiB 降到 4K，**约 512×** 的粒度收
+  益，小函数密集场景内存占用大幅下降。
+
+### 13.6 接入点小结
+
+| 步骤 | 位置 | 行为 |
+|------|------|------|
+| 池创建 split | `EJitCodePool.cpp::newActivePoolLocked`（4K 分支） | 对齐 2MiB 后 `split_2m_to_4k(base, poolSize)` 一次 |
+| allocate | `EJitCodePoolMemoryManager::allocate` | 从池 bump 取 RW slab，**不** `enable_ex` |
+| 4K 封固 | `EJitCodePoolMemoryManager::InFlightAllocImpl::finalize` → `EJitCodePool.cpp::sealCodeRange` | finalize 后对 slab 覆盖的每个 4K 页 `enable_ex(1, pageVA)`；失败返回 Error |
+| lookup | `EJitOrcEngine::lookup` | 4K 模式不再整池封固（已在 finalize 完成）；旧整池模式才在此 `sealPoolContaining` |
+
+不 wrap 全局 `mprotect`、不走 mmap/mprotect 老路径；代码内存全部来自注入的 raw 分配器。
+
+### 13.7 封固 API 在两种模式下的语义
+
+| API | 旧整池模式 | 4K 页模式 |
+|------|-----------|-----------|
+| `sealCodeRange(start, size)` | （可用）逐 4K 页封固覆盖范围 | **主路径**：finalize 处封固写入范围 |
+| `sealPoolContaining(ptr)` | 整池封固包含 `ptr` 的池 | **返回 Error**（裸指针无 size，无法判断封几页；应改用 `sealCodeRange`） |
+| `sealAllWritablePools()` | 封固所有仍可写的池 | **返回 Error**（4K 模式池有意保持部分可写，"全部封固"无正确含义） |
+
+`EJitOrcEngine::lookup` 已对 `sealPoolContaining` 用 `!usesPageSeal()` 守卫，因此 4K 模式
+下不会触发这两个 Error 路径；它们的 Error 仅为防止外部误用。

--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -407,3 +407,24 @@ finalize 的函数塞进同一个 4K 页（那样会在某页 RX 后还要写它
 
 `EJitOrcEngine::lookup` 已对 `sealPoolContaining` 用 `!usesPageSeal()` 守卫，因此 4K 模式
 下不会触发这两个 Error 路径；它们的 Error 仅为防止外部误用。
+
+### 13.8 可定位性 trace（默认无输出）
+
+code pool 与 taskpool 关键路径埋了**默认空展开**的 trace 宏，便于上板时改成 `SRE_printf`：
+
+```cpp
+#ifndef EJIT_CODE_POOL_TRACE
+#define EJIT_CODE_POOL_TRACE(...) do {} while (0)
+#endif
+#ifndef EJIT_TASKPOOL_TRACE
+#define EJIT_TASKPOOL_TRACE(...) do {} while (0)
+#endif
+```
+
+- 默认展开为空，**不产生任何输出、不改变任何行为**。
+- 上板时可用 `-D'EJIT_CODE_POOL_TRACE(...)=SRE_printf(__VA_ARGS__)'` 之类重定义。
+- 参数只用**整数 / 指针 / C 字符串**，不构造 `std::string`、不使用 `raw_ostream`。
+- 埋点：code pool 的 `newActivePoolLocked`（enter / rawAlloc / alignedBase / splitRc）、
+  `allocateCode`（req / res）、`sealCodeRange`（范围 / 每页 rc）、`sealPoolContaining` 的
+  4K 误用；taskpool 的 `compileOrGet`（enter / cacheHit / dedup / queuePush）、`runCompile`
+  （begin / compiled / published）、`pollOne`（empty / dequeued）、`freeCode`（cancel/free）。

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -602,6 +602,26 @@ if(EJIT_SRE_CODE_POOL)
                  "(size=${EJIT_SRE_CODE_POOL_SIZE}, ptNo=${EJIT_SRE_CODE_POOL_PTNO})")
 endif()
 
+# 4K-granular execute-permission sealing for the code pool. The target's large
+# page is still 2MiB (pools stay 2MiB-aligned), but the platform exposes
+# split_2m_to_4k() to break a 2MiB window into 4K mappings and enable_ex() then
+# flips execute permission per 4KiB page. With this ON the pool seals only the
+# 4K pages a finalized function actually covers (instead of a whole 2MiB pool),
+# which is much more memory efficient. Single boolean — no extra numeric knobs;
+# the 2MiB / 4KiB values are baked-in platform constants. Effective only when
+# EJIT_SRE_CODE_POOL is ON; default ON because the code pool targets the SRE
+# platform whose execute-permission interface is now 4K-granular.
+#
+# The -DEJIT_CODE_POOL_4K_SEAL definition is applied narrowly to the LLVMEJIT
+# target (its only user is the SRE adapter EJitSrePlatform.cpp), in
+# llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt, rather than globally — so
+# toggling it does not recompile the whole tree.
+option(EJIT_CODE_POOL_4K_SEAL
+  "Seal JIT code execute permission per 4KiB page (split_2m_to_4k + enable_ex) instead of per 2MiB pool" ON)
+if(EJIT_SRE_CODE_POOL AND EJIT_CODE_POOL_4K_SEAL)
+  message(STATUS "EmbeddedJIT: SRE code pool uses 4K-granular page sealing")
+endif()
+
 set(LLVM_TARGETS_TO_BUILD "all"
     CACHE STRING "Semicolon-separated list of targets to build, or \"all\".")
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -8,17 +8,27 @@
 //
 //  Dedicated machine-code memory pool for EmbeddedJIT on SRE-style targets.
 //
-//  Background: the target's execute-permission primitive (enable_ex) can only
-//  flip permissions at 2MiB granularity, and once a 2MiB region is made RX it
-//  can no longer be written. Wrapping the global mprotect breaks ORC/JITLink's
-//  later writes, so instead EmbeddedJIT owns the JIT code memory directly:
+//  Background: the target's execute-permission primitive (enable_ex) flips
+//  permissions on the 4KiB page containing the supplied VA, but the underlying
+//  large page is still 2MiB: a 2MiB-aligned region must first be split into 4K
+//  mappings via split_2m_to_4k before any per-page enable_ex is legal. Wrapping
+//  the global mprotect breaks ORC/JITLink's later writes, so instead EmbeddedJIT
+//  owns the JIT code memory directly. There are two sealing modes:
 //
-//    * Each pool is a 2MiB-aligned region carved from a raw SRE allocation.
-//    * While JITLink writes machine code the pool stays RW.
-//    * Before a JIT function pointer is handed back to the caller, the pool
-//      containing it is sealed: enable_ex flips it to RX and it is marked
-//      executable. A sealed pool is never written or allocated from again.
-//    * New JIT code always lands in a fresh (or current unsealed) pool.
+//    * Legacy whole-pool seal (fourKSeal = false): each 2MiB-aligned pool is
+//      sealed as a unit (one enable_ex on the pool base); a sealed pool is
+//      never written or allocated from again.
+//    * 4K page seal (fourKSeal = true): the pool is still a 2MiB-aligned region
+//      (split into 4K mappings at creation), but only the 4KiB pages that a
+//      finalized allocation actually covers are sealed (one enable_ex per
+//      page). Each allocation starts on a fresh 4K page and is rounded up to a
+//      4K multiple, so subsequent allocations never touch an already-RX page
+//      and the rest of the pool stays RW. This is far cheaper than burning a
+//      whole 2MiB pool per function.
+//
+//  In both modes, while JITLink writes machine code the affected memory stays
+//  RW; the RW->RX seal happens only after finalize, before a function pointer
+//  is handed back to the caller. New JIT code always lands in writable memory.
 //
 //  This class is intentionally free of any SRE header dependency: the raw
 //  allocator and the seal (enable_ex) primitive are injected as callbacks so
@@ -61,31 +71,50 @@ struct CodePool {
   size_t size = 0;
   /// Bump-allocation offset within [base, base + size).
   size_t used = 0;
-  /// false = RW and still accepting allocations; true = sealed RX, frozen.
+  /// Whole-pool seal flag (legacy mode only): false = RW and still accepting
+  /// allocations; true = sealed RX, frozen. In 4K seal mode the pool is sealed
+  /// per page and this stays false (the pool keeps serving fresh-page allocs).
   bool executable = false;
 };
 
-/// Manages a set of 2MiB JIT code pools with bump allocation and RW->RX
-/// sealing. Not coupled to LLVM containers for the code bytes themselves; the
-/// code storage comes exclusively from the injected raw allocator.
+/// Manages a set of 2MiB-aligned JIT code pools with bump allocation and
+/// RW->RX sealing (whole-pool or per-4K-page). Not coupled to LLVM containers
+/// for the code bytes themselves; the code storage comes exclusively from the
+/// injected raw allocator.
 class EJitCodePoolManager {
 public:
   /// Allocate at least `bytes` of writable memory. Returns nullptr on failure.
   /// On the target this is backed by SRE_MemDbgAlloc; in tests, by a mock.
   using RawAllocFn = std::function<void *(size_t bytes)>;
 
-  /// Seal the 2MiB region whose base is `base2m` (must be 2MiB aligned),
-  /// switching it to RX. Returns 0 on success, non-zero on failure. On the
-  /// target this calls enable_ex(1, base2m); in tests, a mock.
-  using SealFn = std::function<unsigned(void *base2m)>;
+  /// Seal one execute-permission unit, switching it to RX. Returns 0 on
+  /// success, non-zero on failure. On the target this calls enable_ex(1, va);
+  /// in tests, a mock. In legacy whole-pool mode `va` is the 2MiB pool base; in
+  /// 4K page-seal mode it is the base VA of a single 4KiB page.
+  using SealFn = std::function<unsigned(void *va)>;
+
+  /// Split a 2MiB-aligned region [base, base + size) into 4KiB mappings so the
+  /// platform can later flip execute permission per 4K page. Returns 0 on
+  /// success, non-zero on failure. On the target this calls
+  /// split_2m_to_4k(base, size); in tests, a mock. Only used when
+  /// Options::fourKSeal is set.
+  using SplitFn = std::function<unsigned(void *base, size_t size)>;
 
   struct Options {
-    /// Usable bytes per pool (EJIT_SRE_CODE_POOL_SIZE). Default 2MiB.
+    /// Usable bytes per pool (EJIT_SRE_CODE_POOL_SIZE). Default 2MiB. In 4K
+    /// seal mode this is rounded up to a multiple of poolAlign.
     size_t poolSize = static_cast<size_t>(2) * 1024 * 1024;
-    /// Alignment of each pool base — the enable_ex granularity. Default 2MiB.
+    /// Alignment of each pool base — the large-page / split granularity.
+    /// Default 2MiB.
     size_t poolAlign = static_cast<size_t>(2) * 1024 * 1024;
     /// Minimum alignment applied to every code allocation. Default 64.
     size_t minCodeAlign = 64;
+    /// When true, seal execute permission per 4KiB page (split_2m_to_4k at pool
+    /// creation + enable_ex per covered page at finalize) instead of sealing
+    /// the whole 2MiB pool. Default false (legacy whole-pool seal).
+    bool fourKSeal = false;
+    /// Execute-permission seal granularity in 4K mode. Platform constant 4KiB.
+    size_t sealPageSize = 4096;
   };
 
   struct Stats {
@@ -96,22 +125,31 @@ public:
     size_t reservedBytes = 0;   ///< sum of pool sizes across all pools
     size_t wastedBytes = 0;     ///< unused tail bytes inside sealed pools
     size_t sealInvocations = 0; ///< number of successful seal (enable_ex) calls
+                                ///< (per 4K page in 4K seal mode)
+    size_t splitInvocations = 0; ///< number of successful split_2m_to_4k calls
+                                 ///< (one per pool in 4K seal mode)
   };
 
-  EJitCodePoolManager(Options Opts, RawAllocFn Alloc, SealFn Seal);
+  EJitCodePoolManager(Options Opts, RawAllocFn Alloc, SealFn Seal,
+                      SplitFn Split = nullptr);
   ~EJitCodePoolManager();
 
   EJitCodePoolManager(const EJitCodePoolManager &) = delete;
   EJitCodePoolManager &operator=(const EJitCodePoolManager &) = delete;
 
   /// Bump-allocate `Size` bytes of RW code memory aligned to
-  /// max(Align, minCodeAlign). Allocation strategy:
-  ///   1. no active pool          -> new 2MiB pool
-  ///   2. active pool sealed       -> new 2MiB pool
-  ///   3. active pool out of room  -> seal active pool, then new 2MiB pool
+  /// max(Align, minCodeAlign) (and to sealPageSize in 4K seal mode). Allocation
+  /// strategy:
+  ///   1. no active pool          -> new 2MiB-aligned pool
+  ///   2. active pool out of room  -> new 2MiB-aligned pool
+  ///   3. (legacy mode) active pool sealed -> new pool; a full active pool is
+  ///      sealed before rolling over so it is never written again
   ///   4. otherwise                -> bump-allocate inside the active pool
+  /// In 4K seal mode every allocation starts on a fresh 4KiB page and its used
+  /// extent is rounded up to a 4K multiple, so a later allocation never lands
+  /// on an already-sealed (RX) page; pools are not whole-sealed on rollover.
   /// A request larger than the pool size is a clean error (no silent fallback).
-  /// If sealing the full active pool (case 3) fails, returns that Error.
+  /// If sealing the full active pool (legacy case 3) fails, returns that Error.
   Expected<void *> allocateCode(size_t Size, size_t Align);
 
   /// Seal the pool that contains `Ptr` (RW -> RX) if it is not already sealed.
@@ -122,6 +160,18 @@ public:
 
   /// Seal every pool that is still writable. Used at shutdown/quiesce points.
   Error sealAllWritablePools();
+
+  /// 4K seal mode: seal the 4KiB pages covering [Start, Start + Size), i.e.
+  /// [alignDown(Start, sealPageSize), alignUp(Start + Size, sealPageSize)),
+  /// invoking enable_ex(1, pageVA) once per page. Used after a JIT allocation
+  /// has been fully written/finalized, before its function pointer is returned.
+  /// Returns an Error if `Start` is not owned by any pool or if any page seal
+  /// fails (in which case no callable pointer must be handed back).
+  Error sealCodeRange(const void *Start, size_t Size);
+
+  /// True if this manager seals execute permission per 4KiB page (rather than
+  /// per whole 2MiB pool).
+  bool usesPageSeal() const { return Opts_.fourKSeal; }
 
   /// True if `Ptr` falls inside the usable range of any owned pool.
   bool contains(const void *Ptr) const;
@@ -138,11 +188,13 @@ private:
   Options Opts_;
   RawAllocFn Alloc_;
   SealFn Seal_;
+  SplitFn Split_;
 
   // Pool descriptors (ordinary host bookkeeping; never holds code bytes).
   std::vector<std::unique_ptr<CodePool>> Pools_;
   CodePool *Active_ = nullptr;
   size_t SealInvocations_ = 0;
+  size_t SplitInvocations_ = 0;
 
 #ifndef EJIT_FREESTANDING
   mutable std::mutex Mutex_;

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -110,6 +110,14 @@ if(EJIT_DEFAULT_TARGET_TRIPLE)
     EJIT_DEFAULT_TRIPLE="${EJIT_DEFAULT_TARGET_TRIPLE}")
 endif()
 
+# 4K-granular code-pool sealing. The only user of this macro is the SRE adapter
+# (EJitSrePlatform.cpp), so scope it to LLVMEJIT instead of a global
+# add_definitions — toggling it then does not recompile the whole LLVM tree.
+# Effective only when the SRE code pool itself is enabled.
+if(EJIT_SRE_CODE_POOL AND EJIT_CODE_POOL_4K_SEAL)
+  target_compile_definitions(LLVMEJIT PRIVATE EJIT_CODE_POOL_4K_SEAL)
+endif()
+
 # EJIT_FREESTANDING must be visible in LLVMJITLink headers so that
 # std::promise / std::future usage is guarded (bare-metal has no <future>).
 if(EJIT_FREESTANDING)

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -16,6 +16,10 @@ namespace {
 
 inline size_t alignUp(size_t V, size_t A) { return (V + (A - 1)) & ~(A - 1); }
 
+inline uintptr_t alignDownAddr(uintptr_t V, size_t A) {
+  return V & ~(static_cast<uintptr_t>(A) - 1);
+}
+
 inline uintptr_t addr(const void *P) {
   return reinterpret_cast<uintptr_t>(P);
 }
@@ -23,13 +27,24 @@ inline uintptr_t addr(const void *P) {
 } // namespace
 
 EJitCodePoolManager::EJitCodePoolManager(Options Opts, RawAllocFn Alloc,
-                                         SealFn Seal)
-    : Opts_(Opts), Alloc_(std::move(Alloc)), Seal_(std::move(Seal)) {
+                                         SealFn Seal, SplitFn Split)
+    : Opts_(Opts), Alloc_(std::move(Alloc)), Seal_(std::move(Seal)),
+      Split_(std::move(Split)) {
   // minCodeAlign and poolAlign must be powers of two for the masking math.
   if (Opts_.minCodeAlign == 0 || !isPowerOf2_64(Opts_.minCodeAlign))
     Opts_.minCodeAlign = 64;
   if (Opts_.poolAlign == 0 || !isPowerOf2_64(Opts_.poolAlign))
     Opts_.poolAlign = static_cast<size_t>(2) * 1024 * 1024;
+  if (Opts_.fourKSeal) {
+    // 4K seal granularity must be a power of two.
+    if (Opts_.sealPageSize == 0 || !isPowerOf2_64(Opts_.sealPageSize))
+      Opts_.sealPageSize = 4096;
+    // The pool size must be a whole multiple of the large-page / split
+    // granularity (poolAlign); round up if a configured size is not.
+    Opts_.poolSize = alignUp(Opts_.poolSize, Opts_.poolAlign);
+    if (Opts_.poolSize == 0)
+      Opts_.poolSize = Opts_.poolAlign;
+  }
 }
 
 EJitCodePoolManager::~EJitCodePoolManager() = default;
@@ -44,9 +59,12 @@ bool EJitCodePoolManager::poolHasRoomLocked(const CodePool &P, size_t Size,
 }
 
 Error EJitCodePoolManager::newActivePoolLocked() {
-  // raw size must allow rounding the base up to poolAlign while still leaving
-  // poolSize usable bytes: rawSize >= poolSize + poolAlign - 1.
-  size_t RawSize = Opts_.poolSize + Opts_.poolAlign - 1;
+  // Reserve alignment slack so the base can be rounded up to poolAlign while
+  // still leaving poolSize usable bytes. In 4K seal mode the platform contract
+  // wants a full large-page (poolAlign) of slack; legacy mode needs only
+  // poolAlign - 1.
+  size_t RawSize = Opts_.fourKSeal ? (Opts_.poolSize + Opts_.poolAlign)
+                                   : (Opts_.poolSize + Opts_.poolAlign - 1);
   void *Raw = Alloc_ ? Alloc_(RawSize) : nullptr;
   if (!Raw)
     return make_error<StringError>(
@@ -56,6 +74,23 @@ Error EJitCodePoolManager::newActivePoolLocked() {
   auto *RawBytes = static_cast<uint8_t *>(Raw);
   auto *Base = reinterpret_cast<uint8_t *>(
       alignUp(addr(RawBytes), Opts_.poolAlign));
+
+  if (Opts_.fourKSeal) {
+    // The 2MiB-aligned usable window must stay inside the raw allocation.
+    if (addr(Base) + Opts_.poolSize > addr(RawBytes) + RawSize)
+      return make_error<StringError>(
+          "EJitCodePool: aligned pool window exceeds raw allocation",
+          inconvertibleErrorCode());
+    // Split the 2MiB-aligned region into 4K mappings before any enable_ex. One
+    // split per pool; per-page enable_ex happens later at seal time.
+    unsigned Rc = Split_ ? Split_(Base, Opts_.poolSize) : 1;
+    if (Rc != 0)
+      return make_error<StringError>(
+          "EJitCodePool: split_2m_to_4k failed (rc=" + Twine(Rc) +
+              ") for pool base " + Twine(addr(Base)),
+          inconvertibleErrorCode());
+    ++SplitInvocations_;
+  }
 
   auto P = std::make_unique<CodePool>();
   P->raw = RawBytes;
@@ -92,6 +127,10 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
   size_t EffAlign = std::max(Align, Opts_.minCodeAlign);
   if (!isPowerOf2_64(EffAlign))
     EffAlign = alignUp(EffAlign, Opts_.minCodeAlign);
+  // In 4K seal mode every allocation must start on a fresh seal page so a later
+  // allocation never lands on an already-RX page.
+  if (Opts_.fourKSeal)
+    EffAlign = std::max(EffAlign, Opts_.sealPageSize);
 
   // A single allocation can never span pools; reject oversize requests cleanly.
   if (Size > Opts_.poolSize)
@@ -104,7 +143,24 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
   std::lock_guard<std::mutex> Lock(Mutex_);
 #endif
 
-  // Decide whether we can use the current active pool.
+  if (Opts_.fourKSeal) {
+    // 4K seal mode: never whole-seal a pool on rollover. Individual pages are
+    // sealed at finalize; when the active pool runs out of room we simply move
+    // to a fresh pool (the old pool's already-sealed pages stay RX, any unused
+    // tail is just abandoned RW memory).
+    if (!Active_ || !poolHasRoomLocked(*Active_, Size, EffAlign)) {
+      if (auto Err = newActivePoolLocked())
+        return std::move(Err);
+    }
+    size_t Off = alignUp(Active_->used, EffAlign);
+    uint8_t *Ptr = Active_->base + Off;
+    // Round the bump cursor up to a whole seal page so the next allocation
+    // starts on a page this one does not share.
+    Active_->used = alignUp(Off + Size, Opts_.sealPageSize);
+    return static_cast<void *>(Ptr);
+  }
+
+  // Legacy whole-pool seal mode. Decide whether we can use the active pool.
   if (!Active_ || Active_->executable ||
       !poolHasRoomLocked(*Active_, Size, EffAlign)) {
     // Case 3: an unsealed-but-full active pool is sealed before rolling over so
@@ -139,6 +195,17 @@ Error EJitCodePoolManager::sealPoolContaining(const void *Ptr) {
 #ifndef EJIT_FREESTANDING
   std::lock_guard<std::mutex> Lock(Mutex_);
 #endif
+  // Whole-pool sealing is meaningless in 4K page-seal mode: a bare pointer
+  // carries no size, so we cannot know which 4K pages to flip. Callers must use
+  // sealCodeRange(start, size) instead. Returning an Error (rather than sealing
+  // the whole pool) prevents the easy misuse of marking a 2MiB pool executable
+  // off a single address.
+  if (Opts_.fourKSeal) {
+    return make_error<StringError>(
+        "EJitCodePool: sealPoolContaining is not supported in 4K page-seal "
+        "mode; use sealCodeRange to seal the written code range",
+        inconvertibleErrorCode());
+  }
   CodePool *P = findPoolLocked(Ptr);
   if (!P)
     return make_error<StringError>(
@@ -152,11 +219,53 @@ Error EJitCodePoolManager::sealAllWritablePools() {
 #ifndef EJIT_FREESTANDING
   std::lock_guard<std::mutex> Lock(Mutex_);
 #endif
+  // Whole-pool sealing is not supported in 4K page-seal mode: in that mode a
+  // pool intentionally stays partially writable (only the 4K pages of finalized
+  // code are RX), so "seal every writable pool" has no correct meaning. Return
+  // an Error rather than silently no-op so a caller cannot mistakenly believe
+  // all pools are now fully sealed. Use sealCodeRange per finalized allocation.
+  if (Opts_.fourKSeal)
+    return make_error<StringError>(
+        "EJitCodePool: sealAllWritablePools (whole-pool sealing) is not "
+        "supported in 4K page-seal mode; use sealCodeRange",
+        inconvertibleErrorCode());
   Error Err = Error::success();
   for (auto &P : Pools_)
     if (!P->executable)
       Err = joinErrors(std::move(Err), sealPoolLocked(*P));
   return Err;
+}
+
+Error EJitCodePoolManager::sealCodeRange(const void *Start, size_t Size) {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  if (Size == 0)
+    return Error::success();
+  CodePool *P = findPoolLocked(Start);
+  if (!P)
+    return make_error<StringError>(
+        "EJitCodePool: address " + Twine(addr(Start)) +
+            " is not owned by any code pool",
+        inconvertibleErrorCode());
+
+  // Seal every 4KiB page the written code overlaps: page-align the start down
+  // and the end up, then enable_ex(1, pageVA) per page.
+  size_t Page = Opts_.sealPageSize;
+  uintptr_t PageStart = alignDownAddr(addr(Start), Page);
+  uintptr_t PageEnd = alignUp(addr(Start) + Size, Page);
+  for (uintptr_t VA = PageStart; VA < PageEnd; VA += Page) {
+    unsigned Rc = Seal_ ? Seal_(reinterpret_cast<void *>(VA)) : 1;
+    if (Rc != 0)
+      return make_error<StringError>(
+          "EJitCodePool: enable_ex failed (rc=" + Twine(Rc) + ") for page " +
+              Twine(VA),
+          inconvertibleErrorCode());
+    ++SealInvocations_;
+  }
+  // Per platform guidance, enable_ex performs its own permission/cache
+  // synchronization, so we deliberately do NOT call __builtin___clear_cache.
+  return Error::success();
 }
 
 bool EJitCodePoolManager::contains(const void *Ptr) const {
@@ -179,6 +288,7 @@ EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
   Stats S;
   S.poolCount = Pools_.size();
   S.sealInvocations = SealInvocations_;
+  S.splitInvocations = SplitInvocations_;
   for (auto &P : Pools_) {
     S.reservedBytes += P->size;
     S.usedBytes += P->used;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -12,6 +12,16 @@
 using namespace llvm;
 using namespace llvm::ejit;
 
+// Lightweight, default-empty trace hook for code-pool key paths. Expands to
+// nothing unless EJIT_CODE_POOL_TRACE is predefined for on-target bring-up
+// (for example, -D'EJIT_CODE_POOL_TRACE(...)=SRE_printf(__VA_ARGS__)').
+// Arguments are restricted to integers, pointers, and C strings.
+#ifndef EJIT_CODE_POOL_TRACE
+#define EJIT_CODE_POOL_TRACE(...)                                              \
+  do {                                                                         \
+  } while (0)
+#endif
+
 namespace {
 
 inline size_t alignUp(size_t V, size_t A) { return (V + (A - 1)) & ~(A - 1); }
@@ -65,7 +75,13 @@ Error EJitCodePoolManager::newActivePoolLocked() {
   // poolAlign - 1.
   size_t RawSize = Opts_.fourKSeal ? (Opts_.poolSize + Opts_.poolAlign)
                                    : (Opts_.poolSize + Opts_.poolAlign - 1);
+  EJIT_CODE_POOL_TRACE("newActivePool:enter",
+                       (unsigned long long)Opts_.poolSize,
+                       (unsigned)Opts_.fourKSeal,
+                       (unsigned long long)RawSize);
   void *Raw = Alloc_ ? Alloc_(RawSize) : nullptr;
+  EJIT_CODE_POOL_TRACE("newActivePool:rawAlloc", Raw,
+                       (unsigned long long)RawSize);
   if (!Raw)
     return make_error<StringError>(
         "EJitCodePool: raw allocation of " + Twine(RawSize) + " bytes failed",
@@ -74,6 +90,7 @@ Error EJitCodePoolManager::newActivePoolLocked() {
   auto *RawBytes = static_cast<uint8_t *>(Raw);
   auto *Base = reinterpret_cast<uint8_t *>(
       alignUp(addr(RawBytes), Opts_.poolAlign));
+  EJIT_CODE_POOL_TRACE("newActivePool:alignedBase", Base);
 
   if (Opts_.fourKSeal) {
     // The 2MiB-aligned usable window must stay inside the raw allocation.
@@ -84,6 +101,8 @@ Error EJitCodePoolManager::newActivePoolLocked() {
     // Split the 2MiB-aligned region into 4K mappings before any enable_ex. One
     // split per pool; per-page enable_ex happens later at seal time.
     unsigned Rc = Split_ ? Split_(Base, Opts_.poolSize) : 1;
+    EJIT_CODE_POOL_TRACE("newActivePool:splitRc", Base,
+                         (unsigned long long)Opts_.poolSize, Rc);
     if (Rc != 0)
       return make_error<StringError>(
           "EJitCodePool: split_2m_to_4k failed (rc=" + Twine(Rc) +
@@ -124,6 +143,9 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
     return make_error<StringError>("EJitCodePool: zero-size allocation",
                                    inconvertibleErrorCode());
 
+  EJIT_CODE_POOL_TRACE("allocateCode:req", (unsigned long long)Size,
+                       (unsigned long long)Align);
+
   size_t EffAlign = std::max(Align, Opts_.minCodeAlign);
   if (!isPowerOf2_64(EffAlign))
     EffAlign = alignUp(EffAlign, Opts_.minCodeAlign);
@@ -157,6 +179,7 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
     // Round the bump cursor up to a whole seal page so the next allocation
     // starts on a page this one does not share.
     Active_->used = alignUp(Off + Size, Opts_.sealPageSize);
+    EJIT_CODE_POOL_TRACE("allocateCode:res4k", Ptr, (unsigned long long)Size);
     return static_cast<void *>(Ptr);
   }
 
@@ -178,6 +201,7 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
   size_t Off = alignUp(Active_->used, EffAlign);
   uint8_t *Ptr = Active_->base + Off;
   Active_->used = Off + Size;
+  EJIT_CODE_POOL_TRACE("allocateCode:res", Ptr, (unsigned long long)Size);
   return static_cast<void *>(Ptr);
 }
 
@@ -201,6 +225,7 @@ Error EJitCodePoolManager::sealPoolContaining(const void *Ptr) {
   // the whole pool) prevents the easy misuse of marking a 2MiB pool executable
   // off a single address.
   if (Opts_.fourKSeal) {
+    EJIT_CODE_POOL_TRACE("sealPoolContaining:unsupported4k", Ptr);
     return make_error<StringError>(
         "EJitCodePool: sealPoolContaining is not supported in 4K page-seal "
         "mode; use sealCodeRange to seal the written code range",
@@ -254,8 +279,12 @@ Error EJitCodePoolManager::sealCodeRange(const void *Start, size_t Size) {
   size_t Page = Opts_.sealPageSize;
   uintptr_t PageStart = alignDownAddr(addr(Start), Page);
   uintptr_t PageEnd = alignUp(addr(Start) + Size, Page);
+  EJIT_CODE_POOL_TRACE("sealCodeRange", Start, (unsigned long long)Size,
+                       (unsigned long long)PageStart,
+                       (unsigned long long)PageEnd);
   for (uintptr_t VA = PageStart; VA < PageEnd; VA += Page) {
     unsigned Rc = Seal_ ? Seal_(reinterpret_cast<void *>(VA)) : 1;
+    EJIT_CODE_POOL_TRACE("sealCodeRange:pageRc", (unsigned long long)VA, Rc);
     if (Rc != 0)
       return make_error<StringError>(
           "EJitCodePool: enable_ex failed (rc=" + Twine(Rc) + ") for page " +

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -29,16 +29,28 @@ struct EJitCodePoolMemoryManager::FinalizedInfo {
 class EJitCodePoolMemoryManager::InFlightAllocImpl
     : public JITLinkMemoryManager::InFlightAlloc {
 public:
-  InFlightAllocImpl(EJitCodePoolMemoryManager &, LinkGraph &G, BasicLayout BL,
-                    void *Base)
-      : G(&G), BL(std::move(BL)), Base(Base) {}
+  InFlightAllocImpl(EJitCodePoolMemoryManager &MM, LinkGraph &G, BasicLayout BL,
+                    void *Base, size_t Size)
+      : Pool(&MM.getPool()), G(&G), BL(std::move(BL)), Base(Base), Size(Size) {}
 
   void finalize(OnFinalizedFunction OnFinalized) override {
     // The content has already been written into working memory, which (for an
-    // in-process pool) is the executor memory. Deliberately DO NOT apply any
-    // memory protection here: the pool stays RW until it is sealed as a whole
-    // 2MiB region by EJitCodePoolManager. Likewise we do not invalidate the
-    // instruction cache — enable_ex performs that sync on the target.
+    // in-process pool) is the executor memory, and all JITLink fixups are
+    // applied before finalize() runs. Deliberately DO NOT apply any per-segment
+    // memory protection here (no mprotect): the pool stays RW.
+    //
+    // In 4K seal mode, seal exactly the 4KiB pages this allocation covers now
+    // that all writes/relocations are complete, before the function pointer can
+    // be looked up. If any page fails to seal we must not hand back a callable
+    // allocation. (Legacy whole-pool seal is driven later, at lookup, by the
+    // engine.) We do not invalidate the instruction cache here either \u2014
+    // enable_ex performs that sync on the target.
+    if (Pool->usesPageSeal() && Size > 0) {
+      if (auto Err = Pool->sealCodeRange(Base, Size)) {
+        OnFinalized(std::move(Err));
+        return;
+      }
+    }
     runFinalizeActions(
         G->allocActions(),
         [this, OnFinalized = std::move(OnFinalized)](
@@ -66,9 +78,11 @@ public:
   }
 
 private:
+  EJitCodePoolManager *Pool;
   LinkGraph *G;
   BasicLayout BL;
   void *Base;
+  size_t Size;
 };
 
 EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(EJitCodePoolManager &Pool,
@@ -124,7 +138,8 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   }
 
   OnAllocated(
-      std::make_unique<InFlightAllocImpl>(*this, G, std::move(BL), Slab));
+      std::make_unique<InFlightAllocImpl>(*this, G, std::move(BL), Slab,
+                                          static_cast<size_t>(Total)));
 }
 
 void EJitCodePoolMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -308,14 +308,18 @@ Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
   void *Ptr = reinterpret_cast<void *>(addr->getValue());
 
 #ifdef EJIT_SRE_CODE_POOL
-  // Seal the 2MiB pool that contains the resolved function before it is handed
-  // back, so the page is RX (executable) at the call site. This is the only
-  // point a JIT pool transitions RW->RX. Idempotent: a pool already sealed
+  // Legacy whole-pool seal: flip the 2MiB pool that contains the resolved
+  // function to RX before it is handed back. This is the only point a JIT pool
+  // transitions RW->RX in whole-pool mode. Idempotent: a pool already sealed
   // (e.g. on allocation rollover) is not re-flipped, so repeated lookups of the
   // same function do not re-invoke enable_ex. Only pool-backed code is sealed;
   // an address resolved outside the pools (e.g. a process/absolute symbol) is
   // left untouched. If sealing fails we must not return a callable pointer.
-  if (P->codePool && P->codePool->contains(Ptr)) {
+  //
+  // In 4K page-seal mode the seal already happened per-page at finalize (in the
+  // code-pool memory manager), so nothing is done here.
+  if (P->codePool && !P->codePool->usesPageSeal() &&
+      P->codePool->contains(Ptr)) {
     if (auto Err = P->codePool->sealPoolContaining(Ptr))
       return std::move(Err);
   }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -7,17 +7,20 @@
 //===----------------------------------------------------------------------===//
 //
 //  Wires EJitCodePoolManager to the real SRE platform primitives. Compiled
-//  only when EJIT_SRE_CODE_POOL is enabled. Provides weak host fallbacks so a
-//  host build links and runs without the real SRE symbols (the real platform
-//  supplies strong overrides).
+//  only when EJIT_SRE_CODE_POOL is enabled. The platform symbols (enable_ex,
+//  split_2m_to_4k, SRE_MemDbgAlloc) are ONLY declared here — never defined and
+//  never given weak fallbacks. The real platform / business link environment
+//  must supply their strong definitions; if a symbol is missing it must surface
+//  as a link-time error rather than be silently satisfied by a no-op. Host unit
+//  tests do not reference makeSreCodePoolManager (they inject mock callbacks
+//  into EJitCodePoolManager directly), so this translation unit's external
+//  references are never pulled into a host test link.
 //
 //===----------------------------------------------------------------------===//
 
 #ifdef EJIT_SRE_CODE_POOL
 
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
-
-#include <cstdlib>
 
 #ifndef EJIT_SRE_CODE_POOL_SIZE
 #define EJIT_SRE_CODE_POOL_SIZE (static_cast<unsigned long long>(2) * 1024 * 1024)
@@ -38,55 +41,46 @@ constexpr unsigned long long kSrePoolSize = EJIT_SRE_CODE_POOL_SIZE;
 constexpr unsigned char kSrePtNo = static_cast<unsigned char>(EJIT_SRE_CODE_POOL_PTNO);
 constexpr unsigned kSreMid = static_cast<unsigned>(EJIT_SRE_CODE_POOL_MID);
 constexpr size_t k2MiB = static_cast<size_t>(2) * 1024 * 1024;
+constexpr size_t k4KiB = static_cast<size_t>(4) * 1024;
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// Platform primitives
+// Platform primitives (declaration only — defined by the platform/business)
 //
-// enable_ex is renamed via an asm label so the generic identifier
-// ejit_sre_enable_ex is used in C++ while the linker sees "enable_ex".
+// enable_ex / split_2m_to_4k are renamed via asm labels so the generic
+// identifiers (ejit_sre_enable_ex / ejit_sre_split_2m_to_4k) are used in C++
+// while the linker sees the real platform symbol names. These are intentionally
+// NOT given weak fallbacks: in static-pack / partial-link / platform-SDK
+// scenarios a weak local definition could shadow or collide with the real
+// symbol or bind incorrectly. EmbeddedJIT only declares and calls them; the
+// platform must provide the strong definitions.
 //===----------------------------------------------------------------------===//
 extern "C" unsigned ejit_sre_enable_ex(unsigned startLevel,
                                        unsigned long long va)
     __asm__("enable_ex");
 
+// Split a 2MiB-aligned [va, va + size) window into 4KiB mappings. Must be
+// called before any per-page enable_ex on that window. Returns 0 on success.
+extern "C" unsigned ejit_sre_split_2m_to_4k(unsigned long long va,
+                                            unsigned long long size)
+    __asm__("split_2m_to_4k");
+
 extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
                                  unsigned long size, const char *func,
                                  unsigned int line);
-
-//===----------------------------------------------------------------------===//
-// Weak host fallbacks
-//
-// On the real target the platform provides strong definitions that override
-// these. On a host without SRE, the weak versions let an EJIT_SRE_CODE_POOL
-// build link and run: enable_ex becomes a no-op success (host pages are already
-// writable+executable for smoke testing) and allocation uses aligned host
-// memory. They are intentionally NOT used by the unit tests, which inject their
-// own mocks.
-//===----------------------------------------------------------------------===//
-__attribute__((weak)) unsigned ejit_sre_enable_ex(unsigned /*startLevel*/,
-                                                  unsigned long long /*va*/) {
-  return 0; // success no-op on host
-}
-
-__attribute__((weak)) void *SRE_MemDbgAlloc(unsigned int /*mid*/,
-                                            unsigned char /*ptNo*/,
-                                            unsigned long size,
-                                            const char * /*func*/,
-                                            unsigned int /*line*/) {
-  void *P = nullptr;
-  // 2MiB alignment so the pool base is already aligned on the host path.
-  if (posix_memalign(&P, k2MiB, static_cast<size_t>(size)) != 0)
-    return nullptr;
-  return P;
-}
 
 std::unique_ptr<llvm::ejit::EJitCodePoolManager>
 llvm::ejit::makeSreCodePoolManager() {
   EJitCodePoolManager::Options Opts;
   Opts.poolSize = static_cast<size_t>(kSrePoolSize);
-  Opts.poolAlign = k2MiB; // enable_ex granularity
+  Opts.poolAlign = k2MiB; // large-page / split granularity
   Opts.minCodeAlign = 64;
+#ifdef EJIT_CODE_POOL_4K_SEAL
+  // Adapt to the platform's 4K execute-permission interface: the 2MiB pool is
+  // split into 4K mappings at creation and sealed one 4KiB page at a time.
+  Opts.fourKSeal = true;
+  Opts.sealPageSize = k4KiB;
+#endif
 
   auto RawAlloc = [](size_t Bytes) -> void * {
     return SRE_MemDbgAlloc(kSreMid, kSrePtNo,
@@ -94,17 +88,31 @@ llvm::ejit::makeSreCodePoolManager() {
                            __LINE__);
   };
 
-  auto Seal = [](void *Base2M) -> unsigned {
+  auto Seal = [](void *Va) -> unsigned {
 #ifdef EJIT_SRE_ENABLE_EX
-    return ejit_sre_enable_ex(1, reinterpret_cast<unsigned long long>(Base2M));
+    // In 4K seal mode Va is a single 4KiB page; in legacy mode it is the 2MiB
+    // pool base. enable_ex flips the page containing Va to RX either way.
+    return ejit_sre_enable_ex(1, reinterpret_cast<unsigned long long>(Va));
 #else
     // Code-pool routing without permission flips (bring-up / measurement).
-    (void)Base2M;
+    (void)Va;
     return 0;
 #endif
   };
 
-  return std::make_unique<EJitCodePoolManager>(Opts, RawAlloc, Seal);
+  auto Split = [](void *Base, size_t Size) -> unsigned {
+#ifdef EJIT_CODE_POOL_4K_SEAL
+    return ejit_sre_split_2m_to_4k(
+        reinterpret_cast<unsigned long long>(Base),
+        static_cast<unsigned long long>(Size));
+#else
+    (void)Base;
+    (void)Size;
+    return 0;
+#endif
+  };
+
+  return std::make_unique<EJitCodePoolManager>(Opts, RawAlloc, Seal, Split);
 }
 
 #endif // EJIT_SRE_CODE_POOL

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -200,3 +200,175 @@ TEST(EJitCodePoolMemMgr, SecondFunctionUsesNewPoolAfterSeal) {
   cantFail(MM.deallocate(std::move(FA2)));
 }
 
+//===----------------------------------------------------------------------===//
+// 4K page-seal mode tests
+//
+// Drive the memory manager with the pool in 4K seal mode: split_2m_to_4k once
+// per pool at creation, and enable_ex per covered 4KiB page at finalize (the
+// allocate step must not seal anything). All mocks; no real platform symbols.
+//===----------------------------------------------------------------------===//
+namespace {
+
+constexpr size_t kTwoMiB = static_cast<size_t>(2) * 1024 * 1024;
+constexpr size_t kFourKiB = static_cast<size_t>(4) * 1024;
+
+struct MockSre4K {
+  std::vector<void *> Origs;
+  std::vector<std::pair<uintptr_t, size_t>> Splits;
+  unsigned SplitRc = 0;
+  size_t SealCalls = 0;
+  int FailSealOnCall = -1; // 1-based seal index to fail; -1 = never
+  unsigned SealFailRc = 7;
+
+  ~MockSre4K() {
+    for (void *P : Origs)
+      std::free(P);
+  }
+  void *rawAlloc(size_t Bytes) {
+    void *Base = nullptr;
+    // 2MiB-aligned over-allocation; return a deliberately misaligned pointer.
+    if (posix_memalign(&Base, kTwoMiB, Bytes + kTwoMiB) != 0)
+      return nullptr;
+    Origs.push_back(Base);
+    return static_cast<char *>(Base) + kFourKiB;
+  }
+  unsigned split(void *Base, size_t Size) {
+    Splits.push_back({reinterpret_cast<uintptr_t>(Base), Size});
+    return SplitRc;
+  }
+  unsigned seal(void *) {
+    ++SealCalls;
+    if (FailSealOnCall > 0 && static_cast<int>(SealCalls) == FailSealOnCall)
+      return SealFailRc;
+    return 0;
+  }
+};
+
+EJitCodePoolManager::Options fourKMemMgrOpts() {
+  EJitCodePoolManager::Options O;
+  O.poolSize = kTwoMiB;
+  O.poolAlign = kTwoMiB;
+  O.minCodeAlign = 64;
+  O.fourKSeal = true;
+  O.sealPageSize = kFourKiB;
+  return O;
+}
+
+// Backing buffer large enough for a multi-page content block (avoids the 64-byte
+// CodeBytes overread for big graphs).
+const char BigCode[16 * 1024] = {0};
+
+std::unique_ptr<LinkGraph> makeBackedCodeGraph(const char *Buf, size_t Size,
+                                               uint64_t VAddr) {
+  auto G = std::make_unique<LinkGraph>(
+      "g", std::make_shared<orc::SymbolStringPool>(),
+      Triple("x86_64-unknown-linux-gnu"), SubtargetFeatures(),
+      getGenericEdgeKindName);
+  auto &Sec =
+      G->createSection("__text", orc::MemProt::Read | orc::MemProt::Exec);
+  G->createContentBlock(Sec, ArrayRef<char>(Buf, Size),
+                        orc::ExecutorAddr(VAddr), 16, 0);
+  return G;
+}
+
+} // namespace
+
+// allocate() must not seal; finalize() seals exactly the covered 4K page(s);
+// split runs once at pool creation.
+TEST(EJitCodePoolMemMgr4K, FinalizeSealsCoveredPage) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeCodeGraph(64, 0x1000); // 64 bytes -> one 4K page slab
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *CodeAddr = firstBlockAddr(*G);
+  EXPECT_TRUE(Pool.contains(CodeAddr));
+  EXPECT_EQ(M.SealCalls, 0u); // allocate must not enable_ex
+  EXPECT_EQ(Pool.getStats().splitInvocations, 1u);
+
+  auto FA = cantFail(IFA->finalize()); // seals here
+  EXPECT_EQ(M.SealCalls, 1u);          // only the one covered page
+  EXPECT_EQ(Pool.getStats().sealInvocations, 1u);
+
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// A multi-page function seals each covered 4K page at finalize.
+TEST(EJitCodePoolMemMgr4K, FinalizeSealsAllPagesOfMultiPageCode) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  // 9000 bytes of content -> ceil(9000 / 4096) = 3 pages.
+  auto G = makeBackedCodeGraph(BigCode, 9000, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  EXPECT_EQ(M.SealCalls, 0u);
+
+  auto FA = cantFail(IFA->finalize());
+  EXPECT_EQ(M.SealCalls, 3u);
+  EXPECT_EQ(Pool.getStats().sealInvocations, 3u);
+
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// If enable_ex fails for any page, finalize returns an Error (no callable
+// pointer is handed back).
+TEST(EJitCodePoolMemMgr4K, FinalizeReturnsErrorWhenSealFails) {
+  MockSre4K M;
+  M.FailSealOnCall = 1; // fail the first page seal
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeCodeGraph(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  auto FA = IFA->finalize();
+  EXPECT_FALSE(static_cast<bool>(FA)); // finalize failed -> no FinalizedAlloc
+  consumeError(FA.takeError());
+}
+
+// Two functions compiled in turn reuse the SAME 2MiB pool (split once) but land
+// on different 4K pages, and neither lands on the other's sealed page.
+TEST(EJitCodePoolMemMgr4K, SecondFunctionUsesFreshPageSamePool) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G1 = makeCodeGraph(64, 0x1000);
+  auto IFA1 = cantFail(MM.allocate(nullptr, *G1));
+  void *Addr1 = firstBlockAddr(*G1);
+  auto FA1 = cantFail(IFA1->finalize());
+  EXPECT_EQ(M.SealCalls, 1u);
+
+  auto G2 = makeCodeGraph(64, 0x2000);
+  auto IFA2 = cantFail(MM.allocate(nullptr, *G2));
+  void *Addr2 = firstBlockAddr(*G2);
+  auto FA2 = cantFail(IFA2->finalize());
+  EXPECT_EQ(M.SealCalls, 2u);
+
+  auto S = Pool.getStats();
+  EXPECT_EQ(S.poolCount, 1u);        // same pool reused (memory efficient)
+  EXPECT_EQ(S.splitInvocations, 1u); // split once for the one pool
+
+  auto pageOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) & ~static_cast<uintptr_t>(kFourKiB - 1);
+  };
+  EXPECT_NE(pageOf(Addr1), pageOf(Addr2)); // different 4K pages
+
+  cantFail(MM.deallocate(std::move(FA1)));
+  cantFail(MM.deallocate(std::move(FA2)));
+}
+
+

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
@@ -287,3 +287,249 @@ TEST(EJitCodePool, SealUnknownAddressFails) {
   EXPECT_TRUE(static_cast<bool>(Err));
   consumeError(std::move(Err));
 }
+
+//===----------------------------------------------------------------------===//
+// 4K page-seal mode tests
+//
+// These exercise the SRE-platform 4K execute-permission interface: the pool is
+// still 2MiB-aligned (split into 4K mappings via split_2m_to_4k at creation),
+// but only the 4KiB pages a finalized allocation covers are sealed (enable_ex
+// per page). All injected mocks; no real platform symbols.
+//===----------------------------------------------------------------------===//
+namespace {
+
+constexpr size_t kTwoMiB = static_cast<size_t>(2) * 1024 * 1024;
+constexpr size_t kFourKiB = static_cast<size_t>(4) * 1024;
+
+/// Mock SRE backend for 4K mode: deliberately returns a non-2MiB-aligned raw
+/// base, records split_2m_to_4k(base,size) calls and per-page enable_ex calls,
+/// and can be made to fail split or a chosen seal call.
+struct MockSre4K {
+  std::vector<void *> Origs; // posix_memalign bases (freed at teardown)
+  uintptr_t LastRawReturned = 0;
+  size_t LastBytesRequested = 0;
+  size_t AllocCalls = 0;
+
+  std::vector<std::pair<uintptr_t, size_t>> Splits;
+  unsigned SplitRc = 0;
+
+  std::vector<uintptr_t> SealedPages;
+  size_t SealCalls = 0;
+  int FailSealOnCall = -1; // 1-based seal call index to fail; -1 = never
+  unsigned SealFailRc = 7;
+
+  ~MockSre4K() {
+    for (void *P : Origs)
+      std::free(P);
+  }
+
+  void *rawAlloc(size_t Bytes) {
+    ++AllocCalls;
+    LastBytesRequested = Bytes;
+    void *Base = nullptr;
+    // Over-allocate, 2MiB-aligned, then hand back a deliberately misaligned
+    // pointer (offset 4KiB) so the manager must round the base up to 2MiB.
+    if (posix_memalign(&Base, kTwoMiB, Bytes + kTwoMiB) != 0)
+      return nullptr;
+    Origs.push_back(Base);
+    void *Raw = static_cast<char *>(Base) + kFourKiB;
+    LastRawReturned = reinterpret_cast<uintptr_t>(Raw);
+    return Raw;
+  }
+
+  unsigned split(void *Base, size_t Size) {
+    Splits.push_back({reinterpret_cast<uintptr_t>(Base), Size});
+    return SplitRc;
+  }
+
+  unsigned seal(void *PageVA) {
+    ++SealCalls;
+    if (FailSealOnCall > 0 && static_cast<int>(SealCalls) == FailSealOnCall)
+      return SealFailRc;
+    SealedPages.push_back(reinterpret_cast<uintptr_t>(PageVA));
+    return 0;
+  }
+};
+
+EJitCodePoolManager::Options fourKOpts() {
+  EJitCodePoolManager::Options O;
+  O.poolSize = kTwoMiB;
+  O.poolAlign = kTwoMiB;
+  O.minCodeAlign = 64;
+  O.fourKSeal = true;
+  O.sealPageSize = kFourKiB;
+  return O;
+}
+
+EJitCodePoolManager makeManager4K(MockSre4K &M,
+                                  EJitCodePoolManager::Options Opts) {
+  return EJitCodePoolManager(
+      Opts, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+}
+
+} // namespace
+
+// A deliberately non-2MiB-aligned raw base is rounded up to a 2MiB-aligned pool
+// base, and the usable window stays inside the raw allocation.
+TEST(EJitCodePool4K, AlignsMisalignedRawBaseTo2MiB) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(128, 64));
+  // First allocation in 4K mode starts at offset 0, i.e. the pool base.
+  EXPECT_EQ(A(P) % kTwoMiB, 0u);          // aligned base is 2MiB aligned
+  EXPECT_TRUE(Mgr.contains(P));
+  EXPECT_NE(A(P), M.LastRawReturned);     // raw base was misaligned, base != raw
+  // Usable window [base, base+poolSize) must fit within [raw, raw+requested).
+  EXPECT_LE(A(P) + kTwoMiB, M.LastRawReturned + M.LastBytesRequested);
+  // The manager requests poolSize + 2MiB of alignment slack.
+  EXPECT_EQ(M.LastBytesRequested, kTwoMiB + kTwoMiB);
+}
+
+// split_2m_to_4k is called exactly once per pool, with the aligned base and the
+// usable pool size; a second allocation in the same pool does not re-split.
+TEST(EJitCodePool4K, SplitCalledOncePerPool) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(128, 64));
+  ASSERT_EQ(M.Splits.size(), 1u);
+  EXPECT_EQ(M.Splits[0].first, A(P));      // split base == aligned pool base
+  EXPECT_EQ(M.Splits[0].second, kTwoMiB);  // split size == usable pool size
+  EXPECT_EQ(M.Splits[0].first % kTwoMiB, 0u);
+  EXPECT_EQ(Mgr.getStats().splitInvocations, 1u);
+
+  (void)cantFail(Mgr.allocateCode(128, 64)); // same pool, no new split
+  EXPECT_EQ(M.Splits.size(), 1u);
+  EXPECT_EQ(Mgr.getStats().splitInvocations, 1u);
+}
+
+// A small function seals only the single 4K page it covers, not the whole pool.
+TEST(EJitCodePool4K, SmallCodeSealsOnlyCoveredPage) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(100, 64));
+  cantFail(Mgr.sealCodeRange(P, 100));
+
+  EXPECT_EQ(M.SealCalls, 1u); // one page, NOT 512 (the whole 2MiB pool)
+  ASSERT_EQ(M.SealedPages.size(), 1u);
+  EXPECT_EQ(M.SealedPages[0], A(P)); // page base == 4K-aligned code start
+  EXPECT_EQ(Mgr.getStats().sealInvocations, 1u);
+}
+
+// A code range spanning multiple 4K pages loops enable_ex over each page.
+TEST(EJitCodePool4K, MultiPageCodeSealsEachPage) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  size_t Sz = 2 * kFourKiB + 200; // covers 3 pages
+  void *P = cantFail(Mgr.allocateCode(Sz, 64));
+  cantFail(Mgr.sealCodeRange(P, Sz));
+
+  EXPECT_EQ(M.SealCalls, 3u);
+  ASSERT_EQ(M.SealedPages.size(), 3u);
+  EXPECT_EQ(M.SealedPages[0], A(P));
+  EXPECT_EQ(M.SealedPages[1], A(P) + kFourKiB);
+  EXPECT_EQ(M.SealedPages[2], A(P) + 2 * kFourKiB);
+}
+
+// If any page's enable_ex fails, sealCodeRange returns an Error.
+TEST(EJitCodePool4K, EnableExFailureOnAPageReturnsError) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  size_t Sz = 2 * kFourKiB + 200; // 3 pages
+  void *P = cantFail(Mgr.allocateCode(Sz, 64));
+  M.FailSealOnCall = 2; // fail the 2nd page
+
+  Error Err = Mgr.sealCodeRange(P, Sz);
+  EXPECT_TRUE(static_cast<bool>(Err));
+  consumeError(std::move(Err));
+}
+
+// A subsequent allocation lands on a fresh 4K page, never inside a sealed page,
+// and stays in the same (still partially-writable) pool.
+TEST(EJitCodePool4K, NextAllocationSkipsSealedPage) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *A1 = cantFail(Mgr.allocateCode(100, 64)); // page 0
+  cantFail(Mgr.sealCodeRange(A1, 100));           // seal page 0
+  void *A2 = cantFail(Mgr.allocateCode(100, 64)); // must be a later page
+
+  EXPECT_TRUE(Mgr.contains(A2));
+  EXPECT_GE(A(A2), A(A1) + kFourKiB);
+  EXPECT_FALSE(A(A2) >= A(A1) && A(A2) < A(A1) + kFourKiB); // not in sealed page
+  EXPECT_EQ(A(A2) % kFourKiB, 0u);                          // fresh page start
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.poolCount, 1u);          // same pool reused
+  EXPECT_EQ(S.splitInvocations, 1u);
+}
+
+// split_2m_to_4k failure makes pool creation (hence allocateCode) fail cleanly,
+// registering no pool.
+TEST(EJitCodePool4K, SplitFailureFailsPoolCreation) {
+  MockSre4K M;
+  M.SplitRc = 5; // split_2m_to_4k fails
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  auto E = Mgr.allocateCode(128, 64);
+  EXPECT_FALSE(static_cast<bool>(E));
+  consumeError(E.takeError());
+  EXPECT_EQ(Mgr.getStats().poolCount, 0u);
+  EXPECT_EQ(Mgr.getStats().splitInvocations, 0u);
+}
+
+// Rolling over to a new pool splits the new pool exactly once, and no whole-pool
+// seal happens (sealing is per-page at finalize, not on rollover).
+TEST(EJitCodePool4K, RolloverCreatesNewPoolAndSplitsAgain) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  (void)cantFail(Mgr.allocateCode(kTwoMiB, 64)); // fills pool 1 exactly
+  void *P2 = cantFail(Mgr.allocateCode(64, 64)); // forces pool 2
+
+  EXPECT_TRUE(Mgr.contains(P2));
+  auto S = Mgr.getStats();
+  EXPECT_EQ(S.poolCount, 2u);
+  EXPECT_EQ(S.splitInvocations, 2u); // one split per pool
+  EXPECT_EQ(M.SealCalls, 0u);        // no whole-pool seal on rollover
+  EXPECT_EQ(S.sealedCount, 0u);
+}
+
+// In 4K mode the whole-pool seal entry point sealPoolContaining is unsupported
+// (a bare pointer has no size); it must return an Error and never enable_ex.
+TEST(EJitCodePool4K, SealPoolContainingReturnsErrorIn4KMode) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(100, 64));
+  Error Err = Mgr.sealPoolContaining(P);
+  EXPECT_TRUE(static_cast<bool>(Err));
+  consumeError(std::move(Err));
+
+  // No enable_ex was invoked and the pool was not marked sealed.
+  EXPECT_EQ(M.SealCalls, 0u);
+  EXPECT_EQ(Mgr.getStats().sealInvocations, 0u);
+  EXPECT_EQ(Mgr.getStats().sealedCount, 0u);
+}
+
+// In 4K mode sealAllWritablePools (whole-pool sealing) is unsupported and must
+// return an Error rather than silently sealing or no-op succeeding.
+TEST(EJitCodePool4K, SealAllWritablePoolsReturnsErrorIn4KMode) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  (void)cantFail(Mgr.allocateCode(100, 64));
+  Error Err = Mgr.sealAllWritablePools();
+  EXPECT_TRUE(static_cast<bool>(Err));
+  consumeError(std::move(Err));
+
+  EXPECT_EQ(M.SealCalls, 0u);
+  EXPECT_EQ(Mgr.getStats().sealedCount, 0u);
+}
+
+


### PR DESCRIPTION
## Summary

Adds 4K-granular sealing for the existing EmbeddedJIT code-pool path, split separately from the taskpool work.

This PR includes:
- `EJIT_CODE_POOL_4K_SEAL` option, effective only when `EJIT_SRE_CODE_POOL=ON`.
- 2MiB-aligned code pools with one `split_2m_to_4k` call per pool.
- Per-finalized-allocation `sealCodeRange` that loops over covered 4KiB pages and calls `enable_ex` per page.
- 4K mode allocation policy that page-aligns code allocations so later functions do not write into already RX pages.
- Explicit errors for whole-pool sealing APIs in 4K mode (`sealPoolContaining`, `sealAllWritablePools`) because a naked pointer has no code-size range.
- Platform symbols (`enable_ex`, `split_2m_to_4k`, `SRE_MemDbgAlloc`) declared only, with no weak fallback definitions.
- Default-empty code-pool trace hooks for board diagnosis.
- Unit coverage for alignment, split, page sealing, failure propagation, and memory-manager finalize behavior.

## Boundaries

This PR intentionally does not include taskpool scheduling changes. Those live in PR #28.

## Validation

Ran locally:

```bash
cmake --build build-ejit-sre-pool --target check-ejit-code-pool -j8
```

Result: `31/31 PASS`.

## Notes

- Default behavior remains unchanged unless `EJIT_SRE_CODE_POOL=ON`.
- `EJIT_CODE_POOL_4K_SEAL` defaults ON for the code-pool build, but is scoped to `LLVMEJIT` rather than added globally.
- 4K mode still uses 2MiB-aligned backing pools; only execute permission sealing is narrowed to the finalized function's covered 4KiB pages.
- Real platform validation is still required for `split_2m_to_4k` + `enable_ex` permission transitions on target hardware.
- Physical code-pool memory release remains deferred; this PR focuses on allocation/sealing correctness.