### PR TITLE
[EJIT] Trim MCInstPrinter symbols when EJIT_TRIM_LLVM_BACKEND is enabled

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.cpp
@@ -378,6 +378,7 @@ static MCAsmInfo *createAArch64MCAsmInfo(const MCRegisterInfo &MRI,
   return MAI;
 }
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 static MCInstPrinter *createAArch64MCInstPrinter(const Triple &T,
                                                  unsigned SyntaxVariant,
                                                  const MCAsmInfo &MAI,
@@ -390,6 +391,7 @@ static MCInstPrinter *createAArch64MCInstPrinter(const Triple &T,
 
   return nullptr;
 }
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 #ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
 static MCStreamer *
@@ -560,7 +562,9 @@ LLVMInitializeAArch64TargetMC() {
                                                createAArch64NullTargetStreamer);
 
     // Register the MCInstPrinter.
+#ifndef EJIT_TRIM_LLVM_BACKEND
     TargetRegistry::RegisterMCInstPrinter(*T, createAArch64MCInstPrinter);
+#endif
   }
 
   // Register the asm backend.


### PR DESCRIPTION
In EJIT, we emit object code through `MCObjectStreamer`, so we can get rid of some of the `MCInstPrinter` functionality, as some of it is dead weight at the moment. Currently, we have the following symbols being pulled into the final object file:
```
wilson@iZj6c6qj6r9ma9rd93uy93Z:~/ejit/llvm-project$ nm -S --radix=d ejit_test/lipo/ejit.o | grep MCInstPrinter
nm: ejit_test/lipo/ejit.o: no group info for section '.text'
nm: ejit_test/lipo/ejit.o: no group info for section '.rodata'
nm: ejit_test/lipo/ejit.o: no group info for section '.data'
nm: ejit_test/lipo/ejit.o: no group info for section '.bss'
nm: ejit_test/lipo/ejit.o: no group info for section '.init_array'
0000000001924828 0000000000000128 t _ZL26createAArch64MCInstPrinterRKN4llvm6TripleEjRKNS_9MCAsmInfoERKNS_11MCInstrInfoERKNS_14MCRegisterInfoE
0000000008142492 0000000000004308 t _ZN12_GLOBAL__N_19AsmParser16parseMSInlineAsmERNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERjS8_RN4llvm15SmallVectorImplISt4pairIPvbEEERNSA_IS6_EESH_PKNS9_11MCInstrInfoEPNS9_13MCInstPrinterERNS9_23MCAsmParserSemaCallbackE
0000000008420456 0000000000000240 T _ZN4llvm13MCInstPrinter10WithMarkupC1ERS0_RNS_11raw_ostreamENS0_6MarkupEbb
0000000008420456 0000000000000240 T _ZN4llvm13MCInstPrinter10WithMarkupC2ERS0_RNS_11raw_ostreamENS0_6MarkupEbb
0000000008420788 0000000000000128 T _ZN4llvm13MCInstPrinter10WithMarkupD1Ev
0000000008420788 0000000000000128 T _ZN4llvm13MCInstPrinter10WithMarkupD2Ev
0000000008419216 T _ZN4llvm13MCInstPrinter12printRegNameERNS_11raw_ostreamENS_10MCRegisterE
0000000008419216 0000000000000208 T _ZN4llvm13MCInstPrinter15printAnnotationERNS_11raw_ostreamENS_9StringRefE
0000000008419424 0000000000000580 T _ZN4llvm13MCInstPrinter18matchAliasPatternsEPKNS_6MCInstEPKNS_15MCSubtargetInfoERKNS_17AliasMatchingDataE
0000000008420916 0000000000000008 W _ZN4llvm13MCInstPrinter27applyTargetSpecificCLOptionENS_9StringRefE
0000000008420428 0000000000000028 T _ZN4llvm13MCInstPrinter6markupERNS_11raw_ostreamENS0_6MarkupE
0000000008419148 0000000000000004 T _ZN4llvm13MCInstPrinterD0Ev
0000000008419104 0000000000000044 T _ZN4llvm13MCInstPrinterD1Ev
0000000008419104 0000000000000044 T _ZN4llvm13MCInstPrinterD2Ev
0000000008484904 0000000000000044 T _ZN4llvm16MCTargetStreamer14prettyPrintAsmERNS_13MCInstPrinterEmRKNS_6MCInstERKNS_15MCSubtargetInfoERNS_11raw_ostreamE
0000000008292104 0000000000000592 T _ZN4llvm17createAsmStreamerERNS_9MCContextESt10unique_ptrINS_21formatted_raw_ostreamESt14default_deleteIS3_EES2_INS_13MCInstPrinterES4_IS7_EES2_INS_13MCCodeEmitterES4_ISA_EES2_INS_12MCAsmBackendES4_ISD_EE
0000000001757752 0000000000000112 T _ZN4llvm30createAArch64AsmTargetStreamerERNS_10MCStreamerERNS_21formatted_raw_ostreamEPNS_13MCInstPrinterE
0000000008420924 0000000000000528 t _ZN9__gnu_cxx5__ops12_Iter_negateIZN4llvm13MCInstPrinter18matchAliasPatternsEPKNS2_6MCInstEPKNS2_15MCSubtargetInfoERKNS2_17AliasMatchingDataEE3$_1EclIPKNS2_16AliasPatternCondEEEbT_
0000000008419152 0000000000000064 T _ZNK4llvm13MCInstPrinter13getOpcodeNameEj
0000000008420004 0000000000000032 T _ZNK4llvm13MCInstPrinter9formatDecEl
0000000008420036 0000000000000292 T _ZNK4llvm13MCInstPrinter9formatHexEl
0000000008420328 0000000000000100 T _ZNK4llvm13MCInstPrinter9formatHexEm
0000000001840684 0000000000000016 W _ZNK4llvm13MCInstPrinter9formatImmEl
0000000008418736 0000000000000120 T _ZNK4llvm6MCInst11dump_prettyERNS_11raw_ostreamEPKNS_13MCInstPrinterENS_9StringRefEPKNS_9MCContextE
0000000008506576 0000000000000420 T _ZNK4llvm6Target17createAsmStreamerERNS_9MCContextESt10unique_ptrINS_21formatted_raw_ostreamESt14default_deleteIS4_EES3_INS_13MCInstPrinterES5_IS8_EES3_INS_13MCCodeEmitterES5_ISB_EES3_INS_12MCAsmBackendES5_ISE_EE
0000000000288288 0000000000000064 D _ZTVN4llvm13MCInstPrinterE
```
Guarding the registrations in this PR allows `gc-sections` to drop some references to this function and eliminate them from the final merged object file. This trims the size of the final `ejit.o` file by ~600KB.