### PR TITLE
[EJIT] Trim non-ELF writers, x86 upgrade path, and debug/pipeliner passes under EJIT_TRIM_LLVM_BACKEND

### DIFF
--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -58,7 +58,9 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeInterleavedLoadCombinePass(Registry);
   initializeInterleavedAccessPass(Registry);
   initializeJMCInstrumenterPass(Registry);
+#ifndef EJIT_TRIM_LLVM_BACKEND
   initializeLiveDebugValuesLegacyPass(Registry);
+#endif
   initializeLiveDebugVariablesWrapperLegacyPass(Registry);
   initializeLiveIntervalsWrapperPassPass(Registry);
   initializeLiveRangeShrinkPass(Registry);
@@ -89,7 +91,9 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeMachineModuleInfoWrapperPassPass(Registry);
   initializeMachineOptimizationRemarkEmitterPassPass(Registry);
   initializeMachineOutlinerPass(Registry);
+#ifndef EJIT_TRIM_LLVM_BACKEND
   initializeMachinePipelinerPass(Registry);
+#endif
   initializeMachineSanitizerBinaryMetadataLegacyPass(Registry);
   initializeModuloScheduleTestPass(Registry);
   initializeMachinePostDominatorTreeWrapperPassPass(Registry);
@@ -98,7 +102,9 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeMachineSinkingLegacyPass(Registry);
   initializeMachineUniformityAnalysisPassPass(Registry);
   initializeMachineUniformityInfoPrinterPassPass(Registry);
+#ifndef EJIT_TRIM_LLVM_BACKEND
   initializeMachineVerifierLegacyPassPass(Registry);
+#endif
   initializeObjCARCContractLegacyPassPass(Registry);
   initializeOptimizePHIsLegacyPass(Registry);
   initializePEILegacyPass(Registry);

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -493,8 +493,9 @@ static bool shouldUpgradeX86Intrinsic(Function *F, StringRef Name) {
           Name.starts_with("vcvtph2ps.")); // Added in 11.0
 }
 
-static bool upgradeX86IntrinsicFunction(Function *F, StringRef Name,
-                                        Function *&NewFn) {
+[[maybe_unused]] static bool upgradeX86IntrinsicFunction(Function *F,
+                                                        StringRef Name,
+                                                        Function *&NewFn) {
   // Only handle intrinsics that start with "x86.".
   if (!Name.consume_front("x86."))
     return false;
@@ -1581,8 +1582,10 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
     break;
 
   case 'x':
+#ifndef EJIT_TRIM_LLVM_BACKEND
     if (upgradeX86IntrinsicFunction(F, Name, NewFn))
       return true;
+#endif
   }
 
   auto *ST = dyn_cast<StructType>(F->getReturnType());
@@ -2572,8 +2575,9 @@ static Value *upgradeNVVMIntrinsicCall(StringRef Name, CallBase *CI,
   return Rep;
 }
 
-static Value *upgradeX86IntrinsicCall(StringRef Name, CallBase *CI, Function *F,
-                                      IRBuilder<> &Builder) {
+[[maybe_unused]] static Value *upgradeX86IntrinsicCall(StringRef Name,
+                                                       CallBase *CI, Function *F,
+                                                       IRBuilder<> &Builder) {
   LLVMContext &C = F->getContext();
   Value *Rep = nullptr;
 
@@ -4550,7 +4554,9 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     } else if (IsNVVM) {
       Rep = upgradeNVVMIntrinsicCall(Name, CI, F, Builder);
     } else if (IsX86) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
       Rep = upgradeX86IntrinsicCall(Name, CI, F, Builder);
+#endif
     } else if (IsAArch64) {
       Rep = upgradeAArch64IntrinsicCall(Name, CI, F, Builder);
     } else if (IsARM) {

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -32,7 +32,7 @@ MCAsmBackend::createObjectWriter(raw_pwrite_stream &OS) const {
   auto TW = createObjectTargetWriter();
   bool IsLE = Endian == llvm::endianness::little;
   switch (TW->getFormat()) {
-#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#ifndef EJIT_TRIM_LLVM_BACKEND
   case Triple::MachO:
     return std::make_unique<MachObjectWriter>(
         cast<MCMachObjectTargetWriter>(std::move(TW)), OS, IsLE);
@@ -43,7 +43,7 @@ MCAsmBackend::createObjectWriter(raw_pwrite_stream &OS) const {
   case Triple::ELF:
     return std::make_unique<ELFObjectWriter>(
         cast<MCELFObjectTargetWriter>(std::move(TW)), OS, IsLE);
-#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#ifndef EJIT_TRIM_LLVM_BACKEND
   case Triple::SPIRV:
     return createSPIRVObjectWriter(
         cast<MCSPIRVObjectTargetWriter>(std::move(TW)), OS);
@@ -70,7 +70,7 @@ MCAsmBackend::createDwoObjectWriter(raw_pwrite_stream &OS,
                                     raw_pwrite_stream &DwoOS) const {
   auto TW = createObjectTargetWriter();
   switch (TW->getFormat()) {
-#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#ifndef EJIT_TRIM_LLVM_BACKEND
   case Triple::COFF:
     return createWinCOFFDwoObjectWriter(
         cast<MCWinCOFFObjectTargetWriter>(std::move(TW)), OS, DwoOS);
@@ -79,7 +79,7 @@ MCAsmBackend::createDwoObjectWriter(raw_pwrite_stream &OS,
     return std::make_unique<ELFObjectWriter>(
         cast<MCELFObjectTargetWriter>(std::move(TW)), OS, DwoOS,
         Endian == llvm::endianness::little);
-#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
+#ifndef EJIT_TRIM_LLVM_BACKEND
   case Triple::Wasm:
     return createWasmDwoObjectWriter(
         cast<MCWasmObjectTargetWriter>(std::move(TW)), OS, DwoOS);

--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -1070,15 +1070,18 @@ void MCObjectFileInfo::initMCObjectFileInfo(MCContext &MCCtx, bool PIC,
 
   const Triple &TheTriple = Ctx->getTargetTriple();
   switch (Ctx->getObjectFileType()) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   case MCContext::IsMachO:
     initMachOMCObjectFileInfo(TheTriple);
     break;
   case MCContext::IsCOFF:
     initCOFFMCObjectFileInfo(TheTriple);
     break;
+#endif
   case MCContext::IsELF:
     initELFMCObjectFileInfo(TheTriple, LargeCodeModel);
     break;
+#ifndef EJIT_TRIM_LLVM_BACKEND
   case MCContext::IsGOFF:
     initGOFFMCObjectFileInfo(TheTriple);
     break;
@@ -1094,6 +1097,9 @@ void MCObjectFileInfo::initMCObjectFileInfo(MCContext &MCCtx, bool PIC,
   case MCContext::IsDXContainer:
     initDXContainerObjectFileInfo(TheTriple);
     break;
+#endif
+  default:
+    break;
   }
 }
 
@@ -1103,9 +1109,11 @@ MCSection *MCObjectFileInfo::getDwarfComdatSection(const char *Name,
   case Triple::ELF:
     return Ctx->getELFSection(Name, ELF::SHT_PROGBITS, ELF::SHF_GROUP, 0,
                               utostr(Hash), /*IsComdat=*/true);
+#ifndef EJIT_TRIM_LLVM_BACKEND
   case Triple::Wasm:
     return Ctx->getWasmSection(Name, SectionKind::getMetadata(), 0,
                                utostr(Hash), MCSection::NonUniqueID);
+#endif
   case Triple::MachO:
   case Triple::COFF:
   case Triple::GOFF:


### PR DESCRIPTION
Basically the title. This guards the non-ELF object writer dispatch in `MCAsmBackend` and `MCObjectFileInfo` since EJIT only targets ELF/AArch64, so this eliminates `WasmObjectWriter`, `MachObjectWriter`, `WinCOFFObjectWriter`, etc. 

Also trims the x86 intrinsic upgrade path in `AutoUpgrade.cpp` since EJIT only processes AArch64 bitcode. 

Finally, removes the pass registry entries for `LiveDebugValues`, `MachinePipeliner`, and `MachineVerifier` in `CodeGen.cpp`, none are needed in the EJIT pipeline, and skipping their registration prevents the vtable chains from keeping ~165 KB of pass code alive.

Trims the size of the merged object file by around ~507 KB.

Extraction after this patch:
```
wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ bash ejit_test/lipo/run_aarch64_pipeline.sh
[1/4] Building symbol index ...
       92587 symbols indexed
[2/4] Generating linker map ...
[3/4] Extracting .o files + tracing dependencies ...
       iteration 1: +255 .o
       iteration 2: +106 .o
       iteration 3: +71 .o
       iteration 4: +23 .o
       iteration 5: +8 .o
[4/4] Building /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64.a ...
       890 .o files, 88 MB
       (from 36 .a = 117 MB)
       output: /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64.a
[1/3] Extracting .o from input .a ...
       890 .o files, 79 MB
[2/3] Running ld -r --gc-sections ...
       79 MB -> 51 MB (gc-sections)
       note: GNU objcopy cannot handle this ELF (>65280sections from ld -r).  Build llvm-objcopy to enable $x/$d stripping.  The $x/$d symbols are harmless ARM mapping metadata.
[3/3] Building /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64_gc.a ...
       51 MB
       output: /home/wilson/ejit/llvm-project/ejit_test/lipo/libejit_lipo_aarch64_gc.a
[merge] ld -r -T merge.ld -> ejit_test/lipo/ejit.o ...
       31 MB
       output: ejit_test/lipo/ejit.o

Done: 31M ejit_test/lipo/ejit.o
ejit_test/lipo/ejit.o  :
section           size   addr
.text         11986344      0
.rodata        4106380      0
.data           363136      0
.bss            284576      0
.init_array       1872      0
.tbss              152      0
Total         16742460
```

From 32MB -> 31MB.
