### PR TITLE
[EJIT] Add EJIT_FREESTANDING guards around EJitOrc IR dump

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
@@ -32,9 +32,11 @@ struct Config {
   /// static registry table (__ejit_registry_*[]).  For bare-metal where
   /// global constructors are unavailable, or for testing.
   bool forceStaticRegistry = false;
+#ifndef EJIT_FREESTANDING
   /// If non-empty, dump JIT-optimized LLVM IR (.ll) to this directory.
   /// One file per specialization, named <funcName>_<cacheKey>.ll.
   std::string dumpJITDir;
+#endif
 };
 
 } // namespace ejit

--- a/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
@@ -20,9 +20,11 @@ void EJitModuleLoader::registerBitcode(const std::string &funcName,
   uint32_t idx = hashFuncName(funcName);
   auto &entry = entriesByFuncIdx_[idx];
   if (entry.data && entry.funcName != funcName) {
+#ifndef EJIT_FREESTANDING
     errs() << "EJIT PANIC: funcIdx collision — '" << funcName
            << "' and '" << entry.funcName
            << "' both hash to " << idx << "\n";
+#endif
     report_fatal_error("EJIT: hash collision on funcIdx, rename functions");
   }
   entry = {funcName, data, size};

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -44,8 +44,10 @@ struct EJitOrcEngine::Impl {
   /// User-registered symbols (functions + globals) for bare-metal.
   /// Populated via ejit_register_symbol() / addUserSymbol().
   std::map<std::string, void *> userSymbols;
+#ifndef EJIT_FREESTANDING
   /// If non-empty, dump JIT-optimized IR to this directory.
   std::string dumpJITDir;
+#endif
   /// Persistent optimizer — analysis managers are registered once and reused.
   std::unique_ptr<EJitOptimizer> optimizer;
 };
@@ -60,7 +62,9 @@ EJitOrcEngine::Create(const Config &config,
   auto engine = std::unique_ptr<EJitOrcEngine>(new EJitOrcEngine());
   engine->P->periodReg = &periodReg;
   engine->P->runtimeState = &runtimeState;
+#ifndef EJIT_FREESTANDING
   engine->P->dumpJITDir = config.dumpJITDir;
+#endif
 
   // Bare-metal / cross-compiled: use compile-time target triple.
   // Native host: auto-detect via detectHost().
@@ -160,6 +164,7 @@ EJitOrcEngine::Create(const Config &config,
           // (each compilation uses a fresh Module with new IR unit pointers).
           engine->P->optimizer->clearAnalyses();
 
+#ifndef EJIT_FREESTANDING
           // Dump pre-optimization IR (before the JIT pipeline runs).
           if (!engine->P->dumpJITDir.empty()) {
             std::string prePath = engine->P->dumpJITDir + "/" +
@@ -170,9 +175,11 @@ EJitOrcEngine::Create(const Config &config,
             if (!EC)
               M.print(preOS, nullptr);
           }
+#endif
 
           engine->P->optimizer->runPipeline(M, *ctx);
 
+#ifndef EJIT_FREESTANDING
           // Dump post-optimization IR.
           if (!engine->P->dumpJITDir.empty()) {
             std::string path = engine->P->dumpJITDir + "/" +
@@ -183,6 +190,7 @@ EJitOrcEngine::Create(const Config &config,
             if (!EC)
               M.print(OS, nullptr);
           }
+#endif
         });
         return std::move(TSM);
       });

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -30,8 +30,10 @@ static void parseConfig(const ejit_config_t *src, Config &dst) {
     dst.maxCacheSize = src->maxCacheSize;
   dst.enableLogger = src->enableLogger;
   dst.forceStaticRegistry = src->forceStaticRegistry;
+#ifndef EJIT_FREESTANDING
   if (src->dumpJITDir && src->dumpJITDir[0])
     dst.dumpJITDir = src->dumpJITDir;
+#endif
 #ifdef EJIT_FREESTANDING
   dst.enableLogger = false;
 #endif


### PR DESCRIPTION
Guard the dumpJITDir file I/O paths with `EJIT_FREESTANDING`, as they use `raw_fd_ostream` which is unavailable in freestanding builds.