### PR TITLE
[EJIT][Taskpool] Support per-core 4K shared code sealing

### DIFF
--- a/ejit_test/ejit_lifecycle_test.c
+++ b/ejit_test/ejit_lifecycle_test.c
@@ -10,7 +10,9 @@
  * 核心验证: ejit_activate vs ejit_activate_array 的区别
  *   同一 period name ("cell") 关联多个数组时:
  *   - ejit_activate("cell", 0)   → 激活 cellCfg[0] AND cellPhy[0]
- *   - ejit_activate_array("cell", &cellCfg, 0) → 仅激活 cellCfg[0]
+ *   - legacy runtime: ejit_activate_array("cell", &cellCfg, 0) → 仅激活 cellCfg[0]
+ *   - taskpool runtime: multi-array activate_array is clean-rejected because
+ *     the shared switch table is keyed by period/lifecycle + index only.
  */
 
 #include <stdint.h>
@@ -30,9 +32,15 @@ struct CellPhy {
   uint32_t rssi;
 };
 
+struct SingleCfg {
+  __attribute__((ejit_may_const)) uint32_t value;
+  uint32_t padding;
+};
+
 #define N 8
 __attribute__((ejit_period_arr("cell"))) struct CellCfg g_cellCfg[N];
 __attribute__((ejit_period_arr("cell"))) struct CellPhy g_cellPhy[N];
+__attribute__((ejit_period_arr("single"))) struct SingleCfg g_singleCfg[N];
 
 __attribute__((ejit_period("static"))) uint32_t g_sysVer;
 
@@ -43,6 +51,13 @@ uint32_t read_both(
     __attribute__((ejit_period_arr_ind("cell"))) uint8_t ci)
 {
   return g_cellCfg[ci].cellType + g_cellPhy[ci].phyCellId;
+}
+
+__attribute__((ejit_entry))
+uint32_t read_single(
+    __attribute__((ejit_period_arr_ind("single"))) uint8_t ci)
+{
+  return g_singleCfg[ci].value;
 }
 
 //===-- 运行时 API (完整声明) -----------------------------------------------===//
@@ -81,6 +96,7 @@ int main(int argc, char **argv) {
   T(!ejit_is_active("cell", ci),  "cell[%u] NOT active before activate", ci);
   T(!ejit_is_active("cell", ci2), "cell[%u] NOT active before activate", ci2);
   T(!ejit_is_active("trp",  ci),  "unknown period returns false");
+  T(!ejit_is_active("single", ci), "single[%u] NOT active before activate", ci);
 
   //===-- 2. ejit_activate: 激活所有共享 period name 的数组 -----------------===//
   printf("\n--- 2. activate(ci=%u) (激活所有同名数组) ---\n", ci);
@@ -103,36 +119,64 @@ int main(int argc, char **argv) {
 
   // 4a. 仅激活 cellCfg[ci]
   rc = ejit_activate_array("cell", g_cellCfg, ci);
-  T(rc == 0, "activate_array(cell, &cellCfg, %u) returns %d", ci, rc);
-  // isActive 是 period 级语义：只要该 period 下有任一数组在 ci 活跃即返回 true
-  T(ejit_is_active("cell", ci), "cell[%u] IS active (cellCfg activated)", ci);
+  bool multi_array_granularity = (rc == 0);
+  if (multi_array_granularity) {
+    T(rc == 0, "activate_array(cell, &cellCfg, %u) returns %d", ci, rc);
+    // isActive 是 period 级语义：只要该 period 下有任一数组在 ci 活跃即返回 true
+    T(ejit_is_active("cell", ci), "cell[%u] IS active (cellCfg activated)", ci);
 
-  // 4b. 仅激活 cellCfg 不会激活 cellPhy
-  //     验证：deactivate 仅 cellCfg → cellPhy 从未被激活 → isActive 应为 false
-  rc = ejit_deactivate_array("cell", g_cellCfg, ci);
-  T(rc == 0, "deactivate_array(cell, &cellCfg, %u) returns %d", ci, rc);
-  T(!ejit_is_active("cell", ci),
-    "cell[%u] NOT active — only cellCfg was deactivated, cellPhy never activated", ci);
+    // 4b. 仅激活 cellCfg 不会激活 cellPhy
+    //     验证：deactivate 仅 cellCfg → cellPhy 从未被激活 → isActive 应为 false
+    rc = ejit_deactivate_array("cell", g_cellCfg, ci);
+    T(rc == 0, "deactivate_array(cell, &cellCfg, %u) returns %d", ci, rc);
+    T(!ejit_is_active("cell", ci),
+      "cell[%u] NOT active — only cellCfg was deactivated, cellPhy never activated", ci);
 
-  // 4c. 分别激活两个数组 → deactivate 其中一个 → 另一个仍活跃
-  rc = ejit_activate_array("cell", g_cellCfg, ci);
-  T(rc == 0, "activate_array(cell, &cellCfg, %u)", ci);
-  rc = ejit_activate_array("cell", g_cellPhy, ci);
-  T(rc == 0, "activate_array(cell, &cellPhy, %u)", ci);
-  T(ejit_is_active("cell", ci), "cell[%u] active (both arrays activated)", ci);
+    // 4c. 分别激活两个数组 → deactivate 其中一个 → 另一个仍活跃
+    rc = ejit_activate_array("cell", g_cellCfg, ci);
+    T(rc == 0, "activate_array(cell, &cellCfg, %u)", ci);
+    rc = ejit_activate_array("cell", g_cellPhy, ci);
+    T(rc == 0, "activate_array(cell, &cellPhy, %u)", ci);
+    T(ejit_is_active("cell", ci), "cell[%u] active (both arrays activated)", ci);
 
-  // 仅失效 cellCfg
-  rc = ejit_deactivate_array("cell", g_cellCfg, ci);
-  T(rc == 0, "deactivate_array(cell, &cellCfg, %u)", ci);
-  // cellPhy 仍在活跃，isActive 应仍为 true
-  T(ejit_is_active("cell", ci),
-    "cell[%u] still active — only cellCfg deactivated, cellPhy still active", ci);
+    // 仅失效 cellCfg
+    rc = ejit_deactivate_array("cell", g_cellCfg, ci);
+    T(rc == 0, "deactivate_array(cell, &cellCfg, %u)", ci);
+    // cellPhy 仍在活跃，isActive 应仍为 true
+    T(ejit_is_active("cell", ci),
+      "cell[%u] still active — only cellCfg deactivated, cellPhy still active", ci);
 
-  // 再失效 cellPhy
-  rc = ejit_deactivate_array("cell", g_cellPhy, ci);
-  T(rc == 0, "deactivate_array(cell, &cellPhy, %u)", ci);
-  T(!ejit_is_active("cell", ci),
-    "cell[%u] NOT active — both arrays now deactivated", ci);
+    // 再失效 cellPhy
+    rc = ejit_deactivate_array("cell", g_cellPhy, ci);
+    T(rc == 0, "deactivate_array(cell, &cellPhy, %u)", ci);
+    T(!ejit_is_active("cell", ci),
+      "cell[%u] NOT active — both arrays now deactivated", ci);
+  } else {
+    T(rc != 0,
+      "activate_array(cell, &cellCfg, %u) clean-rejected for multi-array period: %d",
+      ci, rc);
+    T(!ejit_is_active("cell", ci),
+      "cell[%u] unchanged after rejected multi-array activate_array", ci);
+    rc = ejit_deactivate_array("cell", g_cellCfg, ci);
+    T(rc != 0,
+      "deactivate_array(cell, &cellCfg, %u) clean-rejected for multi-array period: %d",
+      ci, rc);
+    T(!ejit_is_active("cell", ci),
+      "cell[%u] unchanged after rejected multi-array deactivate_array", ci);
+  }
+
+  // 4d. 单数组 period: legacy/taskpool 都应支持 array-level API.
+  printf("\n--- 4d. activate_array (single-array period) ---\n");
+  ejit_deactivate_all("single");
+  rc = ejit_activate_array("single", g_singleCfg, ci);
+  T(rc == 0, "activate_array(single, &singleCfg, %u) returns %d", ci, rc);
+  T(ejit_is_active("single", ci), "single[%u] IS active after activate_array", ci);
+  g_singleCfg[ci].value = 1234;
+  uint32_t sr = read_single(ci);
+  T(sr == 1234, "read_single(%u) = %u (expected 1234)", ci, sr);
+  rc = ejit_deactivate_array("single", g_singleCfg, ci);
+  T(rc == 0, "deactivate_array(single, &singleCfg, %u) returns %d", ci, rc);
+  T(!ejit_is_active("single", ci), "single[%u] NOT active after deactivate_array", ci);
 
   //===-- 5. ejit_activate vs ejit_activate_array: 粒度差异 ------------------===//
   printf("\n--- 5. period vs array granularity ---\n");
@@ -146,12 +190,22 @@ int main(int argc, char **argv) {
   ejit_deactivate("cell", ci);
   T(!ejit_is_active("cell", ci), "cell[%u] NOT active (period-level deactivate)", ci);
 
-  // 5b. 对比: activate_array + 另一个数组未激活 → deactivate_array 后不应残留
-  ejit_activate_array("cell", g_cellCfg, ci);
-  // cellPhy[ci] 未被激活
-  ejit_deactivate_array("cell", g_cellCfg, ci);
-  T(!ejit_is_active("cell", ci),
-    "cell[%u] NOT active — only cellCfg was array-activated, then deactivated", ci);
+  // 5b. 对比: legacy 支持 multi-array per-array 粒度；taskpool 会 clean reject.
+  rc = ejit_activate_array("cell", g_cellCfg, ci);
+  if (multi_array_granularity) {
+    T(rc == 0, "activate_array(cell, &cellCfg, %u) returns %d", ci, rc);
+    // cellPhy[ci] 未被激活
+    rc = ejit_deactivate_array("cell", g_cellCfg, ci);
+    T(rc == 0, "deactivate_array(cell, &cellCfg, %u) returns %d", ci, rc);
+    T(!ejit_is_active("cell", ci),
+      "cell[%u] NOT active — only cellCfg was array-activated, then deactivated", ci);
+  } else {
+    T(rc != 0,
+      "activate_array(cell, &cellCfg, %u) remains rejected for multi-array period: %d",
+      ci, rc);
+    T(!ejit_is_active("cell", ci),
+      "cell[%u] still NOT active after rejected multi-array activate_array", ci);
+  }
 
   //===-- 6. ejit_activate_all / ejit_deactivate_all: 批量操作 --------------===//
   printf("\n--- 6. activate_all / deactivate_all ---\n");

--- a/jit_design_doc/EJIT_SRE_TASKPOOL.md
+++ b/jit_design_doc/EJIT_SRE_TASKPOOL.md
@@ -1347,8 +1347,8 @@ Vyukov MPSC，单消费者=唯一 owner worker（§1.3 SC 前提不变）：
 - cache：固定槽 POD 表替代 `unordered_map`（共享内存不能放 STL）。
   - publish（仅 owner worker）：桶写锁 spin 到 `readers==0` → **锁内重校验逐实例 version**（commit gate，失配 `VersionMismatch` 不写）→ 同 identity 原地覆盖 / 空槽 / 桶满淘汰 → `storeRelease(state=Ready)` → **锁外**通过 owner 私有 release 回调释放旧/被淘汰 fnPtr（回调可能重入 code pool/ORC/分配器，绝不在临界区内运行）。
   - lookup：桶 `tryRead` → 扫 `Ready` 且 `generation`/identity/version 匹配 → 命中持读 token（调用方用完 `release_read`）。
-- **fnPtr 跨核可共享前提（构建开关 `EJIT_SRE_SHARED_CODE_POINTERS`，默认 OFF）：** 仅当平台保证①同一地址空间、②code pool 在所有核映射到**相同 VA**、③code pool 生命周期覆盖所有读者、④I/D-cache 跨核执行一致时才显式置 ON（`EJitCompileDriver` 据此调 `setCodeSharingEnabled`，**绝不自动猜测平台能力**）。即使地址相同，`enable_ex` 修改的执行权限也可能只属于调用核的 stage-1 映射，因此非 owner 核命中共享 fnPtr 后，必须先通过 `PrepareCodeCallback` 在**当前核**安装执行权限；成功后在 cache slot 的 64-bit `executableCoreMask` 中记录该核，后续同核命中不重复调用。准备失败时返回 `readyButNotShareable`（fallback，**不重新入队**），绝不返回不可执行指针。当前平台适配完整支持 legacy 2MiB seal：按 2MiB 对齐 fnPtr 后调用 `enable_ex(1, poolBase)`；4K seal 模式因裸 fnPtr 不携带完整代码范围而 clean reject，后续需要在 cache slot 增加代码范围后才能安全共享。owner 核读自己的 fnPtr 不重复准备。`codeSharingEnabled` 和 `executePrepareFailed` 在诊断中输出。
-- 大端/内存序：仅固定宽度标量按值访问，无 bitfield、无字节解析；所有发布/消费成对 acquire/release（§10.2）。共享状态 ABI version 因 request/dedup 变化升到 **v2**。
+- **fnPtr 跨核可共享前提（构建开关 `EJIT_SRE_SHARED_CODE_POINTERS`，默认 OFF）：** 仅当平台保证①同一地址空间、②code pool 在所有核映射到**相同 VA**、③code pool 生命周期覆盖所有读者、④I/D-cache 跨核执行一致时才显式置 ON（`EJitCompileDriver` 据此调 `setCodeSharingEnabled`，**绝不自动猜测平台能力**）。即使地址相同，`enable_ex` 修改的执行权限也可能只属于调用核的 stage-1 映射，因此非 owner 核命中共享 fnPtr 后，必须先在**当前核**安装执行权限；成功后在 cache slot 的 64-bit `executableCoreMask` 中记录该核（core id ≥ 64 无法 memo，每次命中重做），后续同核命中不重复调用。准备失败时返回 `readyButNotShareable`（fallback，**不重新入队**），绝不返回不可执行指针。两种 seal 模式均已实现：legacy **2MiB whole-pool seal** 按 2MiB 对齐 fnPtr 后调 `enable_ex(1, poolBase)`（`PrepareCodeCallback`，§6 行为不变）；**4K page seal** 复用 cache slot 携带的真实代码范围（v5），每核对 2MiB pool 先 `split_2m_to_4k` 一次、再对代码覆盖的每个 4K 页 `enable_ex`（详见 §11.11）。owner 核读自己的 fnPtr 不重复准备。`codeSharingEnabled` 和 `executePrepareFailed` 在诊断中输出。
+- 大端/内存序：仅固定宽度标量按值访问，无 bitfield、无字节解析；所有发布/消费成对 acquire/release（§10.2）。共享状态 ABI version 历经 v2（request/dedup）→ v3（registration fingerprint）→ v4（`executableCoreMask`）→ **v5（cache slot 携带可执行代码范围 + 每核每 pool 4K split 就绪表，§11.11）**。
 
 ### 11.7 worker 启动时序、栈与任务生命周期
 
@@ -1385,3 +1385,34 @@ host `EJITSharedTaskPoolTests`（单进程、注入式核 ID 确定性模拟多�
 **本轮明确记录的平台前提：** ① 各核必须看到**同一共享 section、同 VA 或正确共享映射**（否则 fnPtr/原子地址语义不成立）；② `SRE_TaskDelete` 必须是**真 join**（软停+等退），否则靠 generation-aware dedup 兜底但仍可能 worker 回调触碰已销毁 driver；③ `EJIT_SRE_SHARED_CODE_POINTERS=ON` 需同 VA + seal 完成 + I/D cache 一致。
 
 **尚需真实平台（aarch64_be 多核）验证：** ① 真实 `ejit_sre_current_core_id` 与跨核 owner election；② 共享 section 同 VA 映射 + cache coherent；③ `EJIT_SRE_SHARED_CODE_POINTERS=ON` 下跨核执行同一 fnPtr 的 I/D-cache 一致性与 seal 时序；④ host 单进程多 `EJit` 实例共享一份全局状态时，owner 用自身 ORC 为所有 producer 编译——真实平台为单一共享注册镜像，此语义才成立；⑤ 平台 `SRE_TaskCreate` 栈尺寸与 worker 长编译任务的匹配（实测栈峰值）；⑥ 平台 `SRE_TaskDelete` 必须是真 join。
+
+### 11.11 4K 页粒度跨核执行权限准备（per-core 4K shared code sealing）
+
+**为什么同 VA ≠ 同执行权限。** 共享 section 让所有核看到同一份 cache slot 与同一 `fnPtr` 数值；但 `enable_ex` 翻转的是**调用核自己 stage-1 页表**里那一页的执行权限。owner 在编译完成时 seal 了代码，只代表 **owner 核**那份映射可执行；非 owner 核若用各自的 stage-1 翻译上下文，命中同一 VA 仍可能是 NX。因此“能读到 fnPtr”与“本核能执行该地址”是两件事，后者必须**逐核**准备。
+
+**2MiB 物理大页 vs 4KiB 页表拆分。** 真实平台的代码 pool 是 2MiB 对齐的大页；`enable_ex(1, va)` 以 **4KiB 页**为单位翻权限，但前提是该 2MiB 区域已先被 `split_2m_to_4k(base, size)` 拆成 4K 映射。`split` 同样**只影响调用核**的 stage-1 页表。所以一个核要在某 pool 内 seal 任何 4K 页，必须先在本核对该 pool 调一次 `split`。
+
+**两种 peer prepare 流程（§6 的 2M 不变）。**
+- **2M whole-pool**（`EJIT_CODE_POOL_4K_SEAL=OFF`）：非 owner 命中 → 把 fnPtr 向下对齐到 2MiB pool base → `enable_ex(1, poolBase)` 一次 → 置 `executableCoreMask` 本核位。裸 fnPtr 即可，无需范围。
+- **4K page**（`EJIT_CODE_POOL_4K_SEAL=ON`）：非 owner 命中 → 从 slot 读真实范围 → 先 `ensurePoolSplitForCurrentCore`（本核对该 pool 只 split 一次）→ 对 `[alignDown(codeStart,4K), alignUp(codeStart+codeSize,4K))` 每个 4K 页 `enable_ex` → 全部成功才置 `executableCoreMask` 本核位。
+
+为遵守“平台调用期间不持跨核 bucket lock”，命中路径为**快照 → 释放读锁 → 准备（split/enable_ex）→ 重新取读锁并重校验 slot（state=Ready、generation、identity、fnPtr、version 全部不变）→ 命中**；准备期间 slot 被改写/换代则 clean fallback，绝不返回陈旧指针。owner 核命中自身代码直接返回（已 seal）。
+
+**slot 范围元数据来源（绝不估算，且只记可执行段）。** `EJitCompiledCodeInfo{fnPtr,codeStart,codeSize,poolBase,poolSize,poolId}`。owner 侧：`EJitCodePoolMemoryManager` 在布局 slab 时遍历 JITLink `BasicLayout` 的各 segment，仅对**权限含 `MemProt::Exec` 的段**（一次 allocation 可有多个、互不相邻的可执行段）记录其 `[Addr, Addr+ContentSize+ZeroFillSize)`；`finalize`（写入+重定位完成、4K 模式还逐页 seal 后）对**每个可执行段**调 `EJitCodePoolManager::recordFinalizedRange(segAddr,segSize)`。**绝不**把整块 slab（含 rodata/GOT/可写数据页）当作可执行范围记录——页对齐布局保证可执行段与数据段不共享同一 4K 页，故 peer seal 只翻可执行页，绝不把数据/GOT 页置 RX。`recordFinalizedRange` 对**完全相同**的 `[start,size)` 幂等去重（重试 finalize 不增表、不产生等价多匹配）；范围重叠（仅地址复用才可能，v1 不复用）时 `findRange` 以**追加顺序首个包含命中**确定性解析。`compileNow` 拿到 fnPtr 后经 `EJitOrcEngine::findCodeRange → EJitCodePoolManager::findRange` 用 fnPtr 反查所属可执行段（codeStart/codeSize）与所属 pool（poolBase/poolSize/poolId）。查不到（非 pool 地址 / 未记录 / 落在仅数据段 / size=0 / 溢出）→ 干净失败，slot 不带范围。
+
+**内存序链（范围发布→消费）。** owner 在 `cachePublish` 持 bucket **write lock**（`bucketWrite` 自旋到 `readers==0`）内写入全部范围标量（`codeStart/codeSize/poolBase/poolSize/poolId/rangeReserved`），**在 `fnPtr.storeRelease` 与 `state.storeRelease(Ready)` 之前**；peer 在 bucket **read lock** 内先 `state.loadAcquire()==Ready`、再 `fnPtr.loadAcquire()`，随后读范围标量。两处 acquire 与 owner 的 release 配对，故凡 release 之前写入的范围对观察到 `Ready` 的读者一致可见（大端平台亦然——全为固定宽度标量按值访问）。`poolSplits` 的 `splitDoneMask/splitPreparingMask/poolBase` 均经 acquire/release 原子（`fetchOr`/`fetchAnd`/`compareExchange` 为 ACQ_REL），done 位只在 `split` 真正成功后置位。
+
+**(re)init 必须清零全部 v5 字段。** owner 选举/重新初始化在同一份共享 blob 上逐字段重建（`initSharedStorage`），**每次都**清零：① 整张 `poolSplits[]`（`poolBase`/`splitDoneMask`/`splitPreparingMask`）——否则上一代的 stale done 位会让新一代的 peer **跳过** `split_2m_to_4k`，进而 seal 未拆分的页；② 每个 cache slot 的范围字段（`codeStart/codeSize/poolBase/poolSize/poolId/rangeReserved`）、`fnPtr`、`executableCoreMask`、`dims/versions`、`state=Empty`——杜绝跨代读到陈旧范围/陈旧可执行位/陈旧指针。`init` 每次递增 `generation`，重建后首个命中在各核重新 split+seal。
+
+
+**pool split readiness vs code executable readiness（两层 per-core 状态）。**
+- **pool split**：共享 `EJitSharedPoolSplit poolSplits[kEJitSharedPoolSlots=16]`，按 pool base **开放寻址**（同 base 各核探测序列一致，绝不产生重复条目）。每条 `splitDoneMask`/`splitPreparingMask` 为 64-bit per-core 位图。认领：done 位已置→直接复用；否则 `fetchOr` preparing 位——抢到的核调 `split`，成功置 done+清 preparing，失败清 preparing（允许重试）；同核并发时未抢到者**有界自旋**等 done，超时则 fallback。
+- **code executable**：复用每 slot 的 `executableCoreMask`（per-core per-代码范围）。4K 全页 seal 成功后置位；2M 单页 seal 成功后置位。同核后续命中靠该位短路，不重复 split/seal。
+
+**支持核数与容量边界。** memo 位图为 64-bit ⇒ core id `< kEJitSharedMaxMemoCores(64)` 可记忆；**core id ≥ 64** 无法 memo split/seal，语义为**每次命中重做** split+enable_ex（要求平台 `split`/`enable_ex` 幂等；不越界移位、无 UB）。pool readiness 表 16 槽 ⇒ 最多并行跟踪 16 个不同 2MiB pool；**表满**时命中未跟踪 pool 干净 fallback（不溢出、不重复条目）。
+
+**失败回退语义（全部不返回不可执行指针、不重新入队）。** 缺范围/size=0/溢出/代码越出 pool → fallback；`split` 失败 → fallback 且**不置 done**（可重试）、不 seal；中途任一页 `enable_ex` 失败 → fallback 且**不置 ready 位**（下次重做）；pool 表满 → fallback；准备期间 slot 换代/换指针 → fallback；`codeSharingEnabled=OFF` 或 core id 越界且平台不支持 → fallback。每次失败 `executePrepareFailed` 计数。
+
+**尚需真实平台（aarch64_be 多核）验证（4K 专项）：** ① `split_2m_to_4k` 与 `enable_ex` 确为 **per-core stage-1** 作用域、且对已拆分/已 RX 区域**幂等**（影响 core≥64 的重做与同 pool 多函数）；② seal 后跨核执行的 **I-cache / TLB 一致性**与 `enable_ex` 自带同步是否足够（当前约定不调 `__builtin___clear_cache`）；③ 真实 finalized allocation 的可执行段范围与 `recordFinalizedRange(base,size)` 记录一致（段是否含非可执行数据）；④ 多核同时首次 split 同 pool、以及同核抢占式并发命中下 readiness 表的活性（自旋上界是否够、是否需平台让出）；⑤ core id 与 `kEJitSharedMaxMemoCores`、pool 数与 `kEJitSharedPoolSlots` 的实际规模匹配。
+
+**4K 专项测试（`EJITSharedTaskPoolTests` + `EJITCodePoolTests`，mock split/seal/range，无真实线程）：** 单页 split 一次 seal 一页；跨两页非对齐 start/end seal 两页；同核重复命中不重做；同 pool 第二函数不重 split 但封自己页；两 peer 核各自 split+seal；owner 不 peer-prepare；split 失败 fallback+可重试；中途 seal 失败 fallback；缺范围/越出 pool fallback；pool 表满 fallback；core id≥64 每次重做且无 UB；准备期 slot 换指针/换代不返回旧指针；ABI v5 + `EJitSharedPoolSplit` POD + slot 范围字段大端按值语义；codeSharing OFF 下 4K 不触发任何平台调用；**(re)init 把整张 `poolSplits[]` 与每 slot 范围/`fnPtr`/`executableCoreMask`/`state` 全部清零（预写垃圾后选举仍归零）；上一代 split-done 位不跨代存活，重建后同一 peer 核对重建 pool 重新 split**。code pool 侧：`findRange` 命中记录范围/未记录 miss/非 pool 地址 reject/零长忽略/多 pool 不同 poolId；**幂等去重（同 `[start,size)` 多次记录不增表）；同 pool 两个不同可执行段各自解析；重叠范围以追加顺序确定性解析**。memory-manager 侧（`EJITCodePoolTests` 内 `EJitCodePoolMemMgr4K`）：**含 `__text(R+X)`+`__data(R+W)` 的图只 seal 可执行段那一页、不碰数据页，`findRange` 命中可执行指针、拒绝数据指针**。

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitAtomic.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitAtomic.h
@@ -87,6 +87,11 @@ public:
   /// Atomic bitwise OR, returning the previous value (acq_rel).
   T fetchOr(T v) { return __atomic_fetch_or(&value_, v, __ATOMIC_ACQ_REL); }
 
+  /// Atomic bitwise AND, returning the previous value (acq_rel). Used to clear
+  /// individual bits of a shared mask (e.g. roll back a per-core "preparing"
+  /// bit) without a read-modify-write race.
+  T fetchAnd(T v) { return __atomic_fetch_and(&value_, v, __ATOMIC_ACQ_REL); }
+
 private:
   // mutable so const load helpers can form a non-const pointer for the builtin.
   mutable T value_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -46,6 +46,7 @@
 #ifndef LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOL_H
 #define LLVM_EXECUTIONENGINE_EJIT_EJITCODEPOOL_H
 
+#include "llvm/ExecutionEngine/EJIT/EJitCodeRange.h"
 #include "llvm/Support/Error.h"
 #include <cstddef>
 #include <cstdint>
@@ -128,6 +129,8 @@ public:
                                 ///< (per 4K page in 4K seal mode)
     size_t splitInvocations = 0; ///< number of successful split_2m_to_4k calls
                                  ///< (one per pool in 4K seal mode)
+    size_t finalizedRangeCount = 0; ///< distinct executable ranges recorded
+                                    ///< (duplicates are not double-counted)
   };
 
   EJitCodePoolManager(Options Opts, RawAllocFn Alloc, SealFn Seal,
@@ -173,6 +176,23 @@ public:
   /// per whole 2MiB pool).
   bool usesPageSeal() const { return Opts_.fourKSeal; }
 
+  /// Record the executable extent of a finalized JITLink allocation
+  /// [Base, Base + Size). Called by the code-pool memory manager at finalize,
+  /// after all writes/relocations are complete (and, in 4K mode, after the
+  /// range has been sealed RX). The recorded range is the real, fully-prepared
+  /// executable allocation; findRange() later resolves a function pointer back
+  /// to it so a peer core can seal exactly the pages it covers. A zero-size
+  /// record is ignored.
+  void recordFinalizedRange(const void *Base, size_t Size);
+
+  /// Resolve a function pointer to the finalized executable allocation and pool
+  /// that contain it, filling \p Out (codeStart/codeSize from the recorded
+  /// allocation, poolBase/poolSize/poolId from the owning pool, fnPtr = Ptr).
+  /// Returns false (and leaves \p Out unspecified) when \p Ptr is not inside
+  /// any recorded finalized range owned by a known pool — the caller must then
+  /// take a clean fallback and never publish a shared pointer with no range.
+  bool findRange(const void *Ptr, EJitCompiledCodeInfo &Out) const;
+
   /// True if `Ptr` falls inside the usable range of any owned pool.
   bool contains(const void *Ptr) const;
 
@@ -195,6 +215,16 @@ private:
   CodePool *Active_ = nullptr;
   size_t SealInvocations_ = 0;
   size_t SplitInvocations_ = 0;
+
+  /// Finalized executable allocation extents (ordinary host bookkeeping; never
+  /// holds code bytes). Recorded at finalize, queried by findRange(). Append
+  /// only in v1 (pool memory is not reclaimed), so a pointer never resolves to
+  /// a stale range.
+  struct FinalizedRange {
+    uintptr_t start = 0;
+    uint64_t size = 0;
+  };
+  std::vector<FinalizedRange> FinalizedRanges_;
 
 #ifndef EJIT_FREESTANDING
   mutable std::mutex Mutex_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
@@ -1,0 +1,60 @@
+//===-- EJitCodeRange.h - POD executable code range descriptor ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  EJitCompiledCodeInfo: the real executable extent of one finalized JIT
+//  compilation, as recorded by the code pool at JITLink finalize time. It is a
+//  plain POD of fixed-width scalars so it can be carried unchanged from the
+//  owner's compile path into a shared cache slot and read back by a peer core
+//  (which must seal every 4KiB page the code actually covers in its own
+//  translation context).
+//
+//  All values come from the real JITLink/code-pool allocation+finalize
+//  metadata — never estimated, hard-coded, or recovered by scanning machine
+//  code. A zeroed value (codeSize == 0) means "no range metadata available",
+//  which callers treat as a clean fallback (do not hand back a shared pointer).
+//
+//  This header pulls in no STL and no platform symbols; it is safe in
+//  freestanding builds and shared between the code-pool layer and the shared
+//  taskpool without coupling them.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITCODERANGE_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITCODERANGE_H
+
+#include <cstdint>
+
+namespace llvm {
+namespace ejit {
+
+/// Real executable extent of one finalized compilation. Every field is a
+/// fixed-width scalar accessed by value (endian-safe on aarch64_be).
+struct EJitCompiledCodeInfo {
+  /// The resolved function entry pointer (may be anywhere inside the range).
+  void *fnPtr = nullptr;
+  /// Start of the fully-written, relocated, RX-sealed executable allocation
+  /// that contains fnPtr.
+  uintptr_t codeStart = 0;
+  /// Size in bytes of that executable allocation. 0 => no range metadata.
+  uint64_t codeSize = 0;
+  /// Base of the 2MiB-aligned code pool that contains the allocation (the
+  /// split_2m_to_4k granularity on the target).
+  uintptr_t poolBase = 0;
+  /// Usable size of that pool.
+  uint64_t poolSize = 0;
+  /// Stable identifier of the pool (its index in the manager). Lets callers
+  /// key per-pool readiness without comparing raw bases when convenient.
+  uint32_t poolId = 0;
+  /// Reserved (must be 0). Keeps the struct's tail explicit.
+  uint32_t reserved = 0;
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITCODERANGE_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -75,6 +75,12 @@ public:
   /// zeroed snapshot if no pool is active. Available only with
   /// EJIT_SRE_CODE_POOL.
   EJitCodePoolManager::Stats getCodePoolStats() const;
+
+  /// Resolve a compiled function pointer to its real, finalized executable
+  /// range + owning code pool (for cross-core 4K execute-permission
+  /// preparation). Returns false if \p FnPtr is not pool-backed code with a
+  /// recorded finalized range. Available only with EJIT_SRE_CODE_POOL.
+  bool findCodeRange(const void *FnPtr, EJitCompiledCodeInfo &Out) const;
 #endif
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -62,7 +62,11 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// v3: the shared state carries an owner registration fingerprint (peers
 /// validate their funcIndex/dimType mapping against the owner before use).
 /// v4: each cache slot carries a per-core executable-permission ready mask.
-constexpr uint32_t kEJitSharedAbiVersion = 4u;
+/// v5: each cache slot carries the real executable code range
+/// (codeStart/codeSize/poolBase/poolSize/poolId) and the shared state gains a
+/// per-core, per-pool 4K split-readiness table, so a non-owner core in 4K-seal
+/// mode can split its pool once and seal exactly the pages the code covers.
+constexpr uint32_t kEJitSharedAbiVersion = 5u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -30,6 +30,7 @@
 #ifndef LLVM_EXECUTIONENGINE_EJIT_EJITSHAREDTASKPOOL_H
 #define LLVM_EXECUTIONENGINE_EJIT_EJITSHAREDTASKPOOL_H
 
+#include "llvm/ExecutionEngine/EJIT/EJitCodeRange.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h" // EJitCompileMode, status enum
 #include <cstdint>
@@ -88,7 +89,27 @@ public:
   using ReleaseCallback = void (*)(void *ctx, void *oldFn);
   /// Install execute permission for \p fnPtr in the calling core's translation
   /// context. Required before a non-owner core may consume a shared fnPtr.
+  /// Used for the legacy whole-2MiB-pool seal mode (the bare pointer is aligned
+  /// to its 2MiB pool base and that page is sealed). In 4K page-seal mode the
+  /// split + per-page seal callbacks below are used instead.
   using PrepareCodeCallback = bool (*)(void *ctx, const void *fnPtr);
+  /// Owner-private provider that resolves a freshly compiled function pointer
+  /// to its real, finalized executable range + owning pool (from the code-pool
+  /// allocation metadata). The owner records it into the shared cache slot at
+  /// publish so a peer core can later seal exactly the 4KiB pages the code
+  /// covers. Returns false when no range is known (clean fallback). Optional:
+  /// when unset, slots carry no range and 4K peer preparation cleanly fails.
+  using CodeRangeCallback = bool (*)(void *ctx, const void *fnPtr,
+                                     EJitCompiledCodeInfo *outInfo);
+  /// Per-core platform primitive: split a 2MiB-aligned [poolBase, poolBase +
+  /// poolSize) window into 4KiB mappings in the CALLING core's translation
+  /// context (split_2m_to_4k). Returns true on success. Used only in 4K
+  /// page-seal mode.
+  using SplitPoolCallback = bool (*)(void *ctx, uintptr_t poolBase,
+                                     uint64_t poolSize);
+  /// Per-core platform primitive: seal one 4KiB page at \p pageVA to RX in the
+  /// CALLING core's translation context (enable_ex). Returns true on success.
+  using SealPageCallback = bool (*)(void *ctx, uintptr_t pageVA);
 
   /// Worker loop entry (provided by this class, run on the injected task).
   using WorkerEntryFn = void (*)(void *ctx);
@@ -151,6 +172,26 @@ public:
   void setPrepareCodeCallback(PrepareCodeCallback fn, void *ctx) {
     prepareCodeFn_ = fn;
     prepareCodeCtx_ = ctx;
+  }
+  /// Owner: provide the finalized code-range resolver (see CodeRangeCallback).
+  void setCodeRangeProvider(CodeRangeCallback fn, void *ctx) {
+    codeRangeFn_ = fn;
+    codeRangeCtx_ = ctx;
+  }
+  /// Select the execute-permission seal granularity for non-owner preparation:
+  /// true = 4KiB page seal (split the pool once per core, then enable_ex every
+  /// page the code covers), false = legacy whole-2MiB-pool seal. Must match the
+  /// owner's code pool. Default false.
+  void setSealMode(bool fourKSeal) { fourKSeal_ = fourKSeal; }
+  /// 4K mode: per-core split primitive (see SplitPoolCallback).
+  void setSplitPoolCallback(SplitPoolCallback fn, void *ctx) {
+    splitPoolFn_ = fn;
+    splitPoolCtx_ = ctx;
+  }
+  /// 4K mode: per-core per-page seal primitive (see SealPageCallback).
+  void setSealPageCallback(SealPageCallback fn, void *ctx) {
+    sealPageFn_ = fn;
+    sealPageCtx_ = ctx;
   }
   void setWorkerHooks(WorkerStartFn start, WorkerStopFn stop, void *ctx) {
     workerStart_ = start;
@@ -279,7 +320,40 @@ private:
                         uint32_t numDims) const;
   SharedLookup cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
                            uint32_t numDims);
-  EJitPublishStatus cachePublish(const EJitCompileRequest &req, void *fnPtr);
+  EJitPublishStatus cachePublish(const EJitCompileRequest &req, void *fnPtr,
+                                 const EJitCompiledCodeInfo *info);
+
+  /// Snapshot of one Ready cache slot taken under the bucket read lock, so the
+  /// expensive per-core execute-permission preparation (split + enable_ex)
+  /// happens with NO bucket lock held, then is re-validated against the live
+  /// slot before the pointer is returned.
+  struct PeerCodeRange {
+    void *fn = nullptr;
+    uint32_t slotIndex = 0;
+    uint32_t bucket = 0;
+    uint32_t funcIndex = 0;
+    uint32_t numDims = 0;
+    uint32_t generation = 0;
+    EJitDimPair dims[4] = {};
+    uint32_t versions[4] = {};
+    uintptr_t codeStart = 0;
+    uint64_t codeSize = 0;
+    uintptr_t poolBase = 0;
+    uint64_t poolSize = 0;
+  };
+  /// Prepare execute permission for the current core over \p R's code range
+  /// WITHOUT holding any bucket lock. 2M mode delegates to prepareCodeFn_; 4K
+  /// mode ensures the pool is split for this core then seals every covered 4K
+  /// page. Returns true only when the calling core can legally execute the
+  /// code afterwards.
+  bool prepareExecForCurrentCore(const PeerCodeRange &R, uint32_t self);
+  /// Ensure the calling core has split \p poolBase once (4K mode). Coordinates
+  /// concurrent first-touch via the shared per-pool readiness table.
+  bool ensurePoolSplitForCurrentCore(uint32_t self, uintptr_t poolBase,
+                                     uint64_t poolSize);
+  /// Find (or open-address claim) the readiness entry for \p poolBase. Returns
+  /// nullptr when the fixed table is full (clean fallback).
+  EJitSharedPoolSplit *findOrClaimPoolSlot(uintptr_t poolBase);
 
   // switch/version helpers
   bool isInstanceEnabled(uint32_t dimType, uint32_t instanceId) const;
@@ -305,6 +379,13 @@ private:
   void *releaseCtx_ = nullptr;
   PrepareCodeCallback prepareCodeFn_ = nullptr;
   void *prepareCodeCtx_ = nullptr;
+  CodeRangeCallback codeRangeFn_ = nullptr;
+  void *codeRangeCtx_ = nullptr;
+  SplitPoolCallback splitPoolFn_ = nullptr;
+  void *splitPoolCtx_ = nullptr;
+  SealPageCallback sealPageFn_ = nullptr;
+  void *sealPageCtx_ = nullptr;
+  bool fourKSeal_ = false;
   WorkerStartFn workerStart_ = nullptr;
   WorkerStopFn workerStop_ = nullptr;
   void *workerCtx_ = nullptr;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -63,6 +63,13 @@
 #ifndef EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS
 #define EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS 16u
 #endif
+// Number of distinct 2MiB code pools whose per-core 4K split state is tracked
+// in the shared blob. Open-addressed by pool base, so this is a hard capacity:
+// once full, a peer hitting an untracked pool cleanly falls back rather than
+// risking an unbounded table or a duplicate split entry.
+#ifndef EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS
+#define EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS 16u
+#endif
 
 namespace llvm {
 namespace ejit {
@@ -76,7 +83,15 @@ constexpr uint32_t kEJitSharedMaxFuncIndex = EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX;
 constexpr uint32_t kEJitSharedCacheBuckets = EJIT_SRE_TASKPOOL_BUCKETS;
 constexpr uint32_t kEJitSharedCacheSlots = EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS;
 constexpr uint32_t kEJitSharedQueueSlots = EJIT_SRE_TASKPOOL_QUEUE_CAPACITY;
+constexpr uint32_t kEJitSharedPoolSlots = EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS;
 constexpr uint32_t kEJitSharedCacheLine = 64u;
+/// Execute-permission seal granularity (the platform's per-page enable_ex unit)
+/// and the large-page / split granularity. Fixed platform constants.
+constexpr uint64_t kEJitSharedSealPage = 4096u;
+constexpr uint64_t kEJitSharedSplitGranule =
+    static_cast<uint64_t>(2) * 1024 * 1024;
+/// Highest core id whose per-core readiness can be memoized in a 64-bit mask.
+constexpr uint32_t kEJitSharedMaxMemoCores = 64u;
 
 static_assert((kEJitSharedQueueSlots & (kEJitSharedQueueSlots - 1)) == 0 &&
                   kEJitSharedQueueSlots >= 2,
@@ -127,6 +142,19 @@ struct EJitSharedCacheSlot {
   /// code address. Core ids >= 64 are supported but cannot be memoized here,
   /// so they run the preparation callback on every hit.
   EJitAtomicU64 executableCoreMask;
+  /// Real executable extent of the published code, copied from the owner's
+  /// finalized code-pool allocation (v5). A non-owner core in 4K-seal mode
+  /// needs the full [codeStart, codeStart + codeSize) — not just fnPtr — to
+  /// split its pool and seal every 4KiB page the code covers in its own
+  /// translation context. All plain scalars, written under the bucket write
+  /// lock BEFORE state=Ready is released, so an acquiring reader sees them
+  /// consistently. 0 codeSize => no range metadata (peer cleanly falls back).
+  uintptr_t codeStart;    ///< start of the RX-sealed executable allocation
+  uint64_t codeSize;      ///< size in bytes of that allocation (0 = none)
+  uintptr_t poolBase;     ///< 2MiB pool base (split_2m_to_4k granule)
+  uint64_t poolSize;      ///< usable pool size
+  uint32_t poolId;        ///< stable pool index (diagnostic / convenience key)
+  uint32_t rangeReserved; ///< reserved, keeps the tail explicit (must be 0)
 };
 
 //===----------------------------------------------------------------------===//
@@ -147,6 +175,24 @@ struct alignas(kEJitSharedCacheLine) EJitSharedCacheBucket {
 struct EJitSharedQueueCell {
   EJitAtomicU32 sequence;
   EJitCompileRequest data;
+};
+
+//===----------------------------------------------------------------------===//
+// EJitSharedPoolSplit: per-core readiness for ONE 2MiB code pool's 4K split.
+//
+// split_2m_to_4k and enable_ex affect only the CALLING core's stage-1 page
+// table, so each core must split a given pool exactly once before it may seal
+// any 4K page inside it. This POD tracks, per pool (open-addressed by base),
+// which cores have completed the split (splitDoneMask) and which are mid-split
+// (splitPreparingMask), so concurrent first-touch across cores and on one core
+// is coordinated without a lock and a successful split publishes ready only
+// after it actually succeeds. Core ids >= 64 cannot be memoized in the 64-bit
+// masks and re-run the split on every hit.
+//===----------------------------------------------------------------------===//
+struct EJitSharedPoolSplit {
+  EJitAtomicUPtr poolBase;          ///< claimed 2MiB pool base (0 = empty slot)
+  EJitAtomicU64 splitDoneMask;      ///< bit c => core c finished the split
+  EJitAtomicU64 splitPreparingMask; ///< bit c => core c is mid-split
 };
 
 //===----------------------------------------------------------------------===//
@@ -212,6 +258,11 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
   //--- counters (own cache line)
   alignas(kEJitSharedCacheLine) EJitSharedCounters counters;
 
+  //--- per-core 4K split readiness, one entry per tracked 2MiB pool (own cache
+  //    line). Open-addressed by pool base; see EJitSharedPoolSplit.
+  alignas(kEJitSharedCacheLine)
+      EJitSharedPoolSplit poolSplits[kEJitSharedPoolSlots];
+
   //--- result cache (own cache line; each bucket is itself cache-line aligned)
   alignas(kEJitSharedCacheLine)
       EJitSharedCacheBucket buckets[kEJitSharedCacheBuckets];
@@ -254,6 +305,11 @@ static_assert(
         std::is_trivially_destructible<EJitSharedQueueCell>::value &&
         std::is_trivially_default_constructible<EJitSharedQueueCell>::value,
     "EJitSharedQueueCell must be POD-style");
+static_assert(
+    std::is_standard_layout<EJitSharedPoolSplit>::value &&
+        std::is_trivially_destructible<EJitSharedPoolSplit>::value &&
+        std::is_trivially_default_constructible<EJitSharedPoolSplit>::value,
+    "EJitSharedPoolSplit must be POD-style");
 static_assert(alignof(EJitSharedTaskPoolState) == kEJitSharedCacheLine,
               "EJitSharedTaskPoolState must be cache-line aligned");
 static_assert(

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
@@ -40,6 +40,18 @@ std::unique_ptr<EJitCodePoolManager> makeSreCodePoolManager();
 /// extent needed to seal every covered 4K page).
 bool prepareSreCodeForCurrentCore(const void *FnPtr);
 
+/// 4K page-seal mode, per-core: split the 2MiB-aligned pool
+/// [PoolBase, PoolBase + PoolSize) into 4KiB mappings in the CALLING core's
+/// translation context (split_2m_to_4k). A core must do this once per pool
+/// before it may seal any 4K page inside it. Returns true on success. A no-op
+/// returning false when 4K seal mode / the platform seal symbol is not built.
+bool ejitSreSplitPoolForCurrentCore(uintptr_t PoolBase, uint64_t PoolSize);
+
+/// 4K page-seal mode, per-core: seal one 4KiB page at \p PageVA to RX in the
+/// CALLING core's translation context (enable_ex(1, PageVA)). Returns true on
+/// success. A no-op returning false when the platform seal symbol is not built.
+bool ejitSreSealPageForCurrentCore(uintptr_t PageVA);
+
 } // namespace ejit
 } // namespace llvm
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -310,6 +310,74 @@ bool EJitCodePoolManager::contains(const void *Ptr) const {
   return false;
 }
 
+void EJitCodePoolManager::recordFinalizedRange(const void *Base, size_t Size) {
+  if (!Base || Size == 0)
+    return;
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  uintptr_t Start = addr(Base);
+  // Overflow guard: a range whose end wraps is malformed; ignore it (findRange
+  // would otherwise admit any pointer).
+  if (Start + Size < Start)
+    return;
+  // Idempotent record: re-finalizing the identical [Start, Size) extent (e.g. a
+  // retried finalize of the same allocation) must not grow the table or create
+  // duplicate, equally-valid matches. Pool addresses are never reused while a
+  // recorded range is live, so an exact-extent match is the only ambiguity we
+  // can see here; a *partial* overlap would imply address reuse and is treated
+  // as a distinct range (findRange resolves it deterministically: first match
+  // in append order wins).
+  for (const FinalizedRange &R : FinalizedRanges_)
+    if (R.start == Start && R.size == static_cast<uint64_t>(Size)) {
+      EJIT_CODE_POOL_TRACE("recordFinalizedRange.dup", Base,
+                           (unsigned long long)Size);
+      return;
+    }
+  FinalizedRanges_.push_back(
+      FinalizedRange{Start, static_cast<uint64_t>(Size)});
+  EJIT_CODE_POOL_TRACE("recordFinalizedRange", Base, (unsigned long long)Size);
+}
+
+bool EJitCodePoolManager::findRange(const void *Ptr,
+                                    EJitCompiledCodeInfo &Out) const {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  uintptr_t A = addr(Ptr);
+
+  // The pointer must resolve to a real, recorded executable allocation — never
+  // a guessed extent. Find the finalized range that contains it.
+  const FinalizedRange *Found = nullptr;
+  for (const FinalizedRange &R : FinalizedRanges_) {
+    if (A >= R.start && A < R.start + R.size) {
+      Found = &R;
+      break;
+    }
+  }
+  if (!Found)
+    return false;
+
+  // The allocation must also belong to a known pool (so a peer learns the
+  // 2MiB split granule). An address resolved outside the pools (e.g. a
+  // process/absolute symbol) is not handled.
+  for (size_t I = 0; I < Pools_.size(); ++I) {
+    const CodePool &P = *Pools_[I];
+    uintptr_t B = addr(P.base);
+    if (A >= B && A < B + P.size) {
+      Out.fnPtr = const_cast<void *>(Ptr);
+      Out.codeStart = Found->start;
+      Out.codeSize = Found->size;
+      Out.poolBase = B;
+      Out.poolSize = static_cast<uint64_t>(P.size);
+      Out.poolId = static_cast<uint32_t>(I);
+      Out.reserved = 0;
+      return true;
+    }
+  }
+  return false;
+}
+
 EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
 #ifndef EJIT_FREESTANDING
   std::lock_guard<std::mutex> Lock(Mutex_);
@@ -318,6 +386,7 @@ EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
   S.poolCount = Pools_.size();
   S.sealInvocations = SealInvocations_;
   S.splitInvocations = SplitInvocations_;
+  S.finalizedRangeCount = FinalizedRanges_.size();
   for (auto &P : Pools_) {
     S.reservedBytes += P->size;
     S.usedBytes += P->used;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -9,8 +9,10 @@
 #include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/AllocationActions.h"
+#include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
 #include "llvm/Support/MathExtras.h"
 #include <cstring>
+#include <vector>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -18,6 +20,17 @@ using namespace llvm::jitlink;
 
 using orc::ExecutorAddr;
 using WrapperFunctionCall = orc::shared::WrapperFunctionCall;
+
+namespace {
+/// One contiguous executable segment of a finalized allocation (the only kind
+/// of memory that needs execute permission). An allocation may contain several
+/// (non-contiguous) executable segments and any number of non-executable
+/// (read-only / writable / GOT) segments, which are NEVER sealed RX.
+struct ExecSegRange {
+  uintptr_t Addr = 0;
+  uint64_t Size = 0;
+};
+} // namespace
 
 /// Side record used as the FinalizedAlloc handle. Holds the dealloc actions and
 /// the pool-backed base address. Pool memory itself is not freed in v1.
@@ -30,8 +43,9 @@ class EJitCodePoolMemoryManager::InFlightAllocImpl
     : public JITLinkMemoryManager::InFlightAlloc {
 public:
   InFlightAllocImpl(EJitCodePoolMemoryManager &MM, LinkGraph &G, BasicLayout BL,
-                    void *Base, size_t Size)
-      : Pool(&MM.getPool()), G(&G), BL(std::move(BL)), Base(Base), Size(Size) {}
+                    void *Base, std::vector<ExecSegRange> ExecRanges)
+      : Pool(&MM.getPool()), G(&G), BL(std::move(BL)), Base(Base),
+        ExecRanges(std::move(ExecRanges)) {}
 
   void finalize(OnFinalizedFunction OnFinalized) override {
     // The content has already been written into working memory, which (for an
@@ -39,18 +53,28 @@ public:
     // applied before finalize() runs. Deliberately DO NOT apply any per-segment
     // memory protection here (no mprotect): the pool stays RW.
     //
-    // In 4K seal mode, seal exactly the 4KiB pages this allocation covers now
+    // In 4K seal mode, seal ONLY the executable segments' 4KiB pages now
     // that all writes/relocations are complete, before the function pointer can
     // be looked up. If any page fails to seal we must not hand back a callable
     // allocation. (Legacy whole-pool seal is driven later, at lookup, by the
     // engine.) We do not invalidate the instruction cache here either \u2014
     // enable_ex performs that sync on the target.
-    if (Pool->usesPageSeal() && Size > 0) {
-      if (auto Err = Pool->sealCodeRange(Base, Size)) {
-        OnFinalized(std::move(Err));
-        return;
-      }
+    if (Pool->usesPageSeal()) {
+      for (const ExecSegRange &R : ExecRanges)
+        if (auto Err = Pool->sealCodeRange(reinterpret_cast<void *>(R.Addr),
+                                           static_cast<size_t>(R.Size))) {
+          OnFinalized(std::move(Err));
+          return;
+        }
     }
+    // Record the real, fully-written/relocated (and, in 4K mode, RX-sealed)
+    // executable extent so a later function-pointer lookup can recover the
+    // exact [codeStart, codeSize) a peer core must seal in its own translation
+    // context. This is the only source of the cross-core code range — it is
+    // never estimated or recovered by scanning machine code.
+    for (const ExecSegRange &R : ExecRanges)
+      Pool->recordFinalizedRange(reinterpret_cast<void *>(R.Addr),
+                                 static_cast<size_t>(R.Size));
     runFinalizeActions(
         G->allocActions(),
         [this, OnFinalized = std::move(OnFinalized)](
@@ -82,7 +106,7 @@ private:
   LinkGraph *G;
   BasicLayout BL;
   void *Base;
-  size_t Size;
+  std::vector<ExecSegRange> ExecRanges;
 };
 
 EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(EJitCodePoolManager &Pool,
@@ -119,6 +143,12 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   auto NextFinalizeSegAddr =
       ExecutorAddr::fromPtr(SlabBytes + SegsSizes->StandardSegs);
 
+  // Collect the EXECUTABLE segments' assigned ranges as we lay out the slab.
+  // Only segments whose permission includes Exec need execute permission; the
+  // (page-aligned) layout guarantees an executable segment never shares a 4KiB
+  // page with a writable/read-only one, so sealing these ranges never flips a
+  // data/GOT page to RX. An allocation may have several executable segments.
+  std::vector<ExecSegRange> ExecRanges;
   for (auto &KV : BL.segments()) {
     auto &AG = KV.first;
     auto &Seg = KV.second;
@@ -129,6 +159,13 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
 
     Seg.WorkingMem = SegAddr.toPtr<char *>();
     Seg.Addr = SegAddr;
+    if ((AG.getMemProt() & orc::MemProt::Exec) != orc::MemProt::None) {
+      uint64_t SegSize =
+          static_cast<uint64_t>(Seg.ContentSize) + Seg.ZeroFillSize;
+      if (SegSize > 0)
+        ExecRanges.push_back(
+            {reinterpret_cast<uintptr_t>(SegAddr.toPtr<char *>()), SegSize});
+    }
     SegAddr += alignTo(Seg.ContentSize + Seg.ZeroFillSize, PageSize_);
   }
 
@@ -137,9 +174,8 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     return;
   }
 
-  OnAllocated(
-      std::make_unique<InFlightAllocImpl>(*this, G, std::move(BL), Slab,
-                                          static_cast<size_t>(Total)));
+  OnAllocated(std::make_unique<InFlightAllocImpl>(*this, G, std::move(BL), Slab,
+                                                  std::move(ExecRanges)));
 }
 
 void EJitCodePoolMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -38,11 +38,54 @@ bool taskpoolCompileThunk(void *ctx, const EJitCompileRequest &req,
 }
 
 #ifdef EJIT_SRE_SHARED_TASKPOOL
-bool sharedPrepareCodeThunk(void * /*ctx*/, const void *fnPtr) {
+[[maybe_unused]] bool sharedPrepareCodeThunk(void * /*ctx*/,
+                                             const void *fnPtr) {
 #ifdef EJIT_SRE_CODE_POOL
   return prepareSreCodeForCurrentCore(fnPtr);
 #else
   (void)fnPtr;
+  return false;
+#endif
+}
+
+// Owner-private: resolve a freshly compiled pointer to its real, finalized
+// executable range + owning pool (from the code-pool allocation metadata) so it
+// can be published into the shared cache slot for cross-core 4K sealing.
+[[maybe_unused]] bool sharedCodeRangeThunk(void *ctx, const void *fnPtr,
+                                           EJitCompiledCodeInfo *outInfo) {
+#ifdef EJIT_SRE_CODE_POOL
+  auto *drv = static_cast<EJitCompileDriver *>(ctx);
+  EJitOrcEngine *eng = drv->getSyncEngine();
+  if (eng && outInfo)
+    return eng->findCodeRange(fnPtr, *outInfo);
+  return false;
+#else
+  (void)ctx;
+  (void)fnPtr;
+  (void)outInfo;
+  return false;
+#endif
+}
+
+// Per-core platform primitives wrapped so the shared taskpool core never names
+// an SRE symbol directly (spec §7). Both are no-ops returning false when the
+// code pool / seal support is not built.
+[[maybe_unused]] bool sharedSplitPoolThunk(void * /*ctx*/, uintptr_t poolBase,
+                                           uint64_t poolSize) {
+#ifdef EJIT_SRE_CODE_POOL
+  return ejitSreSplitPoolForCurrentCore(poolBase, poolSize);
+#else
+  (void)poolBase;
+  (void)poolSize;
+  return false;
+#endif
+}
+
+[[maybe_unused]] bool sharedSealPageThunk(void * /*ctx*/, uintptr_t pageVA) {
+#ifdef EJIT_SRE_CODE_POOL
+  return ejitSreSealPageForCurrentCore(pageVA);
+#else
+  (void)pageVA;
   return false;
 #endif
 }
@@ -104,9 +147,26 @@ EJitCompileDriver::EJitCompileDriver(const Config &config, EJitCache &cache,
   // EJIT_SRE_SHARED_CODE_POINTERS (default OFF -> clean fallback for non-owner
   // cores). Only the platform may assert same-VA + sealed + I/D-cache-coherent
   // code (spec §11); we never auto-detect it.
+#ifdef EJIT_SRE_CODE_POOL
+  // Owner side (always useful when a code pool exists): resolve each compiled
+  // pointer to its real executable range so the published cache slot carries
+  // the extent a peer must seal. Harmless when sharing is off (no peer reads
+  // it).
+  sharedPool_.setCodeRangeProvider(&sharedCodeRangeThunk, this);
+#endif
 #ifdef EJIT_SRE_SHARED_CODE_POINTERS
   sharedPool_.setCodeSharingEnabled(true);
+#ifdef EJIT_CODE_POOL_4K_SEAL
+  // 4K page seal: a non-owner core splits its 2MiB pool once and then seals
+  // exactly the 4KiB pages the code covers, in its own translation context.
+  sharedPool_.setSealMode(true);
+  sharedPool_.setSplitPoolCallback(&sharedSplitPoolThunk, this);
+  sharedPool_.setSealPageCallback(&sharedSealPageThunk, this);
+#else
+  // Legacy whole-2MiB-pool seal: align fnPtr to its pool base and enable_ex.
+  sharedPool_.setSealMode(false);
   sharedPool_.setPrepareCodeCallback(&sharedPrepareCodeThunk, this);
+#endif
 #else
   sharedPool_.setCodeSharingEnabled(false);
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -347,4 +347,11 @@ EJitCodePoolManager::Stats EJitOrcEngine::getCodePoolStats() const {
     return P->codePool->getStats();
   return EJitCodePoolManager::Stats{};
 }
+
+bool EJitOrcEngine::findCodeRange(const void *FnPtr,
+                                  EJitCompiledCodeInfo &Out) const {
+  if (!P->codePool)
+    return false;
+  return P->codePool->findRange(FnPtr, Out);
+}
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -257,40 +257,217 @@ EJitSharedTaskPool::cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
     if (!fn)
       break;
 
-    // Execute permission is a per-core property on the target. The owner has
-    // already sealed the code before publishing it, but a peer may use a
-    // different stage-1 translation context. Prepare the mapping in the
-    // calling core before returning the shared pointer. A failure is a clean
-    // fallback, never an attempt to execute an unprepared address.
-    if (self != owner) {
-      const bool CanMemoize = self < 64;
-      const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : 0;
-      const bool AlreadyPrepared =
-          CanMemoize &&
-          ((Slot.executableCoreMask.loadAcquire() & CoreBit) != 0);
-      if (!AlreadyPrepared) {
-        if (!prepareCodeFn_ || !prepareCodeFn_(prepareCodeCtx_, fn)) {
-          state_->counters.executePrepareFailed.fetchAdd(1);
-          bucketReadRelease(B);
-          R.readyButNotShareable = true;
-          return R;
-        }
-        if (CanMemoize)
-          Slot.executableCoreMask.fetchOr(CoreBit);
-      }
+    // The owner already has execute permission (it sealed the code before
+    // publishing). Return directly while holding the read token.
+    if (self == owner) {
+      R.fnPtr = fn;
+      R.bucketIndex = bucket;
+      R.hasReadToken = true;
+      return R;
     }
-    R.fnPtr = fn;
-    R.bucketIndex = bucket;
+
+    // Non-owner: execute permission is a per-core property on the target. If
+    // this core has already prepared THIS slot's code (memoized bit), return
+    // immediately under the read lock — no platform call.
+    const bool CanMemoize = self < kEJitSharedMaxMemoCores;
+    const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : uint64_t{0};
+    if (CanMemoize && (Slot.executableCoreMask.loadAcquire() & CoreBit) != 0) {
+      R.fnPtr = fn;
+      R.bucketIndex = bucket;
+      R.hasReadToken = true;
+      return R;
+    }
+
+    // Not prepared yet. Snapshot the identity + the REAL code range, then DROP
+    // the bucket read lock: the per-core platform split/enable_ex calls
+    // (potentially slow) must never run while holding a cross-core bucket lock,
+    // or a concurrent owner publish (which spins for readers==0) would stall.
+    PeerCodeRange Snap;
+    Snap.fn = fn;
+    Snap.slotIndex = s;
+    Snap.bucket = bucket;
+    Snap.funcIndex = Slot.funcIndex;
+    Snap.numDims = Slot.numDims;
+    Snap.generation = Slot.generation;
+    for (uint32_t i = 0; i < Snap.numDims && i < 4; ++i) {
+      Snap.dims[i] = Slot.dims[i];
+      Snap.versions[i] = Slot.versions[i];
+    }
+    Snap.codeStart = Slot.codeStart;
+    Snap.codeSize = Slot.codeSize;
+    Snap.poolBase = Slot.poolBase;
+    Snap.poolSize = Slot.poolSize;
+    bucketReadRelease(B);
+
+    if (!prepareExecForCurrentCore(Snap, self)) {
+      state_->counters.executePrepareFailed.fetchAdd(1);
+      R.readyButNotShareable = true;
+      return R; // clean fallback: no token, no shared pointer handed back.
+    }
+
+    // Re-acquire the read lock and RE-VALIDATE the slot: a publish may have
+    // overwritten it (new code/generation) while we prepared. Only a slot that
+    // is still Ready, same generation + identity + fnPtr, with current
+    // versions, may hand back the prepared pointer; otherwise clean fallback so
+    // a replaced/stale pointer is never returned (spec §11 / §8).
+    if (!bucketTryRead(B)) {
+      R.readyButNotShareable = true;
+      return R;
+    }
+    EJitSharedCacheSlot &S2 = B.slots[Snap.slotIndex];
+    uint32_t curGen2 = state_->generation.loadAcquire();
+    bool stillValid =
+        S2.state.loadAcquire() ==
+            static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
+        S2.generation == curGen2 && S2.generation == Snap.generation &&
+        slotIdentityMatches(S2, Snap.funcIndex, Snap.dims, Snap.numDims) &&
+        reinterpret_cast<void *>(S2.fnPtr.loadAcquire()) == Snap.fn;
+    if (stillValid)
+      for (uint32_t i = 0; i < Snap.numDims; ++i)
+        if (S2.versions[i] !=
+            instanceVersion(Snap.dims[i].dimType, Snap.dims[i].instanceId)) {
+          stillValid = false;
+          break;
+        }
+    if (!stillValid) {
+      bucketReadRelease(B);
+      R.readyButNotShareable = true;
+      return R;
+    }
+    if (CanMemoize)
+      S2.executableCoreMask.fetchOr(CoreBit);
+    R.fnPtr = Snap.fn;
+    R.bucketIndex = Snap.bucket;
     R.hasReadToken = true;
-    return R; // token held; caller releases after using fnPtr.
+    return R; // token held (re-acquired); caller releases after using fnPtr.
   }
 
   bucketReadRelease(B);
   return R;
 }
 
+//===----------------------------------------------------------------------===//
+// Per-core execute-permission preparation (no bucket lock held). 2M mode seals
+// the whole 2MiB pool via prepareCodeFn_ (fnPtr-aligned); 4K mode splits the
+// pool once per core, then seals exactly the 4KiB pages the code covers. All
+// platform work goes through injected callbacks so this core never names a
+// platform symbol (spec §7).
+//===----------------------------------------------------------------------===//
+EJitSharedPoolSplit *EJitSharedTaskPool::findOrClaimPoolSlot(uintptr_t base) {
+  // Open addressing keyed by pool base. Every core probes the SAME slot
+  // sequence for a given base, so concurrent first-touch converges on one entry
+  // (never two entries for the same pool, which would let a core split twice).
+  uint32_t start = static_cast<uint32_t>((base / kEJitSharedSplitGranule) %
+                                         kEJitSharedPoolSlots);
+  for (uint32_t probe = 0; probe < kEJitSharedPoolSlots; ++probe) {
+    uint32_t i = (start + probe) % kEJitSharedPoolSlots;
+    EJitSharedPoolSplit &P = state_->poolSplits[i];
+    uintptr_t cur = P.poolBase.loadAcquire();
+    if (cur == base)
+      return &P;
+    if (cur == 0) {
+      uintptr_t expected = 0;
+      if (P.poolBase.compareExchange(expected, base))
+        return &P; // we claimed this empty entry for `base`.
+      // Lost the race: `expected` now holds the winner's base.
+      if (expected == base)
+        return &P; // another core claimed the same base here.
+      // Claimed by a different base — keep probing.
+    }
+    // Occupied by a different base — keep probing.
+  }
+  return nullptr; // table full: caller cleanly falls back.
+}
+
+bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
+                                                       uintptr_t poolBase,
+                                                       uint64_t poolSize) {
+  // Cores beyond the 64-bit memo width cannot record split state, so they must
+  // re-run the (idempotent) split on every hit rather than risk skipping it.
+  if (self >= kEJitSharedMaxMemoCores)
+    return splitPoolFn_ && splitPoolFn_(splitPoolCtx_, poolBase, poolSize);
+
+  EJitSharedPoolSplit *P = findOrClaimPoolSlot(poolBase);
+  if (!P)
+    return false; // table full -> clean fallback.
+
+  const uint64_t Bit = uint64_t{1} << self;
+  if ((P->splitDoneMask.loadAcquire() & Bit) != 0)
+    return true; // already split on this core.
+
+  // Claim the per-core "preparing" bit. fetchOr returns the previous mask.
+  const uint64_t Prev = P->splitPreparingMask.fetchOr(Bit);
+  if ((Prev & Bit) != 0) {
+    // Another context on THIS core is mid-split: wait (bounded) for it to
+    // publish done; if it clears preparing without done (it failed) or the
+    // bound elapses, cleanly fall back so we never proceed un-split.
+    constexpr uint32_t kSplitSpinBudget = 1u << 16;
+    for (uint32_t i = 0; i < kSplitSpinBudget; ++i) {
+      if ((P->splitDoneMask.loadAcquire() & Bit) != 0)
+        return true;
+      if ((P->splitPreparingMask.loadAcquire() & Bit) == 0)
+        break; // the other context finished without marking done -> it failed.
+      cpuRelax();
+    }
+    return (P->splitDoneMask.loadAcquire() & Bit) != 0;
+  }
+
+  // We own the split for this (pool, core). Run it, publishing done only on
+  // success; on failure roll back preparing so a later hit can retry.
+  bool ok = splitPoolFn_ && splitPoolFn_(splitPoolCtx_, poolBase, poolSize);
+  if (ok) {
+    P->splitDoneMask.fetchOr(Bit);
+    P->splitPreparingMask.fetchAnd(~Bit);
+    return true;
+  }
+  P->splitPreparingMask.fetchAnd(~Bit);
+  return false;
+}
+
+bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
+                                                   uint32_t self) {
+  if (!fourKSeal_) {
+    // Legacy whole-2MiB-pool seal: align fnPtr to its pool base and enable_ex
+    // that page. Range metadata is not required (spec §6 — 2M unchanged). When
+    // no prepare callback is wired the platform/host needs no per-core
+    // preparation (e.g. the single shared address space of the host
+    // simulation), so the pointer is already executable on this core.
+    if (!prepareCodeFn_)
+      return true;
+    return prepareCodeFn_(prepareCodeCtx_, R.fn);
+  }
+
+  // 4K page seal needs the real executable extent. A slot with no recorded
+  // range (or a malformed one) is a clean fallback, never a guessed seal.
+  if (R.codeStart == 0 || R.codeSize == 0 || R.poolBase == 0 || R.poolSize == 0)
+    return false;
+  if (R.codeStart + R.codeSize < R.codeStart) // code range overflow
+    return false;
+  if (R.poolBase + R.poolSize < R.poolBase) // pool range overflow
+    return false;
+  if (R.codeStart < R.poolBase ||
+      R.codeStart + R.codeSize > R.poolBase + R.poolSize)
+    return false; // code must lie wholly inside its pool.
+
+  // This core must have split the 2MiB pool exactly once before sealing pages.
+  if (!ensurePoolSplitForCurrentCore(self, R.poolBase, R.poolSize))
+    return false;
+
+  // Seal every 4KiB page the code overlaps: page-align start down, end up.
+  const uintptr_t Page = static_cast<uintptr_t>(kEJitSharedSealPage);
+  uintptr_t PageStart = R.codeStart & ~(Page - 1);
+  uintptr_t PageEnd =
+      (R.codeStart + static_cast<uintptr_t>(R.codeSize) + Page - 1) &
+      ~(Page - 1);
+  for (uintptr_t VA = PageStart; VA < PageEnd; VA += Page)
+    if (!sealPageFn_ || !sealPageFn_(sealPageCtx_, VA))
+      return false; // any page failure -> no callable pointer is returned.
+  return true;
+}
+
 EJitPublishStatus
-EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr) {
+EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
+                                 const EJitCompiledCodeInfo *info) {
   if (!fnPtr || req.numDims > 4)
     return EJitPublishStatus::InvalidParam;
   uint64_t key = hashIdentity(req.funcIndex, req.dims, req.numDims);
@@ -351,6 +528,25 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr) {
     target->dims[i] = req.dims[i];
     target->versions[i] = req.versions[i];
   }
+  // Copy the real executable range (v5) so a peer core can later seal exactly
+  // the 4KiB pages this code covers. Written BEFORE the fnPtr/state release
+  // below, so an acquiring reader that observes state==Ready also sees a
+  // consistent range. A null/empty info clears the range (0 codeSize), which a
+  // peer treats as "no range -> clean fallback".
+  if (info && info->codeSize != 0) {
+    target->codeStart = info->codeStart;
+    target->codeSize = info->codeSize;
+    target->poolBase = info->poolBase;
+    target->poolSize = info->poolSize;
+    target->poolId = info->poolId;
+  } else {
+    target->codeStart = 0;
+    target->codeSize = 0;
+    target->poolBase = 0;
+    target->poolSize = 0;
+    target->poolId = 0;
+  }
+  target->rangeReserved = 0;
   target->fnPtr.storeRelease(reinterpret_cast<uintptr_t>(fnPtr));
   const uint32_t OwnerCore = state_->ownerCoreId.loadAcquire();
   target->executableCoreMask.storeRelease(
@@ -404,6 +600,16 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
   st->counters.publishFailed.storeRelaxed(0);
   st->counters.instanceDisabled.storeRelaxed(0);
   st->counters.executePrepareFailed.storeRelaxed(0);
+  // Per-core, per-pool 4K split readiness (ABI v5). MUST be cleared on every
+  // (re)initialization: a stale splitDone bit from an earlier generation would
+  // otherwise make a peer skip split_2m_to_4k for a pool the new generation
+  // rebuilt, so it would seal pages that were never split. Cleared, the first
+  // post-reinit hit re-runs the split on each core.
+  for (uint32_t i = 0; i < kEJitSharedPoolSlots; ++i) {
+    st->poolSplits[i].poolBase.storeRelaxed(0);
+    st->poolSplits[i].splitDoneMask.storeRelaxed(0);
+    st->poolSplits[i].splitPreparingMask.storeRelaxed(0);
+  }
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     st->buckets[b].writeFlag.storeRelaxed(0);
     st->buckets[b].readers.storeRelaxed(0);
@@ -414,9 +620,21 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
       Slot.funcIndex = 0;
       Slot.numDims = 0;
       Slot.generation = 0;
+      for (uint32_t i = 0; i < 4; ++i) {
+        Slot.dims[i] = EJitDimPair{0, 0};
+        Slot.versions[i] = 0;
+      }
       Slot.identityHash = 0;
       Slot.fnPtr.storeRelaxed(0);
       Slot.executableCoreMask.storeRelaxed(0);
+      // Executable-range metadata (ABI v5): cleared so a stale range from an
+      // earlier generation can never be read back after a re-init.
+      Slot.codeStart = 0;
+      Slot.codeSize = 0;
+      Slot.poolBase = 0;
+      Slot.poolSize = 0;
+      Slot.poolId = 0;
+      Slot.rangeReserved = 0;
     }
   }
 }
@@ -640,6 +858,14 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
     state_->counters.compileFailed.fetchAdd(1);
     return;
   }
+  // Resolve the real executable range for the freshly compiled pointer (from
+  // the owner's code-pool finalize metadata) so it can be published into the
+  // cache slot for cross-core 4K sealing. Optional: if no provider is wired or
+  // the pointer is not pool-backed, the slot carries no range and a 4K peer
+  // cleanly falls back.
+  EJitCompiledCodeInfo info{};
+  if (codeRangeFn_)
+    (void)codeRangeFn_(codeRangeCtx_, fn, &info);
   // Checkpoint 2: a generation bump OR a toggle during compilation invalidates
   // the result.
   if (req.generation != state_->generation.loadAcquire() ||
@@ -650,7 +876,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
     state_->counters.compileFailed.fetchAdd(1);
     return;
   }
-  EJitPublishStatus PS = cachePublish(req, fn);
+  EJitPublishStatus PS = cachePublish(req, fn, &info);
   switch (PS) {
   case EJitPublishStatus::Published:
     state_->counters.asyncCompiles.fetchAdd(1);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -128,4 +128,35 @@ bool llvm::ejit::prepareSreCodeForCurrentCore(const void *FnPtr) {
 #endif
 }
 
+bool llvm::ejit::ejitSreSplitPoolForCurrentCore(uintptr_t PoolBase,
+                                                uint64_t PoolSize) {
+#if defined(EJIT_SRE_ENABLE_EX) && defined(EJIT_CODE_POOL_4K_SEAL)
+  if (PoolBase == 0 || PoolSize == 0)
+    return false;
+  // Per-core: this splits the 2MiB large page into 4K mappings in the calling
+  // core's stage-1 translation only. enable_ex per page follows.
+  return ejit_sre_split_2m_to_4k(static_cast<unsigned long long>(PoolBase),
+                                 static_cast<unsigned long long>(PoolSize)) ==
+         0;
+#else
+  (void)PoolBase;
+  (void)PoolSize;
+  return false;
+#endif
+}
+
+bool llvm::ejit::ejitSreSealPageForCurrentCore(uintptr_t PageVA) {
+#ifdef EJIT_SRE_ENABLE_EX
+  if (PageVA == 0)
+    return false;
+  // Per-core: flips the 4KiB page containing PageVA to RX in the calling core's
+  // translation context. enable_ex performs its own permission/cache sync, so
+  // no __builtin___clear_cache here.
+  return ejit_sre_enable_ex(1, static_cast<unsigned long long>(PageVA)) == 0;
+#else
+  (void)PageVA;
+  return false;
+#endif
+}
+
 #endif // EJIT_SRE_CODE_POOL

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -215,6 +215,7 @@ constexpr size_t kFourKiB = static_cast<size_t>(4) * 1024;
 struct MockSre4K {
   std::vector<void *> Origs;
   std::vector<std::pair<uintptr_t, size_t>> Splits;
+  std::vector<uintptr_t> SealedPages;
   unsigned SplitRc = 0;
   size_t SealCalls = 0;
   int FailSealOnCall = -1; // 1-based seal index to fail; -1 = never
@@ -236,8 +237,9 @@ struct MockSre4K {
     Splits.push_back({reinterpret_cast<uintptr_t>(Base), Size});
     return SplitRc;
   }
-  unsigned seal(void *) {
+  unsigned seal(void *P) {
     ++SealCalls;
+    SealedPages.push_back(reinterpret_cast<uintptr_t>(P));
     if (FailSealOnCall > 0 && static_cast<int>(SealCalls) == FailSealOnCall)
       return SealFailRc;
     return 0;
@@ -269,6 +271,38 @@ std::unique_ptr<LinkGraph> makeBackedCodeGraph(const char *Buf, size_t Size,
   G->createContentBlock(Sec, ArrayRef<char>(Buf, Size),
                         orc::ExecutorAddr(VAddr), 16, 0);
   return G;
+}
+
+// A graph with one executable (__text, R+X) section and one writable
+// (__data, R+W) section. The two land in separate AllocGroups, so the memory
+// manager lays them out on different (page-aligned) segments.
+std::unique_ptr<LinkGraph> makeTextAndDataGraph(uint64_t TextVAddr,
+                                                uint64_t DataVAddr) {
+  auto G = std::make_unique<LinkGraph>(
+      "g", std::make_shared<orc::SymbolStringPool>(),
+      Triple("x86_64-unknown-linux-gnu"), SubtargetFeatures(),
+      getGenericEdgeKindName);
+  auto &Text =
+      G->createSection("__text", orc::MemProt::Read | orc::MemProt::Exec);
+  G->createContentBlock(Text, ArrayRef<char>(CodeBytes, 64),
+                        orc::ExecutorAddr(TextVAddr), 16, 0);
+  auto &Data =
+      G->createSection("__data", orc::MemProt::Read | orc::MemProt::Write);
+  G->createContentBlock(Data, ArrayRef<char>(CodeBytes, 64),
+                        orc::ExecutorAddr(DataVAddr), 16, 0);
+  return G;
+}
+
+// Returns the assigned address of the first block whose owning section's
+// executable bit matches WantExec (after allocate() has applied the layout).
+void *blockAddrByExec(LinkGraph &G, bool WantExec) {
+  for (Block *B : G.blocks()) {
+    bool IsExec = (B->getSection().getMemProt() & orc::MemProt::Exec) !=
+                  orc::MemProt::None;
+    if (IsExec == WantExec)
+      return B->getAddress().toPtr<void *>();
+  }
+  return nullptr;
 }
 
 } // namespace
@@ -371,4 +405,48 @@ TEST(EJitCodePoolMemMgr4K, SecondFunctionUsesFreshPageSamePool) {
   cantFail(MM.deallocate(std::move(FA2)));
 }
 
+// finalize() must seal ONLY the executable segment's page(s); a writable
+// (__data) segment that lands on its own page is never flipped to RX, and
+// findRange resolves only the executable pointer (the data pointer is rejected
+// because it was never recorded as code). This is the core guarantee that the
+// per-core peer seal touches exactly the executable extent, not the whole slab.
+TEST(EJitCodePoolMemMgr4K, SealsAndRecordsOnlyExecutableSegment) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
 
+  auto G = makeTextAndDataGraph(0x1000, 0x2000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *TextAddr = blockAddrByExec(*G, /*WantExec=*/true);
+  void *DataAddr = blockAddrByExec(*G, /*WantExec=*/false);
+  ASSERT_NE(TextAddr, nullptr);
+  ASSERT_NE(DataAddr, nullptr);
+  EXPECT_EQ(M.SealCalls, 0u); // allocate must not seal anything
+
+  auto pageOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) &
+           ~static_cast<uintptr_t>(kFourKiB - 1);
+  };
+  ASSERT_NE(pageOf(TextAddr), pageOf(DataAddr)); // distinct pages
+
+  auto FA = cantFail(IFA->finalize());
+
+  // Exactly one page sealed, and it is the executable page (never the data
+  // one).
+  EXPECT_EQ(M.SealCalls, 1u);
+  ASSERT_EQ(M.SealedPages.size(), 1u);
+  EXPECT_EQ(M.SealedPages[0], pageOf(TextAddr));
+  for (uintptr_t Sealed : M.SealedPages)
+    EXPECT_NE(Sealed, pageOf(DataAddr));
+
+  // Only the executable pointer resolves to a recorded code range.
+  EJitCompiledCodeInfo Info{};
+  EXPECT_TRUE(Pool.findRange(TextAddr, Info));
+  EXPECT_EQ(Info.fnPtr, TextAddr);
+  EXPECT_FALSE(Pool.findRange(DataAddr, Info));
+
+  cantFail(MM.deallocate(std::move(FA)));
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
@@ -532,4 +532,150 @@ TEST(EJitCodePool4K, SealAllWritablePoolsReturnsErrorIn4KMode) {
   EXPECT_EQ(Mgr.getStats().sealedCount, 0u);
 }
 
+//===----------------------------------------------------------------------===//
+// findRange: recover the real executable extent + owning pool for a pointer.
+// This is the cross-core 4K-seal range source — it must come from recorded
+// finalized allocations, never a guess.
+//===----------------------------------------------------------------------===//
 
+// A pointer anywhere inside a recorded finalized allocation resolves to its
+// real [codeStart, codeSize) and the owning pool's base/size/id.
+TEST(EJitCodePoolRange, FindRangeResolvesRecordedAllocation) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(200, 64));
+  Mgr.recordFinalizedRange(P, 200);
+
+  EJitCompiledCodeInfo Info{};
+  void *Mid = reinterpret_cast<void *>(A(P) + 64); // interior pointer
+  ASSERT_TRUE(Mgr.findRange(Mid, Info));
+  EXPECT_EQ(Info.codeStart, A(P));
+  EXPECT_EQ(Info.codeSize, 200u);
+  EXPECT_EQ(Info.poolBase % kTwoMiB, 0u);
+  EXPECT_EQ(Info.poolSize, kTwoMiB);
+  EXPECT_GE(A(P), Info.poolBase);
+  EXPECT_LE(A(P) + 200, Info.poolBase + Info.poolSize);
+  EXPECT_EQ(Info.fnPtr, Mid);
+}
+
+// A pointer with NO recorded finalized range is a clean miss (no guessed extent
+// is fabricated from the pool alone).
+TEST(EJitCodePoolRange, FindRangeMissForUnrecordedPointer) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(200, 64)); // allocated but NOT recorded
+  EJitCompiledCodeInfo Info{};
+  EXPECT_FALSE(Mgr.findRange(P, Info));
+}
+
+// A non-pool address (e.g. a stack pointer) is never mishandled.
+TEST(EJitCodePoolRange, FindRangeRejectsNonPoolAddress) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(200, 64));
+  Mgr.recordFinalizedRange(P, 200);
+
+  int OnStack = 0;
+  EJitCompiledCodeInfo Info{};
+  EXPECT_FALSE(Mgr.findRange(&OnStack, Info));
+}
+
+// A zero-size finalized record is ignored (the pointer then misses).
+TEST(EJitCodePoolRange, RecordZeroSizeRangeIgnored) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(200, 64));
+  Mgr.recordFinalizedRange(P, 0); // ignored
+  EJitCompiledCodeInfo Info{};
+  EXPECT_FALSE(Mgr.findRange(P, Info));
+}
+
+// Distinct pools yield distinct poolBase and poolId.
+TEST(EJitCodePoolRange, FindRangeReportsDistinctPoolIds) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P0 = cantFail(Mgr.allocateCode(kTwoMiB, 64)); // fills pool 0
+  Mgr.recordFinalizedRange(P0, 100);
+  void *P1 = cantFail(Mgr.allocateCode(100, 64)); // forces a new pool
+  Mgr.recordFinalizedRange(P1, 100);
+
+  EJitCompiledCodeInfo I0{}, I1{};
+  ASSERT_TRUE(Mgr.findRange(P0, I0));
+  ASSERT_TRUE(Mgr.findRange(P1, I1));
+  EXPECT_NE(I0.poolBase, I1.poolBase);
+  EXPECT_NE(I0.poolId, I1.poolId);
+}
+
+// Recording the IDENTICAL [start, size) extent more than once is idempotent:
+// the range table does not grow and findRange still resolves the pointer. This
+// guards against a retried finalize creating duplicate, equally-valid matches.
+TEST(EJitCodePoolRange, RecordDuplicateRangeIsIdempotent) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(200, 64));
+  Mgr.recordFinalizedRange(P, 200);
+  Mgr.recordFinalizedRange(P, 200); // exact duplicate
+  Mgr.recordFinalizedRange(P, 200); // and again
+
+  EXPECT_EQ(Mgr.getStats().finalizedRangeCount, 1u);
+
+  EJitCompiledCodeInfo Info{};
+  ASSERT_TRUE(Mgr.findRange(P, Info));
+  EXPECT_EQ(Info.codeStart, A(P));
+  EXPECT_EQ(Info.codeSize, 200u);
+}
+
+// Two distinct, non-overlapping executable extents in the SAME pool are both
+// recorded and each pointer resolves to its own range.
+TEST(EJitCodePoolRange, TwoDistinctRangesResolveIndependently) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P0 = cantFail(Mgr.allocateCode(128, 64));
+  void *P1 = cantFail(Mgr.allocateCode(256, 64));
+  Mgr.recordFinalizedRange(P0, 128);
+  Mgr.recordFinalizedRange(P1, 256);
+
+  EXPECT_EQ(Mgr.getStats().finalizedRangeCount, 2u);
+
+  EJitCompiledCodeInfo I0{}, I1{};
+  ASSERT_TRUE(Mgr.findRange(P0, I0));
+  ASSERT_TRUE(Mgr.findRange(P1, I1));
+  EXPECT_EQ(I0.codeStart, A(P0));
+  EXPECT_EQ(I0.codeSize, 128u);
+  EXPECT_EQ(I1.codeStart, A(P1));
+  EXPECT_EQ(I1.codeSize, 256u);
+  // Same pool, so identical pool identity.
+  EXPECT_EQ(I0.poolBase, I1.poolBase);
+  EXPECT_EQ(I0.poolId, I1.poolId);
+}
+
+// findRange is deterministic when ranges overlap (an invariant violation that
+// could only arise from address reuse): the first recorded range that contains
+// the pointer wins, in append order. No UB, no ambiguity.
+TEST(EJitCodePoolRange, OverlappingRangesResolveDeterministically) {
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, fourKOpts());
+
+  void *P = cantFail(Mgr.allocateCode(400, 64));
+  // Two overlapping extents covering the same interior pointer, recorded in a
+  // fixed order. (In practice pool addresses are never reused while live, so
+  // this cannot occur; the test pins the deterministic resolution anyway.)
+  Mgr.recordFinalizedRange(P, 400);                                  // first
+  Mgr.recordFinalizedRange(reinterpret_cast<void *>(A(P) + 64), 64); // second
+
+  EXPECT_EQ(Mgr.getStats().finalizedRangeCount, 2u);
+
+  EJitCompiledCodeInfo Info{};
+  void *Mid = reinterpret_cast<void *>(A(P) + 100);
+  ASSERT_TRUE(Mgr.findRange(Mid, Info));
+  // First (append order) containing range wins.
+  EXPECT_EQ(Info.codeStart, A(P));
+  EXPECT_EQ(Info.codeSize, 400u);
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -18,6 +18,8 @@
 #include "gtest/gtest.h"
 #include <memory>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 using namespace llvm::ejit;
 
@@ -66,6 +68,59 @@ bool mockPrepareCode(void *ctx, const void * /*fnPtr*/) {
   auto *log = static_cast<PrepareLog *>(ctx);
   log->cores.push_back(EJitCoreId::current());
   return log->succeed;
+}
+
+//===----------------------------------------------------------------------===//
+// 4K page-seal mocks: a per-core split + per-page seal that log which core ran
+// them and (optionally) fail or inject a concurrent slot/generation change at a
+// chosen seal step (to exercise the re-validate-after-prepare protocol).
+//===----------------------------------------------------------------------===//
+struct FourKLog {
+  std::vector<std::pair<uintptr_t, uint32_t>> splits; // (poolBase, core)
+  std::vector<std::pair<uintptr_t, uint32_t>> seals;  // (pageVA, core)
+  bool splitOk = true;
+  int failSealAtIndex = -1;           // fail the Nth (0-based) seal call
+  void (*raceHook)(void *) = nullptr; // run during a chosen seal (no lock held)
+  void *raceCtx = nullptr;
+  int raceAtSealIndex = -1;
+};
+bool mockSplitPool(void *ctx, uintptr_t poolBase, uint64_t /*poolSize*/) {
+  auto *l = static_cast<FourKLog *>(ctx);
+  l->splits.push_back({poolBase, EJitCoreId::current()});
+  return l->splitOk;
+}
+bool mockSealPage(void *ctx, uintptr_t pageVA) {
+  auto *l = static_cast<FourKLog *>(ctx);
+  int idx = static_cast<int>(l->seals.size());
+  l->seals.push_back({pageVA, EJitCoreId::current()});
+  if (l->raceHook && idx == l->raceAtSealIndex)
+    l->raceHook(l->raceCtx); // simulate a concurrent publish during prepare
+  if (l->failSealAtIndex == idx)
+    return false;
+  return true;
+}
+
+// Owner-side resolver of a compiled pointer to a (test-controlled) executable
+// range. Mutating the RangeCtx between compiles models distinct code extents.
+struct RangeCtx {
+  uintptr_t poolBase = 0x40000000ull;
+  uint64_t poolSize = 0x200000ull; // 2 MiB
+  uintptr_t codeStart = 0x40000000ull;
+  uint64_t codeSize = 64;
+  uint32_t poolId = 0;
+  bool provide = true;
+};
+bool mockCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
+  auto *r = static_cast<RangeCtx *>(ctx);
+  if (!r->provide)
+    return false;
+  out->fnPtr = const_cast<void *>(fnPtr);
+  out->codeStart = r->codeStart;
+  out->codeSize = r->codeSize;
+  out->poolBase = r->poolBase;
+  out->poolSize = r->poolSize;
+  out->poolId = r->poolId;
+  return true;
 }
 
 // Compiler that returns a distinct, non-null pointer on every call (models a
@@ -128,6 +183,43 @@ protected:
     pool.setMode(EJitCompileMode::Async);
     pool.setCodeSharingEnabled(codeSharing);
     ASSERT_EQ(pool.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  }
+
+  // Bring up a 4K-seal owner with code sharing ON, an injected range provider,
+  // and mock per-core split + per-page seal callbacks.
+  void bringUpOwner4K(EJitSharedTaskPool &pool, FourKLog &fourK,
+                      RangeCtx &range) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.bind(state_.get());
+    pool.setCompiler(&mockCompile, nullptr);
+    pool.setMode(EJitCompileMode::Async);
+    pool.setCodeSharingEnabled(true);
+    pool.setSealMode(true);
+    pool.setCodeRangeProvider(&mockCodeRange, &range);
+    pool.setSplitPoolCallback(&mockSplitPool, &fourK);
+    pool.setSealPageCallback(&mockSealPage, &fourK);
+    ASSERT_EQ(pool.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  }
+
+  // Compile + publish one (funcIndex, no-dims) entry on the owner core.
+  void publish(EJitSharedTaskPool &owner, uint32_t funcIndex) {
+    EJitCoreId::setCurrentForTest(0);
+    ASSERT_EQ(
+        owner.compileOrGet(funcIndex, nullptr, 0, codeFor(funcIndex)).status,
+        EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(owner.pollOne());
+  }
+
+  EJitSharedCacheSlot *findReadySlot(uint32_t funcIndex) {
+    for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
+      for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+        EJitSharedCacheSlot &Slot = state_->buckets[b].slots[s];
+        if (Slot.state.loadAcquire() ==
+                static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
+            Slot.funcIndex == funcIndex)
+          return &Slot;
+      }
+    return nullptr;
   }
 
   std::unique_ptr<EJitSharedTaskPoolState> state_;
@@ -1144,6 +1236,487 @@ TEST_F(SharedTaskPoolTest, RegistrationFingerprintMismatchRejected) {
   EJitCoreId::setCurrentForTest(2);
   EXPECT_EQ(peer.init(), EJitSharedTaskPool::InitResult::FingerprintMismatch);
   EXPECT_FALSE(peer.isOwner());
+}
+
+//===----------------------------------------------------------------------===//
+// 4K per-core shared code execute-permission preparation.
+//===----------------------------------------------------------------------===//
+
+// 1/ Single-page function: the peer splits its pool ONCE and seals ONE page.
+TEST_F(SharedTaskPoolTest, FourKPeerSplitsOnceSealsSinglePage) {
+  FourKLog fourK;
+  RangeCtx range; // codeStart 0x40000000, size 64 -> one 4K page
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto hit = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(hit.fnPtr, codeFor(1));
+  EXPECT_TRUE(hit.hasReadToken);
+  owner.releaseRead(hit.bucketIndex);
+
+  ASSERT_EQ(fourK.splits.size(), 1u);
+  EXPECT_EQ(fourK.splits[0].first, range.poolBase);
+  EXPECT_EQ(fourK.splits[0].second, 3u);
+  ASSERT_EQ(fourK.seals.size(), 1u);
+  EXPECT_EQ(fourK.seals[0].first, 0x40000000ull);
+  EXPECT_EQ(fourK.seals[0].second, 3u);
+}
+
+// 2/3 Range spanning two pages with an unaligned start/end: seal BOTH pages.
+TEST_F(SharedTaskPoolTest, FourKPeerSealsEveryCoveredPageUnaligned) {
+  FourKLog fourK;
+  RangeCtx range;
+  range.codeStart = 0x40000F00ull; // unaligned, near the end of page 0
+  range.codeSize = 0x200;          // crosses into page 1
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 2);
+
+  EJitCoreId::setCurrentForTest(5);
+  auto hit = owner.compileOrGet(2, nullptr, 0, codeFor(2));
+  ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(hit.bucketIndex);
+
+  ASSERT_EQ(fourK.seals.size(), 2u);
+  EXPECT_EQ(fourK.seals[0].first, 0x40000000ull); // page-aligned down
+  EXPECT_EQ(fourK.seals[1].first, 0x40001000ull); // page-aligned up
+}
+
+// 4/ Repeated hit on the SAME core does NOT re-split or re-seal (memoized).
+TEST_F(SharedTaskPoolTest, FourKSameCoreRepeatHitNoRework) {
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto h1 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h1.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h1.bucketIndex);
+  auto h2 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h2.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h2.bucketIndex);
+
+  EXPECT_EQ(fourK.splits.size(), 1u); // not repeated
+  EXPECT_EQ(fourK.seals.size(), 1u);  // not repeated
+}
+
+// 5/ A second function in the SAME pool: no re-split, but seals its OWN pages.
+TEST_F(SharedTaskPoolTest, FourKSecondFuncSamePoolNoResplit) {
+  FourKLog fourK;
+  RangeCtx range;
+  range.codeStart = 0x40000000ull; // func 1 -> page 0
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+  range.codeStart = 0x40010000ull; // func 2 -> a different page, SAME pool
+  publish(owner, 2);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto h1 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h1.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h1.bucketIndex);
+  auto h2 = owner.compileOrGet(2, nullptr, 0, codeFor(2));
+  ASSERT_EQ(h2.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h2.bucketIndex);
+
+  EXPECT_EQ(fourK.splits.size(), 1u); // split once for the shared pool
+  ASSERT_EQ(fourK.seals.size(), 2u);  // but each func sealed its own page
+  EXPECT_EQ(fourK.seals[0].first, 0x40000000ull);
+  EXPECT_EQ(fourK.seals[1].first, 0x40010000ull);
+}
+
+// 6/ Two peer cores each split + seal in their own translation context.
+TEST_F(SharedTaskPoolTest, FourKTwoPeerCoresEachPrepare) {
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto h3 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h3.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h3.bucketIndex);
+  EJitCoreId::setCurrentForTest(4);
+  auto h4 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h4.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h4.bucketIndex);
+
+  ASSERT_EQ(fourK.splits.size(), 2u);
+  EXPECT_EQ(fourK.splits[0].second, 3u);
+  EXPECT_EQ(fourK.splits[1].second, 4u);
+  ASSERT_EQ(fourK.seals.size(), 2u);
+  EXPECT_EQ(fourK.seals[0].second, 3u);
+  EXPECT_EQ(fourK.seals[1].second, 4u);
+}
+
+// 7/ The owner never runs peer preparation (it sealed the code itself).
+TEST_F(SharedTaskPoolTest, FourKOwnerDoesNotPeerPrepare) {
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(0); // owner
+  auto hit = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(hit.bucketIndex);
+  EXPECT_TRUE(fourK.splits.empty());
+  EXPECT_TRUE(fourK.seals.empty());
+}
+
+// 8/ Split failure: clean fallback, NO ready bit, NO seal; a later retry can
+// succeed once the platform recovers.
+TEST_F(SharedTaskPoolTest, FourKSplitFailureFallsBackAndRetries) {
+  FourKLog fourK;
+  fourK.splitOk = false;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto miss = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  EXPECT_EQ(miss.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(miss.readyButNotShareable);
+  EXPECT_FALSE(miss.hasReadToken);
+  EXPECT_TRUE(fourK.seals.empty()); // never sealed after a failed split
+  EXPECT_EQ(state_->counters.executePrepareFailed.loadAcquire(), 1u);
+  // The per-core split-done bit must NOT be set, so a retry re-attempts.
+  fourK.splitOk = true;
+  auto hit = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(hit.bucketIndex);
+  EXPECT_EQ(fourK.splits.size(), 2u); // re-attempted
+  EXPECT_EQ(fourK.seals.size(), 1u);
+}
+
+// 9/ A mid-range seal failure: clean fallback, the slot is NOT marked ready for
+// this core (the next hit re-prepares).
+TEST_F(SharedTaskPoolTest, FourKMidSealFailureFallsBack) {
+  FourKLog fourK;
+  fourK.failSealAtIndex = 1; // first page seals, second fails
+  RangeCtx range;
+  range.codeStart = 0x40000F00ull;
+  range.codeSize = 0x200; // two pages
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto miss = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  EXPECT_EQ(miss.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(miss.readyButNotShareable);
+  EXPECT_EQ(fourK.seals.size(), 2u); // attempted both, second failed
+  EXPECT_EQ(state_->counters.executePrepareFailed.loadAcquire(), 1u);
+  // Not memoized: a retry (now succeeding) re-seals.
+  fourK.failSealAtIndex = -1;
+  auto hit = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(hit.bucketIndex);
+}
+
+// 10/ Missing / zero-size / overflowing range: clean fallback, no platform
+// call.
+TEST_F(SharedTaskPoolTest, FourKMissingRangeFallsBack) {
+  FourKLog fourK;
+  RangeCtx range;
+  range.provide = false; // owner publishes NO range (codeSize stays 0)
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+  // Slot carries no range metadata.
+  EJitSharedCacheSlot *slot = findReadySlot(1);
+  ASSERT_NE(slot, nullptr);
+  EXPECT_EQ(slot->codeSize, 0ull);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto miss = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  EXPECT_EQ(miss.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(miss.readyButNotShareable);
+  EXPECT_TRUE(fourK.splits.empty());
+  EXPECT_TRUE(fourK.seals.empty());
+}
+
+// 10b/ A range whose code lies outside its pool is rejected (no seal).
+TEST_F(SharedTaskPoolTest, FourKOutOfPoolRangeRejected) {
+  FourKLog fourK;
+  RangeCtx range;
+  range.codeStart = 0x40000000ull;
+  range.codeSize = 0x300000ull; // 3 MiB > 2 MiB pool: code escapes the pool
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(3);
+  auto miss = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  EXPECT_EQ(miss.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(miss.readyButNotShareable);
+  EXPECT_TRUE(fourK.seals.empty());
+}
+
+// 11/ Pool-readiness table full: a peer hitting an untracked pool cleanly falls
+// back rather than overflow the fixed table.
+TEST_F(SharedTaskPoolTest, FourKPoolTableFullFallsBack) {
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  // Publish kEJitSharedPoolSlots + 1 functions, each in a DISTINCT 2MiB pool.
+  const uint32_t N = kEJitSharedPoolSlots + 1;
+  for (uint32_t f = 0; f < N; ++f) {
+    range.poolBase = 0x40000000ull + static_cast<uint64_t>(f) * 0x200000ull;
+    range.codeStart = range.poolBase;
+    range.codeSize = 64;
+    publish(owner, f);
+  }
+  // A single peer core touches every pool; the table holds only
+  // kEJitSharedPoolSlots, so exactly one distinct pool cannot be tracked and
+  // that hit cleanly falls back.
+  EJitCoreId::setCurrentForTest(3);
+  uint32_t fallbacks = 0, hits = 0;
+  for (uint32_t f = 0; f < N; ++f) {
+    auto r = owner.compileOrGet(f, nullptr, 0, codeFor(f));
+    if (r.status == EJitCompileOrGetStatus::CacheHit) {
+      ++hits;
+      owner.releaseRead(r.bucketIndex);
+    } else {
+      EXPECT_EQ(r.status, EJitCompileOrGetStatus::OffMode);
+      EXPECT_TRUE(r.readyButNotShareable);
+      ++fallbacks;
+    }
+  }
+  EXPECT_EQ(hits, kEJitSharedPoolSlots);
+  EXPECT_EQ(fallbacks, 1u);
+}
+
+// 12/ Core id beyond the 64-bit memo width: no UB, and (documented) the split +
+// seal re-run on every hit since the per-core bit cannot be recorded.
+TEST_F(SharedTaskPoolTest, FourKOutOfRangeCoreRePreparesEachHit) {
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(100); // >= kEJitSharedMaxMemoCores
+  auto h1 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h1.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h1.fnPtr, codeFor(1));
+  owner.releaseRead(h1.bucketIndex);
+  auto h2 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h2.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h2.bucketIndex);
+  EXPECT_EQ(fourK.splits.size(), 2u); // re-prepared (no memoization)
+  EXPECT_EQ(fourK.seals.size(), 2u);
+}
+
+// 13/ Slot replaced (fnPtr changed) DURING preparation: the prepared pointer is
+// re-validated and the now-stale pointer is NOT returned.
+TEST_F(SharedTaskPoolTest, FourKSlotReplacedDuringPrepareNotReturned) {
+  static EJitSharedCacheSlot *gSlot = nullptr;
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+  gSlot = findReadySlot(1);
+  ASSERT_NE(gSlot, nullptr);
+  // During the (only) seal call — after the bucket read lock was released —
+  // overwrite the slot's fnPtr to model a concurrent same-generation republish.
+  fourK.raceAtSealIndex = 0;
+  fourK.raceCtx = nullptr;
+  fourK.raceHook = [](void *) {
+    gSlot->fnPtr.storeRelease(
+        reinterpret_cast<uintptr_t>(reinterpret_cast<void *>(0xBADC0DEull)));
+  };
+
+  EJitCoreId::setCurrentForTest(3);
+  auto r = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  EXPECT_EQ(r.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(r.readyButNotShareable);
+  EXPECT_FALSE(r.hasReadToken);
+}
+
+// 14/ Generation changed DURING preparation: the prepared pointer is discarded.
+TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
+  static EJitSharedTaskPoolState *gState = nullptr;
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+  gState = state_.get();
+  fourK.raceAtSealIndex = 0;
+  fourK.raceHook = [](void *) {
+    gState->generation.storeRelease(gState->generation.loadAcquire() + 1);
+  };
+
+  EJitCoreId::setCurrentForTest(3);
+  auto r = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  EXPECT_EQ(r.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(r.readyButNotShareable);
+}
+
+// 16/17 ABI v5 layout: the slot carries the executable range as fixed-width,
+// naturally-aligned scalars (read back by value — endian-safe), and the
+// pool-split table is POD.
+TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
+  EXPECT_EQ(kEJitSharedAbiVersion, 5u);
+  EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
+  EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
+  EXPECT_TRUE(
+      std::is_trivially_default_constructible<EJitSharedPoolSplit>::value);
+
+  FourKLog fourK;
+  RangeCtx range;
+  range.codeStart = 0x40012340ull;
+  range.codeSize = 0x456;
+  range.poolBase = 0x40000000ull;
+  range.poolSize = 0x200000ull;
+  range.poolId = 7;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  EXPECT_EQ(state_->abiVersion, kEJitSharedAbiVersion);
+  publish(owner, 1);
+
+  EJitSharedCacheSlot *slot = findReadySlot(1);
+  ASSERT_NE(slot, nullptr);
+  EXPECT_EQ(slot->codeStart, 0x40012340ull);
+  EXPECT_EQ(slot->codeSize, 0x456ull);
+  EXPECT_EQ(slot->poolBase, 0x40000000ull);
+  EXPECT_EQ(slot->poolSize, 0x200000ull);
+  EXPECT_EQ(slot->poolId, 7u);
+  EXPECT_EQ(slot->rangeReserved, 0u);
+}
+
+// 18/ Code-sharing OFF in 4K mode: a non-owner cleanly rejects and triggers NO
+// platform split/seal call at all.
+TEST_F(SharedTaskPoolTest, FourKCodeSharingOffMakesNoPlatformCall) {
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  EJitCoreId::setCurrentForTest(0);
+  owner.bind(state_.get());
+  owner.setCompiler(&mockCompile, nullptr);
+  owner.setMode(EJitCompileMode::Async);
+  owner.setCodeSharingEnabled(false); // capability OFF
+  owner.setSealMode(true);
+  owner.setCodeRangeProvider(&mockCodeRange, &range);
+  owner.setSplitPoolCallback(&mockSplitPool, &fourK);
+  owner.setSealPageCallback(&mockSealPage, &fourK);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(3);
+  void *fallback = reinterpret_cast<void *>(0xFEEDull);
+  auto r = owner.compileOrGet(1, nullptr, 0, fallback);
+  EXPECT_EQ(r.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(r.readyButNotShareable);
+  EXPECT_EQ(r.fnPtr, fallback);
+  EXPECT_TRUE(fourK.splits.empty());
+  EXPECT_TRUE(fourK.seals.empty());
+}
+
+// 19/ Re-init scrubs EVERY ABI-v5 field. A re-initialization runs over the same
+// shared blob, so initSharedStorage must clear the per-pool split table AND the
+// per-slot executable-range metadata (plus fnPtr / executableCoreMask / state).
+// Pre-stain the raw blob with garbage and prove the owner election zeroes it.
+TEST_F(SharedTaskPoolTest, FourKReinitScrubsStaleV5Fields) {
+  // Stain the per-pool split table.
+  for (uint32_t i = 0; i < kEJitSharedPoolSlots; ++i) {
+    state_->poolSplits[i].poolBase.storeRelaxed(0xDEADBEEFull);
+    state_->poolSplits[i].splitDoneMask.storeRelaxed(~uint64_t(0));
+    state_->poolSplits[i].splitPreparingMask.storeRelaxed(~uint64_t(0));
+  }
+  // Stain every cache slot's range + sharing fields and mark it (falsely)
+  // Ready.
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = state_->buckets[b].slots[s];
+      Slot.state.storeRelaxed(
+          static_cast<uint32_t>(EJitSharedSlotState::Ready));
+      Slot.fnPtr.storeRelaxed(0xBADC0DEull);
+      Slot.executableCoreMask.storeRelaxed(~uint64_t(0));
+      Slot.codeStart = 0x1111;
+      Slot.codeSize = 0x2222;
+      Slot.poolBase = 0x3333;
+      Slot.poolSize = 0x4444;
+      Slot.poolId = 0x5555;
+      Slot.rangeReserved = 0x6666;
+    }
+
+  // init-state was left Uninitialized, so owner election runs
+  // initSharedStorage.
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+
+  for (uint32_t i = 0; i < kEJitSharedPoolSlots; ++i) {
+    EXPECT_EQ(state_->poolSplits[i].poolBase.loadRelaxed(), 0u);
+    EXPECT_EQ(state_->poolSplits[i].splitDoneMask.loadRelaxed(), 0u);
+    EXPECT_EQ(state_->poolSplits[i].splitPreparingMask.loadRelaxed(), 0u);
+  }
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = state_->buckets[b].slots[s];
+      EXPECT_EQ(Slot.state.loadAcquire(),
+                static_cast<uint32_t>(EJitSharedSlotState::Empty));
+      EXPECT_EQ(Slot.fnPtr.loadRelaxed(), 0u);
+      EXPECT_EQ(Slot.executableCoreMask.loadRelaxed(), 0u);
+      EXPECT_EQ(Slot.codeStart, 0u);
+      EXPECT_EQ(Slot.codeSize, 0u);
+      EXPECT_EQ(Slot.poolBase, 0u);
+      EXPECT_EQ(Slot.poolSize, 0u);
+      EXPECT_EQ(Slot.poolId, 0u);
+      EXPECT_EQ(Slot.rangeReserved, 0u);
+    }
+}
+
+// 20/ A per-core split-done bit recorded under one generation must NOT survive
+// a re-init: after the owner tears down and re-initializes (new generation),
+// the same peer core re-runs split_2m_to_4k for the rebuilt pool (a stale done
+// bit would otherwise let it seal pages that were never split in this
+// generation).
+TEST_F(SharedTaskPoolTest, FourKReinitForcesPeerToReSplit) {
+  FourKLog fourK;
+  RangeCtx range;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  // Peer core 3 prepares once: records a split + a per-core done bit.
+  EJitCoreId::setCurrentForTest(3);
+  auto h = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h.bucketIndex);
+  ASSERT_EQ(fourK.splits.size(), 1u);
+
+  // Tear down + re-init on the owner core: the whole blob (and split table) is
+  // rebuilt under a fresh generation.
+  EJitCoreId::setCurrentForTest(0);
+  owner.ownerShutdown();
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  for (uint32_t i = 0; i < kEJitSharedPoolSlots; ++i) {
+    EXPECT_EQ(state_->poolSplits[i].poolBase.loadRelaxed(), 0u);
+    EXPECT_EQ(state_->poolSplits[i].splitDoneMask.loadRelaxed(), 0u);
+  }
+  publish(owner, 1);
+
+  // The same peer core must split AGAIN for the rebuilt pool.
+  EJitCoreId::setCurrentForTest(3);
+  auto h2 = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(h2.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(h2.bucketIndex);
+  EXPECT_EQ(fourK.splits.size(), 2u); // re-split after re-init
+  EXPECT_EQ(fourK.splits[1].second, 3u);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Add per-core 4K execute-permission support for the shared taskpool/code-pool path.

This keeps the existing 2MiB sealing behavior intact, but when 4K sealing is enabled it records finalized executable ranges, splits each 2MiB pool into 4K mappings once per pool, and seals only executable code pages before handing out callable pointers across cores.

## Key Changes

- Reset shared 4K pool/range metadata during shared-state initialization.
- Track finalized executable ranges from JITLink memory-manager allocations.
- Seal executable 4K pages only, instead of sealing the full slab.
- Preserve declared-only platform symbols for `enable_ex` and `split_2m_to_4k`.
- Add tests for stale split metadata, range recording, idempotent range handling, and exec-only sealing behavior.

## Validation Reported Locally

- `EJITCodePoolTests`: 40 passing
- `EJITSharedTaskPoolTests`: 52 passing
- `EJITTaskPoolTests`: 75 passing
- Checked both 4K and 2MiB configurations in the local host environment.

## Notes

Real aarch64_be SRE validation is still required for per-core Stage-1 permission behavior, `split_2m_to_4k` idempotency, and final I-cache/TLB synchronization semantics.