### PR TITLE
[EJIT] Fix remaining test failures when ASYNC EJIT is enabled

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -199,8 +199,16 @@ declare -A PRIMARY_SRC
 PRIMARY_SRC[ejit_baremetal_link_test]="ejit_multi_tu_test.c"
 
 # Custom linker script (-Wl,-T) for a test, relative to this dir.
+# Both ctors-disabled tests need it: the static registry tables live in the
+# dot-named .ejit_bitcode/.ejit_period sections, for which the linker does NOT
+# auto-synthesize __start_/__stop_ bound symbols (dot is not a C identifier).
+# Without the script those weak bounds stay NULL, the static walk registers
+# nothing, and the funcIndex globals are never backfilled — so the async wrapper
+# can never JIT (it falls through to the AOT body). The script provides the
+# bounds so the static-registry path actually loads and specializes.
 declare -A LINKER_SCRIPT
 LINKER_SCRIPT[ejit_baremetal_link_test]="ejit_baremetal.ld"
+LINKER_SCRIPT[ejit_manual_register_test]="ejit_baremetal.ld"
 
 # Extra translation units linked alongside <test>.c (space-separated, with .c).
 # Used by multi-TU tests that exercise cross-TU linking.

--- a/ejit_test/ejit_multidim_test.c
+++ b/ejit_test/ejit_multidim_test.c
@@ -120,6 +120,10 @@ int main(int argc, char **argv) {
   // total = 160 + 160 = 320
   uint32_t exp_a = 320;
   T(r == exp_a, "classify_slot(%u) = %u (expected %u)", ci, r, exp_a);
+  // Async: drain so this specialization compiles/publishes before the next
+  // deactivate/activate bumps the version and invalidates the in-flight compile.
+  // (No-op in sync builds.)
+  ejit_drain_taskpool();
 
   //===-- 场景 A2: 改值后 deactivate + activate → 重新 JIT -------------------===//
   printf("\n--- A2: 改值后重新 JIT (ci=%u) ---\n", ci);
@@ -133,6 +137,7 @@ int main(int argc, char **argv) {
   r = classify_slot(ci);
   uint32_t exp_a2 = 8 * 1 * 10;  // 8 slots × priority=1 × 10 = 80
   T(r == exp_a2, "classify_slot(%u) after change = %u (expected %u)", ci, r, exp_a2);
+  ejit_drain_taskpool();
 
   //===-- 场景 B: 2D nested struct access -----------------------------------===//
   printf("\n--- B: 2D nested check_outer2d(ci=%u) ---\n", ci);
@@ -142,6 +147,7 @@ int main(int argc, char **argv) {
   ejit_activate("cell", ci);
   r = check_outer2d(ci);
   T(r == 777, "check_outer2d(%u) mode=0x55 = %u (expected 777)", ci, r);
+  ejit_drain_taskpool();
 
   // 改值
   ejit_deactivate("cell", ci);
@@ -149,6 +155,7 @@ int main(int argc, char **argv) {
   ejit_activate("cell", ci);
   r = check_outer2d(ci);
   T(r == 888, "check_outer2d(%u) mode=0xAA = %u (expected 888)", ci, r);
+  ejit_drain_taskpool();
 
   // 无匹配
   ejit_deactivate("cell", ci);

--- a/ejit_test/ejit_nested_struct_test.c
+++ b/ejit_test/ejit_nested_struct_test.c
@@ -136,6 +136,10 @@ int main(int argc, char **argv) {
   ejit_activate("cell", ci);
   uint32_t r = check_2level(ci);
   T(r == 60, "check_2level(%u) AA+55 = %u (expected gain*2 = 60)", ci, r);
+  // Async: drain so this specialization compiles/publishes before the next
+  // deactivate/activate bumps the version and invalidates the in-flight compile.
+  // (No-op in sync builds.)
+  ejit_drain_taskpool();
 
   //===-- 2 层嵌套: BB → gain (deactivate → 改值 → activate)---------------===//
   printf("\n--- 2层嵌套 (type=0xBB, gain=80) ---\n");
@@ -147,6 +151,7 @@ int main(int argc, char **argv) {
 
   r = check_2level(ci);
   T(r == 80, "check_2level(%u) BB = %u (expected gain = 80)", ci, r);
+  ejit_drain_taskpool();
 
   //===-- 2 层嵌套: 其他 → 0 ------------------------------------------------===//
   printf("\n--- 2层嵌套 (type=0xCC, no match) ---\n");
@@ -157,6 +162,7 @@ int main(int argc, char **argv) {
 
   r = check_2level(ci);
   T(r == 0, "check_2level(%u) no match = %u (expected 0)", ci, r);
+  ejit_drain_taskpool();
 
   //===-- 3 层嵌套: 11 + v>100 → v+1000 ------------------------------------===//
   printf("\n--- 3层嵌套 (root_type=0x11, l3.value=200) ---\n");
@@ -168,6 +174,7 @@ int main(int argc, char **argv) {
 
   r = check_3level(ci);
   T(r == 1200, "check_3level(%u) 11+200 = %u (expected 200+1000=1200)", ci, r);
+  ejit_drain_taskpool();
 
   //===-- 3 层嵌套: 22 → v+2000 ---------------------------------------------===//
   printf("\n--- 3层嵌套 (root_type=0x22, l3.value=50) ---\n");
@@ -179,6 +186,7 @@ int main(int argc, char **argv) {
 
   r = check_3level(ci);
   T(r == 2050, "check_3level(%u) 22+50 = %u (expected 50+2000=2050)", ci, r);
+  ejit_drain_taskpool();
 
   //===-- 3 层嵌套: 其他 → v ------------------------------------------------===//
   printf("\n--- 3层嵌套 (root_type=0x33, l3.value=77) ---\n");


### PR DESCRIPTION
As a continuation of the [refactoring](https://github.com/dongjianqiang2/llvm-project/commit/58e8560e3ee48fdf57e7d1a6f5fb0346eda12901) of the ejit tests, this fixes the remaining test failures when `EJIT_SRE_TASKPOOL`/`EJIT_SRE_SHARED_TASKPOOL` is enabled.

Similar to [#43](https://github.com/dongjianqiang2/llvm-project/pull/43), we drain the JIT compilation in the task pool before we continue in the ASYNC mode, so that we can collect stats/info for this compilation to be used in the assertions.

There are also some fixes to the `ejit_test` build script for the `manual_register` test, since it uses `-enable-ejit-global-ctors=false`, we need to use the `ejit_baremetal.ld` linker script, so the static registry path actually loads and specializes. Currently, no JIT compilation is being done and only defaults to AOT.