### PR TITLE
[EJIT] Remove redundant SimplifyCFG pass in L2 pipeline

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -41,8 +41,8 @@ EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
   L1FPM_.addPass(ADCEPass());
   L1FPM_.addPass(SimplifyCFGPass());
 
-  // L2: SimplifyCFG cleanup after inlining.
-  L2FPM_.addPass(SimplifyCFGPass());
+  // L2: reserved for post-inline cleanup.
+  // TODO: populate once inlining is re-enabled in runPipeline.
 
   // L3: LoopSimplify → FullUnroll → IndVarSimplify → LoopDeletion →
   //     Promote → SCCP → SimplifyCFG.


### PR DESCRIPTION
The L2 `SimplifyCFG` pass seems to be redundant.

```
  L1FPM_.addPass(ADCEPass());
  L1FPM_.addPass(SimplifyCFGPass());              <- runs here

  // L2: SimplifyCFG cleanup after inlining.
  L2FPM_.addPass(SimplifyCFGPass());              <- runs here again!

  // L3: LoopSimplify → FullUnroll → IndVarSimplify → LoopDeletion →
  //     Promote → SCCP → SimplifyCFG.
```