### PR TITLE
[EJIT] Add diagnostic logging for maintainability and fault localization

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -334,8 +334,11 @@ bool EJit::activate(const std::string &periodName, uint8_t cellIdx) {
 #endif
     return true;
   }
-  if (!runtimeState_->getRegistry().getArrays(periodName))
+  if (!runtimeState_->getRegistry().getArrays(periodName)) {
+    EJIT_DIAG("activate reject(%s,%u): unknown period (not a lifecycle/array)",
+              periodName.c_str(), cellIdx);
     return false;
+  }
   runtimeState_->activate(periodName, cellIdx);
   return true;
 #else
@@ -364,8 +367,11 @@ bool EJit::deactivate(const std::string &periodName, uint8_t cellIdx) {
 #endif
     return true;
   }
-  if (!runtimeState_->getRegistry().getArrays(periodName))
+  if (!runtimeState_->getRegistry().getArrays(periodName)) {
+    EJIT_DIAG("deactivate reject(%s,%u): unknown period (not a lifecycle/array)",
+              periodName.c_str(), cellIdx);
     return false;
+  }
   runtimeState_->deactivate(periodName, cellIdx);
   return true;
 #else
@@ -381,8 +387,11 @@ bool EJit::activateArray(const std::string &periodName, void *arrayPtr,
   // period matches periodName.
   const PeriodArrayInfo *info =
       runtimeState_->getRegistry().getArrayByBaseAddr(arrayPtr);
-  if (!info || info->periodName != periodName)
+  if (!info || info->periodName != periodName) {
+    EJIT_DIAG("activateArray reject(%s,%u): arrayPtr=%p not a registered %s array",
+              periodName.c_str(), cellIdx, arrayPtr, periodName.c_str());
     return false;
+  }
 #ifdef EJIT_SRE_TASKPOOL
   // The taskpool SwitchController identity is ONLY (dimType, instanceId) — it
   // carries NO array identity. A lifecycle may own several arrays (cell ->
@@ -397,11 +406,17 @@ bool EJit::activateArray(const std::string &periodName, void *arrayPtr,
   // invalidation.
   const std::vector<PeriodArrayInfo> *arrays =
       runtimeState_->getRegistry().getArrays(periodName);
-  if (!arrays || arrays->size() != 1)
+  if (!arrays || arrays->size() != 1) {
+    EJIT_DIAG("activateArray reject(%s,%u): lifecycle owns %zu array(s), need 1",
+              periodName.c_str(), cellIdx, arrays ? arrays->size() : 0);
     return false;
+  }
   uint32_t dt = EJitLifecycleRegistry::instance().lookup(periodName);
-  if (dt == kEJitInvalidDimType)
+  if (dt == kEJitInvalidDimType) {
+    EJIT_DIAG("activateArray reject(%s,%u): not a registered lifecycle",
+              periodName.c_str(), cellIdx);
     return false;
+  }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (EJitSharedTaskPool *sp = sharedTaskPool())
     sp->setInstanceEnabled(dt, cellIdx, /*enabled=*/true);
@@ -421,19 +436,28 @@ bool EJit::deactivateArray(const std::string &periodName, void *arrayPtr,
                            uint8_t cellIdx) {
   const PeriodArrayInfo *info =
       runtimeState_->getRegistry().getArrayByBaseAddr(arrayPtr);
-  if (!info || info->periodName != periodName)
+  if (!info || info->periodName != periodName) {
+    EJIT_DIAG("deactivateArray reject(%s,%u): arrayPtr=%p not a registered %s array",
+              periodName.c_str(), cellIdx, arrayPtr, periodName.c_str());
     return false;
+  }
 #ifdef EJIT_SRE_TASKPOOL
   // See activateArray: a multi-array (or zero-array) lifecycle is a clean
   // reject because (dimType, instanceId) cannot distinguish individual arrays —
   // see the detailed comment above. Rejection mutates nothing.
   const std::vector<PeriodArrayInfo> *arrays =
       runtimeState_->getRegistry().getArrays(periodName);
-  if (!arrays || arrays->size() != 1)
+  if (!arrays || arrays->size() != 1) {
+    EJIT_DIAG("deactivateArray reject(%s,%u): lifecycle owns %zu array(s), need 1",
+              periodName.c_str(), cellIdx, arrays ? arrays->size() : 0);
     return false;
+  }
   uint32_t dt = EJitLifecycleRegistry::instance().lookup(periodName);
-  if (dt == kEJitInvalidDimType)
+  if (dt == kEJitInvalidDimType) {
+    EJIT_DIAG("deactivateArray reject(%s,%u): not a registered lifecycle",
+              periodName.c_str(), cellIdx);
     return false;
+  }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (EJitSharedTaskPool *sp = sharedTaskPool())
     sp->setInstanceEnabled(dt, cellIdx, /*enabled=*/false);
@@ -465,8 +489,10 @@ bool EJit::activateAll(const std::string &periodName) {
 #endif
     return true;
   }
-  if (!runtimeState_->getRegistry().getArrays(periodName))
+  if (!runtimeState_->getRegistry().getArrays(periodName)) {
+    EJIT_DIAG("activateAll reject(%s): unknown period", periodName.c_str());
     return false;
+  }
   runtimeState_->activateAll(periodName);
   return true;
 #else
@@ -491,8 +517,10 @@ bool EJit::deactivateAll(const std::string &periodName) {
 #endif
     return true;
   }
-  if (!runtimeState_->getRegistry().getArrays(periodName))
+  if (!runtimeState_->getRegistry().getArrays(periodName)) {
+    EJIT_DIAG("deactivateAll reject(%s): unknown period", periodName.c_str());
     return false;
+  }
   runtimeState_->deactivateAll(periodName);
   return true;
 #else
@@ -549,13 +577,18 @@ bool EJit::registerBitcode(const std::string &funcName, const uint8_t *data,
   // Post-init runtime registration. The bool propagates to the caller (the C
   // ABI records a failure into the registration-error sink); construction-time
   // registration validates separately in the constructor (recordInitError).
-  if (!moduleLoader_)
+  if (!moduleLoader_) {
+    EJIT_DIAG("registerBitcode reject func=%s: no module loader", funcName.c_str());
     return false;
+  }
 #ifdef EJIT_SRE_TASKPOOL
   // Frozen after init: the worker reads the loader/registries lock-free, so no
   // runtime registration is allowed (nothing is mutated on rejection).
-  if (registrationFrozen())
+  if (registrationFrozen()) {
+    EJIT_DIAG("registerBitcode reject func=%s: registration frozen after init",
+              funcName.c_str());
     return false;
+  }
 #endif
   return moduleLoader_->registerBitcode(funcName, data, size);
 }
@@ -563,11 +596,17 @@ bool EJit::registerBitcode(const std::string &funcName, const uint8_t *data,
 bool EJit::registerPeriodArray(const std::string &periodName,
                                const std::string &varName, void *baseAddr,
                                uint64_t arraySize) {
-  if (!runtimeState_)
+  if (!runtimeState_) {
+    EJIT_DIAG("registerPeriodArray reject period=%s: no runtime state",
+              periodName.c_str());
     return false;
+  }
 #ifdef EJIT_SRE_TASKPOOL
-  if (registrationFrozen())
+  if (registrationFrozen()) {
+    EJIT_DIAG("registerPeriodArray reject period=%s: registration frozen",
+              periodName.c_str());
     return false;
+  }
 #endif
   runtimeState_->getRegistry().registerArray(periodName, varName, baseAddr,
                                              arraySize);
@@ -575,11 +614,17 @@ bool EJit::registerPeriodArray(const std::string &periodName,
 }
 
 bool EJit::registerStaticVar(const std::string &varName, void *varAddr) {
-  if (!runtimeState_)
+  if (!runtimeState_) {
+    EJIT_DIAG("registerStaticVar reject var=%s: no runtime state",
+              varName.c_str());
     return false;
+  }
 #ifdef EJIT_SRE_TASKPOOL
-  if (registrationFrozen())
+  if (registrationFrozen()) {
+    EJIT_DIAG("registerStaticVar reject var=%s: registration frozen",
+              varName.c_str());
     return false;
+  }
 #endif
   runtimeState_->getRegistry().registerStaticVar(varName, varAddr);
   return true;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitAsyncCompiler.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitAsyncCompiler.cpp
@@ -3,6 +3,7 @@
 #ifndef EJIT_FREESTANDING
 
 #include "llvm/ExecutionEngine/EJIT/EJitAsyncCompiler.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSyncCompiler.h"
 
@@ -21,21 +22,28 @@ EJitAsyncCompiler::~EJitAsyncCompiler() {
 void EJitAsyncCompiler::start() {
   if (running_.exchange(true))
     return;
+  EJIT_DIAG("async compiler start");
 
   syncCompiler_ = std::make_unique<EJitSyncCompiler>();
 
   // Create isolated engine for the worker thread
   auto engine = EJitOrcEngine::Create(
       config_, runtimeState_.getRegistry(), runtimeState_);
-  if (engine)
+  if (engine) {
     workerEngine_ = std::move(*engine);
+  } else {
+    EJIT_DIAG("async compiler start FAIL: worker engine create failed");
+    consumeError(engine.takeError());
+  }
 
   workerThread_ = std::thread(&EJitAsyncCompiler::workerLoop, this);
+  EJIT_DIAG("async compiler worker thread started");
 }
 
 void EJitAsyncCompiler::stop() {
   if (!running_.exchange(false))
     return;
+  EJIT_DIAG("async compiler stop begin");
 
   stopping_ = true;
   queueCV_.notify_all();
@@ -44,14 +52,20 @@ void EJitAsyncCompiler::stop() {
     workerThread_.join();
 
   stopping_ = false;
+  EJIT_DIAG("async compiler stop complete");
 }
 
 void EJitAsyncCompiler::submitRequest(CompileRequest req) {
+  EJIT_DIAG("async submit key=0x%016lx func=%s", req.ctx.cacheKey,
+            req.ctx.fnName.c_str());
   // Dedup: skip if same key is already in flight
   {
     std::lock_guard<std::mutex> lock(inFlightMutex_);
-    if (requestsInFlight_.count(req.ctx.cacheKey))
+    if (requestsInFlight_.count(req.ctx.cacheKey)) {
+      EJIT_DIAG("async submit key=0x%016lx: dropped, already in flight",
+                req.ctx.cacheKey);
       return;
+    }
     requestsInFlight_.insert(req.ctx.cacheKey);
   }
 
@@ -63,6 +77,7 @@ void EJitAsyncCompiler::submitRequest(CompileRequest req) {
 }
 
 void EJitAsyncCompiler::workerLoop() {
+  EJIT_DIAG("async worker loop enter");
   while (!stopping_) {
     CompileRequest req;
     {
@@ -83,17 +98,27 @@ void EJitAsyncCompiler::workerLoop() {
       requestsInFlight_.erase(req.ctx.cacheKey);
     }
   }
+  EJIT_DIAG("async worker loop leave");
 }
 
 void EJitAsyncCompiler::compileOne(const CompileRequest &req) {
+  EJIT_DIAG("async compileOne key=0x%016lx func=%s", req.ctx.cacheKey,
+            req.ctx.fnName.c_str());
   // Re-check time window state before compiling
   for (auto &dim : req.ctx.dimensions) {
-    if (!runtimeState_.isActive(dim.periodName, dim.cellIdx))
+    if (!runtimeState_.isActive(dim.periodName, dim.cellIdx)) {
+      EJIT_DIAG("async compileOne SKIP key=0x%016lx: period %s[%u] not active",
+                req.ctx.cacheKey, dim.periodName.c_str(), dim.cellIdx);
       return;
+    }
   }
 
-  if (!workerEngine_ || !syncCompiler_)
+  if (!workerEngine_ || !syncCompiler_) {
+    EJIT_DIAG("async compileOne SKIP key=0x%016lx: engine=%p sync=%p",
+              req.ctx.cacheKey, static_cast<void *>(workerEngine_.get()),
+              static_cast<void *>(syncCompiler_.get()));
     return;
+  }
 
   auto result =
       syncCompiler_->compile(*workerEngine_, req.bitcodeData, req.ctx);
@@ -103,6 +128,10 @@ void EJitAsyncCompiler::compileOne(const CompileRequest &req) {
     for (auto &dim : req.ctx.dimensions)
       deps.push_back(dim.periodName + "=" + std::to_string(dim.cellIdx));
     cache_.put(req.ctx.cacheKey, result.funcPtr, result.codeSize, deps);
+    EJIT_DIAG("async compileOne OK key=0x%016lx pfn=%p cached", req.ctx.cacheKey,
+              result.funcPtr);
+  } else {
+    EJIT_DIAG("async compileOne FAIL key=0x%016lx: no funcPtr", req.ctx.cacheKey);
   }
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCache.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCache.cpp
@@ -34,10 +34,15 @@ void *EJitCache::getOrNull(uint64_t cacheKey) {
 bool EJitCache::put(uint64_t cacheKey, void *funcPtr,
                     size_t codeSize,
                     ArrayRef<std::string> periodDeps) {
+  EJIT_DIAG("cache put key=0x%016lx fn=%p size=%zu deps=%zu", cacheKey, funcPtr,
+            codeSize, periodDeps.size());
   std::unique_lock<decltype(mutex_)> lock(mutex_);
 
-  if (codeSize > maxSingleFuncSize_)
+  if (codeSize > maxSingleFuncSize_) {
+    EJIT_DIAG("cache put REJECT key=0x%016lx: size=%zu > maxSingle=%zu",
+              cacheKey, codeSize, maxSingleFuncSize_);
     return false;
+  }
 
   // 1. Remove old entry for the same key if present (re-compilation after
   //    deactivate).  Done first so the entry is never in an intermediate
@@ -78,12 +83,17 @@ bool EJitCache::put(uint64_t cacheKey, void *funcPtr,
 
 void EJitCache::invalidateByPeriod(const std::string &periodName,
                                    uint8_t cellIdx) {
+  EJIT_DIAG("cache invalidate begin period=%s cellIdx=%u", periodName.c_str(),
+            cellIdx);
   std::unique_lock<decltype(mutex_)> lock(mutex_);
   std::string dep = periodName + "=" + std::to_string(cellIdx);
 
   auto it = periodIndex_.find(dep);
-  if (it == periodIndex_.end())
+  if (it == periodIndex_.end()) {
+    EJIT_DIAG("cache invalidate period=%s cellIdx=%u: no matching entries",
+              periodName.c_str(), cellIdx);
     return;
+  }
 
   size_t removed = 0;
   for (uint64_t key : it->second) {
@@ -146,8 +156,11 @@ void EJitCache::evictLRU() {
 
   auto it = cache_.find(key);
   assert(it != cache_.end() && "lruList_/cache_ invariant broken");
-  if (it == cache_.end())
+  if (it == cache_.end()) {
+    EJIT_DIAG("cache evict LRU key=0x%016lx: INARIANT BROKEN (key not in cache)",
+              key);
     return;
+  }
 
   currentTotalSize_ -= it->second.codeSize;
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -7,20 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/Support/MathExtras.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
-
-// Lightweight, default-empty trace hook for code-pool key paths. Expands to
-// nothing unless EJIT_CODE_POOL_TRACE is predefined for on-target bring-up
-// (for example, -D'EJIT_CODE_POOL_TRACE(...)=SRE_printf(__VA_ARGS__)').
-// Arguments are restricted to integers, pointers, and C strings.
-#ifndef EJIT_CODE_POOL_TRACE
-#define EJIT_CODE_POOL_TRACE(...)                                              \
-  do {                                                                         \
-  } while (0)
-#endif
 
 namespace {
 
@@ -55,6 +46,10 @@ EJitCodePoolManager::EJitCodePoolManager(Options Opts, RawAllocFn Alloc,
     if (Opts_.poolSize == 0)
       Opts_.poolSize = Opts_.poolAlign;
   }
+  EJIT_DIAG("code pool ctor: poolSize=%zu poolAlign=%zu minCodeAlign=%zu "
+            "fourKSeal=%u sealPage=%zu",
+            Opts_.poolSize, Opts_.poolAlign, Opts_.minCodeAlign,
+            static_cast<unsigned>(Opts_.fourKSeal), Opts_.sealPageSize);
 }
 
 EJitCodePoolManager::~EJitCodePoolManager() = default;
@@ -75,39 +70,46 @@ Error EJitCodePoolManager::newActivePoolLocked() {
   // poolAlign - 1.
   size_t RawSize = Opts_.fourKSeal ? (Opts_.poolSize + Opts_.poolAlign)
                                    : (Opts_.poolSize + Opts_.poolAlign - 1);
-  EJIT_CODE_POOL_TRACE("newActivePool:enter",
-                       (unsigned long long)Opts_.poolSize,
-                       (unsigned)Opts_.fourKSeal,
-                       (unsigned long long)RawSize);
+  EJIT_DIAG("newActivePool: poolSize=%zu fourKSeal=%u rawSize=%zu",
+            Opts_.poolSize, static_cast<unsigned>(Opts_.fourKSeal), RawSize);
   void *Raw = Alloc_ ? Alloc_(RawSize) : nullptr;
-  EJIT_CODE_POOL_TRACE("newActivePool:rawAlloc", Raw,
-                       (unsigned long long)RawSize);
-  if (!Raw)
+  if (!Raw) {
+    EJIT_DIAG("newActivePool FAIL: raw alloc %zu bytes returned null (hasAlloc=%u)",
+              RawSize, static_cast<unsigned>(static_cast<bool>(Alloc_)));
     return make_error<StringError>(
         "EJitCodePool: raw allocation of " + Twine(RawSize) + " bytes failed",
         inconvertibleErrorCode());
+  }
+  EJIT_DIAG("newActivePool: rawAlloc=%p size=%zu", Raw, RawSize);
 
   auto *RawBytes = static_cast<uint8_t *>(Raw);
   auto *Base = reinterpret_cast<uint8_t *>(
       alignUp(addr(RawBytes), Opts_.poolAlign));
-  EJIT_CODE_POOL_TRACE("newActivePool:alignedBase", Base);
+  EJIT_DIAG("newActivePool: alignedBase=%p", static_cast<void *>(Base));
 
   if (Opts_.fourKSeal) {
     // The 2MiB-aligned usable window must stay inside the raw allocation.
-    if (addr(Base) + Opts_.poolSize > addr(RawBytes) + RawSize)
+    if (addr(Base) + Opts_.poolSize > addr(RawBytes) + RawSize) {
+      EJIT_DIAG("newActivePool FAIL: aligned window base=%p +%zu > raw %p +%zu",
+                static_cast<void *>(Base), Opts_.poolSize,
+                static_cast<void *>(RawBytes), RawSize);
       return make_error<StringError>(
           "EJitCodePool: aligned pool window exceeds raw allocation",
           inconvertibleErrorCode());
+    }
     // Split the 2MiB-aligned region into 4K mappings before any enable_ex. One
     // split per pool; per-page enable_ex happens later at seal time.
     unsigned Rc = Split_ ? Split_(Base, Opts_.poolSize) : 1;
-    EJIT_CODE_POOL_TRACE("newActivePool:splitRc", Base,
-                         (unsigned long long)Opts_.poolSize, Rc);
-    if (Rc != 0)
+    if (Rc != 0) {
+      EJIT_DIAG("newActivePool FAIL: split_2m_to_4k base=%p size=%zu rc=%u",
+                static_cast<void *>(Base), Opts_.poolSize, Rc);
       return make_error<StringError>(
           "EJitCodePool: split_2m_to_4k failed (rc=" + Twine(Rc) +
               ") for pool base " + Twine(addr(Base)),
           inconvertibleErrorCode());
+    }
+    EJIT_DIAG("newActivePool: split ok base=%p size=%zu",
+              static_cast<void *>(Base), Opts_.poolSize);
     ++SplitInvocations_;
   }
 
@@ -119,6 +121,8 @@ Error EJitCodePoolManager::newActivePoolLocked() {
   P->executable = false;
   Active_ = P.get();
   Pools_.push_back(std::move(P));
+  EJIT_DIAG("newActivePool OK: base=%p pools=%zu", static_cast<void *>(Base),
+            Pools_.size());
   return Error::success();
 }
 
@@ -126,25 +130,31 @@ Error EJitCodePoolManager::sealPoolLocked(CodePool &P) {
   if (P.executable)
     return Error::success(); // already sealed — never re-invoke enable_ex
   unsigned Rc = Seal_ ? Seal_(P.base) : 1;
-  if (Rc != 0)
+  if (Rc != 0) {
+    EJIT_DIAG("sealPool FAIL: enable_ex base=%p rc=%u",
+              static_cast<void *>(P.base), Rc);
     return make_error<StringError>(
         "EJitCodePool: enable_ex failed (rc=" + Twine(Rc) + ") for pool base " +
             Twine(addr(P.base)),
         inconvertibleErrorCode());
+  }
   P.executable = true;
   ++SealInvocations_;
+  EJIT_DIAG("sealPool OK: base=%p (invocations=%zu)",
+            static_cast<void *>(P.base), SealInvocations_);
   // Per platform guidance, enable_ex performs its own permission/cache
   // synchronization, so we deliberately do NOT call __builtin___clear_cache.
   return Error::success();
 }
 
 Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
-  if (Size == 0)
+  if (Size == 0) {
+    EJIT_DIAG("allocateCode FAIL: zero-size request");
     return make_error<StringError>("EJitCodePool: zero-size allocation",
                                    inconvertibleErrorCode());
+  }
 
-  EJIT_CODE_POOL_TRACE("allocateCode:req", (unsigned long long)Size,
-                       (unsigned long long)Align);
+  EJIT_DIAG("allocateCode req: size=%zu align=%zu", Size, Align);
 
   size_t EffAlign = std::max(Align, Opts_.minCodeAlign);
   if (!isPowerOf2_64(EffAlign))
@@ -155,11 +165,14 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
     EffAlign = std::max(EffAlign, Opts_.sealPageSize);
 
   // A single allocation can never span pools; reject oversize requests cleanly.
-  if (Size > Opts_.poolSize)
+  if (Size > Opts_.poolSize) {
+    EJIT_DIAG("allocateCode FAIL: size=%zu exceeds poolSize=%zu", Size,
+              Opts_.poolSize);
     return make_error<StringError>(
         "EJitCodePool: request of " + Twine(Size) +
             " bytes exceeds pool size " + Twine(Opts_.poolSize),
         inconvertibleErrorCode());
+  }
 
 #ifndef EJIT_FREESTANDING
   std::lock_guard<std::mutex> Lock(Mutex_);
@@ -179,7 +192,8 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
     // Round the bump cursor up to a whole seal page so the next allocation
     // starts on a page this one does not share.
     Active_->used = alignUp(Off + Size, Opts_.sealPageSize);
-    EJIT_CODE_POOL_TRACE("allocateCode:res4k", Ptr, (unsigned long long)Size);
+    EJIT_DIAG("allocateCode res4k: ptr=%p size=%zu", static_cast<void *>(Ptr),
+              Size);
     return static_cast<void *>(Ptr);
   }
 
@@ -201,7 +215,8 @@ Expected<void *> EJitCodePoolManager::allocateCode(size_t Size, size_t Align) {
   size_t Off = alignUp(Active_->used, EffAlign);
   uint8_t *Ptr = Active_->base + Off;
   Active_->used = Off + Size;
-  EJIT_CODE_POOL_TRACE("allocateCode:res", Ptr, (unsigned long long)Size);
+  EJIT_DIAG("allocateCode res: ptr=%p size=%zu", static_cast<void *>(Ptr),
+            Size);
   return static_cast<void *>(Ptr);
 }
 
@@ -225,18 +240,20 @@ Error EJitCodePoolManager::sealPoolContaining(const void *Ptr) {
   // the whole pool) prevents the easy misuse of marking a 2MiB pool executable
   // off a single address.
   if (Opts_.fourKSeal) {
-    EJIT_CODE_POOL_TRACE("sealPoolContaining:unsupported4k", Ptr);
+    EJIT_DIAG("sealPoolContaining FAIL: unsupported in 4K mode ptr=%p", Ptr);
     return make_error<StringError>(
         "EJitCodePool: sealPoolContaining is not supported in 4K page-seal "
         "mode; use sealCodeRange to seal the written code range",
         inconvertibleErrorCode());
   }
   CodePool *P = findPoolLocked(Ptr);
-  if (!P)
+  if (!P) {
+    EJIT_DIAG("sealPoolContaining FAIL: ptr=%p not owned by any pool", Ptr);
     return make_error<StringError>(
         "EJitCodePool: address " + Twine(addr(Ptr)) +
             " is not owned by any code pool",
         inconvertibleErrorCode());
+  }
   return sealPoolLocked(*P);
 }
 
@@ -249,11 +266,14 @@ Error EJitCodePoolManager::sealAllWritablePools() {
   // code are RX), so "seal every writable pool" has no correct meaning. Return
   // an Error rather than silently no-op so a caller cannot mistakenly believe
   // all pools are now fully sealed. Use sealCodeRange per finalized allocation.
-  if (Opts_.fourKSeal)
+  if (Opts_.fourKSeal) {
+    EJIT_DIAG("sealAllWritablePools FAIL: unsupported in 4K mode");
     return make_error<StringError>(
         "EJitCodePool: sealAllWritablePools (whole-pool sealing) is not "
         "supported in 4K page-seal mode; use sealCodeRange",
         inconvertibleErrorCode());
+  }
+  EJIT_DIAG("sealAllWritablePools: pools=%zu", Pools_.size());
   Error Err = Error::success();
   for (auto &P : Pools_)
     if (!P->executable)
@@ -268,30 +288,37 @@ Error EJitCodePoolManager::sealCodeRange(const void *Start, size_t Size) {
   if (Size == 0)
     return Error::success();
   CodePool *P = findPoolLocked(Start);
-  if (!P)
+  if (!P) {
+    EJIT_DIAG("sealCodeRange FAIL: start=%p size=%zu not owned by any pool",
+              Start, Size);
     return make_error<StringError>(
         "EJitCodePool: address " + Twine(addr(Start)) +
             " is not owned by any code pool",
         inconvertibleErrorCode());
+  }
 
   // Seal every 4KiB page the written code overlaps: page-align the start down
   // and the end up, then enable_ex(1, pageVA) per page.
   size_t Page = Opts_.sealPageSize;
   uintptr_t PageStart = alignDownAddr(addr(Start), Page);
   uintptr_t PageEnd = alignUp(addr(Start) + Size, Page);
-  EJIT_CODE_POOL_TRACE("sealCodeRange", Start, (unsigned long long)Size,
-                       (unsigned long long)PageStart,
-                       (unsigned long long)PageEnd);
+  EJIT_DIAG("sealCodeRange: start=%p size=%zu pageStart=0x%llx pageEnd=0x%llx",
+            Start, Size, static_cast<unsigned long long>(PageStart),
+            static_cast<unsigned long long>(PageEnd));
   for (uintptr_t VA = PageStart; VA < PageEnd; VA += Page) {
     unsigned Rc = Seal_ ? Seal_(reinterpret_cast<void *>(VA)) : 1;
-    EJIT_CODE_POOL_TRACE("sealCodeRange:pageRc", (unsigned long long)VA, Rc);
-    if (Rc != 0)
+    if (Rc != 0) {
+      EJIT_DIAG("sealCodeRange FAIL: enable_ex page=0x%llx rc=%u",
+                static_cast<unsigned long long>(VA), Rc);
       return make_error<StringError>(
           "EJitCodePool: enable_ex failed (rc=" + Twine(Rc) + ") for page " +
               Twine(VA),
           inconvertibleErrorCode());
+    }
     ++SealInvocations_;
   }
+  EJIT_DIAG("sealCodeRange OK: start=%p size=%zu (invocations=%zu)", Start, Size,
+            SealInvocations_);
   // Per platform guidance, enable_ex performs its own permission/cache
   // synchronization, so we deliberately do NOT call __builtin___clear_cache.
   return Error::success();
@@ -311,16 +338,22 @@ bool EJitCodePoolManager::contains(const void *Ptr) const {
 }
 
 void EJitCodePoolManager::recordFinalizedRange(const void *Base, size_t Size) {
-  if (!Base || Size == 0)
+  if (!Base || Size == 0) {
+    EJIT_DIAG("recordFinalizedRange skip: base=%p size=%zu", Base, Size);
     return;
+  }
+  EJIT_DIAG("recordFinalizedRange: base=%p size=%zu", Base, Size);
 #ifndef EJIT_FREESTANDING
   std::lock_guard<std::mutex> Lock(Mutex_);
 #endif
   uintptr_t Start = addr(Base);
   // Overflow guard: a range whose end wraps is malformed; ignore it (findRange
   // would otherwise admit any pointer).
-  if (Start + Size < Start)
+  if (Start + Size < Start) {
+    EJIT_DIAG("recordFinalizedRange skip: wraparound start=0x%llx size=%zu",
+              static_cast<unsigned long long>(Start), Size);
     return;
+  }
   // Idempotent record: re-finalizing the identical [Start, Size) extent (e.g. a
   // retried finalize of the same allocation) must not grow the table or create
   // duplicate, equally-valid matches. Pool addresses are never reused while a
@@ -330,13 +363,14 @@ void EJitCodePoolManager::recordFinalizedRange(const void *Base, size_t Size) {
   // in append order wins).
   for (const FinalizedRange &R : FinalizedRanges_)
     if (R.start == Start && R.size == static_cast<uint64_t>(Size)) {
-      EJIT_CODE_POOL_TRACE("recordFinalizedRange.dup", Base,
-                           (unsigned long long)Size);
+      EJIT_DIAG("recordFinalizedRange dup: base=%p size=%zu (already recorded)",
+                Base, Size);
       return;
     }
   FinalizedRanges_.push_back(
       FinalizedRange{Start, static_cast<uint64_t>(Size)});
-  EJIT_CODE_POOL_TRACE("recordFinalizedRange", Base, (unsigned long long)Size);
+  EJIT_DIAG("recordFinalizedRange OK: base=%p size=%zu total=%zu", Base, Size,
+            FinalizedRanges_.size());
 }
 
 bool EJitCodePoolManager::findRange(const void *Ptr,
@@ -355,8 +389,10 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
       break;
     }
   }
-  if (!Found)
+  if (!Found) {
+    EJIT_DIAG("findRange miss: ptr=%p not in any finalized range", Ptr);
     return false;
+  }
 
   // The allocation must also belong to a known pool (so a peer learns the
   // 2MiB split granule). An address resolved outside the pools (e.g. a
@@ -372,9 +408,13 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
       Out.poolSize = static_cast<uint64_t>(P.size);
       Out.poolId = static_cast<uint32_t>(I);
       Out.reserved = 0;
+      EJIT_DIAG("findRange OK: ptr=%p codeStart=0x%llx codeSize=%llu poolId=%u",
+                Ptr, static_cast<unsigned long long>(Out.codeStart),
+                static_cast<unsigned long long>(Out.codeSize), Out.poolId);
       return true;
     }
   }
+  EJIT_DIAG("findRange miss: ptr=%p in finalized range but not in any pool", Ptr);
   return false;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/Orc/Shared/AllocationActions.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
@@ -63,6 +64,9 @@ public:
       for (const ExecSegRange &R : ExecRanges)
         if (auto Err = Pool->sealCodeRange(reinterpret_cast<void *>(R.Addr),
                                            static_cast<size_t>(R.Size))) {
+          EJIT_DIAG("finalize FAIL: sealCodeRange addr=0x%llx size=%llu",
+                    static_cast<unsigned long long>(R.Addr),
+                    static_cast<unsigned long long>(R.Size));
           OnFinalized(std::move(Err));
           return;
         }
@@ -80,6 +84,7 @@ public:
         [this, OnFinalized = std::move(OnFinalized)](
             Expected<std::vector<WrapperFunctionCall>> DeallocActions) mutable {
           if (!DeallocActions) {
+            EJIT_DIAG("finalize FAIL: runFinalizeActions error base=%p", Base);
             OnFinalized(DeallocActions.takeError());
             return;
           }
@@ -119,16 +124,23 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
 
   auto SegsSizes = BL.getContiguousPageBasedLayoutSizes(PageSize_);
   if (!SegsSizes) {
+    EJIT_DIAG("allocate FAIL: layout sizes error graph=%s",
+              G.getName().c_str());
     OnAllocated(SegsSizes.takeError());
     return;
   }
 
   uint64_t Total = SegsSizes->total();
+  EJIT_DIAG("allocate: graph=%s total=%llu pageSize=%zu",
+            G.getName().c_str(),
+            static_cast<unsigned long long>(Total), PageSize_);
 
   void *Slab = nullptr;
   if (Total > 0) {
     auto MemOrErr = Pool_.allocateCode(static_cast<size_t>(Total), PageSize_);
     if (!MemOrErr) {
+      EJIT_DIAG("allocate FAIL: pool allocateCode total=%llu",
+                static_cast<unsigned long long>(Total));
       OnAllocated(MemOrErr.takeError());
       return;
     }
@@ -170,24 +182,31 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   }
 
   if (auto Err = BL.apply()) {
+    EJIT_DIAG("allocate FAIL: BasicLayout apply error graph=%s",
+              G.getName().c_str());
     OnAllocated(std::move(Err));
     return;
   }
 
+  EJIT_DIAG("allocate OK: slab=%p total=%llu execRanges=%zu", Slab,
+            static_cast<unsigned long long>(Total), ExecRanges.size());
   OnAllocated(std::make_unique<InFlightAllocImpl>(*this, G, std::move(BL), Slab,
                                                   std::move(ExecRanges)));
 }
 
 void EJitCodePoolMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,
                                            OnDeallocatedFunction OnDeallocated) {
+  EJIT_DIAG("deallocate: %zu finalized alloc(s)", Allocs.size());
   Error DeallocErr = Error::success();
   for (auto &Alloc : Allocs) {
     auto *Info = Alloc.release().toPtr<FinalizedInfo *>();
     // Run dealloc actions in reverse order. Pool memory is intentionally not
     // released in v1 (sealed/RX pages must not be recycled; see design doc).
     while (!Info->DeallocActions.empty()) {
-      if (auto Err = Info->DeallocActions.back().runWithSPSRetErrorMerged())
+      if (auto Err = Info->DeallocActions.back().runWithSPSRetErrorMerged()) {
+        EJIT_DIAG("deallocate FAIL: dealloc action error base=%p", Info->Base);
         DeallocErr = joinErrors(std::move(DeallocErr), std::move(Err));
+      }
       Info->DeallocActions.pop_back();
     }
     delete Info;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -187,10 +187,13 @@ bool EJitCompileDriver::sharedWorkerStart(
     uint64_t *outTaskId) {
   auto *drv = static_cast<EJitCompileDriver *>(ctx);
   if (!EJitSreTask::create(drv->sharedWorkerTask_, entry, entryCtx,
-                           "ejit-shared-worker"))
+                           "ejit-shared-worker")) {
+    EJIT_DIAG("shared worker start FAILED: SRE task create rejected");
     return false;
+  }
   if (outTaskId)
     *outTaskId = 1; // host has no numeric task id; diagnostic only.
+  EJIT_DIAG("shared worker started");
   return true;
 }
 
@@ -212,17 +215,32 @@ bool EJitCompileDriver::startSharedTaskPool() {
   sharedPool_.setRegistrationFingerprint(
       EJitFuncRegistry::instance().fingerprint() * 0x9e3779b97f4a7c15ULL ^
       EJitLifecycleRegistry::instance().fingerprint());
-  switch (sharedPool_.init()) {
+  EJitSharedTaskPool::InitResult r = sharedPool_.init();
+  switch (r) {
   case EJitSharedTaskPool::InitResult::BecameOwner:
+    EJIT_DIAG("shared taskpool init: became owner");
+    return true;
   case EJitSharedTaskPool::InitResult::AttachedReady:
+    EJIT_DIAG("shared taskpool init: attached ready");
     return true;
   case EJitSharedTaskPool::InitResult::OwnerFailed:
+    EJIT_DIAG("shared taskpool init FAILED: owner worker start failed");
+    return false;
   case EJitSharedTaskPool::InitResult::InitInProgress:
+    EJIT_DIAG("shared taskpool init FAILED: peer still initializing");
+    return false;
   case EJitSharedTaskPool::InitResult::AbiMismatch:
+    EJIT_DIAG("shared taskpool init FAILED: ABI mismatch (magic/version/size)");
+    return false;
   case EJitSharedTaskPool::InitResult::FingerprintMismatch:
+    EJIT_DIAG("shared taskpool init FAILED: registration fingerprint mismatch");
+    return false;
   case EJitSharedTaskPool::InitResult::NoState:
+    EJIT_DIAG("shared taskpool init FAILED: no shared state bound");
     return false;
   }
+  EJIT_DIAG("shared taskpool init FAILED: unknown result=%u",
+            static_cast<unsigned>(r));
   return false;
 }
 #endif
@@ -397,18 +415,28 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, bool storeLru) {
 
 #ifdef EJIT_SRE_TASKPOOL
 void *EJitCompileDriver::compileNow(const EJitCompileRequest &req) {
-  if (req.numDims > 4)
+  EJIT_DIAG("compileNow begin func=%u dims=%u", req.funcIndex, req.numDims);
+  if (req.numDims > 4) {
+    EJIT_DIAG("compileNow reject func=%u: numDims=%u > 4", req.funcIndex,
+              req.numDims);
     return nullptr;
+  }
 
   // Validate the request: instanceIds must be encodable in the legacy 8-bit
   // cacheKey slots, and no two dims may share a dimType (a duplicated lifecycle
   // dimension).
   SmallVector<uint32_t, 4> seenDimTypes;
   for (uint32_t i = 0; i < req.numDims; ++i) {
-    if (req.dims[i].instanceId > 255u)
+    if (req.dims[i].instanceId > 255u) {
+      EJIT_DIAG("compileNow reject func=%u: instanceId=%u > 255 (dim[%u])",
+                req.funcIndex, req.dims[i].instanceId, i);
       return nullptr;
-    if (llvm::is_contained(seenDimTypes, req.dims[i].dimType))
+    }
+    if (llvm::is_contained(seenDimTypes, req.dims[i].dimType)) {
+      EJIT_DIAG("compileNow reject func=%u: duplicate dimType=%u (dim[%u])",
+                req.funcIndex, req.dims[i].dimType, i);
       return nullptr;
+    }
     seenDimTypes.push_back(req.dims[i].dimType);
   }
 
@@ -420,8 +448,11 @@ void *EJitCompileDriver::compileNow(const EJitCompileRequest &req) {
   uint8_t packedDims[4] = {0, 0, 0, 0};
   for (unsigned i = 0; i < meta.dimCount && i < 4; ++i) {
     uint32_t wantedType = meta.dimTypes[i];
-    if (wantedType == kEJitInvalidDimType)
+    if (wantedType == kEJitInvalidDimType) {
+      EJIT_DIAG("compileNow reject func=%u: meta dim[%u] dimType invalid",
+                req.funcIndex, i);
       return nullptr;
+    }
     bool found = false;
     for (uint32_t j = 0; j < req.numDims; ++j) {
       if (req.dims[j].dimType == wantedType) {
@@ -430,8 +461,11 @@ void *EJitCompileDriver::compileNow(const EJitCompileRequest &req) {
         break;
       }
     }
-    if (!found)
+    if (!found) {
+      EJIT_DIAG("compileNow reject func=%u: no request dim for meta dimType=%u",
+                req.funcIndex, wantedType);
       return nullptr;
+    }
   }
 
   uint64_t cacheKey = (static_cast<uint64_t>(req.funcIndex) << 32) |
@@ -439,6 +473,9 @@ void *EJitCompileDriver::compileNow(const EJitCompileRequest &req) {
                       (static_cast<uint64_t>(packedDims[1]) << 8) |
                       (static_cast<uint64_t>(packedDims[2]) << 16) |
                       (static_cast<uint64_t>(packedDims[3]) << 24);
+  EJIT_DIAG("compileNow dispatch func=%u key=0x%016lx dims=[%u,%u,%u,%u]",
+            req.funcIndex, cacheKey, packedDims[0], packedDims[1], packedDims[2],
+            packedDims[3]);
   return compileCold(cacheKey, /*storeLru=*/false);
 }
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLogger.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLogger.cpp
@@ -1,6 +1,7 @@
 //===-- EJitLogger.cpp - EmbeddedJIT Error Logger -------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitLogger.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 
 #ifndef EJIT_FREESTANDING
 
@@ -12,6 +13,8 @@ using namespace llvm::ejit;
 void EJitLogger::log(int code, const std::string &message,
                      const std::string &funcName, const std::string &cacheKey,
                      size_t attemptedMemUsage) {
+  EJIT_DIAG("logger log: code=%d func=%s key=%s msg=%s", code,
+            funcName.c_str(), cacheKey.c_str(), message.c_str());
   std::lock_guard<std::mutex> lock(mutex_);
   uint64_t ts = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now().time_since_epoch()).count();
@@ -56,6 +59,7 @@ std::vector<EJitError> EJitLogger::getErrors(size_t limit) const {
 }
 
 void EJitLogger::clear() {
+  EJIT_DIAG("logger clear: dropping %zu error(s)", count_);
   std::lock_guard<std::mutex> lock(mutex_);
   writeIdx_ = 0;
   count_ = 0;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
@@ -22,7 +22,7 @@ bool EJitModuleLoader::registerBitcode(const std::string &funcName,
   // ejit_init (never builds a half-registered taskpool).
   if (!data || size == 0) {
     EJIT_DIAG("bitcode register reject name=%s data=%p size=%zu",
-              funcName.c_str(), data, size);
+              funcName.c_str(), static_cast<const void *>(data), size);
     return false;
   }
   // Dense, order-independent funcIndex assigned ONCE by name in the process-
@@ -63,7 +63,7 @@ bool EJitModuleLoader::registerBitcode(const std::string &funcName,
   E.size = size;
   entriesByFuncIdx_.emplace(idx, std::move(E));
   EJIT_DIAG("bitcode registered name=%s idx=%u data=%p size=%zu",
-            funcName.c_str(), idx, data, size);
+            funcName.c_str(), idx, static_cast<const void *>(data), size);
   return true;
 }
 
@@ -93,14 +93,19 @@ EJitModuleLoader::getOrCacheFuncMeta(uint32_t funcIdx) {
   if (it != funcMetaCache_.end())
     return it->second;
 
+  EJIT_DIAG("getOrCacheFuncMeta: building meta for funcIdx=%u", funcIdx);
   FuncMeta &meta = funcMetaCache_[funcIdx];
   auto Eit = entriesByFuncIdx_.find(funcIdx);
-  if (Eit == entriesByFuncIdx_.end())
+  if (Eit == entriesByFuncIdx_.end()) {
+    EJIT_DIAG("getOrCacheFuncMeta FAIL funcIdx=%u: not registered", funcIdx);
     return meta;
+  }
   const std::string FuncName = Eit->second.funcName;
 
   auto bitcode = getBitcodeByFuncIdx(funcIdx);
   if (!bitcode) {
+    EJIT_DIAG("getOrCacheFuncMeta FAIL funcIdx=%u func=%s: bitcode lookup error",
+              funcIdx, FuncName.c_str());
     consumeError(bitcode.takeError());
     return meta;
   }
@@ -110,6 +115,8 @@ EJitModuleLoader::getOrCacheFuncMeta(uint32_t funcIdx) {
       *bitcode, "meta_" + std::to_string(funcIdx) + ".bc");
   auto MOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
   if (!MOrErr) {
+    EJIT_DIAG("getOrCacheFuncMeta FAIL funcIdx=%u func=%s: parse bitcode error",
+              funcIdx, FuncName.c_str());
     consumeError(MOrErr.takeError());
     return meta;
   }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -1,6 +1,7 @@
 //===-- EJitOptimizer.cpp - JIT Optimization Pipeline ---------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
@@ -73,12 +74,18 @@ void EJitOptimizer::clearAnalyses() {
 
 void EJitOptimizer::runPipeline(Module &M,
                                 const SpecializationContext &ctx) {
+  EJIT_DIAG("pipeline begin func=%s key=0x%016lx opt=%d dims=%zu module=%s",
+            ctx.fnName.c_str(), ctx.cacheKey, static_cast<int>(ctx.optLevel),
+            ctx.dimensions.size(), M.getName().str().c_str());
+
   // 1. Parameter substitution: replace ejit_period_arr_ind args with constants
   preReplacePeriodIndices(M, ctx);
+  EJIT_DIAG("pipeline stage1 done: preReplacePeriodIndices");
 
   // 2. InstCombine: fold constant GEP chains from substituted params
   //    so StructFieldPass can compute correct byte offsets.
   runInstCombine(M);
+  EJIT_DIAG("pipeline stage2 done: InstCombine");
 
   // 3. Inline (L2+): currently disabled. The AOT pre-optimization in
   //    EJitRegisterBitcodePass already runs AlwaysInline + ModuleInliner(O2),
@@ -94,9 +101,12 @@ void EJitOptimizer::runPipeline(Module &M,
 
   // 4. StructFieldPass: replace may_const loads with runtime constants.
   runStructFieldPass(M);
+  EJIT_DIAG("pipeline stage4 done: StructFieldPass");
 
   // 5. Core optimization at the configured level
   runOptimizationPipeline(M, ctx.optLevel);
+  EJIT_DIAG("pipeline done func=%s key=0x%016lx", ctx.fnName.c_str(),
+            ctx.cacheKey);
 }
 
 void EJitOptimizer::preReplacePeriodIndices(
@@ -157,6 +167,8 @@ void EJitOptimizer::runStructFieldPass(Module &M) {
 
 void EJitOptimizer::runOptimizationPipeline(Module &M,
                                             OptimizationLevel level) {
+  EJIT_DIAG("pipeline stage5: core opt level=%d module=%s",
+            static_cast<int>(level), M.getName().str().c_str());
   // L1: SCCP + ADCE + SimplifyCFG — constant propagation, dead code
   // elimination, and CFG cleanup. Captures the vast majority of EJIT
   // performance gains (may_const load → constant → branch folding).

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -1,6 +1,7 @@
 //===-- EJitOrcEngine.cpp - OrcJIT Engine Wrapper -------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #include "llvm/Bitcode/BitcodeReader.h"
@@ -57,6 +58,9 @@ Expected<std::unique_ptr<EJitOrcEngine>>
 EJitOrcEngine::Create(const Config &config,
                       PeriodArrayRegistry &periodReg,
                       EJitRuntimeState &runtimeState) {
+  EJIT_DIAG("create: opt=%d dump=%s",
+            static_cast<int>(config.optLevel),
+            config.dumpJITDir.empty() ? "(off)" : config.dumpJITDir.c_str());
   auto engine = std::unique_ptr<EJitOrcEngine>(new EJitOrcEngine());
   engine->P->periodReg = &periodReg;
   engine->P->runtimeState = &runtimeState;
@@ -74,8 +78,10 @@ EJitOrcEngine::Create(const Config &config,
 #else
   auto JTMBOrErr = orc::JITTargetMachineBuilder::detectHost();
 #endif
-  if (!JTMBOrErr)
+  if (!JTMBOrErr) {
+    EJIT_DIAG("create FAIL: target machine builder error");
     return JTMBOrErr.takeError();
+  }
 
   // Use Large code model so JITLink can generate 64-bit absolute relocations.
   JTMBOrErr->setCodeModel(CodeModel::Large);
@@ -114,8 +120,10 @@ EJitOrcEngine::Create(const Config &config,
 #endif
 
   auto J = Builder.create();
-  if (!J)
+  if (!J) {
+    EJIT_DIAG("create FAIL: LLJIT builder error");
     return J.takeError();
+  }
 
   engine->P->J = std::move(*J);
 
@@ -135,11 +143,14 @@ EJitOrcEngine::Create(const Config &config,
           orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(kv.varAddr),
                                  JITSymbolFlags::Exported);
     if (!symMap.empty()) {
+      size_t n = symMap.size();
       if (auto Err = JD.define(orc::absoluteSymbols(std::move(symMap))))
-        LLVM_DEBUG(dbgs() << "ejit-orc-engine: define static vars: "
-                          << toString(std::move(Err)) << "\n");
+        EJIT_DIAG("create: define %zu static var(s) FAILED: %s", n,
+                  toString(std::move(Err)).c_str());
     }
   }
+  EJIT_DIAG("create: static vars registered=%zu",
+            periodReg.getStaticVars().size());
 
   // Set up IR transform layer: runs the specialization pipeline during
   // JIT compilation (parameter substitution → InstCombine → StructFieldPass
@@ -187,18 +198,23 @@ EJitOrcEngine::Create(const Config &config,
         return std::move(TSM);
       });
 
+  EJIT_DIAG("create OK: LLJIT ready");
   return engine;
 }
 
 Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
                                        uint64_t cacheKey,
                                        const std::string &origFnName) {
+  EJIT_DIAG("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
+            origFnName.c_str(), bitcodeData.size());
   auto Ctx = std::make_unique<LLVMContext>();
   auto Buf = MemoryBuffer::getMemBuffer(
       bitcodeData, ("spec_" + std::to_string(cacheKey) + ".bc"));
   auto ModuleOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
-  if (!ModuleOrErr)
+  if (!ModuleOrErr) {
+    EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error", cacheKey);
     return ModuleOrErr.takeError();
+  }
 
   Triple TT((*ModuleOrErr)->getTargetTriple());
   if (TT.isAArch64() && TT.isOSBinFormatELF()) {
@@ -240,14 +256,16 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   auto it = P->specDylibs.find(cacheKey);
   if (it != P->specDylibs.end()) {
     if (auto Err = P->J->getExecutionSession().removeJITDylib(*it->second))
-      LLVM_DEBUG(dbgs() << "ejit-orc-engine: remove stale JD: "
-                        << toString(std::move(Err)) << "\n");
+      EJIT_DIAG("loadBitcode key=0x%016lx: remove stale JD FAILED: %s",
+                cacheKey, toString(std::move(Err)).c_str());
     P->specDylibs.erase(it);
   }
 
   auto JDOrErr = P->J->createJITDylib("spec_" + std::to_string(cacheKey));
-  if (!JDOrErr)
+  if (!JDOrErr) {
+    EJIT_DIAG("loadBitcode FAIL key=0x%016lx: create JITDylib error", cacheKey);
     return JDOrErr.takeError();
+  }
 
   // Resolve undefined function symbols from user-registered table.
   // Required for bare-metal where dynamic lookup (dlsym) is unavailable.
@@ -280,31 +298,42 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
 
   // Define all collected symbols in the spec JITDylib before loading the
   // IR module so the JIT linker can resolve external references.
-  if (!globalSymbols.empty())
+  if (!globalSymbols.empty()) {
+    size_t nGlobals = globalSymbols.size();
     if (auto Err = JDOrErr->define(
             orc::absoluteSymbols(std::move(globalSymbols))))
-      LLVM_DEBUG(dbgs() << "ejit-orc-engine: define globals: "
-                        << toString(std::move(Err)) << "\n");
+      EJIT_DIAG("loadBitcode key=0x%016lx: define %zu global(s) FAILED: %s",
+                cacheKey, nGlobals, toString(std::move(Err)).c_str());
+  }
 
   if (auto Err = P->J->addIRModule(*JDOrErr,
-      orc::ThreadSafeModule(std::move(*ModuleOrErr), std::move(Ctx))))
+      orc::ThreadSafeModule(std::move(*ModuleOrErr), std::move(Ctx)))) {
+    EJIT_DIAG("loadBitcode FAIL key=0x%016lx: add IR module error", cacheKey);
     return Err;
+  }
 
   P->specDylibs[cacheKey] = &*JDOrErr;
+  EJIT_DIAG("loadBitcode OK key=0x%016lx func=%s", cacheKey, origFnName.c_str());
   return Error::success();
 }
 
 Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
                                        const std::string &name) {
   auto it = P->specDylibs.find(cacheKey);
-  if (it == P->specDylibs.end())
+  if (it == P->specDylibs.end()) {
+    EJIT_DIAG("lookup FAIL key=0x%016lx name=%s: no spec JITDylib", cacheKey,
+              name.c_str());
     return make_error<StringError>(
         "No specialization JITDylib found for: " + std::to_string(cacheKey),
         inconvertibleErrorCode());
+  }
 
   auto addr = P->J->lookup(*it->second, name);
-  if (!addr)
+  if (!addr) {
+    EJIT_DIAG("lookup FAIL key=0x%016lx name=%s: symbol not found", cacheKey,
+              name.c_str());
     return addr.takeError();
+  }
   void *Ptr = reinterpret_cast<void *>(addr->getValue());
 
 #ifdef EJIT_SRE_CODE_POOL
@@ -320,11 +349,16 @@ Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
   // code-pool memory manager), so nothing is done here.
   if (P->codePool && !P->codePool->usesPageSeal() &&
       P->codePool->contains(Ptr)) {
-    if (auto Err = P->codePool->sealPoolContaining(Ptr))
+    if (auto Err = P->codePool->sealPoolContaining(Ptr)) {
+      EJIT_DIAG("lookup FAIL key=0x%016lx ptr=%p: seal pool error", cacheKey,
+                Ptr);
       return std::move(Err);
+    }
   }
 #endif
 
+  EJIT_DIAG("lookup OK key=0x%016lx name=%s ptr=%p", cacheKey, name.c_str(),
+            Ptr);
   return Ptr;
 }
 
@@ -350,8 +384,10 @@ EJitCodePoolManager::Stats EJitOrcEngine::getCodePoolStats() const {
 
 bool EJitOrcEngine::findCodeRange(const void *FnPtr,
                                   EJitCompiledCodeInfo &Out) const {
-  if (!P->codePool)
+  if (!P->codePool) {
+    EJIT_DIAG("findCodeRange FAIL: no code pool (fnPtr=%p)", FnPtr);
     return false;
+  }
   return P->codePool->findRange(FnPtr, Out);
 }
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRegistrationStore.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRegistrationStore.cpp
@@ -2,6 +2,7 @@
 //--------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include <mutex>
 
 using namespace llvm::ejit;
@@ -13,6 +14,8 @@ EJitRegistrationStore &EJitRegistrationStore::instance() {
 
 void EJitRegistrationStore::registerBitcode(const std::string &funcName,
                                             const uint8_t *data, size_t size) {
+  EJIT_DIAG("regstore stage bitcode name=%s data=%p size=%zu",
+            funcName.c_str(), static_cast<const void *>(data), size);
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   bitcodes_.push_back({funcName, data, size});
 }
@@ -21,18 +24,24 @@ void EJitRegistrationStore::registerPeriodArray(const std::string &periodName,
                                                 const std::string &varName,
                                                 void *baseAddr,
                                                 uint64_t arraySize) {
+  EJIT_DIAG("regstore stage periodArray period=%s var=%s base=%p size=%llu",
+            periodName.c_str(), varName.c_str(), baseAddr,
+            static_cast<unsigned long long>(arraySize));
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   periodArrays_.push_back({periodName, varName, baseAddr, arraySize});
 }
 
 void EJitRegistrationStore::registerStaticVar(const std::string &varName,
                                               void *varAddr) {
+  EJIT_DIAG("regstore stage staticVar var=%s addr=%p", varName.c_str(),
+            varAddr);
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   staticVars_.push_back({varName, varAddr});
 }
 
 void EJitRegistrationStore::registerSymbol(const std::string &name,
                                            void *addr) {
+  EJIT_DIAG("regstore stage symbol name=%s addr=%p", name.c_str(), addr);
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   userSymbols_.push_back({name, addr});
 }
@@ -41,11 +50,17 @@ void EJitRegistrationStore::recordError(int code, const std::string &message,
                                         const std::string &funcName) {
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   // Preserve the first error so the earliest root cause is reported.
-  if (error_.code != 0)
+  if (error_.code != 0) {
+    EJIT_DIAG("regstore recordError suppressed (first error kept): code=%d "
+              "func=%s msg=%s",
+              code, funcName.c_str(), message.c_str());
     return;
+  }
   error_.code = code;
   error_.message = message;
   error_.funcName = funcName;
+  EJIT_DIAG("regstore recordError: code=%d func=%s msg=%s", code,
+            funcName.c_str(), message.c_str());
 }
 
 bool EJitRegistrationStore::hasError() const {
@@ -58,6 +73,8 @@ RegistrationError EJitRegistrationStore::consumeError() {
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   RegistrationError taken = error_;
   error_ = RegistrationError{};
+  EJIT_DIAG("regstore consumeError: code=%d func=%s", taken.code,
+            taken.funcName.c_str());
   return taken;
 }
 
@@ -72,5 +89,9 @@ StoredData EJitRegistrationStore::consume() {
   periodArrays_.clear();
   staticVars_.clear();
   userSymbols_.clear();
+  EJIT_DIAG("regstore consume: bitcodes=%zu periodArrays=%zu staticVars=%zu "
+            "symbols=%zu",
+            data.bitcodes.size(), data.periodArrays.size(),
+            data.staticVars.size(), data.userSymbols.size());
   return data;
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -90,6 +90,7 @@ void ejit_shutdown(void) {
 }
 
 void ejit_register_symbol(const char *name, void *addr) {
+  EJIT_DIAG("register_symbol name=%s addr=%p", name ? name : "<null>", addr);
   if (gEJIT) {
     gEJIT->registerSymbol(name, addr);
   } else {
@@ -100,15 +101,21 @@ void ejit_register_symbol(const char *name, void *addr) {
 
 void ejit_register_bitcode(const char *funcName, const uint8_t *bitcodeData,
                            uint64_t bitcodeSize) {
+  EJIT_DIAG("register_bitcode name=%s size=%llu",
+            funcName ? funcName : "<null>",
+            static_cast<unsigned long long>(bitcodeSize));
   if (gEJIT) {
     // Post-init runtime registration: the void ABI cannot return a status, so a
     // rejection (null/zero payload, funcIndex capacity, conflicting payload) is
     // recorded in the registration-error sink for observability.
     if (!gEJIT->registerBitcode(funcName, bitcodeData,
-                                static_cast<size_t>(bitcodeSize)))
+                                static_cast<size_t>(bitcodeSize))) {
       EJitRegistrationStore::instance().recordError(
           EJIT_ERR_INVALID_PARAM, "runtime bitcode registration rejected",
           funcName ? funcName : "");
+      EJIT_DIAG("register_bitcode FAIL name=%s: runtime registration rejected",
+                funcName ? funcName : "<null>");
+    }
   } else {
     EJitRegistrationStore::instance().registerBitcode(
         funcName, bitcodeData, static_cast<size_t>(bitcodeSize));
@@ -117,13 +124,19 @@ void ejit_register_bitcode(const char *funcName, const uint8_t *bitcodeData,
 
 void ejit_register_period_array(const char *periodName, const char *varName,
                                 void *baseAddr, uint64_t arraySize) {
+  EJIT_DIAG("register_period_array period=%s var=%s size=%llu",
+            periodName ? periodName : "<null>", varName ? varName : "<null>",
+            static_cast<unsigned long long>(arraySize));
   if (gEJIT) {
     // Post-init: rejected once registration is frozen (taskpool); the void ABI
     // records the failure for observability and mutates nothing.
-    if (!gEJIT->registerPeriodArray(periodName, varName, baseAddr, arraySize))
+    if (!gEJIT->registerPeriodArray(periodName, varName, baseAddr, arraySize)) {
       EJitRegistrationStore::instance().recordError(
           EJIT_ERR_INVALID_PARAM, "runtime period-array registration rejected",
           periodName ? periodName : "");
+      EJIT_DIAG("register_period_array FAIL period=%s: rejected",
+                periodName ? periodName : "<null>");
+    }
   } else {
     EJitRegistrationStore::instance().registerPeriodArray(periodName, varName,
                                                           baseAddr, arraySize);
@@ -131,11 +144,16 @@ void ejit_register_period_array(const char *periodName, const char *varName,
 }
 
 void ejit_register_static_var(const char *varName, void *varAddr) {
+  EJIT_DIAG("register_static_var var=%s addr=%p",
+            varName ? varName : "<null>", varAddr);
   if (gEJIT) {
-    if (!gEJIT->registerStaticVar(varName, varAddr))
+    if (!gEJIT->registerStaticVar(varName, varAddr)) {
       EJitRegistrationStore::instance().recordError(
           EJIT_ERR_INVALID_PARAM, "runtime static-var registration rejected",
           varName ? varName : "");
+      EJIT_DIAG("register_static_var FAIL var=%s: rejected",
+                varName ? varName : "<null>");
+    }
   } else {
     EJitRegistrationStore::instance().registerStaticVar(varName, varAddr);
   }
@@ -148,8 +166,12 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut) {
   // registry-table walk. Idempotent — the same name always yields the same
   // slot. A capacity failure (the 9th distinct lifecycle) leaves *slotOut
   // invalid AND is recorded so ejit_init fails instead of silently continuing.
-  if (!lifecycleName || !slotOut)
+  if (!lifecycleName || !slotOut) {
+    EJIT_DIAG("register_lifecycle reject: name=%p slotOut=%p",
+              (const void *)lifecycleName, (void *)slotOut);
     return;
+  }
+  EJIT_DIAG("register_lifecycle name=%s", lifecycleName);
 #ifdef EJIT_SRE_TASKPOOL
   // Once a taskpool init has frozen registration, the worker reads the registry
   // lock-free: refuse to mutate it (leave *slotOut and the registry unchanged).
@@ -157,16 +179,23 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut) {
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_INVALID_PARAM, "lifecycle registration after init is frozen",
         lifecycleName);
+    EJIT_DIAG("register_lifecycle reject name=%s: registration frozen",
+              lifecycleName);
     return;
   }
 #endif
   uint32_t slot =
       EJitLifecycleRegistry::instance().resolveAssign(lifecycleName);
   *slotOut = slot;
-  if (slot == kEJitInvalidDimType)
+  if (slot == kEJitInvalidDimType) {
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_CACHE_FULL, "lifecycle (dimType) capacity exhausted",
         lifecycleName);
+    EJIT_DIAG("register_lifecycle FAIL name=%s: dimType capacity exhausted",
+              lifecycleName);
+  } else {
+    EJIT_DIAG("register_lifecycle OK name=%s slot=%u", lifecycleName, slot);
+  }
 }
 
 void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
@@ -174,22 +203,33 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
   // lifecycle. Idempotent by name. Capacity exhaustion leaves *slotOut invalid
   // (the wrapper then falls back without entering the taskpool) AND is recorded
   // so ejit_init fails rather than building a half-registered taskpool.
-  if (!funcName || !slotOut)
+  if (!funcName || !slotOut) {
+    EJIT_DIAG("register_funcindex reject: name=%p slotOut=%p",
+              (const void *)funcName, (void *)slotOut);
     return;
+  }
+  EJIT_DIAG("register_funcindex name=%s", funcName);
 #ifdef EJIT_SRE_TASKPOOL
   if (gEJIT && gEJIT->registrationFrozen()) {
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_INVALID_PARAM, "funcIndex registration after init is frozen",
         funcName);
+    EJIT_DIAG("register_funcindex reject name=%s: registration frozen",
+              funcName);
     return;
   }
 #endif
   uint32_t idx = EJitFuncRegistry::instance().resolveAssign(funcName);
   *slotOut = idx;
-  if (idx == kEJitInvalidFuncIndex)
+  if (idx == kEJitInvalidFuncIndex) {
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_CACHE_FULL, "funcIndex capacity exhausted for function",
         funcName);
+    EJIT_DIAG("register_funcindex FAIL name=%s: funcIndex capacity exhausted",
+              funcName);
+  } else {
+    EJIT_DIAG("register_funcindex OK name=%s idx=%u", funcName, idx);
+  }
 }
 
 ejit_status_t ejit_activate(const char *periodName, uint8_t cellIdx) {
@@ -220,8 +260,12 @@ ejit_status_t ejit_deactivate(const char *periodName, uint8_t cellIdx) {
 
 ejit_status_t ejit_activate_array(const char *periodName, void *arrayPtr,
                                   uint8_t cellIdx) {
-  if (!gEJIT)
+  EJIT_DIAG("activate_array(%s,%u) ptr=%p", periodName, cellIdx, arrayPtr);
+  if (!gEJIT) {
+    EJIT_DIAG("activate_array(%s,%u) failed: not initialized", periodName,
+              cellIdx);
     return EJIT_ERR_NOT_ACTIVE;
+  }
   // Validation is unified in EJit::activateArray (registered array + matching
   // period + registered lifecycle in a taskpool build) so it stays consistent
   // with the SwitchController sync. No duplicate pre-checks here.
@@ -232,8 +276,12 @@ ejit_status_t ejit_activate_array(const char *periodName, void *arrayPtr,
 
 ejit_status_t ejit_deactivate_array(const char *periodName, void *arrayPtr,
                                     uint8_t cellIdx) {
-  if (!gEJIT)
+  EJIT_DIAG("deactivate_array(%s,%u) ptr=%p", periodName, cellIdx, arrayPtr);
+  if (!gEJIT) {
+    EJIT_DIAG("deactivate_array(%s,%u) failed: not initialized", periodName,
+              cellIdx);
     return EJIT_ERR_NOT_ACTIVE;
+  }
   if (!gEJIT->deactivateArray(periodName, arrayPtr, cellIdx))
     return EJIT_ERR_INVALID_PARAM;
   gEJIT->invalidateByPeriod(periodName, cellIdx);
@@ -241,16 +289,22 @@ ejit_status_t ejit_deactivate_array(const char *periodName, void *arrayPtr,
 }
 
 ejit_status_t ejit_activate_all(const char *periodName) {
-  if (!gEJIT)
+  EJIT_DIAG("activate_all(%s)", periodName);
+  if (!gEJIT) {
+    EJIT_DIAG("activate_all(%s) failed: not initialized", periodName);
     return EJIT_ERR_NOT_ACTIVE;
+  }
   if (!gEJIT->activateAll(periodName))
     return EJIT_ERR_INVALID_PARAM;
   return EJIT_OK;
 }
 
 ejit_status_t ejit_deactivate_all(const char *periodName) {
-  if (!gEJIT)
+  EJIT_DIAG("deactivate_all(%s)", periodName);
+  if (!gEJIT) {
+    EJIT_DIAG("deactivate_all(%s) failed: not initialized", periodName);
     return EJIT_ERR_NOT_ACTIVE;
+  }
   if (!gEJIT->deactivateAll(periodName))
     return EJIT_ERR_INVALID_PARAM;
   gEJIT->invalidateAllByPeriod(periodName);
@@ -258,8 +312,10 @@ ejit_status_t ejit_deactivate_all(const char *periodName) {
 }
 
 bool ejit_is_active(const char *periodName, uint8_t cellIdx) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("is_active(%s,%u) failed: not initialized", periodName, cellIdx);
     return false;
+  }
   return gEJIT->isActive(periodName, cellIdx);
 }
 
@@ -291,10 +347,14 @@ void ejit_invalidate(const char *periodName, uint8_t cellIdx) {
 }
 
 ejit_status_t ejit_get_stats(ejit_stats_t *stats) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("get_stats failed: not initialized");
     return EJIT_ERR_NOT_ACTIVE;
-  if (!stats)
+  }
+  if (!stats) {
+    EJIT_DIAG("get_stats failed: null stats pointer");
     return EJIT_ERR_INVALID_PARAM;
+  }
 
   auto s = gEJIT->getStats();
   stats->entryCount = s.entryCount;
@@ -307,8 +367,10 @@ ejit_status_t ejit_get_stats(ejit_stats_t *stats) {
 }
 
 const ejit_error_t *ejit_get_last_error(void) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("get_last_error: not initialized");
     return nullptr;
+  }
   static ejit_error_t err;
   const EJitError *last = gEJIT->getLastError();
   if (!last)
@@ -320,14 +382,19 @@ const ejit_error_t *ejit_get_last_error(void) {
 }
 
 void ejit_set_compile_mode(ejit_compile_mode_t mode) {
+  EJIT_DIAG("set_compile_mode mode=%u", static_cast<unsigned>(mode));
   if (gEJIT)
     (void)gEJIT->setCompileMode(mode == EJIT_COMPILE_ASYNC ? CompileMode::Async
                                                            : CompileMode::Sync);
+  else
+    EJIT_DIAG("set_compile_mode reject: not initialized");
 }
 
 ejit_compile_mode_t ejit_get_compile_mode(void) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("get_compile_mode: not initialized (default sync)");
     return EJIT_COMPILE_SYNC;
+  }
   return gEJIT->getCompileMode() == CompileMode::Async ? EJIT_COMPILE_ASYNC
                                                        : EJIT_COMPILE_SYNC;
 }
@@ -381,24 +448,42 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     *outFn = nullptr;
   if (outBucket)
     *outBucket = 0;
-  if (!gEJIT)
+  EJIT_DIAG("taskpool_compile_or_get func=%u dims=%u", funcIndex, numDims);
+  if (!gEJIT) {
+    EJIT_DIAG("taskpool_compile_or_get reject func=%u: not initialized",
+              funcIndex);
     return EJIT_ERR_NOT_ACTIVE;
+  }
   auto *tp = activeTaskPool();
-  if (!tp)
+  if (!tp) {
+    EJIT_DIAG("taskpool_compile_or_get reject func=%u: no taskpool", funcIndex);
     return EJIT_ERR_NOT_ACTIVE;
+  }
 
   EJitDimPair localDims[4];
-  if (numDims > 4)
+  if (numDims > 4) {
+    EJIT_DIAG("taskpool_compile_or_get reject func=%u: numDims=%u > 4",
+              funcIndex, numDims);
     return EJIT_ERR_INVALID_PARAM;
-  if (numDims > 0 && !dims)
+  }
+  if (numDims > 0 && !dims) {
+    EJIT_DIAG("taskpool_compile_or_get reject func=%u: dims=null numDims=%u",
+              funcIndex, numDims);
     return EJIT_ERR_INVALID_PARAM;
+  }
   for (uint32_t i = 0; i < numDims; ++i) {
     // dimType is an explicit lifecycle index in [0, MAX_DIM_TYPES); instanceId
     // is in [0, MAX_INSTANCES). Both are range-checked (spec §5.1).
-    if (dims[i].dimType >= EJitSwitchController::MAX_DIM_TYPES)
+    if (dims[i].dimType >= EJitSwitchController::MAX_DIM_TYPES) {
+      EJIT_DIAG("taskpool_compile_or_get reject func=%u: dim[%u] dimType=%u OOR",
+                funcIndex, i, dims[i].dimType);
       return EJIT_ERR_INVALID_PARAM;
-    if (dims[i].instanceId >= EJitSwitchController::MAX_INSTANCES)
+    }
+    if (dims[i].instanceId >= EJitSwitchController::MAX_INSTANCES) {
+      EJIT_DIAG("taskpool_compile_or_get reject func=%u: dim[%u] instanceId=%u OOR",
+                funcIndex, i, dims[i].instanceId);
       return EJIT_ERR_INVALID_PARAM;
+    }
     localDims[i].dimType = dims[i].dimType;
     localDims[i].instanceId = dims[i].instanceId;
   }
@@ -409,73 +494,106 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
+  EJIT_DIAG("taskpool_compile_or_get func=%u status=%u fn=%p", funcIndex,
+            static_cast<unsigned>(r.status), r.fnPtr);
   return taskpoolStatus(r.status);
 }
 
 void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
                                         uint32_t enabled) {
-  if (!gEJIT)
+  EJIT_DIAG("taskpool_set_instance_enabled dim=%u inst=%u enabled=%u", dimType,
+            instanceId, enabled);
+  if (!gEJIT) {
+    EJIT_DIAG("taskpool_set_instance_enabled reject: not initialized");
     return;
+  }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   EJitSharedTaskPool *sp = gEJIT->sharedTaskPool();
-  if (!sp)
+  if (!sp) {
+    EJIT_DIAG("taskpool_set_instance_enabled reject: no shared taskpool");
     return;
+  }
   sp->setInstanceEnabled(dimType, instanceId, enabled != 0);
 #else
   EJitTaskPool *tp = gEJIT->taskPool();
-  if (!tp)
+  if (!tp) {
+    EJIT_DIAG("taskpool_set_instance_enabled reject: no taskpool");
     return;
+  }
   tp->switchController().setEnabled(dimType, instanceId, enabled != 0);
 #endif
 }
 
 void ejit_taskpool_release_read(uint32_t bucketIndex) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("taskpool_release_read bucket=%u reject: not initialized",
+              bucketIndex);
     return;
+  }
   auto *tp = activeTaskPool();
-  if (!tp)
+  if (!tp) {
+    EJIT_DIAG("taskpool_release_read bucket=%u reject: no taskpool", bucketIndex);
     return;
+  }
   tp->releaseRead(bucketIndex);
 }
 
 #ifdef EJIT_SRE_TASKPOOL_TESTING
 unsigned ejit_taskpool_poll_one(void) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("taskpool_poll_one reject: not initialized");
     return 0;
+  }
   auto *tp = activeTaskPool();
-  if (!tp)
+  if (!tp) {
+    EJIT_DIAG("taskpool_poll_one reject: no taskpool");
     return 0;
+  }
   return tp->pollOne() ? 1u : 0u;
 }
 
 unsigned ejit_taskpool_poll_budget(unsigned maxItems) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("taskpool_poll_budget max=%u reject: not initialized", maxItems);
     return 0;
+  }
   auto *tp = activeTaskPool();
-  if (!tp)
+  if (!tp) {
+    EJIT_DIAG("taskpool_poll_budget max=%u reject: no taskpool", maxItems);
     return 0;
+  }
   return tp->pollBudget(maxItems);
 }
 #endif
 
 unsigned ejit_taskpool_pending_count(void) {
-  if (!gEJIT)
+  if (!gEJIT) {
+    EJIT_DIAG("taskpool_pending_count reject: not initialized");
     return 0;
+  }
   auto *tp = activeTaskPool();
-  if (!tp)
+  if (!tp) {
+    EJIT_DIAG("taskpool_pending_count reject: no taskpool");
     return 0;
+  }
   return tp->pendingCount();
 }
 
 ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out) {
-  if (!out)
+  if (!out) {
+    EJIT_DIAG("taskpool_get_stats failed: null out pointer");
     return EJIT_ERR_INVALID_PARAM;
-  if (!gEJIT)
+  }
+  if (!gEJIT) {
+    EJIT_DIAG("taskpool_get_stats failed: not initialized");
     return EJIT_ERR_NOT_ACTIVE;
+  }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   EJitSharedTaskPool *sp = gEJIT->sharedTaskPool();
-  if (!sp)
+  if (!sp) {
+    EJIT_DIAG("taskpool_get_stats failed: no shared taskpool");
     return EJIT_ERR_NOT_ACTIVE;
+  }
   EJitSharedDiagnostics d;
   sp->getDiagnostics(d);
   out->cacheHits = d.cacheHits;
@@ -493,8 +611,10 @@ ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out) {
   return EJIT_OK;
 #else
   EJitTaskPool *tp = gEJIT->taskPool();
-  if (!tp)
+  if (!tp) {
+    EJIT_DIAG("taskpool_get_stats failed: no taskpool");
     return EJIT_ERR_NOT_ACTIVE;
+  }
 
   EJitTaskPoolStatsSnapshot s;
   tp->getStats(s);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntimeState.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntimeState.cpp
@@ -1,6 +1,7 @@
 //===-- EJitRuntimeState.cpp - Activate/Deactivate State ------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include <cassert>
 #include <mutex>
 
@@ -9,6 +10,8 @@ using namespace llvm::ejit;
 void PeriodArrayRegistry::registerArray(const std::string &periodName,
                                         const std::string &varName,
                                         void *baseAddr, size_t size) {
+  EJIT_DIAG("registry registerArray period=%s var=%s base=%p size=%zu",
+            periodName.c_str(), varName.c_str(), baseAddr, size);
   PeriodArrayInfo info{varName, periodName, baseAddr, size};
   arraysByPeriod_[periodName].push_back(info);
   varNameIndex_[varName] = info;
@@ -17,6 +20,8 @@ void PeriodArrayRegistry::registerArray(const std::string &periodName,
 
 void PeriodArrayRegistry::registerStaticVar(const std::string &varName,
                                             void *varAddr) {
+  EJIT_DIAG("registry registerStaticVar var=%s addr=%p", varName.c_str(),
+            varAddr);
   staticVars_.push_back({varName, varAddr});
   staticVarIndex_[varName] = varAddr;
 }
@@ -55,6 +60,8 @@ PeriodArrayRegistry::getArrayByBaseAddr(void *addr) const {
 
 void EJitRuntimeState::activate(const std::string &periodName,
                                 uint8_t cellIdx) {
+  EJIT_DIAG("runtimeState activate period=%s cellIdx=%u", periodName.c_str(),
+            cellIdx);
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif
@@ -69,6 +76,8 @@ void EJitRuntimeState::activate(const std::string &periodName,
 
 void EJitRuntimeState::deactivate(const std::string &periodName,
                                   uint8_t cellIdx) {
+  EJIT_DIAG("runtimeState deactivate period=%s cellIdx=%u", periodName.c_str(),
+            cellIdx);
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif
@@ -81,8 +90,13 @@ void EJitRuntimeState::deactivate(const std::string &periodName,
 }
 
 void EJitRuntimeState::activateArray(void *arrayPtr, uint8_t cellIdx) {
-  assert(registry_.getArrayByBaseAddr(arrayPtr) &&
-         "activateArray: arrayPtr is not a registered period array");
+  if (!registry_.getArrayByBaseAddr(arrayPtr)) {
+    EJIT_DIAG("runtimeState activateArray FAIL: arrayPtr=%p not registered",
+              arrayPtr);
+    assert(registry_.getArrayByBaseAddr(arrayPtr) &&
+           "activateArray: arrayPtr is not a registered period array");
+  }
+  EJIT_DIAG("runtimeState activateArray ptr=%p cellIdx=%u", arrayPtr, cellIdx);
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif
@@ -91,8 +105,14 @@ void EJitRuntimeState::activateArray(void *arrayPtr, uint8_t cellIdx) {
 }
 
 void EJitRuntimeState::deactivateArray(void *arrayPtr, uint8_t cellIdx) {
-  assert(registry_.getArrayByBaseAddr(arrayPtr) &&
-         "deactivateArray: arrayPtr is not a registered period array");
+  if (!registry_.getArrayByBaseAddr(arrayPtr)) {
+    EJIT_DIAG("runtimeState deactivateArray FAIL: arrayPtr=%p not registered",
+              arrayPtr);
+    assert(registry_.getArrayByBaseAddr(arrayPtr) &&
+           "deactivateArray: arrayPtr is not a registered period array");
+  }
+  EJIT_DIAG("runtimeState deactivateArray ptr=%p cellIdx=%u", arrayPtr,
+            cellIdx);
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif
@@ -101,6 +121,7 @@ void EJitRuntimeState::deactivateArray(void *arrayPtr, uint8_t cellIdx) {
 }
 
 void EJitRuntimeState::activateAll(const std::string &periodName) {
+  EJIT_DIAG("runtimeState activateAll period=%s", periodName.c_str());
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif
@@ -115,6 +136,7 @@ void EJitRuntimeState::activateAll(const std::string &periodName) {
 }
 
 void EJitRuntimeState::deactivateAll(const std::string &periodName) {
+  EJIT_DIAG("runtimeState deactivateAll period=%s", periodName.c_str());
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -88,8 +88,13 @@ uint32_t EJitSharedTaskPool::instanceVersion(uint32_t dimType,
 bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
                                             uint32_t instanceId, bool enabled) {
   if (!state_ || dimType >= kEJitSharedDimTypes ||
-      instanceId >= kEJitSharedInstances)
+      instanceId >= kEJitSharedInstances) {
+    EJIT_DIAG("shared setInstanceEnabled reject: state=%p dim=%u inst=%u "
+              "(OOR dim<%u inst<%u)",
+              (void *)state_, dimType, instanceId, kEJitSharedDimTypes,
+              kEJitSharedInstances);
     return false;
+  }
   uint8_t expected = enabled ? 0 : 1;
   uint8_t desired = enabled ? 1 : 0;
   if (state_->enabled[dimType][instanceId].compareExchange(expected, desired)) {
@@ -382,14 +387,25 @@ EJitSharedPoolSplit *EJitSharedTaskPool::findOrClaimPoolSlot(uintptr_t base) {
 bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
                                                        uintptr_t poolBase,
                                                        uint64_t poolSize) {
+  EJIT_DIAG("ensurePoolSplit: core=%u poolBase=0x%llx size=%llu", self,
+            static_cast<unsigned long long>(poolBase),
+            static_cast<unsigned long long>(poolSize));
   // Cores beyond the 64-bit memo width cannot record split state, so they must
   // re-run the (idempotent) split on every hit rather than risk skipping it.
-  if (self >= kEJitSharedMaxMemoCores)
-    return splitPoolFn_ && splitPoolFn_(splitPoolCtx_, poolBase, poolSize);
+  if (self >= kEJitSharedMaxMemoCores) {
+    bool ok = splitPoolFn_ && splitPoolFn_(splitPoolCtx_, poolBase, poolSize);
+    if (!ok)
+      EJIT_DIAG("ensurePoolSplit FAIL: core=%u >= memoWidth, split callback "
+                "missing/failed", self);
+    return ok;
+  }
 
   EJitSharedPoolSplit *P = findOrClaimPoolSlot(poolBase);
-  if (!P)
+  if (!P) {
+    EJIT_DIAG("ensurePoolSplit fallback: core=%u poolBase=0x%llx split table full",
+              self, static_cast<unsigned long long>(poolBase));
     return false; // table full -> clean fallback.
+  }
 
   const uint64_t Bit = uint64_t{1} << self;
   if ((P->splitDoneMask.loadAcquire() & Bit) != 0)
@@ -409,7 +425,12 @@ bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
         break; // the other context finished without marking done -> it failed.
       cpuRelax();
     }
-    return (P->splitDoneMask.loadAcquire() & Bit) != 0;
+    bool done = (P->splitDoneMask.loadAcquire() & Bit) != 0;
+    if (!done)
+      EJIT_DIAG("ensurePoolSplit fallback: core=%u poolBase=0x%llx peer split "
+                "did not publish done", self,
+                static_cast<unsigned long long>(poolBase));
+    return done;
   }
 
   // We own the split for this (pool, core). Run it, publishing done only on
@@ -420,12 +441,20 @@ bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
     P->splitPreparingMask.fetchAnd(~Bit);
     return true;
   }
+  EJIT_DIAG("ensurePoolSplit FAIL: core=%u poolBase=0x%llx split callback failed",
+            self, static_cast<unsigned long long>(poolBase));
   P->splitPreparingMask.fetchAnd(~Bit);
   return false;
 }
 
 bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
                                                    uint32_t self) {
+  EJIT_DIAG("prepareExec: core=%u fn=%p codeStart=0x%llx codeSize=%llu "
+            "poolBase=0x%llx fourK=%u", self, R.fn,
+            static_cast<unsigned long long>(R.codeStart),
+            static_cast<unsigned long long>(R.codeSize),
+            static_cast<unsigned long long>(R.poolBase),
+            static_cast<unsigned>(fourKSeal_));
   if (!fourKSeal_) {
     // Legacy whole-2MiB-pool seal: align fnPtr to its pool base and enable_ex
     // that page. Range metadata is not required (spec §6 — 2M unchanged). When
@@ -434,24 +463,42 @@ bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
     // simulation), so the pointer is already executable on this core.
     if (!prepareCodeFn_)
       return true;
-    return prepareCodeFn_(prepareCodeCtx_, R.fn);
+    bool ok = prepareCodeFn_(prepareCodeCtx_, R.fn);
+    if (!ok)
+      EJIT_DIAG("prepareExec FAIL: core=%u legacy prepareCode fn=%p", self, R.fn);
+    return ok;
   }
 
   // 4K page seal needs the real executable extent. A slot with no recorded
   // range (or a malformed one) is a clean fallback, never a guessed seal.
-  if (R.codeStart == 0 || R.codeSize == 0 || R.poolBase == 0 || R.poolSize == 0)
+  if (R.codeStart == 0 || R.codeSize == 0 || R.poolBase == 0 || R.poolSize == 0) {
+    EJIT_DIAG("prepareExec fallback: core=%u fn=%p malformed range "
+              "(codeStart=0x%llx codeSize=%llu poolBase=0x%llx poolSize=%llu)",
+              self, R.fn, static_cast<unsigned long long>(R.codeStart),
+              static_cast<unsigned long long>(R.codeSize),
+              static_cast<unsigned long long>(R.poolBase),
+              static_cast<unsigned long long>(R.poolSize));
     return false;
-  if (R.codeStart + R.codeSize < R.codeStart) // code range overflow
+  }
+  if (R.codeStart + R.codeSize < R.codeStart) { // code range overflow
+    EJIT_DIAG("prepareExec fallback: core=%u code range overflow", self);
     return false;
-  if (R.poolBase + R.poolSize < R.poolBase) // pool range overflow
+  }
+  if (R.poolBase + R.poolSize < R.poolBase) { // pool range overflow
+    EJIT_DIAG("prepareExec fallback: core=%u pool range overflow", self);
     return false;
+  }
   if (R.codeStart < R.poolBase ||
-      R.codeStart + R.codeSize > R.poolBase + R.poolSize)
+      R.codeStart + R.codeSize > R.poolBase + R.poolSize) {
+    EJIT_DIAG("prepareExec fallback: core=%u code not inside pool", self);
     return false; // code must lie wholly inside its pool.
+  }
 
   // This core must have split the 2MiB pool exactly once before sealing pages.
-  if (!ensurePoolSplitForCurrentCore(self, R.poolBase, R.poolSize))
+  if (!ensurePoolSplitForCurrentCore(self, R.poolBase, R.poolSize)) {
+    EJIT_DIAG("prepareExec FAIL: core=%u pool split not done", self);
     return false;
+  }
 
   // Seal every 4KiB page the code overlaps: page-align start down, end up.
   const uintptr_t Page = static_cast<uintptr_t>(kEJitSharedSealPage);
@@ -460,8 +507,14 @@ bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
       (R.codeStart + static_cast<uintptr_t>(R.codeSize) + Page - 1) &
       ~(Page - 1);
   for (uintptr_t VA = PageStart; VA < PageEnd; VA += Page)
-    if (!sealPageFn_ || !sealPageFn_(sealPageCtx_, VA))
+    if (!sealPageFn_ || !sealPageFn_(sealPageCtx_, VA)) {
+      EJIT_DIAG("prepareExec FAIL: core=%u sealPage pageVA=0x%llx",
+                self, static_cast<unsigned long long>(VA));
       return false; // any page failure -> no callable pointer is returned.
+    }
+  EJIT_DIAG("prepareExec OK: core=%u fn=%p pages=[0x%llx,0x%llx)", self, R.fn,
+            static_cast<unsigned long long>(PageStart),
+            static_cast<unsigned long long>(PageEnd));
   return true;
 }
 
@@ -566,8 +619,11 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
 }
 
 void EJitSharedTaskPool::releaseRead(uint32_t bucketIndex) {
-  if (!state_ || bucketIndex >= kEJitSharedCacheBuckets)
+  if (!state_ || bucketIndex >= kEJitSharedCacheBuckets) {
+    EJIT_DIAG("shared releaseRead reject: state=%p bucket=%u (max=%u)",
+              (void *)state_, bucketIndex, kEJitSharedCacheBuckets);
     return;
+  }
   bucketReadRelease(state_->buckets[bucketIndex]);
 }
 
@@ -641,8 +697,13 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
 } // namespace
 
 EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
-  if (!state_)
+  if (!state_) {
+    EJIT_DIAG("shared taskpool init FAILED: no shared state bound");
     return InitResult::NoState;
+  }
+  EJIT_DIAG("shared taskpool init: state=%p fingerprint=0x%llx",
+            static_cast<void *>(state_),
+            static_cast<unsigned long long>(regFingerprint_));
 
   // Bounded retry so an in-progress peer never deadlocks us.
   constexpr uint32_t kMaxSpins = 1u << 20;
@@ -711,8 +772,13 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
     case EJitSharedInitState::Ready:
       if (state_->magic != kEJitSharedAbiMagic ||
           state_->abiVersion != kEJitSharedAbiVersion ||
-          state_->structSize != sizeof(EJitSharedTaskPoolState))
+          state_->structSize != sizeof(EJitSharedTaskPoolState)) {
+        EJIT_DIAG("shared taskpool attach REJECTED: ABI mismatch "
+                  "(magic=0x%x ver=%u size=%u exp_size=%zu)",
+                  state_->magic, state_->abiVersion, state_->structSize,
+                  sizeof(EJitSharedTaskPoolState));
         return InitResult::AbiMismatch;
+      }
       // Registration consistency: a peer whose funcIndex/dimType mapping digest
       // differs from the owner's must NOT submit requests against mismatched
       // indices. Clean-fail instead (the owner itself re-observes its own
@@ -725,13 +791,19 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
                   static_cast<unsigned long long>(regFingerprint_));
         return InitResult::FingerprintMismatch;
       }
+      EJIT_DIAG("shared taskpool attached ready (owner=%u)",
+                state_->ownerCoreId.loadAcquire());
       return InitResult::AttachedReady;
     case EJitSharedInitState::Failed:
+      EJIT_DIAG("shared taskpool init FAILED: owner reported Failed (err=%u)",
+                state_->lastInitError.loadAcquire());
       return InitResult::OwnerFailed;
     case EJitSharedInitState::Stopping:
+      EJIT_DIAG("shared taskpool init FAILED: owner is Stopping");
       return InitResult::OwnerFailed;
     }
   }
+  EJIT_DIAG("shared taskpool init FAILED: peer still initializing after spins");
   return InitResult::InitInProgress; // peer still initializing; pending, no
                                      // hang.
 }
@@ -739,6 +811,7 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
 void EJitSharedTaskPool::ownerShutdown() {
   if (!state_ || !isOwner_)
     return;
+  EJIT_DIAG("shared taskpool owner shutdown begin");
   // Signal the worker loop to exit, then join it BEFORE returning state to
   // Uninitialized so no worker can touch owner-private state afterwards.
   state_->initState.storeRelease(
@@ -751,6 +824,7 @@ void EJitSharedTaskPool::ownerShutdown() {
   state_->initState.storeRelease(
       static_cast<uint32_t>(EJitSharedInitState::Uninitialized));
   isOwner_ = false;
+  EJIT_DIAG("shared taskpool owner shutdown complete");
 }
 
 //===----------------------------------------------------------------------===//
@@ -761,11 +835,16 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                  uint32_t numDims, void *fallback) {
   CompileOrGetResult R;
   R.fnPtr = fallback;
+  EJIT_DIAG("shared taskpool request func=%u dims=%u fallback=%p", funcIndex,
+            numDims, fallback);
   if (!state_ || state_->initState.loadAcquire() != kReady) {
+    EJIT_DIAG("shared taskpool fallback func=%u: not Ready", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode; // not Ready → clean fallback.
     return R;
   }
   if ((numDims > 0 && !dims) || numDims > 4) {
+    EJIT_DIAG("shared taskpool reject func=%u: invalid dims ptr=%p count=%u",
+              funcIndex, static_cast<const void *>(dims), numDims);
     R.status = EJitCompileOrGetStatus::InvalidParam;
     return R;
   }
@@ -773,6 +852,8 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   for (uint32_t i = 0; i < numDims; ++i)
     if (!isInstanceEnabled(dims[i].dimType, dims[i].instanceId)) {
       state_->counters.instanceDisabled.fetchAdd(1);
+      EJIT_DIAG("shared taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex,
+                i, dims[i].dimType, dims[i].instanceId);
       R.status = EJitCompileOrGetStatus::InstanceDisabled;
       return R;
     }
@@ -784,11 +865,15 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.fnPtr = Hit.fnPtr;
     R.bucketIndex = Hit.bucketIndex;
     R.hasReadToken = true;
+    EJIT_DIAG("shared taskpool hit func=%u bucket=%u fn=%p", funcIndex,
+              Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
   if (Hit.readyButNotShareable) {
     // The work is already done but this core may not read the cross-core
     // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
+    EJIT_DIAG("shared taskpool fallback func=%u: ready but not shareable on this core",
+              funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;
     R.readyButNotShareable = true;
     return R;
@@ -796,6 +881,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   // Off mode (§5.2 step 2).
   if (state_->mode.loadAcquire() ==
       static_cast<uint32_t>(EJitCompileMode::Off)) {
+    EJIT_DIAG("shared taskpool fallback func=%u: mode off", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;
     return R;
   }
@@ -813,9 +899,11 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   switch (dedupMark(funcIndex, gen)) {
   case EJitDedupResult::AlreadyPending:
     state_->counters.alreadyPending.fetchAdd(1);
+    EJIT_DIAG("shared taskpool coalesced func=%u: already pending", funcIndex);
     R.status = EJitCompileOrGetStatus::AlreadyPending;
     return R;
   case EJitDedupResult::InvalidFuncIndex:
+    EJIT_DIAG("shared taskpool reject func=%u: out of range", funcIndex);
     R.status = EJitCompileOrGetStatus::InvalidParam;
     return R;
   case EJitDedupResult::Claimed:
@@ -824,10 +912,12 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (!queuePush(Req)) {
     dedupClear(funcIndex, gen); // queue full → roll back the in-flight slot.
     state_->counters.queueFull.fetchAdd(1);
+    EJIT_DIAG("shared taskpool fallback func=%u: queue full", funcIndex);
     R.status = EJitCompileOrGetStatus::QueueFullFallback;
     return R;
   }
   state_->counters.asyncEnqueues.fetchAdd(1);
+  EJIT_DIAG("shared taskpool enqueued func=%u gen=%u", funcIndex, gen);
   R.status = EJitCompileOrGetStatus::EnqueuedPending;
   return R;
 }
@@ -836,6 +926,8 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
 // Consumer path (§5.3) — runs on the single owner worker (or a test driver).
 //===----------------------------------------------------------------------===//
 void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
+  EJIT_DIAG("shared worker compile begin func=%u dims=%u gen=%u", req.funcIndex,
+            req.numDims, req.generation);
   // Checkpoint 0 (spec §11): generation guard. A request enqueued under an
   // earlier generation (owner re-init in between) is dropped before compiling.
   // dedupClear is generation-aware, so this never clears a NEW generation's
@@ -843,12 +935,15 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   if (req.generation != state_->generation.loadAcquire()) {
     dedupClear(req.funcIndex, req.generation);
     state_->counters.compileFailed.fetchAdd(1);
+    EJIT_DIAG("shared worker compile drop func=%u: generation changed", req.funcIndex);
     return;
   }
   // Checkpoint 1: invalidated before compile started.
   if (!versionsCurrent(req)) {
     dedupClear(req.funcIndex, req.generation);
     state_->counters.compileFailed.fetchAdd(1);
+    EJIT_DIAG("shared worker compile drop func=%u: version changed before compile",
+              req.funcIndex);
     return;
   }
   void *fn = nullptr;
@@ -856,6 +951,8 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   if (!ok || !fn) {
     dedupClear(req.funcIndex, req.generation);
     state_->counters.compileFailed.fetchAdd(1);
+    EJIT_DIAG("shared worker compile failed func=%u ok=%u fn=%p", req.funcIndex,
+              static_cast<unsigned>(ok), fn);
     return;
   }
   // Resolve the real executable range for the freshly compiled pointer (from
@@ -874,6 +971,8 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
       releaseFn_(releaseCtx_, fn);
     dedupClear(req.funcIndex, req.generation);
     state_->counters.compileFailed.fetchAdd(1);
+    EJIT_DIAG("shared worker compile drop func=%u: version/gen changed after compile",
+              req.funcIndex);
     return;
   }
   EJitPublishStatus PS = cachePublish(req, fn, &info);
@@ -881,12 +980,14 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   case EJitPublishStatus::Published:
     state_->counters.asyncCompiles.fetchAdd(1);
     dedupClear(req.funcIndex, req.generation);
+    EJIT_DIAG("shared worker publish ok func=%u fn=%p", req.funcIndex, fn);
     return;
   case EJitPublishStatus::VersionMismatch:
     if (releaseFn_)
       releaseFn_(releaseCtx_, fn);
     dedupClear(req.funcIndex, req.generation);
     state_->counters.compileFailed.fetchAdd(1);
+    EJIT_DIAG("shared worker publish drop func=%u: version mismatch", req.funcIndex);
     return;
   case EJitPublishStatus::InvalidParam:
   case EJitPublishStatus::Failed:
@@ -894,6 +995,8 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
       releaseFn_(releaseCtx_, fn);
     dedupClear(req.funcIndex, req.generation);
     state_->counters.publishFailed.fetchAdd(1);
+    EJIT_DIAG("shared worker publish failed func=%u status=%u", req.funcIndex,
+              static_cast<unsigned>(PS));
     return;
   }
 }
@@ -933,11 +1036,13 @@ EJitWorkerStep EJitSharedTaskPool::workerPollOnce() {
   case EJitSharedInitState::Failed:
   case EJitSharedInitState::Stopping:
   default:
+    EJIT_DIAG("shared worker exit: state=%u", st);
     return EJitWorkerStep::Exit;
   }
 }
 
 void EJitSharedTaskPool::runWorkerLoop() {
+  EJIT_DIAG("shared worker loop enter");
   // Loop until a terminal state. The worker is a PRODUCTION-lifetime task: it
   // never exits just because the owner is slightly slow to publish Ready (no
   // spin budget). On every non-consuming iteration — waiting through
@@ -949,11 +1054,12 @@ void EJitSharedTaskPool::runWorkerLoop() {
   for (;;) {
     EJitWorkerStep s = workerPollOnce();
     if (s == EJitWorkerStep::Exit)
-      return;
+      break;
     if (s == EJitWorkerStep::WaitForReady || s == EJitWorkerStep::Idle)
       workerIdle();
     // Consumed: loop immediately, more work is likely queued.
   }
+  EJIT_DIAG("shared worker loop leave");
 }
 
 void EJitSharedTaskPool::workerIdle() {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -21,6 +21,7 @@
 #ifdef EJIT_SRE_CODE_POOL
 
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 
 #ifndef EJIT_SRE_CODE_POOL_SIZE
 #define EJIT_SRE_CODE_POOL_SIZE                                                \
@@ -77,6 +78,8 @@ llvm::ejit::makeSreCodePoolManager() {
   Opts.poolSize = static_cast<size_t>(kSrePoolSize);
   Opts.poolAlign = k2MiB; // large-page / split granularity
   Opts.minCodeAlign = 64;
+  EJIT_DIAG("makeSreCodePoolManager: poolSize=%llu poolAlign=%zu",
+            kSrePoolSize, k2MiB);
 #ifdef EJIT_CODE_POOL_4K_SEAL
   // Adapt to the platform's 4K execute-permission interface: the 2MiB pool is
   // split into 4K mappings at creation and sealed one 4KiB page at a time.
@@ -117,28 +120,52 @@ llvm::ejit::makeSreCodePoolManager() {
 
 bool llvm::ejit::prepareSreCodeForCurrentCore(const void *FnPtr) {
 #if !defined(EJIT_SRE_ENABLE_EX) || defined(EJIT_CODE_POOL_4K_SEAL)
+  EJIT_DIAG("prepareSreCode: unsupported config (FnPtr=%p), clean fallback",
+            FnPtr);
   (void)FnPtr;
   return false;
 #else
-  if (!FnPtr)
+  if (!FnPtr) {
+    EJIT_DIAG("prepareSreCode: null FnPtr, reject");
     return false;
+  }
   const auto Address = reinterpret_cast<uintptr_t>(FnPtr);
   const auto PoolBase = Address & ~(static_cast<uintptr_t>(k2MiB) - 1);
-  return ejit_sre_enable_ex(1, static_cast<unsigned long long>(PoolBase)) == 0;
+  unsigned Rc = ejit_sre_enable_ex(1, static_cast<unsigned long long>(PoolBase));
+  if (Rc != 0) {
+    EJIT_DIAG("prepareSreCode FAIL: enable_ex poolBase=0x%llx rc=%u",
+              static_cast<unsigned long long>(PoolBase), Rc);
+    return false;
+  }
+  return true;
 #endif
 }
 
 bool llvm::ejit::ejitSreSplitPoolForCurrentCore(uintptr_t PoolBase,
                                                 uint64_t PoolSize) {
 #if defined(EJIT_SRE_ENABLE_EX) && defined(EJIT_CODE_POOL_4K_SEAL)
-  if (PoolBase == 0 || PoolSize == 0)
+  if (PoolBase == 0 || PoolSize == 0) {
+    EJIT_DIAG("splitPoolForCurrentCore reject: poolBase=0x%llx size=%llu",
+              static_cast<unsigned long long>(PoolBase),
+              static_cast<unsigned long long>(PoolSize));
     return false;
+  }
   // Per-core: this splits the 2MiB large page into 4K mappings in the calling
   // core's stage-1 translation only. enable_ex per page follows.
-  return ejit_sre_split_2m_to_4k(static_cast<unsigned long long>(PoolBase),
-                                 static_cast<unsigned long long>(PoolSize)) ==
-         0;
+  unsigned Rc = ejit_sre_split_2m_to_4k(
+      static_cast<unsigned long long>(PoolBase),
+      static_cast<unsigned long long>(PoolSize));
+  if (Rc != 0) {
+    EJIT_DIAG("splitPoolForCurrentCore FAIL: split_2m_to_4k poolBase=0x%llx "
+              "size=%llu rc=%u",
+              static_cast<unsigned long long>(PoolBase),
+              static_cast<unsigned long long>(PoolSize), Rc);
+    return false;
+  }
+  return true;
 #else
+  EJIT_DIAG("splitPoolForCurrentCore unsupported config: poolBase=0x%llx",
+            static_cast<unsigned long long>(PoolBase));
   (void)PoolBase;
   (void)PoolSize;
   return false;
@@ -147,13 +174,23 @@ bool llvm::ejit::ejitSreSplitPoolForCurrentCore(uintptr_t PoolBase,
 
 bool llvm::ejit::ejitSreSealPageForCurrentCore(uintptr_t PageVA) {
 #ifdef EJIT_SRE_ENABLE_EX
-  if (PageVA == 0)
+  if (PageVA == 0) {
+    EJIT_DIAG("sealPageForCurrentCore reject: null PageVA");
     return false;
+  }
   // Per-core: flips the 4KiB page containing PageVA to RX in the calling core's
   // translation context. enable_ex performs its own permission/cache sync, so
   // no __builtin___clear_cache here.
-  return ejit_sre_enable_ex(1, static_cast<unsigned long long>(PageVA)) == 0;
+  unsigned Rc = ejit_sre_enable_ex(1, static_cast<unsigned long long>(PageVA));
+  if (Rc != 0) {
+    EJIT_DIAG("sealPageForCurrentCore FAIL: enable_ex pageVA=0x%llx rc=%u",
+              static_cast<unsigned long long>(PageVA), Rc);
+    return false;
+  }
+  return true;
 #else
+  EJIT_DIAG("sealPageForCurrentCore unsupported config: pageVA=0x%llx",
+            static_cast<unsigned long long>(PageVA));
   (void)PageVA;
   return false;
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSreTask_host.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSreTask_host.cpp
@@ -1,6 +1,7 @@
 //===-- EJitSreTask_host.cpp - Host task implementation -------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitSreTask.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 
 #ifndef EJIT_FREESTANDING
 #include <new>
@@ -21,8 +22,12 @@ struct HostTaskHandle {
 bool EJitSreTask::create(EJitSreTask &out, EntryFn entry, void *ctx,
                          const char *name) {
   (void)name;
-  if (out.handle_)
+  if (out.handle_) {
+    EJIT_DIAG("host task create ignored: handle=%p", out.handle_);
     return true;
+  }
+  EJIT_DIAG("host task create begin name=%s entry=%p ctx=%p",
+            name ? name : "<null>", reinterpret_cast<void *>(entry), ctx);
   out.stopFlag_.storeRelease(0);
   out.entry_ = entry;
   out.ctx_ = ctx;
@@ -30,15 +35,21 @@ bool EJitSreTask::create(EJitSreTask &out, EntryFn entry, void *ctx,
     if (out.entry_)
       out.entry_(out.ctx_);
   }));
-  if (!H)
+  if (!H) {
+    EJIT_DIAG("host task create failed: out of memory");
     return false;
+  }
   out.handle_ = H;
+  EJIT_DIAG("host task create OK handle=%p", out.handle_);
   return true;
 }
 
 void EJitSreTask::destroy(EJitSreTask &task) {
-  if (!task.handle_)
+  if (!task.handle_) {
+    EJIT_DIAG("host task destroy ignored: no handle");
     return;
+  }
+  EJIT_DIAG("host task destroy begin handle=%p", task.handle_);
   task.stopFlag_.storeRelease(1);
   auto *H = static_cast<HostTaskHandle *>(task.handle_);
   if (H->th.joinable())
@@ -47,6 +58,7 @@ void EJitSreTask::destroy(EJitSreTask &task) {
   task.handle_ = nullptr;
   task.entry_ = nullptr;
   task.ctx_ = nullptr;
+  EJIT_DIAG("host task destroy complete");
 }
 
 void EJitSreTask::yield() { std::this_thread::yield(); }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -1,6 +1,7 @@
 //===-- EJitStructFieldPass.cpp - JIT Constant Substitution ---------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
@@ -21,6 +22,8 @@ using namespace llvm::ejit;
 #define DEBUG_TYPE "ejit-struct-field"
 
 void EJitStructFieldPass::initFromModule(Module &M) {
+  EJIT_DIAG("struct-field initFromModule module=%s globals=%zu",
+            M.getName().str().c_str(), M.global_size());
   // Build GV period map.
   for (GlobalVariable &GV : M.globals()) {
     MDNode *MD = GV.getMetadata(MD_EJIT_METADATA);
@@ -326,8 +329,12 @@ tryReplaceIndirect(LoadInst *LI, const Value *PtrOp,
 PreservedAnalyses
 EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
   Module *M = F.getParent();
-  if (!M)
+  if (!M) {
+    EJIT_DIAG("struct-field run SKIP func=%s: no parent module",
+              F.getName().str().c_str());
     return PreservedAnalyses::all();
+  }
+  EJIT_DIAG("struct-field run func=%s", F.getName().str().c_str());
 
   assert(mapsBuilt_ && "EJitStructFieldPass::initFromModule() must be "
                        "called before run()");
@@ -380,6 +387,8 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
     changed = true;
   }
 
+  EJIT_DIAG("struct-field run func=%s replaced=%zu", F.getName().str().c_str(),
+            replacements.size());
   LLVM_DEBUG(if (changed) dbgs() << "ejit-struct-field: replaced "
                                  << replacements.size() << " load(s) in "
                                  << F.getName() << "\n");

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSyncCompiler.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSyncCompiler.cpp
@@ -3,6 +3,7 @@
 #ifndef EJIT_FREESTANDING
 
 #include "llvm/ExecutionEngine/EJIT/EJitSyncCompiler.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include <chrono>
 
@@ -14,6 +15,8 @@ EJitSyncCompiler::compile(EJitOrcEngine &engine,
                           const std::string &bitcodeData,
                           const SpecializationContext &ctx) {
   Result result;
+  EJIT_DIAG("sync compile begin func=%s key=0x%016lx size=%zu",
+            ctx.fnName.c_str(), ctx.cacheKey, bitcodeData.size());
 
   auto start = std::chrono::steady_clock::now();
 
@@ -21,14 +24,21 @@ EJitSyncCompiler::compile(EJitOrcEngine &engine,
 
   if (auto Err = engine.loadBitcodeModule(bitcodeData, ctx.cacheKey, ctx.fnName)) {
     engine.setActiveContext(nullptr);
+    EJIT_DIAG("sync compile FAIL func=%s key=0x%016lx: load bitcode failed",
+              ctx.fnName.c_str(), ctx.cacheKey);
+    consumeError(std::move(Err));
     return result;
   }
 
   auto addrOrErr = engine.lookup(ctx.cacheKey, ctx.fnName);
   engine.setActiveContext(nullptr);
 
-  if (!addrOrErr)
+  if (!addrOrErr) {
+    EJIT_DIAG("sync compile FAIL func=%s key=0x%016lx: lookup failed",
+              ctx.fnName.c_str(), ctx.cacheKey);
+    consumeError(addrOrErr.takeError());
     return result;
+  }
 
   result.funcPtr = *addrOrErr;
   // NOTE: codeSize is bitcode size, not compiled machine code size.
@@ -38,6 +48,9 @@ EJitSyncCompiler::compile(EJitOrcEngine &engine,
   result.compileTimeMs =
       std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
 
+  EJIT_DIAG("sync compile OK func=%s key=0x%016lx pfn=%p time=%llums",
+            ctx.fnName.c_str(), ctx.cacheKey, result.funcPtr,
+            static_cast<unsigned long long>(result.compileTimeMs));
   return result;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -324,7 +324,7 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   // 1. Parameter check.
   if ((numDims > 0 && !dims) || numDims > 4) {
     EJIT_DIAG("taskpool reject func=%u: invalid dims ptr=%p count=%u",
-              funcIndex, dims, numDims);
+              funcIndex, static_cast<const void *>(dims), numDims);
     R.status = EJitCompileOrGetStatus::InvalidParam;
     return R;
   }


### PR DESCRIPTION
Instrument the EJIT runtime with EJIT_DIAG across function entry points, internal module boundaries, and every exceptional path, so abnormal flows record enough context (cacheKey, funcName/funcIndex, periodName, cellIdx, dimType/instanceId, rc, pointers, sizes, status codes) to locate the scene.

- EJitCodePool: replace the standalone EJIT_CODE_POOL_TRACE macro with EJIT_DIAG (single diagnostic interface), logging raw alloc/split/enable_ex failures and pool rollover/sealing transitions.
- EJitSharedTaskPool: add diagnostics to the previously bare producer (compileOrGet) and consumer (runCompile) paths, covering checkpoint drops, publish rejections, and owner-election results.
- EJitRuntime (C ABI): log taskpool API entry/rejection and register/activate series; EJit: log unknown-period and frozen-registration rejections.
- EJitOrcEngine/Sync/Async/Optimizer/StructFieldPass/CompileDriver/Cache/ ModuleLoader/RuntimeState/Logger/RegistrationStore/SreTask: add entry and module-boundary logs plus exceptional-path context. LLVM_DEBUG is preserved.
- CompileDriver::compileNow: replace silent nullptr rejections with logged reasons; sharedWorkerStart/startSharedTaskPool: log each init result.

No-op when EJIT_DIAG_ENABLE is undefined (macro expands to ((void)0)). Verified to compile across host x86 (diagnostics ON, type-checking all call sites) and freestanding aarch64 builds.