### PR TITLE
[EJIT] Default to GNU objcopy when llvm-objcopy is unavailable

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -24,7 +24,7 @@ The resulting ejit.o (~30-40 MB) can replace all individual LLVM .a files
 when linking EJIT test binaries.
 """
 
-import subprocess as sp, os, sys, re, argparse, struct, glob
+import subprocess as sp, os, sys, re, argparse, struct, glob, shutil
 
 
 # ── per-architecture configuration ──────────────────────────────────────────
@@ -98,11 +98,19 @@ def build_symbol_index(build_dir):
 # ── objcopy helpers ──────────────────────────────────────────────────────────
 
 def _find_objcopy(build_dir):
-    """Return (tool_path, is_llvm) for the best available objcopy."""
+    """Return (tool_path, is_llvm) for the best available objcopy.
+
+    Prefer the build's llvm-objcopy (handles extended ELF with >65280
+    sections), then llvm-objcopy on PATH, and finally fall back to GNU
+    objcopy when no llvm-objcopy is available.
+    """
     llvm_oc = os.path.join(build_dir, "bin", "llvm-objcopy")
     if os.path.exists(llvm_oc):
         return llvm_oc, True
-    return "llvm-objcopy", True
+    if shutil.which("llvm-objcopy"):
+        return "llvm-objcopy", True
+    # No llvm-objcopy anywhere; fall back to GNU objcopy.
+    return "objcopy", False
 
 
 def _try_strip_arm_mapping_symbols(merged_o, work_dir, build_dir):


### PR DESCRIPTION
After [#41](https://github.com/dongjianqiang2/llvm-project/pull/41) got merged, I now have the following failure when running the lipo pipeline:

```
    r = sp.run([objcopy_tool, "-w", "-N", "$x", "-N", "$d",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'llvm-objcopy'
```

We should default to GNU objcopy when `llvm-objcopy` doesn't exist.