### PR TITLE
[EJIT] Strip per-CPU instruction scheduling tables from AArch64 ejit.o in lipo pipeline

### DIFF
--- a/ejit_test/lipo/ejit_strip_sched_models.py
+++ b/ejit_test/lipo/ejit_strip_sched_models.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+ejit_strip_sched_models.py — Null out per-CPU scheduling model table pointers
+in the TableGen-generated AArch64GenSubtargetInfo.inc.
+
+Background
+----------
+AArch64GenSubtargetInfo.inc defines ~24 per-CPU scheduling models, each holding
+a ~24 KB MCSchedClassDesc array and a smaller MCProcResourceDesc array.  All
+models are kept alive by AArch64SubTypeKV (the CPU-name lookup table used during
+subtarget initialization), so gc-sections cannot eliminate them through normal
+linkage.
+
+This script patches three fields in every MCSchedModel initializer that should
+be stripped:
+  ProcResourceTable        → nullptr
+  SchedClassTable          → nullptr
+  NumProcResourceKinds     → 0
+  NumSchedClasses          → 0
+
+After patching, those arrays become unreferenced and gc-sections in the lipo
+pipeline eliminates them.
+
+Usage
+-----
+    python3 ejit_strip_sched_models.py BUILD_DIR [KEEP_CPU]
+
+  BUILD_DIR   Path to the cmake build directory (e.g. build_release_aarch64).
+  KEEP_CPU    LLVM CPU name whose scheduling model should be preserved intact.
+              All other non-generic models are stripped.  Omit to strip every
+              model.
+
+              Examples:
+                "cortex-a57"   → keeps CortexA57Model (also used by a72/a73/a75–a78c)
+                "neoverse-n2"  → keeps NeoverseN2Model
+                ""  or omit   → strips all models
+
+After patching, rebuild the two libraries that include the .inc file:
+    ninja -C BUILD_DIR LLVMAArch64CodeGen LLVMAArch64Desc
+
+To restore the original .inc, delete it and run:
+    ninja -C BUILD_DIR AArch64CommonTableGen
+run_aarch64_pipeline.sh does this automatically when switching to no-strip mode.
+"""
+
+import sys
+import re
+import os
+
+INC_PATH = "lib/Target/AArch64/AArch64GenSubtargetInfo.inc"
+SENTINEL = "// EJIT: stripped"
+
+
+def find_keep_model(content: str, keep_cpu: str) -> str | None:
+    """Return the MCSchedModel variable name mapped to keep_cpu in AArch64SubTypeKV."""
+    kv_start = content.find('AArch64SubTypeKV[]')
+    if kv_start == -1:
+        return None
+    kv_end = content.find('\n};', kv_start)
+    if kv_end == -1:
+        return None
+    kv_block = content[kv_start:kv_end]
+
+    # Each KV entry is one line: { "cpu-name", {...}, {...}, &ModelName }
+    pos = kv_block.find(f'"{keep_cpu}"')
+    if pos == -1:
+        return None
+
+    # Scan forward from the CPU string to the end of its entry.
+    m = re.search(r'&(\w+Model)\s*\}', kv_block[pos:])
+    if m:
+        return m.group(1)  # e.g. "CortexA57Model"
+    return None
+
+
+def patch(build_dir: str, keep_cpu: str) -> None:
+    inc = os.path.join(build_dir, INC_PATH)
+    if not os.path.exists(inc):
+        print(f"ERROR: {inc} not found — is BUILD_DIR correct?")
+        sys.exit(1)
+
+    with open(inc) as f:
+        content = f.read()
+
+    if SENTINEL in content:
+        print("Already patched — nothing to do.")
+        return
+
+    # Resolve which model struct to keep (if any).
+    keep_model: str | None = None
+    if keep_cpu:
+        keep_model = find_keep_model(content, keep_cpu)
+        if keep_model is None:
+            print(f"WARNING: {keep_cpu!r} not found in AArch64SubTypeKV — "
+                  f"stripping all models.")
+        else:
+            print(f"Keeping scheduling model for {keep_cpu!r}: {keep_model}")
+
+    keep_proc  = (keep_model + "ProcResources") if keep_model else None
+    keep_sched = (keep_model + "SchedClasses")  if keep_model else None
+
+    n_stripped_proc  = 0
+    n_stripped_sched = 0
+
+    # Step 1 — replace  "  XxxModelProcResources,"  with  nullptr.
+    # Only matches struct-initializer lines (2-space indent, identifier ending
+    # in ModelProcResources, trailing comma).  Does NOT match array definitions
+    # ("static const ... XxxModelProcResources[] = {").
+    def replace_proc(m: re.Match) -> str:
+        nonlocal n_stripped_proc
+        if keep_proc and m.group(2) == keep_proc:
+            return m.group(0)
+        n_stripped_proc += 1
+        return f'{m.group(1)}nullptr,  {SENTINEL}'
+
+    content = re.sub(
+        r'^(  )(\w+ModelProcResources),[ \t]*$',
+        replace_proc,
+        content,
+        flags=re.MULTILINE,
+    )
+
+    # Step 2 — same for SchedClasses.
+    def replace_sched(m: re.Match) -> str:
+        nonlocal n_stripped_sched
+        if keep_sched and m.group(2) == keep_sched:
+            return m.group(0)
+        n_stripped_sched += 1
+        return f'{m.group(1)}nullptr,  {SENTINEL}'
+
+    content = re.sub(
+        r'^(  )(\w+ModelSchedClasses),[ \t]*$',
+        replace_sched,
+        content,
+        flags=re.MULTILINE,
+    )
+
+    # Step 3 — zero NumProcResourceKinds and NumSchedClasses for each stripped
+    # pair.  Pattern after steps 1+2 (for a stripped model):
+    #   nullptr,  // EJIT: stripped        ← ProcResources
+    #   nullptr,  // EJIT: stripped        ← SchedClasses   ← matched here
+    #   NN,                                ← NumProcResourceKinds
+    #   MM,                                ← NumSchedClasses
+    content, n_counts = re.subn(
+        r'(  nullptr,  ' + re.escape(SENTINEL) + r'\n)'
+        r'  (\d+),\n'
+        r'  (\d+),\n',
+        r'\1'
+        r'  0,  ' + SENTINEL + r' (NumProcResourceKinds)\n'
+        r'  0,  ' + SENTINEL + r' (NumSchedClasses)\n',
+        content,
+    )
+
+    with open(inc, "w") as f:
+        f.write(content)
+
+    kept_note = f" (kept {keep_model})" if keep_model else " (all stripped)"
+    print(f"Patched{kept_note}:")
+    print(f"  {n_stripped_proc}  ProcResources references  → nullptr")
+    print(f"  {n_stripped_sched}  SchedClasses references   → nullptr")
+    print(f"  {n_counts}  count-field pairs         → 0, 0")
+    est_kb = n_stripped_proc * 24836 // 1024
+    print()
+    print("Next steps:")
+    print(f"  ninja -C {build_dir} LLVMAArch64CodeGen LLVMAArch64Desc")
+    print("  (then re-run run_aarch64_pipeline.sh)")
+    print()
+    print(f"Expected savings in ejit.o: ~{est_kb} KB ({n_stripped_proc} models stripped)")
+
+
+if __name__ == "__main__":
+    build_dir = sys.argv[1] if len(sys.argv) > 1 else "build_release_aarch64"
+    keep_cpu  = sys.argv[2] if len(sys.argv) > 2 else ""
+    patch(build_dir, keep_cpu)

--- a/ejit_test/lipo/run_aarch64_pipeline.sh
+++ b/ejit_test/lipo/run_aarch64_pipeline.sh
@@ -4,18 +4,103 @@
 #   ninja -C build_release_aarch64 clang LLVMEJIT lld
 #
 # Uses the build directory's own clang/clang++ and ld.lld (native aarch64).
-# No --exclude needed; the resulting ejit.o is ~37 MB (larger than the
-# bare-metal version, but includes full LLVM functionality).
+#
+# Options:
+#   --keep CPUNAME   Strip all per-CPU scheduling models except CPUNAME.
+#                    CPUNAME must be an LLVM CPU name present in
+#                    AArch64SubTypeKV (e.g. "cortex-a57", "neoverse-n2").
+#   --keep-none      Strip scheduling models for all CPUs.
+#                    Without --keep / --keep-none, no stripping is done (default).
+#
+# Default behaviour (no --keep):
+#   If AArch64GenSubtargetInfo.inc was previously patched (contains the EJIT
+#   sentinel), it is regenerated from TableGen sources (llvm-tblgen) and the
+#   libraries are rebuilt before running the lipo pipeline.
+#
+# Positional args (both optional):
+#   $1  BUILD_DIR   (default: build_release_aarch64)
+#   $2  OUTPUT      (default: ejit_test/lipo/ejit.o)
 
 set -euo pipefail
 
-BUILD_DIR="${1:-build_release_aarch64}"
-OUTPUT="${2:-ejit_test/lipo/ejit.o}"
+# ── Parse options ─────────────────────────────────────────────────────────────
+DO_STRIP=0
+KEEP_MODEL=""
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep)
+      DO_STRIP=1
+      KEEP_MODEL="$2"
+      shift 2
+      ;;
+    --keep-none)
+      DO_STRIP=1
+      KEEP_MODEL=""
+      shift
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+BUILD_DIR="${POSITIONAL[0]:-build_release_aarch64}"
+OUTPUT="${POSITIONAL[1]:-ejit_test/lipo/ejit.o}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WORK_DIR="$SCRIPT_DIR/.lipo_work_aarch64"
 
+INC="$BUILD_DIR/lib/Target/AArch64/AArch64GenSubtargetInfo.inc"
+
 rm -rf "$WORK_DIR"
+
+# Regenerate AArch64GenSubtargetInfo.inc from TableGen sources.
+# Deleting the file forces ninja to re-run llvm-tblgen even if AArch64.td
+# has not changed (a patched .inc would otherwise look up-to-date by mtime).
+regen_inc() {
+  echo "── Regenerating AArch64GenSubtargetInfo.inc (llvm-tblgen -gen-subtarget) ──"
+  rm -f "$INC"
+  ninja -C "$BUILD_DIR" AArch64CommonTableGen
+}
+
+# ── Step 0: manage per-CPU scheduling model tables ───────────────────────────
+# AArch64GenSubtargetInfo.inc defines ~24 per-CPU MCSchedModel structs (~600 KB
+# of .rodata total).  They survive gc-sections because AArch64SubTypeKV holds a
+# pointer to every model struct.
+#
+# With --keep CPUNAME: patch the .inc, nulling all models except CPUNAME's.
+#   gc-sections in Step 2 then eliminates the unused arrays (~575 KB saved).
+# With --keep-none: null every model (~600 KB saved).
+# Without --keep / --keep-none (default): use the full unstripped tablegen.
+#   If the .inc was previously patched it is regenerated from source first.
+if [[ $DO_STRIP -eq 1 ]]; then
+  # If the .inc is already patched from a previous run, regenerate to get a
+  # clean slate before applying the new patch.
+  if grep -q "EJIT: stripped" "$INC" 2>/dev/null; then
+    regen_inc
+  fi
+  if [[ -n "$KEEP_MODEL" ]]; then
+    echo "── Step 0: stripping sched models (keeping ${KEEP_MODEL}) ──"
+  else
+    echo "── Step 0: stripping all sched models (--keep-none) ──"
+  fi
+  python3 "$SCRIPT_DIR/ejit_strip_sched_models.py" "$BUILD_DIR" "$KEEP_MODEL"
+  echo "── Rebuilding LLVMAArch64CodeGen + LLVMAArch64Desc ──"
+  ninja -C "$BUILD_DIR" LLVMAArch64CodeGen LLVMAArch64Desc
+else
+  # No-strip: if the .inc is currently patched, regenerate from source.
+  if grep -q "EJIT: stripped" "$INC" 2>/dev/null; then
+    echo "── Step 0: .inc is patched — regenerating from TableGen sources ──"
+    regen_inc
+    echo "── Rebuilding LLVMAArch64CodeGen + LLVMAArch64Desc ──"
+    ninja -C "$BUILD_DIR" LLVMAArch64CodeGen LLVMAArch64Desc
+  else
+    echo "── Step 0: no-strip, .inc is already original ──"
+  fi
+fi
+echo ""
 
 # ── Step 1: extract ───────────────────────────────────────────────────────────
 # Compiles a reference binary, parses the linker map, and uses nm -u dependency


### PR DESCRIPTION
Currently, the final `ejit.o` contains scheduling model tables for every AArch64 CPU variant LLVM supports:
```
wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ nm -S --radix=d ejit_test/lipo/ejit.o | c++filt | grep ModelSched
nm: ejit_test/lipo/ejit.o: no group info for section '.text'
nm: ejit_test/lipo/ejit.o: no group info for section '.rodata'
nm: ejit_test/lipo/ejit.o: no group info for section '.data'
nm: ejit_test/lipo/ejit.o: no group info for section '.bss'
nm: ejit_test/lipo/ejit.o: no group info for section '.init_array'
0000000003136320 0000000000024836 r llvm::KryoModelSchedClasses
0000000002713080 0000000000024836 r llvm::A64FXModelSchedClasses
0000000003186168 0000000000024836 r llvm::OryonModelSchedClasses
0000000003111440 0000000000024836 r llvm::FalkorModelSchedClasses
0000000003285764 0000000000024836 r llvm::TSV110ModelSchedClasses
0000000002737944 0000000000024836 r llvm::Ampere1ModelSchedClasses
0000000002787644 0000000000024836 r llvm::CycloneModelSchedClasses
0000000002762808 0000000000024836 r llvm::Ampere1BModelSchedClasses
0000000003036480 0000000000024836 r llvm::ExynosM3ModelSchedClasses
0000000003061520 0000000000024836 r llvm::ExynosM4ModelSchedClasses
0000000003086548 0000000000024836 r llvm::ExynosM5ModelSchedClasses
0000000002837316 0000000000024836 r llvm::CortexA53ModelSchedClasses
0000000002887020 0000000000024836 r llvm::CortexA55ModelSchedClasses
0000000002911868 0000000000024836 r llvm::CortexA57ModelSchedClasses
0000000002812480 0000000000024836 r llvm::CortexA320ModelSchedClasses
0000000002862184 0000000000024836 r llvm::CortexA510ModelSchedClasses
0000000003161180 0000000000024836 r llvm::NeoverseN1ModelSchedClasses
0000000002936752 0000000000024836 r llvm::NeoverseN2ModelSchedClasses
0000000002961636 0000000000024836 r llvm::NeoverseN3ModelSchedClasses
0000000002986552 0000000000024836 r llvm::NeoverseV1ModelSchedClasses
0000000003011524 0000000000024836 r llvm::NeoverseV2ModelSchedClasses
0000000003211004 0000000000024836 r llvm::ThunderXT8XModelSchedClasses
0000000003235912 0000000000024836 r llvm::ThunderX2T99ModelSchedClasses
0000000003260896 0000000000024836 r llvm::ThunderX3T110ModelSchedClasses
```
and
```
wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ nm -S --radix=d ejit_test/lipo/ejit.o | c++filt | grep ModelProcResources
nm: ejit_test/lipo/ejit.o: no group info for section '.text'
nm: ejit_test/lipo/ejit.o: no group info for section '.rodata'
nm: ejit_test/lipo/ejit.o: no group info for section '.data'
nm: ejit_test/lipo/ejit.o: no group info for section '.bss'
nm: ejit_test/lipo/ejit.o: no group info for section '.init_array'
0000000000141936 0000000000000352 d llvm::KryoModelProcResources
0000000000129872 0000000000000768 d llvm::A64FXModelProcResources
0000000000142608 0000000000001280 d llvm::OryonModelProcResources
0000000000141360 0000000000000576 d llvm::FalkorModelProcResources
0000000000145360 0000000000000352 d llvm::TSV110ModelProcResources
0000000000130640 0000000000000352 d llvm::Ampere1ModelProcResources
0000000000131344 0000000000000448 d llvm::CycloneModelProcResources
0000000000130992 0000000000000352 d llvm::Ampere1BModelProcResources
0000000000135888 0000000000001472 d llvm::ExynosM3ModelProcResources
0000000000137360 0000000000002016 d llvm::ExynosM4ModelProcResources
0000000000139376 0000000000001984 d llvm::ExynosM5ModelProcResources
0000000000132112 0000000000000256 d llvm::CortexA53ModelProcResources
0000000000132880 0000000000000320 d llvm::CortexA55ModelProcResources
0000000000133200 0000000000000288 d llvm::CortexA57ModelProcResources
0000000000131792 0000000000000320 d llvm::CortexA320ModelProcResources
0000000000132368 0000000000000512 d llvm::CortexA510ModelProcResources
0000000000142288 0000000000000320 d llvm::NeoverseN1ModelProcResources
0000000000133488 0000000000000448 d llvm::NeoverseN2ModelProcResources
0000000000133936 0000000000000448 d llvm::NeoverseN3ModelProcResources
0000000000134384 0000000000000640 d llvm::NeoverseV1ModelProcResources
0000000000135024 0000000000000864 d llvm::NeoverseV2ModelProcResources
0000000000143888 0000000000000256 d llvm::ThunderXT8XModelProcResources
0000000000144144 0000000000000480 d llvm::ThunderX2T99ModelProcResources
0000000000144624 0000000000000736 d llvm::ThunderX3T110ModelProcResources
```

Each `ModelSchedClasses` array is 24,836 bytes and 24 of them amounts to ~582 KB. The `ModelProcResources` arrays add another ~15 KB. All of them survive, but we don't need these.

This patch introduces `ejit_strip_sched_models.py`, called from `run_aarch64_pipeline.sh`, which patches `AArch64GenSubtargetInfo.inc` to null out `ProcResourceTable`, `SchedClassTable`, `NumProcResourceKinds`, and `NumSchedClasses` in every `MCSchedModel` initializer that should be stripped. The arrays then become unreferenced and `--gc-sections` eliminates them in the merge step.

Three modes are supported via flags to `run_aarch64_pipeline.sh`:
| Flag | Behaviour |
|---|---|
| _(none)_ | No stripping (default). If the `.inc` was previously patched it is regenerated from TableGen sources before the pipeline runs. |
| `--keep cortex-a57` | Strips all models except `CortexA57Model`. Any CPU that shares the same model (e.g. cortex-a72, cortex-a75 through cortex-a78c) is also preserved. Saves ~575 KB. |
| `--keep-none` | Strips scheduling tables for every CPU model. Saves ~600 KB. |

with `--keep-none`, the ejit.o file is reduced to ~30MB:
<img width="1784" height="1126" alt="image" src="https://github.com/user-attachments/assets/611cf101-8a9b-4605-9512-a959574b6d8a" />
