### PR TITLE
[EJIT] resolve codegen-synthesized and bitcast-wrapped symbols

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h
@@ -1,0 +1,48 @@
+//===-- EJitLibcallStubs.h - Codegen-synthesized runtime symbols ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The JIT back-end lowers llvm.memset/memcpy/memmove/memcmp intrinsics and
+// stack-protector function attributes into references to plain C library and
+// ABI symbols (memset, memcpy, __stack_chk_guard, __stack_chk_fail, ...).
+// These symbols never appear as IR declarations in the extracted bitcode, so
+// the AOT symbol collector cannot register them. On freestanding targets the
+// engine also disables process-symbol lookup, leaving the references
+// unresolved and every JIT compilation failing at link time.
+//
+// This header exposes that small set of symbols together with addresses the
+// engine can install as absolute symbols in each specialization JITDylib.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITLIBCALLSTUBS_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITLIBCALLSTUBS_H
+
+#include "llvm/ADT/ArrayRef.h"
+
+namespace llvm {
+namespace ejit {
+
+struct LibcallSymbol {
+  const char *name;
+  void *addr;
+};
+
+/// Returns the codegen-synthesized runtime symbols the JIT must resolve but
+/// the AOT pass cannot collect: memset/memcpy/memmove/memcmp (lowered from
+/// the llvm.mem* intrinsics) and __stack_chk_guard/__stack_chk_fail (emitted
+/// by -fstack-protector). No symbol is defined by the EJIT runtime: the mem*
+/// entries point at the freestanding-mandated C library functions and the
+/// stack-protector entries point at the target's existing
+/// __stack_chk_guard/__stack_chk_fail (provided by its pseudo-OS / compiler-rt
+/// runtime). The engine only forwards these addresses as absolute symbols.
+ArrayRef<LibcallSymbol> getLibcallSymbols();
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITLIBCALLSTUBS_H

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -56,6 +56,7 @@ set(EJIT_SOURCES
   EJitRuntime.cpp
   EJitRegistryTable.c
   EJitOrcEngine.cpp
+  EJitLibcallStubs.cpp
   EJitCompileDriver.cpp
   EJitCache.cpp
   EJitRuntimeState.cpp

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLibcallStubs.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLibcallStubs.cpp
@@ -1,0 +1,53 @@
+//===-- EJitLibcallStubs.cpp - Codegen-synthesized runtime symbols --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Addresses for the symbols exposed by EJitLibcallStubs.h. See the header
+// for the rationale.
+//
+// None of these symbols are defined here. memset/memcpy/memmove/memcmp are
+// the freestanding-mandated C library functions (already linked into the AOT
+// binary that hosts the EJIT runtime); __stack_chk_guard/__stack_chk_fail are
+// the stack-protector ABI symbols provided by the target's underlying
+// pseudo-OS / compiler-rt runtime. We only take their addresses so the engine
+// can install them as absolute symbols in each specialization JITDylib —
+// exactly like the user-registered symbols, just for names the AOT pass
+// cannot collect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
+
+#include <cstdint>
+#include <cstring>
+
+// The stack-protector ABI symbols have no standard C++ header. Declare them
+// extern so taking their address resolves to the target's existing
+// definitions (uintptr_t matches the compiler-rt declaration). Provided by
+// the bare-metal pseudo-OS runtime already linked into the AOT binary.
+extern "C" {
+extern uintptr_t __stack_chk_guard;
+extern void __stack_chk_fail(void);
+}
+
+namespace llvm {
+namespace ejit {
+
+ArrayRef<LibcallSymbol> getLibcallSymbols() {
+  static const LibcallSymbol Symbols[] = {
+      {"memset", reinterpret_cast<void *>(&std::memset)},
+      {"memcpy", reinterpret_cast<void *>(&std::memcpy)},
+      {"memmove", reinterpret_cast<void *>(&std::memmove)},
+      {"memcmp", reinterpret_cast<void *>(&std::memcmp)},
+      {"__stack_chk_guard", reinterpret_cast<void *>(&__stack_chk_guard)},
+      {"__stack_chk_fail", reinterpret_cast<void *>(&__stack_chk_fail)},
+  };
+  return Symbols;
+}
+
+} // namespace ejit
+} // namespace llvm

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -2,6 +2,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #include "llvm/Bitcode/BitcodeReader.h"
@@ -126,6 +127,17 @@ EJitOrcEngine::Create(const Config &config,
   }
 
   engine->P->J = std::move(*J);
+
+  // Override the default error reporter (logErrorsToStdErr → errs() →
+  // raw_fd_ostream) with a bare-metal-safe version using EJIT_DIAG.  On
+  // SRE / bare-metal the default reporter crashes because raw_fd_ostream
+  // internally calls POSIX I/O (open / write / isatty) whose GOT/PLT
+  // entries may be unmapped.  EJIT_DIAG uses SRE_printf / std::printf
+  // which are always available on the target.
+  engine->P->J->getExecutionSession().setErrorReporter(
+      [](Error Err) {
+        EJIT_DIAG("JIT error: %s", toString(std::move(Err)).c_str());
+      });
 
   // Create persistent optimizer — analysis managers are registered once here
   // and reused across compilations (cleared between runs).
@@ -276,8 +288,12 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     if (globalSymbols.count(P->J->mangleAndIntern(name)))
       continue;
     auto it = P->userSymbols.find(name);
-    if (it == P->userSymbols.end())
+    if (it == P->userSymbols.end()) {
+      if (!F.isIntrinsic())
+        EJIT_DIAG("loadBitcode: unresolved external func not registered: %s",
+                  name.c_str());
       continue;
+    }
     globalSymbols[P->J->mangleAndIntern(name)] =
         orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(it->second),
                                JITSymbolFlags::Exported);
@@ -289,12 +305,28 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     if (globalSymbols.count(P->J->mangleAndIntern(name)))
       continue;
     auto it = P->userSymbols.find(name);
-    if (it == P->userSymbols.end())
+    if (it == P->userSymbols.end()) {
+      EJIT_DIAG("loadBitcode: unresolved external global not registered: %s",
+                name.c_str());
       continue;
+    }
     globalSymbols[P->J->mangleAndIntern(name)] =
         orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(it->second),
                                JITSymbolFlags::Exported);
   }
+
+  // Provide codegen-synthesized runtime symbols (memset/memcpy/memmove/memcmp
+  // and the stack-protector guard/fail) that the AOT symbol collector cannot
+  // register because they are never present as IR declarations — the JIT
+  // back-end lowers the llvm.mem* intrinsics and -fstack-protector attributes
+  // into references to them. On freestanding targets process-symbol lookup is
+  // disabled, so without these every JIT compilation fails at link time.
+  // They go into the spec JITDylib (which is isolated: it does not link back
+  // to the main JITDylib) so each specialization resolves them locally.
+  for (const LibcallSymbol &LCS : getLibcallSymbols())
+    globalSymbols[P->J->mangleAndIntern(LCS.name)] =
+        orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(LCS.addr),
+                               JITSymbolFlags::Exported);
 
   // Define all collected symbols in the spec JITDylib before loading the
   // IR module so the JIT linker can resolve external references.

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -50,12 +50,29 @@ static void collectEntryFunctions(Module &M,
   }
 }
 
+static const GlobalVariable *findRootGV(const Value *V, APInt &Offset,
+                                        const DataLayout &DL);
+
+/// Resolve a value to the underlying GlobalVariable it references, walking
+/// through bitcasts, addrspacecasts and constant-offset GEP chains (mirrors
+/// findRootGV). This is the single definition of "this operand references a
+/// global", shared by the closure collector and both symbol-registration
+/// emitters. Keeping them on one helper avoids the class of bug where a
+/// global is kept in the extracted bitcode (as an external declaration) by
+/// the collector but never registered by the emitters — which the JIT linker
+/// then fails to resolve.
+static GlobalVariable *rootGlobal(Value *V, const DataLayout &DL) {
+  APInt Offset;
+  return const_cast<GlobalVariable *>(findRootGV(V, Offset, DL));
+}
+
 static void collectReferencedGlobals(Function &F,
                                      SetVector<GlobalVariable *> &Globals) {
+  const DataLayout &DL = F.getParent()->getDataLayout();
   for (BasicBlock &BB : F)
     for (Instruction &I : BB)
       for (Value *Op : I.operands())
-        if (auto *GV = dyn_cast<GlobalVariable>(Op->stripPointerCasts()))
+        if (auto *GV = rootGlobal(Op, DL))
           Globals.insert(GV);
 }
 
@@ -307,6 +324,7 @@ static void generateSymbolRegisters(
     const SetVector<Function *> &ClosureFuncs,
     Function *AutoReg) {
   LLVMContext &Ctx = M.getContext();
+  const DataLayout &DL = M.getDataLayout();
   auto *VoidTy = Type::getVoidTy(Ctx);
   auto *PtrTy = PointerType::getUnqual(Ctx);
 
@@ -340,19 +358,20 @@ static void generateSymbolRegisters(
           }
         }
         // External global variable references. Skip constants (compiler-
-        // generated strings etc.) — they're embedded in the bitcode.
+        // generated strings etc.) — they're embedded in the bitcode. Resolve
+        // through bitcasts/GEPs via rootGlobal so every global the collector
+        // kept in the extracted bitcode is actually registered here.
         for (Use &U : I.operands()) {
-          if (auto *GV = dyn_cast<GlobalVariable>(U.get())) {
-            if (GV->isConstant())
-              continue;
-            if (GV->isDeclaration() || !isPeriodVar(*GV)) {
-              std::string Name = GV->getName().str();
-              if (registered.insert(Name).second) {
-                IRBuilder<> Builder(InsertBefore);
-                Builder.CreateCall(M.getFunction("ejit_register_symbol"),
-                    {Builder.CreateGlobalString(Name),
-                     Builder.CreateBitCast(GV, PtrTy)});
-              }
+          auto *GV = rootGlobal(U.get(), DL);
+          if (!GV || GV->isConstant())
+            continue;
+          if (GV->isDeclaration() || !isPeriodVar(*GV)) {
+            std::string Name = GV->getName().str();
+            if (registered.insert(Name).second) {
+              IRBuilder<> Builder(InsertBefore);
+              Builder.CreateCall(M.getFunction("ejit_register_symbol"),
+                  {Builder.CreateGlobalString(Name),
+                   Builder.CreateBitCast(GV, PtrTy)});
             }
           }
         }
@@ -474,28 +493,32 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
     }
   }
 
-  // Global variable symbol entries
+  // Global variable symbol entries. Resolve through bitcasts/GEPs via
+  // rootGlobal so registration matches what collectReferencedGlobals kept in
+  // the extracted bitcode.
   SmallPtrSet<const GlobalVariable *, 4> GVsDone;
+  const DataLayout &DL = M.getDataLayout();
   for (Function *F : ClosureFuncs) {
     for (const BasicBlock &BB : *F) {
       for (const Instruction &I : BB) {
         for (const Value *Op : I.operands()) {
-          if (const GlobalVariable *GV = dyn_cast<GlobalVariable>(Op)) {
-            if (!GV->isConstant() && !GV->getName().starts_with("llvm.") &&
-                GVsDone.insert(GV).second) {
-              Constant *NameStr = ConstantDataArray::getString(Ctx, GV->getName(), true);
-              auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
-                  GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
-              Entries.push_back(ConstantStruct::get(EntryTy, {
-                  ConstantInt::get(I32Ty, 3),                // EJIT_REG_SYMBOL
-                  ConstantExpr::getBitCast(NameGV, PtrTy),   // name1 string
-                  ConstantPointerNull::get(PtrTy),
-                  ConstantExpr::getBitCast(
-                      const_cast<GlobalVariable *>(GV), PtrTy),
-                  ConstantInt::get(I64Ty, 0),
-              }));
-            }
-          }
+          const GlobalVariable *GV =
+              rootGlobal(const_cast<Value *>(Op), DL);
+          if (!GV || GV->isConstant() || GV->getName().starts_with("llvm."))
+            continue;
+          if (!GVsDone.insert(GV).second)
+            continue;
+          Constant *NameStr = ConstantDataArray::getString(Ctx, GV->getName(), true);
+          auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
+              GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
+          Entries.push_back(ConstantStruct::get(EntryTy, {
+              ConstantInt::get(I32Ty, 3),                // EJIT_REG_SYMBOL
+              ConstantExpr::getBitCast(NameGV, PtrTy),   // name1 string
+              ConstantPointerNull::get(PtrTy),
+              ConstantExpr::getBitCast(
+                  const_cast<GlobalVariable *>(GV), PtrTy),
+              ConstantInt::get(I64Ty, 0),
+          }));
         }
       }
     }


### PR DESCRIPTION
Two symbol-resolution gaps caused every JIT compilation in the DLSCH run.log to fail at JITLink (cache MISS=9, compile FAIL=8, lookup OK=0), ending in an OOM abort.

1. Codegen-synthesized runtime symbols (memset/memcpy/memmove/memcmp and __stack_chk_guard/__stack_chk_fail) are emitted by the back-end when lowering llvm.mem* intrinsics and -fstack-protector, so they never appear as IR declarations and the AOT symbol collector cannot register them. With process-symbol lookup disabled in freestanding mode this left them unresolved. Add EJitLibcallStubs exposing their addresses (pointing at the target's existing libc / stack-protector symbols, not defining new ones) and register them as absolute symbols in each specialization JITDylib so each resolves them locally without a link order to main.

2. The bitcode closure collector (collectReferencedGlobals) strips pointer casts, but the two symbol-registration emitters (generateSymbolRegisters, generateRegistryTable) used bare dyn_cast<GlobalVariable>, so globals reached only via bitcast/GEP were kept in the extracted bitcode as external declarations yet never registered. Unify all three on a rootGlobal() helper built on the existing findRootGV so registration matches what the collector kept.