### PR TITLE
[EJIT] Retain only RAGreedy register allocator under EJIT_TRIM_LLVM_BACKEND

### DIFF
--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -111,9 +111,11 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializePostRASchedulerLegacyPass(Registry);
   initializePreISelIntrinsicLoweringLegacyPassPass(Registry);
   initializeProcessImplicitDefsPass(Registry);
+#ifndef EJIT_TRIM_LLVM_BACKEND
   initializeRABasicPass(Registry);
-  initializeRAGreedyLegacyPass(Registry);
   initializeRegAllocFastPass(Registry);
+#endif // EJIT_TRIM_LLVM_BACKEND
+  initializeRAGreedyLegacyPass(Registry);
   initializeRegUsageInfoCollectorLegacyPass(Registry);
   initializeRegUsageInfoPropagationLegacyPass(Registry);
   initializeRegisterCoalescerLegacyPass(Registry);

--- a/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
+++ b/llvm/lib/CodeGen/MLRegAllocEvictAdvisor.cpp
@@ -103,7 +103,9 @@ public:
   static char ID;
 
   RegAllocScoring() : MachineFunctionPass(ID) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
     initializeRegAllocScoringPass(*PassRegistry::getPassRegistry());
+#endif
   }
 
   ~RegAllocScoring() override = default;
@@ -130,8 +132,10 @@ FunctionPass *createRegAllocScoringPass() { return new RegAllocScoring(); }
 
 } // namespace llvm
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 INITIALIZE_PASS(RegAllocScoring, "regallocscoringpass",
                 "Register Allocation Scoring Pass", false, false)
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 // ===================================
 // Common ML Advisor declarations

--- a/llvm/lib/CodeGen/RegAllocBasic.cpp
+++ b/llvm/lib/CodeGen/RegAllocBasic.cpp
@@ -39,8 +39,10 @@ using namespace llvm;
 
 #define DEBUG_TYPE "regalloc"
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 static RegisterRegAlloc basicRegAlloc("basic", "basic register allocator",
                                       createBasicRegisterAllocator);
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 namespace {
   struct CompSpillWeight {
@@ -127,6 +129,7 @@ char RABasic::ID = 0;
 
 char &llvm::RABasicID = RABasic::ID;
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 INITIALIZE_PASS_BEGIN(RABasic, "regallocbasic", "Basic Register Allocator",
                       false, false)
 INITIALIZE_PASS_DEPENDENCY(LiveDebugVariablesWrapperLegacy)
@@ -143,6 +146,7 @@ INITIALIZE_PASS_DEPENDENCY(LiveRegMatrixWrapperLegacy)
 INITIALIZE_PASS_DEPENDENCY(ProfileSummaryInfoWrapperPass)
 INITIALIZE_PASS_END(RABasic, "regallocbasic", "Basic Register Allocator", false,
                     false)
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 bool RABasic::LRE_CanEraseVirtReg(Register VirtReg) {
   LiveInterval &LI = LIS->getInterval(VirtReg);

--- a/llvm/lib/CodeGen/RegAllocEvictionAdvisor.cpp
+++ b/llvm/lib/CodeGen/RegAllocEvictionAdvisor.cpp
@@ -27,6 +27,7 @@
 
 using namespace llvm;
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 static cl::opt<RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode> Mode(
     "regalloc-enable-advisor", cl::Hidden,
     cl::init(RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode::Default),
@@ -39,6 +40,7 @@ static cl::opt<RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode> Mode(
         clEnumValN(
             RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode::Development,
             "development", "for training")));
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 static cl::opt<bool> EnableLocalReassignment(
     "enable-local-reassign", cl::Hidden,
@@ -117,6 +119,9 @@ void RegAllocEvictionAdvisorAnalysis::initializeProvider(
     RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode Mode, LLVMContext &Ctx) {
   if (Provider)
     return;
+#ifdef EJIT_TRIM_LLVM_BACKEND
+  Provider.reset(new DefaultEvictionAdvisorProvider(/*NotAsRequested=*/false, Ctx));
+#else
   switch (Mode) {
   case RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode::Default:
     Provider.reset(
@@ -134,18 +139,27 @@ void RegAllocEvictionAdvisorAnalysis::initializeProvider(
     Provider.reset(createReleaseModeAdvisorProvider(Ctx));
     return;
   }
+#endif // EJIT_TRIM_LLVM_BACKEND
 }
 
 RegAllocEvictionAdvisorAnalysis::Result
 RegAllocEvictionAdvisorAnalysis::run(MachineFunction &MF,
                                      MachineFunctionAnalysisManager &MFAM) {
   // Lazy initialization of the provider.
+#ifndef EJIT_TRIM_LLVM_BACKEND
   initializeProvider(::Mode, MF.getFunction().getContext());
+#else
+  initializeProvider(RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode::Default,
+                     MF.getFunction().getContext());
+#endif
   return Result{Provider.get()};
 }
 
 template <>
 Pass *llvm::callDefaultCtor<RegAllocEvictionAdvisorAnalysisLegacy>() {
+#ifdef EJIT_TRIM_LLVM_BACKEND
+  return new DefaultEvictionAdvisorAnalysisLegacy(/*NotAsRequested=*/false);
+#else
   switch (Mode) {
   case RegAllocEvictionAdvisorAnalysisLegacy::AdvisorMode::Default:
     return new DefaultEvictionAdvisorAnalysisLegacy(/*NotAsRequested=*/false);
@@ -164,6 +178,7 @@ Pass *llvm::callDefaultCtor<RegAllocEvictionAdvisorAnalysisLegacy>() {
 #endif
   }
   llvm_unreachable("unexpected advisor mode");
+#endif // EJIT_TRIM_LLVM_BACKEND
 }
 
 StringRef RegAllocEvictionAdvisorAnalysisLegacy::getPassName() const {

--- a/llvm/lib/CodeGen/RegAllocFast.cpp
+++ b/llvm/lib/CodeGen/RegAllocFast.cpp
@@ -58,8 +58,10 @@ STATISTIC(NumCoalesced, "Number of copies coalesced");
 static cl::opt<bool> IgnoreMissingDefs("rafast-ignore-missing-defs",
                                        cl::Hidden);
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 static RegisterRegAlloc fastRegAlloc("fast", "fast register allocator",
                                      createFastRegisterAllocator);
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 namespace {
 
@@ -437,8 +439,10 @@ public:
 
 char RegAllocFast::ID = 0;
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 INITIALIZE_PASS(RegAllocFast, "regallocfast", "Fast Register Allocator", false,
                 false)
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 bool RegAllocFastImpl::shouldAllocateRegister(const Register Reg) const {
   assert(Reg.isVirtual());

--- a/llvm/lib/CodeGen/RegAllocPBQP.cpp
+++ b/llvm/lib/CodeGen/RegAllocPBQP.cpp
@@ -90,9 +90,11 @@ using namespace llvm;
 
 #define DEBUG_TYPE "regalloc"
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 static RegisterRegAlloc
 RegisterPBQPRepAlloc("pbqp", "PBQP register allocator",
                        createDefaultPBQPRegisterAllocator);
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 static cl::opt<bool>
 PBQPCoalescing("pbqp-coalescing",

--- a/llvm/lib/CodeGen/RegAllocPriorityAdvisor.cpp
+++ b/llvm/lib/CodeGen/RegAllocPriorityAdvisor.cpp
@@ -20,6 +20,7 @@
 
 using namespace llvm;
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 static cl::opt<RegAllocPriorityAdvisorProvider::AdvisorMode> Mode(
     "regalloc-enable-priority-advisor", cl::Hidden,
     cl::init(RegAllocPriorityAdvisorProvider::AdvisorMode::Default),
@@ -34,6 +35,7 @@ static cl::opt<RegAllocPriorityAdvisorProvider::AdvisorMode> Mode(
         clEnumValN(
             RegAllocPriorityAdvisorProvider::AdvisorMode::Dummy, "dummy",
             "prioritize low virtual register numbers for test and debug")));
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 char RegAllocPriorityAdvisorAnalysisLegacy::ID = 0;
 INITIALIZE_PASS(RegAllocPriorityAdvisorAnalysisLegacy, "regalloc-priority",
@@ -136,6 +138,9 @@ private:
 void RegAllocPriorityAdvisorAnalysis::initializeProvider(LLVMContext &Ctx) {
   if (Provider)
     return;
+#ifdef EJIT_TRIM_LLVM_BACKEND
+  Provider.reset(new DefaultPriorityAdvisorProvider(/*NotAsRequested=*/false, Ctx));
+#else
   switch (Mode) {
   case RegAllocPriorityAdvisorProvider::AdvisorMode::Dummy:
     Provider.reset(new DummyPriorityAdvisorProvider());
@@ -156,6 +161,7 @@ void RegAllocPriorityAdvisorAnalysis::initializeProvider(LLVMContext &Ctx) {
     Provider.reset(createReleaseModePriorityAdvisorProvider());
     return;
   }
+#endif // EJIT_TRIM_LLVM_BACKEND
 }
 
 AnalysisKey RegAllocPriorityAdvisorAnalysis::Key;
@@ -171,6 +177,9 @@ RegAllocPriorityAdvisorAnalysis::run(MachineFunction &MF,
 
 template <>
 Pass *llvm::callDefaultCtor<RegAllocPriorityAdvisorAnalysisLegacy>() {
+#ifdef EJIT_TRIM_LLVM_BACKEND
+  return new DefaultPriorityAdvisorAnalysisLegacy(/*NotAsRequested=*/false);
+#else
   Pass *Ret = nullptr;
   switch (Mode) {
   case RegAllocPriorityAdvisorProvider::AdvisorMode::Default:
@@ -191,6 +200,7 @@ Pass *llvm::callDefaultCtor<RegAllocPriorityAdvisorAnalysisLegacy>() {
   if (Ret)
     return Ret;
   return new DefaultPriorityAdvisorAnalysisLegacy(/*NotAsRequested*/ true);
+#endif // EJIT_TRIM_LLVM_BACKEND
 }
 
 StringRef RegAllocPriorityAdvisorAnalysisLegacy::getPassName() const {

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -1103,11 +1103,13 @@ bool TargetPassConfig::addISelPasses() {
 }
 
 /// -regalloc=... command line option.
+#ifndef EJIT_TRIM_LLVM_BACKEND
 static FunctionPass *useDefaultRegisterAllocator() { return nullptr; }
 static cl::opt<RegisterRegAlloc::FunctionPassCtor, false,
                RegisterPassParser<RegisterRegAlloc>>
     RegAlloc("regalloc", cl::Hidden, cl::init(&useDefaultRegisterAllocator),
              cl::desc("Register allocator to use"));
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 /// Add the complete set of target-independent postISel code generator passes.
 ///
@@ -1361,6 +1363,7 @@ bool TargetPassConfig::getOptimizeRegAlloc() const {
   llvm_unreachable("Invalid optimize-regalloc state");
 }
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 /// A dummy default pass factory indicates whether the register allocator is
 /// overridden on the command line.
 static llvm::once_flag InitializeDefaultRegisterAllocatorFlag;
@@ -1374,6 +1377,7 @@ static void initializeDefaultRegisterAllocatorOnce() {
   if (!RegisterRegAlloc::getDefault())
     RegisterRegAlloc::setDefault(RegAlloc);
 }
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 /// Instantiate the default register allocator pass for this target for either
 /// the optimized or unoptimized allocation path. This will be added to the pass
@@ -1384,10 +1388,14 @@ static void initializeDefaultRegisterAllocatorOnce() {
 /// allocation may still override this for per-target regalloc
 /// selection. But -regalloc=... always takes precedence.
 FunctionPass *TargetPassConfig::createTargetRegisterAllocator(bool Optimized) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   if (Optimized)
     return createGreedyRegisterAllocator();
   else
     return createFastRegisterAllocator();
+#else
+  return createGreedyRegisterAllocator();
+#endif
 }
 
 /// Find and instantiate the register allocation pass requested by this target
@@ -1400,6 +1408,7 @@ FunctionPass *TargetPassConfig::createTargetRegisterAllocator(bool Optimized) {
 /// FIXME: When MachinePassRegistry register pass IDs instead of function ptrs,
 /// this can be folded into addPass.
 FunctionPass *TargetPassConfig::createRegAllocPass(bool Optimized) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   // Initialize the global default.
   llvm::call_once(InitializeDefaultRegisterAllocatorFlag,
                   initializeDefaultRegisterAllocatorOnce);
@@ -1407,21 +1416,27 @@ FunctionPass *TargetPassConfig::createRegAllocPass(bool Optimized) {
   RegisterRegAlloc::FunctionPassCtor Ctor = RegisterRegAlloc::getDefault();
   if (Ctor != useDefaultRegisterAllocator)
     return Ctor();
-
+#endif // EJIT_TRIM_LLVM_BACKEND
   // With no -regalloc= override, ask the target for a regalloc pass.
   return createTargetRegisterAllocator(Optimized);
 }
 
 bool TargetPassConfig::isCustomizedRegAlloc() {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   return RegAlloc !=
          (RegisterRegAlloc::FunctionPassCtor)&useDefaultRegisterAllocator;
+#else
+  return false;
+#endif
 }
 
 bool TargetPassConfig::addRegAssignAndRewriteFast() {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   if (RegAlloc != (RegisterRegAlloc::FunctionPassCtor)&useDefaultRegisterAllocator &&
       RegAlloc != (RegisterRegAlloc::FunctionPassCtor)&createFastRegisterAllocator)
     reportFatalUsageError(
         "Must use fast (default) register allocator for unoptimized regalloc.");
+#endif // EJIT_TRIM_LLVM_BACKEND
 
   addPass(createRegAllocPass(false));
 
@@ -1441,16 +1456,22 @@ bool TargetPassConfig::addRegAssignAndRewriteOptimized() {
   // Finally rewrite virtual registers.
   addPass(&VirtRegRewriterID);
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
   // Regalloc scoring for ML-driven eviction - noop except when learning a new
   // eviction policy.
   addPass(createRegAllocScoringPass());
+#endif // EJIT_TRIM_LLVM_BACKEND
   return true;
 }
 
 /// Return true if the default global register allocator is in use and
 /// has not be overriden on the command line with '-regalloc=...'
 bool TargetPassConfig::usingDefaultRegAlloc() const {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   return RegAlloc.getNumOccurrences() == 0;
+#else
+  return true;
+#endif
 }
 
 /// Add the minimum set of target-independent passes that are required for

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -635,7 +635,11 @@ bool AArch64Subtarget::supportsAddressTopByteIgnored() const {
 
 std::unique_ptr<PBQPRAConstraint>
 AArch64Subtarget::getCustomPBQPConstraints() const {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   return balanceFPOps() ? std::make_unique<A57ChainingConstraint>() : nullptr;
+#else
+  return nullptr;
+#endif
 }
 
 void AArch64Subtarget::mirFileLoaded(MachineFunction &MF) const {


### PR DESCRIPTION
Currently, we have a couple of register allocation objects being drawn into the static library archive:
```
wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ ar tv ejit_test/lipo/libejit_lipo_aarch64.a | grep RegAlloc
rw-r--r-- 0/0  71704 Jan  1 08:00 1970 libLLVMAArch64CodeGen__AArch64PBQPRegAlloc.cpp.o
rw-r--r-- 0/0  98424 Jan  1 08:00 1970 libLLVMCodeGen__MLRegAllocEvictAdvisor.cpp.o
rw-r--r-- 0/0  39952 Jan  1 08:00 1970 libLLVMCodeGen__MLRegAllocPriorityAdvisor.cpp.o
rw-r--r-- 0/0  32360 Jan  1 08:00 1970 libLLVMCodeGen__RegAllocBase.cpp.o
rw-r--r-- 0/0  58048 Jan  1 08:00 1970 libLLVMCodeGen__RegAllocEvictionAdvisor.cpp.o
rw-r--r-- 0/0 138928 Jan  1 08:00 1970 libLLVMCodeGen__RegAllocFast.cpp.o
rw-r--r-- 0/0 261440 Jan  1 08:00 1970 libLLVMCodeGen__RegAllocGreedy.cpp.o
rw-r--r-- 0/0 216576 Jan  1 08:00 1970 libLLVMCodeGen__RegAllocPBQP.cpp.o
rw-r--r-- 0/0  45512 Jan  1 08:00 1970 libLLVMCodeGen__RegAllocPriorityAdvisor.cpp.o
```

This guards RAFast, RABasic, PBQP, and ML advisor release mode paths under `EJIT_TRIM_LLVM_BACKEND` so gc-sections eliminates them from `ejit.o`. EJIT always compiles at O2, which selects RAGreedy; the other allocators are unreachable and only add binary size.

This properly guards these and the size of the final merged object file is reduced by ~500KB.