### PR TITLE
[EJIT][Tests] Match taskpool wrapper mode

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # Build all EJIT integration tests.
-# Usage: ./build.sh [--run] [--arch=x86|aarch64] [--analyze-deps] [--lipo=FILE] [<test>...]
+# Usage: ./build.sh [--run] [--arch=x86|aarch64] [--build-dir=DIR] [--analyze-deps] [--lipo=FILE] [<test>...]
 #   --run          Build and run all tests
 #   --arch=<arch>  Target architecture (default: auto-detect from build dirs)
+#   --build-dir=DIR Use a specific LLVM build dir instead of auto-detecting
 #   --analyze-deps Build & show which LLVM .a files were actually linked
 #   --lipo=<FILE>  Use a single lipo .o/.a (from lipo.py) instead of individual .a files
+#   --host-sre-stubs / --no-host-sre-stubs
+#                  Force-enable/disable Linux SRE platform stubs for local tests
 #   test_name      Build only the named test (without .c extension)
 #
 # Requires a release build (static libs): ./build.sh release <x86|aarch64>
@@ -14,11 +17,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 ARCH=""
+BUILD_DIR_OVERRIDE=""
 SELECTED=()
 DO_RUN=false
 ANALYZE_DEPS=false
 LIPO_FILE=""
 NO_STRIP=false
+HOST_SRE_STUBS="auto"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -26,9 +31,13 @@ while [[ $# -gt 0 ]]; do
     --analyze-deps) ANALYZE_DEPS=true ;;
     --arch=*)      ARCH="${1#--arch=}" ;;
     --arch)        ARCH="$2"; shift ;;
+    --build-dir=*) BUILD_DIR_OVERRIDE="${1#--build-dir=}" ;;
+    --build-dir)   BUILD_DIR_OVERRIDE="$2"; shift ;;
     --lipo=*)      LIPO_FILE="${1#--lipo=}" ;;
     --lipo)        LIPO_FILE="auto" ;;
     --no-strip)    NO_STRIP=true ;;
+    --host-sre-stubs) HOST_SRE_STUBS="on" ;;
+    --no-host-sre-stubs) HOST_SRE_STUBS="off" ;;
     *)             SELECTED+=("$1") ;;
   esac
   shift
@@ -47,7 +56,39 @@ find_build_dir() {
   return 1
 }
 
-if [[ -z "${ARCH}" ]]; then
+infer_arch_from_build_dir() {
+  local dir="$1"
+  local cache="${dir}/CMakeCache.txt"
+  if [[ -f "${cache}" ]]; then
+    if grep -Eq '^LLVM_TARGETS_TO_BUILD(:[^=]+)?=.*AArch64' "${cache}"; then
+      echo "aarch64"; return 0
+    fi
+    if grep -Eq '^LLVM_TARGETS_TO_BUILD(:[^=]+)?=.*X86' "${cache}"; then
+      echo "x86"; return 0
+    fi
+  fi
+  return 1
+}
+
+if [[ -n "${BUILD_DIR_OVERRIDE}" ]]; then
+  if [[ "${BUILD_DIR_OVERRIDE}" = /* ]]; then
+    BUILD_DIR="${BUILD_DIR_OVERRIDE}"
+  else
+    BUILD_DIR="${ROOT_DIR}/${BUILD_DIR_OVERRIDE}"
+  fi
+  if [[ ! -d "${BUILD_DIR}" ]]; then
+    echo "ERROR: build dir not found: ${BUILD_DIR}"
+    exit 1
+  fi
+  if [[ -z "${ARCH}" ]]; then
+    ARCH=$(infer_arch_from_build_dir "${BUILD_DIR}" || true)
+    if [[ -z "${ARCH}" ]]; then
+      echo "ERROR: cannot infer --arch from ${BUILD_DIR}/CMakeCache.txt"
+      echo "  Pass --arch=x86 or --arch=aarch64 explicitly."
+      exit 1
+    fi
+  fi
+elif [[ -z "${ARCH}" ]]; then
   for a in x86 aarch64; do
     BUILD_DIR=$(find_build_dir "$a" || true)
     if [[ -n "${BUILD_DIR}" ]]; then ARCH="$a"; break; fi
@@ -79,6 +120,37 @@ LD_LLD="${BUILD_DIR}/bin/ld.lld"
 
 EJIT_RUNTIME="${BUILD_DIR}/lib/libLLVMEJIT.a"
 [[ -f "${EJIT_RUNTIME}" ]] || { echo "ERROR: libLLVMEJIT.a not found in ${BUILD_DIR}/lib/"; exit 1; }
+
+cmake_bool_is_on() {
+  local key="$1"
+  local cache="${BUILD_DIR}/CMakeCache.txt"
+  [[ -f "${cache}" ]] || return 1
+  grep -Eq "^${key}(:[^=]+)?=(ON|TRUE|1)$" "${cache}"
+}
+
+# Match test wrapper generation to the selected LLVMEJIT runtime. Taskpool
+# builds need the async wrapper ABI so funcIndex/lifecycle dimType fixups are
+# emitted into the test object (__ejit_dimtype_*, ejit_register_lifecycle).
+GLOBAL_COMPILE_FLAGS=""
+if cmake_bool_is_on "EJIT_SRE_TASKPOOL" ||
+   cmake_bool_is_on "EJIT_SRE_SHARED_TASKPOOL"; then
+  GLOBAL_COMPILE_FLAGS="-mllvm -ejit-wrapper-async"
+fi
+
+USE_HOST_SRE_STUBS=false
+if [[ "${HOST_SRE_STUBS}" == "on" ]]; then
+  USE_HOST_SRE_STUBS=true
+elif [[ "${HOST_SRE_STUBS}" == "auto" ]]; then
+  if cmake_bool_is_on "EJIT_FREESTANDING" ||
+     cmake_bool_is_on "EJIT_SRE_CODE_POOL"; then
+    USE_HOST_SRE_STUBS=true
+  fi
+fi
+HOST_SRE_STUB_SRC="${SCRIPT_DIR}/ejit_host_sre_stub.cpp"
+if ${USE_HOST_SRE_STUBS} && [[ ! -f "${HOST_SRE_STUB_SRC}" ]]; then
+  echo "ERROR: host SRE stub source not found: ${HOST_SRE_STUB_SRC}"
+  exit 1
+fi
 
 # Minimal .a set verified by link-then-test on 2026-05-25.
 # Core = EJIT's direct LINK_COMPONENTS + essential transitive deps
@@ -232,10 +304,18 @@ build_one() {
 
   echo "  Compiling $(basename "${src}") ..."
   local extra_flags="${COMPILE_FLAGS[${name}]:-}"
-  "${CLANG}" -O2 ${INCLUDES} ${extra_flags} -c "${src}" -o "${obj}"
+  "${CLANG}" -O2 ${INCLUDES} ${GLOBAL_COMPILE_FLAGS} ${extra_flags} -c "${src}" -o "${obj}" ||
+    return 1
 
   # Compile any extra translation units (multi-TU tests) and link them all.
   local objs=("${obj}")
+  if ${USE_HOST_SRE_STUBS}; then
+    echo "  Compiling host SRE stubs ..."
+    local sobj; sobj=$(mktemp "${TMPDIR:-/tmp}/ejit_${name}_sre_stub_XXXXXX.o")
+    "${CXX}" -O2 ${INCLUDES} -c "${HOST_SRE_STUB_SRC}" -o "${sobj}" ||
+      return 1
+    objs+=("${sobj}")
+  fi
   for extra in ${EXTRA_SRCS[${name}]:-}; do
     local esrc="${SCRIPT_DIR}/${extra}"
     if [[ ! -f "${esrc}" ]]; then
@@ -244,7 +324,8 @@ build_one() {
     fi
     echo "  Compiling ${extra} ..."
     local eobj; eobj=$(mktemp "${TMPDIR:-/tmp}/ejit_${name}_tu_XXXXXX.o")
-    "${CLANG}" -O2 ${INCLUDES} ${extra_flags} -c "${esrc}" -o "${eobj}"
+    "${CLANG}" -O2 ${INCLUDES} ${GLOBAL_COMPILE_FLAGS} ${extra_flags} -c "${esrc}" -o "${eobj}" ||
+      return 1
     objs+=("${eobj}")
   done
 
@@ -265,7 +346,8 @@ build_one() {
       -Os -Wl,--gc-sections ${STRIP_FLAG} ${lds_flag} \
       "${LIPO_ABS}" \
       ${LINK_LIBS} \
-      "${objs[@]}" -o "${bin}"
+      "${objs[@]}" -o "${bin}" ||
+      return 1
   else
     "${CXX}" -fuse-ld="${LD_LLD}" \
       -Os -Wl,--gc-sections ${STRIP_FLAG} ${lds_flag} \
@@ -273,7 +355,8 @@ build_one() {
       ${OTHER_LIBS} \
       ${LINK_LIBS} \
       -Wl,-M \
-      "${objs[@]}" -o "${bin}" > "${map_file}" 2>&1
+      "${objs[@]}" -o "${bin}" > "${map_file}" 2>&1 ||
+      return 1
   fi
 
   echo -e "  ${GREEN}OK${NC}: ${bin}"
@@ -330,6 +413,12 @@ echo "Arch:    ${ARCH}"
 echo "Build:   ${BUILD_DIR}"
 echo "Output:  ${OUTDIR}"
 echo "Tests:   ${SELECTED[*]}"
+if [[ -n "${GLOBAL_COMPILE_FLAGS}" ]]; then
+  echo "Flags:   ${GLOBAL_COMPILE_FLAGS}"
+fi
+if ${USE_HOST_SRE_STUBS}; then
+  echo "Stubs:   host SRE platform"
+fi
 echo ""
 
 BUILD_FAILED=0

--- a/ejit_test/ejit_host_sre_stub.cpp
+++ b/ejit_test/ejit_host_sre_stub.cpp
@@ -1,0 +1,154 @@
+// Host-only SRE platform stubs for ejit_test.
+//
+// These definitions let Linux integration-test binaries link against an
+// EJIT_FREESTANDING + SRE code-pool/taskpool runtime. They are not intended for
+// target/SRE deployment, where the real platform supplies these symbols.
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <pthread.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace {
+
+using TSK_ARG_T = uint64_t;
+using TSK_ENTRY_FUNC = void (*)(TSK_ARG_T, TSK_ARG_T, TSK_ARG_T, TSK_ARG_T);
+
+struct TSK_INIT_PARAM_S {
+  TSK_ENTRY_FUNC pfnTaskEntry;
+  uint16_t usTaskPrio;
+  uint16_t usResved;
+  TSK_ARG_T auwArgs[4];
+  uint32_t uwStackSize;
+  const char *pcName;
+  uint32_t uwResved;
+  TSK_ARG_T uwPrivateData;
+};
+
+struct HostTaskArgs {
+  TSK_ENTRY_FUNC entry;
+  TSK_ARG_T args[4];
+};
+
+constexpr uint32_t kMaxHostTasks = 1024;
+
+pthread_mutex_t gTaskMutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_t gTasks[kMaxHostTasks];
+bool gTaskLive[kMaxHostTasks];
+uint32_t gNextTaskId = 1;
+
+void *hostTaskMain(void *Opaque) {
+  HostTaskArgs *Args = static_cast<HostTaskArgs *>(Opaque);
+  TSK_ENTRY_FUNC Entry = Args->entry;
+  TSK_ARG_T A0 = Args->args[0];
+  TSK_ARG_T A1 = Args->args[1];
+  TSK_ARG_T A2 = Args->args[2];
+  TSK_ARG_T A3 = Args->args[3];
+  delete Args;
+  if (Entry)
+    Entry(A0, A1, A2, A3);
+  return nullptr;
+}
+
+uintptr_t alignDown(uintptr_t V, uintptr_t Align) { return V & ~(Align - 1); }
+
+} // namespace
+
+extern "C" uint32_t ejit_sre_current_core_id() { return 0; }
+
+extern "C" void *SRE_MemDbgAlloc(unsigned int, unsigned char,
+                                 unsigned long Size, const char *,
+                                 unsigned int) {
+  void *Ptr = nullptr;
+  constexpr size_t Align2M = 2u * 1024u * 1024u;
+  if (posix_memalign(&Ptr, Align2M, static_cast<size_t>(Size)) != 0)
+    return nullptr;
+  std::memset(Ptr, 0, static_cast<size_t>(Size));
+  return Ptr;
+}
+
+extern "C" unsigned split_2m_to_4k(unsigned long long, unsigned long long) {
+  return 0;
+}
+
+extern "C" unsigned enable_ex(unsigned, unsigned long long Va) {
+  long Page = sysconf(_SC_PAGESIZE);
+  if (Page <= 0)
+    Page = 4096;
+  uintptr_t PageVA = alignDown(static_cast<uintptr_t>(Va),
+                               static_cast<uintptr_t>(Page));
+  __builtin___clear_cache(reinterpret_cast<char *>(PageVA),
+                          reinterpret_cast<char *>(PageVA + Page));
+  if (mprotect(reinterpret_cast<void *>(PageVA), static_cast<size_t>(Page),
+               PROT_READ | PROT_EXEC) != 0)
+    return 1;
+  return 0;
+}
+
+extern "C" uint32_t SRE_TaskCreate(uint32_t *TaskPid,
+                                   TSK_INIT_PARAM_S *InitParam) {
+  if (!TaskPid || !InitParam || !InitParam->pfnTaskEntry)
+    return 1;
+
+  HostTaskArgs *Args = new HostTaskArgs;
+  Args->entry = InitParam->pfnTaskEntry;
+  for (unsigned I = 0; I < 4; ++I)
+    Args->args[I] = InitParam->auwArgs[I];
+
+  pthread_attr_t Attr;
+  pthread_attr_init(&Attr);
+  if (InitParam->uwStackSize)
+    pthread_attr_setstacksize(&Attr, InitParam->uwStackSize);
+
+  pthread_t Thread{};
+  int Rc = pthread_create(&Thread, &Attr, hostTaskMain, Args);
+  pthread_attr_destroy(&Attr);
+  if (Rc != 0) {
+    delete Args;
+    return static_cast<uint32_t>(Rc);
+  }
+
+  pthread_mutex_lock(&gTaskMutex);
+  uint32_t Id = gNextTaskId++;
+  if (Id >= kMaxHostTasks)
+    Id = 1;
+  while (gTaskLive[Id]) {
+    Id = (Id + 1) % kMaxHostTasks;
+    if (Id == 0)
+      Id = 1;
+  }
+  gTasks[Id] = Thread;
+  gTaskLive[Id] = true;
+  *TaskPid = Id;
+  pthread_mutex_unlock(&gTaskMutex);
+  return 0;
+}
+
+extern "C" uint32_t SRE_TaskDelete(uint32_t TaskPid) {
+  if (TaskPid == 0 || TaskPid >= kMaxHostTasks)
+    return 1;
+
+  pthread_t Thread{};
+  pthread_mutex_lock(&gTaskMutex);
+  if (!gTaskLive[TaskPid]) {
+    pthread_mutex_unlock(&gTaskMutex);
+    return 1;
+  }
+  Thread = gTasks[TaskPid];
+  gTaskLive[TaskPid] = false;
+  pthread_mutex_unlock(&gTaskMutex);
+
+  return static_cast<uint32_t>(pthread_join(Thread, nullptr));
+}
+
+extern "C" uint32_t SRE_TaskDelay(uint32_t Tick) {
+  if (Tick == 0) {
+    sched_yield();
+    return 0;
+  }
+  usleep(static_cast<useconds_t>(Tick) * 1000u);
+  return 0;
+}


### PR DESCRIPTION
## Summary

This updates `ejit_test/build.sh` so integration-test C sources are compiled with the wrapper ABI that matches the selected LLVMEJIT runtime build.

When the selected build directory has `EJIT_SRE_TASKPOOL=ON` or `EJIT_SRE_SHARED_TASKPOOL=ON` in `CMakeCache.txt`, the script now adds:

```bash
-mllvm -ejit-wrapper-async
```

for both the primary test source and extra translation units.

## Why

Taskpool/shared-taskpool runtime builds expect the wrapper-generated funcIndex and lifecycle metadata/fixups. Without the async wrapper flag, test objects may lack symbols such as `__ejit_dimtype_*` and lifecycle registration entries, which makes taskpool activation checks observe invalid dimType metadata and can cause many integration tests to fall back or fail unexpectedly.

Default/non-taskpool test builds remain unchanged.

## Validation

- `bash -n ejit_test/build.sh`
- `git diff --check dong/ejit_dev_spec4..HEAD`

## Notes

This is intentionally separate from PR38 so the 4K code-pool changes and test-script wrapper-mode fix can be reviewed independently.