### PR TITLE
[EJIT] Trim remaining CodeView symbols in final merged object

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -4800,6 +4800,7 @@ std::tuple<const MCSymbol *, uint64_t, const MCSymbol *,
            codeview::JumpTableEntrySize>
 AsmPrinter::getCodeViewJumpTableInfo(int JTI, const MachineInstr *BranchInstr,
                                      const MCSymbol *BranchLabel) const {
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   const auto TLI = MF->getSubtarget().getTargetLowering();
   const auto BaseExpr =
       TLI->getPICJumpTableRelocBaseExpr(MF, JTI, MMI->getContext());
@@ -4809,6 +4810,9 @@ AsmPrinter::getCodeViewJumpTableInfo(int JTI, const MachineInstr *BranchInstr,
   // EK_LabelDifference32 is implemented as an Int32 from the base address.
   return std::make_tuple(Base, 0, BranchLabel,
                          codeview::JumpTableEntrySize::Int32);
+#else
+  return {};
+#endif
 }
 
 void AsmPrinter::emitCOFFReplaceableFunctionData(Module &M) {

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -1749,6 +1749,7 @@ MCSymbol *MCAsmStreamer::getDwarfLineTableSymbol(unsigned CUID) {
 bool MCAsmStreamer::emitCVFileDirective(unsigned FileNo, StringRef Filename,
                                         ArrayRef<uint8_t> Checksum,
                                         unsigned ChecksumKind) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   if (!getContext().getCVContext().addFile(*this, FileNo, Filename, Checksum,
                                            ChecksumKind))
     return false;
@@ -1767,6 +1768,9 @@ bool MCAsmStreamer::emitCVFileDirective(unsigned FileNo, StringRef Filename,
 
   EmitEOL();
   return true;
+#else
+  return false;
+#endif
 }
 
 bool MCAsmStreamer::emitCVFuncIdDirective(unsigned FuncId) {

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -1038,15 +1038,23 @@ bool MCAssembler::relaxDwarfCallFrameFragment(MCDwarfCallFrameFragment &DF) {
 }
 
 bool MCAssembler::relaxCVInlineLineTable(MCCVInlineLineTableFragment &F) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   unsigned OldSize = F.getContents().size();
   getContext().getCVContext().encodeInlineLineTable(*this, F);
   return OldSize != F.getContents().size();
+#else
+  return false;
+#endif
 }
 
 bool MCAssembler::relaxCVDefRange(MCCVDefRangeFragment &F) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   unsigned OldSize = F.getContents().size();
   getContext().getCVContext().encodeDefRange(*this, F);
   return OldSize != F.getContents().size();
+#else
+  return false;
+#endif
 }
 
 bool MCAssembler::relaxFill(MCFillFragment &F) {

--- a/llvm/lib/MC/MCCodeView.cpp
+++ b/llvm/lib/MC/MCCodeView.cpp
@@ -30,6 +30,7 @@ void CodeViewContext::finish() {
     StrTabFragment->setContents(StrTab);
 }
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 /// This is a valid number for use with .cv_loc if we've already seen a .cv_file
 /// for it.
 bool CodeViewContext::isValidFileNumber(unsigned FileNumber) const {
@@ -70,6 +71,11 @@ bool CodeViewContext::addFile(MCStreamer &OS, unsigned FileNumber,
 
   return true;
 }
+#else
+bool CodeViewContext::isValidFileNumber(unsigned) const { return false; }
+bool CodeViewContext::addFile(MCStreamer &, unsigned, StringRef,
+                              ArrayRef<uint8_t>, uint8_t) { return false; }
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 MCCVFunctionInfo *CodeViewContext::getCVFunctionInfo(unsigned FuncId) {
   if (FuncId >= Functions.size())
@@ -131,6 +137,7 @@ void CodeViewContext::recordCVLoc(MCContext &Ctx, const MCSymbol *Label,
       Label, FunctionId, FileNo, Line, Column, PrologueEnd, IsStmt});
 }
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 std::pair<StringRef, unsigned> CodeViewContext::addToStringTable(StringRef S) {
   auto Insertion =
       StringTable.insert(std::make_pair(S, unsigned(StrTab.size())));
@@ -143,6 +150,11 @@ std::pair<StringRef, unsigned> CodeViewContext::addToStringTable(StringRef S) {
   }
   return Ret;
 }
+#else
+std::pair<StringRef, unsigned> CodeViewContext::addToStringTable(StringRef) {
+  return {};
+}
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 unsigned CodeViewContext::getStringTableOffset(StringRef S) {
   // A string table offset of zero is always the empty string.

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -531,6 +531,7 @@ void MCObjectStreamer::emitCVLocDirective(unsigned FunctionId, unsigned FileNo,
                                           unsigned Line, unsigned Column,
                                           bool PrologueEnd, bool IsStmt,
                                           StringRef FileName, SMLoc Loc) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   // Validate the directive.
   if (!checkCVLocSection(FunctionId, FileNo, Loc))
     return;
@@ -541,44 +542,57 @@ void MCObjectStreamer::emitCVLocDirective(unsigned FunctionId, unsigned FileNo,
   getContext().getCVContext().recordCVLoc(getContext(), LineSym, FunctionId,
                                           FileNo, Line, Column, PrologueEnd,
                                           IsStmt);
+#endif
 }
 
 void MCObjectStreamer::emitCVLinetableDirective(unsigned FunctionId,
                                                 const MCSymbol *Begin,
                                                 const MCSymbol *End) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   getContext().getCVContext().emitLineTableForFunction(*this, FunctionId, Begin,
                                                        End);
   this->MCStreamer::emitCVLinetableDirective(FunctionId, Begin, End);
+#endif
 }
 
 void MCObjectStreamer::emitCVInlineLinetableDirective(
     unsigned PrimaryFunctionId, unsigned SourceFileId, unsigned SourceLineNum,
     const MCSymbol *FnStartSym, const MCSymbol *FnEndSym) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   getContext().getCVContext().emitInlineLineTableForFunction(
       *this, PrimaryFunctionId, SourceFileId, SourceLineNum, FnStartSym,
       FnEndSym);
   this->MCStreamer::emitCVInlineLinetableDirective(
       PrimaryFunctionId, SourceFileId, SourceLineNum, FnStartSym, FnEndSym);
+#endif
 }
 
 void MCObjectStreamer::emitCVDefRangeDirective(
     ArrayRef<std::pair<const MCSymbol *, const MCSymbol *>> Ranges,
     StringRef FixedSizePortion) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   getContext().getCVContext().emitDefRange(*this, Ranges, FixedSizePortion);
   // Attach labels that were pending before we created the defrange fragment to
   // the beginning of the new fragment.
   this->MCStreamer::emitCVDefRangeDirective(Ranges, FixedSizePortion);
+#endif
 }
 
 void MCObjectStreamer::emitCVStringTableDirective() {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   getContext().getCVContext().emitStringTable(*this);
+#endif
 }
 void MCObjectStreamer::emitCVFileChecksumsDirective() {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   getContext().getCVContext().emitFileChecksums(*this);
+#endif
 }
 
 void MCObjectStreamer::emitCVFileChecksumOffsetDirective(unsigned FileNo) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   getContext().getCVContext().emitFileChecksumOffset(*this, FileNo);
+#endif
 }
 
 void MCObjectStreamer::emitBytes(StringRef Data) {

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -276,18 +276,27 @@ MCDwarfFrameInfo *MCStreamer::getCurrentDwarfFrameInfo() {
 bool MCStreamer::emitCVFileDirective(unsigned FileNo, StringRef Filename,
                                      ArrayRef<uint8_t> Checksum,
                                      unsigned ChecksumKind) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   return getContext().getCVContext().addFile(*this, FileNo, Filename, Checksum,
                                              ChecksumKind);
+#else
+  return false;
+#endif
 }
 
 bool MCStreamer::emitCVFuncIdDirective(unsigned FunctionId) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   return getContext().getCVContext().recordFunctionId(FunctionId);
+#else
+  return false;
+#endif
 }
 
 bool MCStreamer::emitCVInlineSiteIdDirective(unsigned FunctionId,
                                              unsigned IAFunc, unsigned IAFile,
                                              unsigned IALine, unsigned IACol,
                                              SMLoc Loc) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   if (getContext().getCVContext().getCVFunctionInfo(IAFunc) == nullptr) {
     getContext().reportError(Loc, "parent function id not introduced by "
                                   ".cv_func_id or .cv_inline_site_id");
@@ -296,6 +305,9 @@ bool MCStreamer::emitCVInlineSiteIdDirective(unsigned FunctionId,
 
   return getContext().getCVContext().recordInlinedCallSiteId(
       FunctionId, IAFunc, IAFile, IALine, IACol);
+#else
+  return false;
+#endif
 }
 
 void MCStreamer::emitCVLocDirective(unsigned FunctionId, unsigned FileNo,
@@ -305,6 +317,7 @@ void MCStreamer::emitCVLocDirective(unsigned FunctionId, unsigned FileNo,
 
 bool MCStreamer::checkCVLocSection(unsigned FuncId, unsigned FileNo,
                                    SMLoc Loc) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   CodeViewContext &CVC = getContext().getCVContext();
   MCCVFunctionInfo *FI = CVC.getCVFunctionInfo(FuncId);
   if (!FI) {
@@ -323,6 +336,9 @@ bool MCStreamer::checkCVLocSection(unsigned FuncId, unsigned FileNo,
     return false;
   }
   return true;
+#else
+  return false;
+#endif
 }
 
 void MCStreamer::emitCVLinetableDirective(unsigned FunctionId,

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -1329,6 +1329,7 @@ std::tuple<const MCSymbol *, uint64_t, const MCSymbol *,
 AArch64AsmPrinter::getCodeViewJumpTableInfo(int JTI,
                                             const MachineInstr *BranchInstr,
                                             const MCSymbol *BranchLabel) const {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   const auto AFI = MF->getInfo<AArch64FunctionInfo>();
   const auto Base = AArch64FI->getJumpTableEntryPCRelSymbol(JTI);
   codeview::JumpTableEntrySize EntrySize;
@@ -1346,6 +1347,9 @@ AArch64AsmPrinter::getCodeViewJumpTableInfo(int JTI,
     llvm_unreachable("Unexpected jump table entry size");
   }
   return std::make_tuple(Base, 0, BranchLabel, EntrySize);
+#else
+  return {};
+#endif
 }
 
 void AArch64AsmPrinter::emitFunctionEntryLabel() {


### PR DESCRIPTION
Currently, we still have some `CodeView` symbols in the merged object file, see:
```
wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ nm ejit_test/lipo/ejit.o | grep CodeView
nm: ejit_test/lipo/ejit.o: no group info for section '.text'
nm: ejit_test/lipo/ejit.o: no group info for section '.rodata'
nm: ejit_test/lipo/ejit.o: no group info for section '.data'
nm: ejit_test/lipo/ejit.o: no group info for section '.bss'
nm: ejit_test/lipo/ejit.o: no group info for section '.init_array'
000000000083867c T _ZN4llvm15CodeViewContext11recordCVLocERNS_9MCContextEPKNS_8MCSymbolEjjjjbb
00000000008386c4 T _ZN4llvm15CodeViewContext12addLineEntryERKNS_7MCCVLocE
0000000000839460 T _ZN4llvm15CodeViewContext12emitDefRangeERNS_16MCObjectStreamerENS_8ArrayRefISt4pairIPKNS_8MCSymbolES7_EEENS_9StringRefE
0000000000838e70 T _ZN4llvm15CodeViewContext13getLineExtentEj
0000000000839aa0 T _ZN4llvm15CodeViewContext14encodeDefRangeERKNS_11MCAssemblerERNS_20MCCVDefRangeFragmentE
000000000083876c T _ZN4llvm15CodeViewContext15emitStringTableERNS_16MCObjectStreamerE
0000000000838354 T _ZN4llvm15CodeViewContext16addToStringTableENS_9StringRefE
0000000000838440 T _ZN4llvm15CodeViewContext16recordFunctionIdEj
00000000008388dc T _ZN4llvm15CodeViewContext17emitFileChecksumsERNS_16MCObjectStreamerE
00000000008383fc T _ZN4llvm15CodeViewContext17getCVFunctionInfoEj
0000000000839604 T _ZN4llvm15CodeViewContext21encodeInlineLineTableERKNS_11MCAssemblerERNS_27MCCVInlineLineTableFragmentE
0000000000838b28 T _ZN4llvm15CodeViewContext22emitFileChecksumOffsetERNS_16MCObjectStreamerEj
0000000000838bc8 T _ZN4llvm15CodeViewContext22getFunctionLineEntriesEj
00000000008384ec T _ZN4llvm15CodeViewContext23recordInlinedCallSiteIdEjjjjj
0000000000838ec8 T _ZN4llvm15CodeViewContext24emitLineTableForFunctionERNS_16MCObjectStreamerEjPKNS_8MCSymbolES5_
00000000008393b0 T _ZN4llvm15CodeViewContext30emitInlineLineTableForFunctionERNS_16MCObjectStreamerEjjjPKNS_8MCSymbolES5_
0000000000838d74 T _ZN4llvm15CodeViewContext30getLineExtentIncludingInlineesEj
0000000000838240 T _ZN4llvm15CodeViewContext7addFileERNS_10MCStreamerEjNS_9StringRefENS_8ArrayRefIhEEh
0000000000840444 W _ZN4llvm15CodeViewContextC2EPNS_9MCContextE
0000000000aa878c W _ZN4llvm15MachineFunction21addCodeViewAnnotationEPNS_8MCSymbolEPNS_6MDNodeE
0000000000839e3c W _ZN4llvm15SmallVectorImplINS_15CodeViewContext8FileInfoEE10resizeImplILb0EEEvm
0000000000031228 t _ZNK12_GLOBAL__N_117AArch64AsmPrinter24getCodeViewJumpTableInfoEiPKN4llvm12MachineInstrEPKNS1_8MCSymbolE
00000000002e6684 T _ZNK4llvm10AsmPrinter24getCodeViewJumpTableInfoEiPKNS_12MachineInstrEPKNS_8MCSymbolE
0000000000838210 T _ZNK4llvm15CodeViewContext17isValidFileNumberEj
0000000000840ddc W _ZNKSt14default_deleteIN4llvm15CodeViewContextEEclEPS1_
```

After this patch, this is reduced to those absolutely necessary for the stable build.