### PR TITLE
[EJIT] Trim MachineVerifier, textual asm output, and instr-name tables when EJIT_TRIM_LLVM_BACKEND is enabled

### DIFF
--- a/llvm/include/llvm/MC/MCInstrInfo.h
+++ b/llvm/include/llvm/MC/MCInstrInfo.h
@@ -70,6 +70,10 @@ public:
   /// Returns the name for the instructions with the given opcode.
   StringRef getName(unsigned Opcode) const {
     assert(Opcode < NumOpcodes && "Invalid opcode!");
+#ifdef EJIT_TRIM_LLVM_BACKEND
+    if (!InstrNameData || !InstrNameIndices)
+      return StringRef();
+#endif
     return StringRef(&InstrNameData[InstrNameIndices[Opcode]]);
   }
 

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -168,6 +168,11 @@ CodeGenTargetMachineImpl::createMCStreamer(raw_pwrite_stream &Out,
 
   switch (FileType) {
   case CodeGenFileType::AssemblyFile: {
+#ifdef EJIT_TRIM_LLVM_BACKEND
+    return make_error<StringError>(
+        "textual assembly output unavailable in EJIT_TRIM_LLVM_BACKEND build",
+        inconvertibleErrorCode());
+#else
     std::unique_ptr<MCInstPrinter> InstPrinter(getTarget().createMCInstPrinter(
         getTargetTriple(),
         Options.MCOptions.OutputAsmVariant.value_or(MAI.getAssemblerDialect()),
@@ -189,6 +194,7 @@ CodeGenTargetMachineImpl::createMCStreamer(raw_pwrite_stream &Out,
         std::move(MAB));
     AsmStreamer.reset(S);
     break;
+#endif
   }
   case CodeGenFileType::ObjectFile: {
     // Create the code emitter for the target if it exists.  If not, .o file

--- a/llvm/lib/CodeGen/MachineVerifier.cpp
+++ b/llvm/lib/CodeGen/MachineVerifier.cpp
@@ -414,6 +414,7 @@ FunctionPass *llvm::createMachineVerifierPass(const std::string &Banner) {
   return new MachineVerifierLegacyPass(Banner);
 }
 
+#ifndef EJIT_TRIM_LLVM_BACKEND
 void llvm::verifyMachineFunction(const std::string &Banner,
                                  const MachineFunction &MF) {
   // TODO: Use MFAM after porting below analyses.
@@ -442,6 +443,27 @@ bool MachineFunction::verify(LiveIntervals *LiveInts, SlotIndexes *Indexes,
                          /*LiveStks=*/nullptr, Indexes, OS, AbortOnError)
       .verify(*this);
 }
+#else
+void llvm::verifyMachineFunction(const std::string &Banner,
+                                 const MachineFunction &MF) {}
+
+bool MachineFunction::verify(Pass *p, const char *Banner, raw_ostream *OS,
+                             bool AbortOnError) const {
+  return true;
+}
+
+bool MachineFunction::verify(MachineFunctionAnalysisManager &MFAM,
+                             const char *Banner, raw_ostream *OS,
+                             bool AbortOnError) const {
+  return true;
+}
+
+bool MachineFunction::verify(LiveIntervals *LiveInts, SlotIndexes *Indexes,
+                             const char *Banner, raw_ostream *OS,
+                             bool AbortOnError) const {
+  return true;
+}
+#endif // EJIT_TRIM_LLVM_BACKEND
 
 void MachineVerifier::verifySlotIndexes() const {
   if (Indexes == nullptr)

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -791,6 +791,7 @@ void TargetPassConfig::addPrintPass(const std::string &Banner) {
 }
 
 void TargetPassConfig::addVerifyPass(const std::string &Banner) {
+#ifndef EJIT_TRIM_LLVM_BACKEND
   bool Verify = VerifyMachineCode == cl::BOU_TRUE;
 #ifdef EXPENSIVE_CHECKS
   if (VerifyMachineCode == cl::BOU_UNSET)
@@ -798,6 +799,9 @@ void TargetPassConfig::addVerifyPass(const std::string &Banner) {
 #endif
   if (Verify)
     PM->add(createMachineVerifierPass(Banner));
+#else
+  (void)Banner;
+#endif
 }
 
 void TargetPassConfig::addDebugifyPass() {

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -980,8 +980,14 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
   Timer.startTimer("Emit initialization routine");
   OS << "static inline void Init" << TargetName
      << "MCInstrInfo(MCInstrInfo *II) {\n";
-  OS << "  II->InitMCInstrInfo(" << TargetName << "Descs.Insts, " << TargetName
-     << "InstrNameIndices, " << TargetName << "InstrNameData, ";
+  OS << "  II->InitMCInstrInfo(" << TargetName << "Descs.Insts,\n"
+     << "#ifdef EJIT_TRIM_LLVM_BACKEND\n"
+     << "                      nullptr, nullptr,\n"
+     << "#else\n"
+     << "                      " << TargetName << "InstrNameIndices, "
+     << TargetName << "InstrNameData,\n"
+     << "#endif\n"
+     << "                      ";
   if (HasDeprecationFeatures)
     OS << TargetName << "InstrDeprecationFeatures, ";
   else
@@ -1042,8 +1048,14 @@ void InstrInfoEmitter::run(raw_ostream &OS) {
         "CatchRetOpcode, unsigned ReturnOpcode)\n"
      << "  : TargetInstrInfo(CFSetupOpcode, CFDestroyOpcode, CatchRetOpcode, "
         "ReturnOpcode) {\n"
-     << "  InitMCInstrInfo(" << TargetName << "Descs.Insts, " << TargetName
-     << "InstrNameIndices, " << TargetName << "InstrNameData, ";
+     << "  InitMCInstrInfo(" << TargetName << "Descs.Insts,\n"
+     << "#ifdef EJIT_TRIM_LLVM_BACKEND\n"
+     << "                  nullptr, nullptr,\n"
+     << "#else\n"
+     << "                  " << TargetName << "InstrNameIndices, "
+     << TargetName << "InstrNameData,\n"
+     << "#endif\n"
+     << "                  ";
   if (HasDeprecationFeatures)
     OS << TargetName << "InstrDeprecationFeatures, ";
   else


### PR DESCRIPTION
Some more Codegen trimming:
- MachineVerifier: guard addVerifyPass and the `MachineFunction::verify` overloads so gc-sections drops `MachineVerifier::verify` (~50 KB).
- Textual asm output: guard `CodeGenFileType::AssemblyFile` branch in `createMCStreamer` (EJIT emits objects only), dropping `MCAsmStreamer` (~30 KB) and the `MCInstPrinter` reference.
- Instruction-name tables: emit null name tables from `InstrInfoEmitter` under the flag and make `MCInstrInfo::getName` null safe, dropping the AArch64 instruction-name .rodata (~147 KB). Names are unavailable in trim builds.