### PR TITLE
[WIP][EJIT] Add SRE product profile and centralize SRE build defaults

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,8 @@
 #   -b              build only (skip configure)
 #   --static        debug build with static libs (for ejit_test with assertions)
 #   --no-ccache     disable ccache
-#   --trim-llvm-backend-experimental    build with EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=ON (backend: trim non-ELF formats)
+#   --trim-llvm-backend                 build with EJIT_TRIM_LLVM_BACKEND=ON (standard backend size trim)
+#   --trim-llvm-backend-experimental    build with EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=ON (riskier backend trim; implies standard trim)
 #   --freestanding  build with EJIT_FREESTANDING=ON (runtime: no OS threads/I/O)
 #   --target-triple=<triple>  set EJIT_DEFAULT_TARGET_TRIPLE
 #   --sre-code-pool / --no-sre-code-pool  force EmbeddedJIT SRE code pool on/off
@@ -29,18 +30,16 @@
 #   --sre-taskpool-worker-stack-size=<bytes>  shared worker task stack size (default: 1048576)
 #   --sre-shared-code-pointers / --no-sre-shared-code-pointers  allow non-owner cores to read shared cache fnPtrs (default OFF; needs platform same-VA + cache coherence)
 #   --ejit-sre-code-pool-profile   convenience alias: --sre-code-pool
-#   --ejit-sre-profile             convenience alias: --sre-taskpool
-#   --ejit-sre-async-profile       convenience alias: --sre-taskpool + --sre-code-pool
-#                                  (async vs sync is still a runtime choice; this
-#                                   alias only bundles the build features and adds
-#                                   no new macro)
+#   --ejit-sre-profile             SRE product profile: backend trim + code pool + shared taskpool
+#   --ejit-sre-async-profile       compatibility alias for --ejit-sre-profile
+#                                  (async vs sync is still a runtime choice)
 #   -h              show help
 #
-# Aggregate profiles are pure convenience entries that expand into the existing
-# --sre-* switches; they add no new macro and change no macro semantics. Flags
-# are applied left-to-right and the last occurrence wins, so an explicit flag
-# placed after a profile overrides that part of the profile. See
-# jit_design_doc/EJIT_MACRO_MATRIX.md §8 for the authoritative precedence rules.
+# Aggregate profiles expand into existing CMake switches. `--ejit-sre-profile`
+# is the authoritative product profile for SRE: it enables standard backend
+# trim, SRE code pool, taskpool, and shared taskpool. Riskier experimental trim
+# and shared fnPtr consumption remain explicit opt-ins. Flags are applied
+# left-to-right; later explicit flags override earlier profile assignments.
 #===----------------------------------------------------------------------===#
 
 set -euo pipefail
@@ -103,6 +102,8 @@ do_configure() {
   local ccache_opts=""
   if $USE_CCACHE; then
     ccache_opts="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+  else
+    ccache_opts="-U CMAKE_C_COMPILER_LAUNCHER -U CMAKE_CXX_COMPILER_LAUNCHER"
   fi
 
   if [ "$type" = "debug" ]; then
@@ -115,6 +116,9 @@ do_configure() {
         -DLLVM_OPTIMIZED_TABLEGEN=ON \
         "-DLLVM_TARGETS_TO_BUILD=${target}" \
         -DLLVM_ENABLE_PROJECTS="clang;lld" \
+        -DEJIT_SRE_PROFILE=${EJIT_SRE_PROFILE} \
+        -DEJIT_TRIM_LLVM_BACKEND=${EJIT_TRIM_LLVM_BACKEND} \
+        -DEJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=${EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL} \
         -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
         -DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO} \
         -DEJIT_SRE_TASKPOOL=${EJIT_SRE_TASKPOOL} \
@@ -138,6 +142,9 @@ do_configure() {
         -DLLVM_OPTIMIZED_TABLEGEN=ON \
         "-DLLVM_TARGETS_TO_BUILD=${target}" \
         -DLLVM_ENABLE_PROJECTS="clang;lld" \
+        -DEJIT_SRE_PROFILE=${EJIT_SRE_PROFILE} \
+        -DEJIT_TRIM_LLVM_BACKEND=${EJIT_TRIM_LLVM_BACKEND} \
+        -DEJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=${EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL} \
         -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
         -DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO} \
         -DEJIT_SRE_TASKPOOL=${EJIT_SRE_TASKPOOL} \
@@ -195,6 +202,8 @@ do_configure() {
       -DLLVM_ENABLE_PROJECTS="clang;lld" \
       "-DCMAKE_C_COMPILER=${cc}" \
       "-DCMAKE_CXX_COMPILER=${cxx}" \
+      -DEJIT_SRE_PROFILE=${EJIT_SRE_PROFILE} \
+      -DEJIT_TRIM_LLVM_BACKEND=${EJIT_TRIM_LLVM_BACKEND} \
       -DEJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=${EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL} \
       -DEJIT_FREESTANDING=${EJIT_FREESTANDING} \
       -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
@@ -234,6 +243,8 @@ do_configure() {
       -DLLVM_ENABLE_PROJECTS="clang;lld" \
       "-DCMAKE_C_COMPILER=${cc}" \
       "-DCMAKE_CXX_COMPILER=${cxx}" \
+      -DEJIT_SRE_PROFILE=${EJIT_SRE_PROFILE} \
+      -DEJIT_TRIM_LLVM_BACKEND=${EJIT_TRIM_LLVM_BACKEND} \
       -DEJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=${EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL} \
       -DEJIT_FREESTANDING=${EJIT_FREESTANDING} \
       -DEJIT_SRE_CODE_POOL=${EJIT_SRE_CODE_POOL} \
@@ -257,19 +268,19 @@ do_build() {
     debug)
       if [ "$variant" = "static" ]; then
         log "Building debug static: ${build_dir}..."
-        ninja -C "${build_dir}" clang LLVMEJIT lld
+        ninja -C "${build_dir}" clang LLVMEJIT lld -j8
       else
         log "Building debug: ${build_dir}..."
-        ninja -C "${build_dir}" clang opt lld
+        ninja -C "${build_dir}" clang opt lld -j8
       fi
       ;;
     release)
       if [ "$variant" = "minimal" ]; then
         log "Building release minimal: ${build_dir}..."
-        ninja -C "${build_dir}" ejit_minimal
+        ninja -C "${build_dir}" ejit_minimal -j8
       else
         log "Building release: ${build_dir}..."
-        ninja -C "${build_dir}" clang LLVMEJIT lld
+        ninja -C "${build_dir}" clang LLVMEJIT lld -j8
       fi
       ;;
   esac
@@ -283,6 +294,8 @@ VARIANT="default"
 DO_CONFIGURE=true
 DO_BUILD=true
 USE_CCACHE=true
+EJIT_SRE_PROFILE=OFF
+EJIT_TRIM_LLVM_BACKEND=OFF
 EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=OFF
 EJIT_FREESTANDING=OFF
 EJIT_TARGET_TRIPLE=""
@@ -308,27 +321,39 @@ while [[ $# -gt 0 ]]; do
     -c) DO_BUILD=false ;;
     -b) DO_CONFIGURE=false ;;
     --no-ccache) USE_CCACHE=false ;;
-    --trim-llvm-backend-experimental) EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=ON ;;
+    --trim-llvm-backend) EJIT_TRIM_LLVM_BACKEND=ON ;;
+    --trim-llvm-backend-experimental) EJIT_TRIM_LLVM_BACKEND=ON; EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL=ON ;;
     --freestanding) EJIT_FREESTANDING=ON ;;
     --target-triple=*) EJIT_TARGET_TRIPLE="${1#--target-triple=}" ;;
     --sre-code-pool) EJIT_SRE_CODE_POOL=ON ;;
-    --no-sre-code-pool) EJIT_SRE_CODE_POOL=OFF ;;
+    --no-sre-code-pool) EJIT_SRE_PROFILE=OFF; EJIT_SRE_CODE_POOL=OFF ;;
     --sre-code-pool-ptno=*) EJIT_SRE_CODE_POOL_PTNO="${1#--sre-code-pool-ptno=}" ;;
     --sre-taskpool) EJIT_SRE_TASKPOOL=ON ;;
-    --no-sre-taskpool) EJIT_SRE_TASKPOOL=OFF ;;
+    --no-sre-taskpool) EJIT_SRE_PROFILE=OFF; EJIT_SRE_TASKPOOL=OFF ;;
     --sre-taskpool-buckets=*) EJIT_SRE_TASKPOOL_BUCKETS="${1#--sre-taskpool-buckets=}" ;;
     --sre-taskpool-queue-capacity=*) EJIT_SRE_TASKPOOL_QUEUE_CAPACITY="${1#--sre-taskpool-queue-capacity=}" ;;
     --sre-shared-taskpool) EJIT_SRE_SHARED_TASKPOOL=ON ;;
-    --no-sre-shared-taskpool) EJIT_SRE_SHARED_TASKPOOL=OFF ;;
+    --no-sre-shared-taskpool) EJIT_SRE_PROFILE=OFF; EJIT_SRE_SHARED_TASKPOOL=OFF ;;
     --sre-taskpool-worker-stack-size=*) EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE="${1#--sre-taskpool-worker-stack-size=}" ;;
     --sre-shared-code-pointers) EJIT_SRE_SHARED_CODE_POINTERS=ON ;;
     --no-sre-shared-code-pointers) EJIT_SRE_SHARED_CODE_POINTERS=OFF ;;
-    # Aggregate convenience profiles. Pure aliases: they only set the same
-    # EJIT_SRE_* variables the explicit --sre-* flags set (no new macro, no
-    # changed semantics). Applied left-to-right; a later explicit flag overrides.
+    # Aggregate convenience profiles. Applied left-to-right; a later explicit
+    # flag overrides the profile assignment.
     --ejit-sre-code-pool-profile) EJIT_SRE_CODE_POOL=ON ;;
-    --ejit-sre-profile) EJIT_SRE_TASKPOOL=ON ;;
-    --ejit-sre-async-profile) EJIT_SRE_TASKPOOL=ON; EJIT_SRE_CODE_POOL=ON ;;
+    --ejit-sre-profile)
+      EJIT_SRE_PROFILE=ON
+      EJIT_TRIM_LLVM_BACKEND=ON
+      EJIT_SRE_CODE_POOL=ON
+      EJIT_SRE_TASKPOOL=ON
+      EJIT_SRE_SHARED_TASKPOOL=ON
+      ;;
+    --ejit-sre-async-profile)
+      EJIT_SRE_PROFILE=ON
+      EJIT_TRIM_LLVM_BACKEND=ON
+      EJIT_SRE_CODE_POOL=ON
+      EJIT_SRE_TASKPOOL=ON
+      EJIT_SRE_SHARED_TASKPOOL=ON
+      ;;
     -h|--help)
       sed -n '2,40p' "$0"
       exit 0
@@ -360,7 +385,8 @@ fi
 
 BUILD_DIR=$(build_dir "$TYPE" "$ARCH" "$VARIANT")
 log "Type=${TYPE}  Arch=${ARCH}  Variant=${VARIANT}  ccache=$($USE_CCACHE && echo on || echo off)"
-log "EJIT: triple=${EJIT_TARGET_TRIPLE:-$(target_triple "$ARCH")}  sre-code-pool=${EJIT_SRE_CODE_POOL}  ptno=${EJIT_SRE_CODE_POOL_PTNO}"
+log "EJIT: triple=${EJIT_TARGET_TRIPLE:-$(target_triple "$ARCH")}  sre-profile=${EJIT_SRE_PROFILE} trim=${EJIT_TRIM_LLVM_BACKEND} trim-exp=${EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL}"
+log "EJIT: sre-code-pool=${EJIT_SRE_CODE_POOL}  ptno=${EJIT_SRE_CODE_POOL_PTNO}"
 log "EJIT: sre-taskpool=${EJIT_SRE_TASKPOOL} buckets=${EJIT_SRE_TASKPOOL_BUCKETS} queue=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}"
 log "EJIT: sre-shared-taskpool=${EJIT_SRE_SHARED_TASKPOOL} worker-stack=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE} shared-code-pointers=${EJIT_SRE_SHARED_CODE_POINTERS}"
 log "Build dir: ${BUILD_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,19 @@
 #   --sre-shared-taskpool / --no-sre-shared-taskpool  cross-core shared taskpool, single shared worker (default OFF; needs --sre-taskpool)
 #   --sre-taskpool-worker-stack-size=<bytes>  shared worker task stack size (default: 1048576)
 #   --sre-shared-code-pointers / --no-sre-shared-code-pointers  allow non-owner cores to read shared cache fnPtrs (default OFF; needs platform same-VA + cache coherence)
+#   --ejit-sre-code-pool-profile   convenience alias: --sre-code-pool
+#   --ejit-sre-profile             convenience alias: --sre-taskpool
+#   --ejit-sre-async-profile       convenience alias: --sre-taskpool + --sre-code-pool
+#                                  (async vs sync is still a runtime choice; this
+#                                   alias only bundles the build features and adds
+#                                   no new macro)
 #   -h              show help
+#
+# Aggregate profiles are pure convenience entries that expand into the existing
+# --sre-* switches; they add no new macro and change no macro semantics. Flags
+# are applied left-to-right and the last occurrence wins, so an explicit flag
+# placed after a profile overrides that part of the profile. See
+# jit_design_doc/EJIT_MACRO_MATRIX.md §8 for the authoritative precedence rules.
 #===----------------------------------------------------------------------===#
 
 set -euo pipefail
@@ -284,7 +296,7 @@ EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=1048576
 EJIT_SRE_SHARED_CODE_POINTERS=OFF
 
 if [[ "${1:-}" = "-h" || "${1:-}" = "--help" ]]; then
-  sed -n '2,29p' "$0"
+  sed -n '2,40p' "$0"
   exit 0
 fi
 
@@ -311,8 +323,14 @@ while [[ $# -gt 0 ]]; do
     --sre-taskpool-worker-stack-size=*) EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE="${1#--sre-taskpool-worker-stack-size=}" ;;
     --sre-shared-code-pointers) EJIT_SRE_SHARED_CODE_POINTERS=ON ;;
     --no-sre-shared-code-pointers) EJIT_SRE_SHARED_CODE_POINTERS=OFF ;;
+    # Aggregate convenience profiles. Pure aliases: they only set the same
+    # EJIT_SRE_* variables the explicit --sre-* flags set (no new macro, no
+    # changed semantics). Applied left-to-right; a later explicit flag overrides.
+    --ejit-sre-code-pool-profile) EJIT_SRE_CODE_POOL=ON ;;
+    --ejit-sre-profile) EJIT_SRE_TASKPOOL=ON ;;
+    --ejit-sre-async-profile) EJIT_SRE_TASKPOOL=ON; EJIT_SRE_CODE_POOL=ON ;;
     -h|--help)
-      sed -n '2,29p' "$0"
+      sed -n '2,40p' "$0"
       exit 0
       ;;
     *) err "Unknown argument: $1"; exit 1 ;;

--- a/jit_design_doc/EJIT_MACRO_MATRIX.md
+++ b/jit_design_doc/EJIT_MACRO_MATRIX.md
@@ -1,0 +1,215 @@
+# EmbeddedJIT Macro / Build-Switch Matrix
+
+**Status**: Phase 1 — documentation + build-entry aggregation only.
+**Scope**: This document inventories the EmbeddedJIT (EJIT) compile-time macros
+and the `build.sh` / CMake switches that drive them, classifies them, and
+records why several macros cannot be deleted yet. It is intentionally
+non-invasive: it does **not** change any runtime behavior, does **not** remove
+any macro, and does **not** alter the meaning of any existing CMake option.
+
+> **Baseline note (important)**: This document is based on `ejit_dev_spec4`,
+> which already contains the cross-core shared taskpool implementation. Shared
+> taskpool macros are therefore documented as real, load-bearing bring-up
+> switches. Phase 1 does **not** delete, fold, runtime-ize, or otherwise alter
+> those paths.
+
+---
+
+## 1. How the layers fit together
+
+```
+build.sh flag  ─►  CMake option (cache var)  ─►  add_definitions(-DMACRO)  ─►  #ifdef in C/C++
+   (convenience)        (llvm/CMakeLists.txt,            (compile-time)            (source)
+                         llvm/lib/.../EJIT/CMakeLists.txt)
+```
+
+`build.sh` is only a convenience front-end: every flag expands into one or more
+`-DEJIT_*` CMake cache variables. The CMake layer is the single source of truth
+for macro semantics. This document does not change that mapping; the Phase-1
+`build.sh` additions (see [§6](#6-aggregate-convenience-switches-buildsh-only))
+are pure aliases that expand into the **existing** CMake options.
+
+---
+
+## 2. Category A — Compile-time macros that MUST be kept
+
+These select mutually-incompatible ABI / code-generation / platform paths. They
+cannot become pure runtime flags without shipping both code paths in one binary,
+which defeats the size and freestanding goals of EmbeddedJIT.
+
+| Macro | Driven by | Why it must stay a compile-time macro |
+|-------|-----------|----------------------------------------|
+| `EJIT_FREESTANDING` | CMake `EJIT_FREESTANDING` (+ `build.sh --freestanding`) | Removes OS threads, file I/O, and logging; swaps in bare-metal mutex behavior and excludes `EJitSyncCompiler.cpp` / `EJitAsyncCompiler.cpp` from the library. It also flips `<future>`/`std::promise` guards in JITLink headers. A runtime flag cannot un-link `std::thread`. **52 `#ifdef` sites.** |
+| `EJIT_SRE_TASKPOOL` | CMake `EJIT_SRE_TASKPOOL` (+ `build.sh --sre-taskpool`) | Compiles the taskpool sources (`EJitTaskPool.cpp`, `EJitSreQueue.cpp`, `EJitWorker.cpp`, `EJitSreTask_*.cpp`) into the library and reroutes `ejit_compile_or_get`. Toggling it changes which translation units exist. **23 `#ifdef` sites.** |
+| `EJIT_SRE_SHARED_TASKPOOL` | CMake `EJIT_SRE_SHARED_TASKPOOL` (+ `build.sh --sre-shared-taskpool`) | Enables the cross-core shared taskpool layer: shared state, owner election, shared queue/cache/dedup/control state, and single-worker coordination. It requires `EJIT_SRE_TASKPOOL=ON` and changes runtime wiring, so it must remain compile-time until the shared path is fully productized. |
+| `EJIT_SRE_CODE_POOL` | CMake `EJIT_SRE_CODE_POOL` (+ `build.sh --sre-code-pool`) | Routes JIT code memory through the SRE 2 MiB code pools and (implicitly) enables `EJIT_SRE_ENABLE_EX` RX sealing. Changes the memory-manager path used to hand back executable pointers. **9 `#ifdef` sites.** |
+| `EJIT_TRIM_LLVM_BACKEND` | CMake `EJIT_TRIM_LLVM_BACKEND` | Disables heavyweight debug-info / GlobalISel / optional AArch64 SME-SVE passes at build time. Purely a link/size decision. |
+| `EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL` | CMake option (+ `build.sh --trim-llvm-backend-experimental`) | Bare-metal backend trim (non-ELF formats, non-AArch64 targets, DWARF/CFI). Implies `EJIT_TRIM_LLVM_BACKEND`. Build-time only. |
+| `EJIT_SRE_SHARED_TASKPOOL_PLATFORM` | CMake-derived define when `EJIT_SRE_SHARED_TASKPOOL=ON` and `EJIT_FREESTANDING=ON` | Selects the real platform-facing shared-taskpool hooks instead of host/test seams. It affects core-id/current-core behavior and shared-section expectations, so it is not a runtime flag. |
+| `EJIT_DEFAULT_TRIPLE` (from `EJIT_DEFAULT_TARGET_TRIPLE`) | EJIT lib CMake (+ `build.sh --target-triple=`) | Baked-in target triple that replaces host detection; required by freestanding. It is a compile-time string define on `LLVMEJIT`. |
+
+**Rule**: none of these may be deleted or runtime-ized in Phase 1.
+
+---
+
+## 3. Category B — Numeric parameter macros (candidates for FUTURE runtime config)
+
+These are integers that size fixed tables / pools. They could *in principle*
+migrate to a runtime config struct later, but only after the owning subsystem's
+data structures stop using them for static sizing. They are **not** touched in
+Phase 1.
+
+| Macro | Driven by | Default | Future note |
+|-------|-----------|---------|-------------|
+| `EJIT_SRE_CODE_POOL_SIZE` | CMake `EJIT_SRE_CODE_POOL_SIZE` | `2097152` (2 MiB) | Must remain a multiple of the enable_ex granularity; currently a compile-time constant. Not yet exposed in `build.sh`. |
+| `EJIT_SRE_CODE_POOL_PTNO` | CMake (+ `build.sh --sre-code-pool-ptno=`) | `8` | SRE memory partition number handed to `SRE_MemDbgAlloc`. Already reachable from `build.sh`. |
+| `EJIT_SRE_TASKPOOL_BUCKETS` | CMake (+ `build.sh --sre-taskpool-buckets=`) | `32` | Dedup/cache bucket count. |
+| `EJIT_SRE_TASKPOOL_QUEUE_CAPACITY` | CMake (+ `build.sh --sre-taskpool-queue-capacity=`) | `1024` | Async queue capacity, rounded to power of two. |
+| `EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX` | CMake `EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX` | `4096` | Flat dedup-table capacity (`inFlight_[]`). Sizes a static array today → cannot be runtime-ized without reworking that table. Not yet exposed in `build.sh`. |
+| `EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE` | CMake (+ `build.sh --sre-taskpool-worker-stack-size=`) | `1048576` | Shared worker stack size. It is already a build parameter but still participates in platform task creation and should not be changed by macro cleanup. |
+| `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS` | CMake `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS` | `16` | Fixed-slot shared cache size. Static shared-state layout depends on it. |
+
+**Rule**: leave as compile-time; do not runtime-ize a batch of these in Phase 1.
+
+---
+
+## 4. Category C — Macros that could be ALIASED / AGGREGATED later
+
+These are not deletable, but callers frequently want to enable them **together**
+for a given bring-up scenario. Phase 1 adds `build.sh` convenience aliases that
+bundle them (see [§6](#6-aggregate-convenience-switches-buildsh-only)); the
+underlying CMake options and macro semantics are unchanged.
+
+| Underlying CMake option | Existing explicit `build.sh` flag | Bundled by aggregate profile |
+|-------------------------|-----------------------------------|------------------------------|
+| `EJIT_SRE_CODE_POOL` | `--sre-code-pool` / `--no-sre-code-pool` | `--ejit-sre-code-pool-profile`, `--ejit-sre-async-profile` |
+| `EJIT_SRE_TASKPOOL` | `--sre-taskpool` / `--no-sre-taskpool` | `--ejit-sre-profile`, `--ejit-sre-async-profile` |
+| `EJIT_SRE_SHARED_TASKPOOL` | `--sre-shared-taskpool` / `--no-sre-shared-taskpool` | Not bundled in Phase 1; enable explicitly so cross-core behavior is never switched on by surprise. |
+| `EJIT_SRE_SHARED_CODE_POINTERS` | `--sre-shared-code-pointers` / `--no-sre-shared-code-pointers` | Not bundled in Phase 1; requires platform same-VA and per-core executable permission/coherency validation. |
+
+---
+
+## 5. Shared-taskpool cleanup boundary
+
+The shared taskpool exists in this baseline and has already been exercised on
+target hardware. That makes it a poor candidate for a first-round macro
+cleanup. In this phase:
+
+- do not merge `EJitTaskPool` and `EJitSharedTaskPool`;
+- do not remove `EJIT_SRE_SHARED_TASKPOOL`;
+- do not fold `EJIT_SRE_SHARED_TASKPOOL_PLATFORM` into a runtime flag;
+- do not put shared code-pointer enablement into an aggregate profile;
+- do not change owner election, shared queue, shared cache, dedup, activation
+  state, worker startup, or code-permission behavior.
+
+Future cleanup can introduce a facade or higher-level build profile after the
+shared path has a stable product configuration, but that is intentionally out of
+scope for this documentation/build-entry-only phase.
+
+---
+
+## 6. Bring-up macros that CANNOT be deleted yet (justification)
+
+The task specifically asks why the following cannot be removed. Note that some
+are compile-time paths still under active bring-up and some are simply not
+present here.
+
+- **`EJIT_FREESTANDING`** — Load-bearing. It gates 52 `#ifdef` sites, removes
+  entire translation units from the library, injects bare-metal mutex behavior,
+  and toggles `<future>`/`std::promise` guards inside JITLink headers. Deleting
+  it would either force OS-thread dependencies into bare-metal targets or delete
+  the freestanding target entirely. Keep.
+
+- **`EJIT_SRE_CODE_POOL`** — Load-bearing. It swaps the JIT executable-memory
+  manager for the SRE 2 MiB pool + `enable_ex` RX-seal path (`EJIT_SRE_ENABLE_EX`
+  is implied). Removing it would drop the sealed-code-memory path required by the
+  target platform. Keep. (Permission / 4K-2M sealing logic is explicitly out of
+  scope for this phase.)
+
+- **`EJIT_TRIM_LLVM_BACKEND`** — Load-bearing for size-constrained builds. It is
+  the switch that trims debug-info/GlobalISel/optional AArch64 passes, and it is
+  implied by `EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL`. Removing it would either bloat
+  the trimmed builds or silently break the experimental trim. Keep.
+
+- **`EJIT_SRE_SHARED_TASKPOOL_PLATFORM`** — Load-bearing for the SRE
+  cross-core shared-taskpool path. It selects platform-facing behavior for
+  current-core identity / shared-state placement instead of host test seams.
+  Turning this into a runtime flag would require shipping both platform and host
+  seams in one binary and would make freestanding link behavior less explicit.
+  Keep.
+
+- **`EJIT_DIAG_ENABLE`** — Diagnostic logging gate in
+  `llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h`. When undefined, the
+  `EJIT_DIAG(...)` macros compile to no-ops; when defined they emit logging. It is
+  a manual/per-TU compile define (not wired into a CMake option), used during
+  bring-up and debugging. Deleting it would remove the ability to turn EJIT trace
+  logging on without editing source. Keep as a compile-time gate.
+
+---
+
+## 7. Other compile-time defines observed (manual / test-only)
+
+Recorded for completeness; not wired to a CMake option and **not** changed here.
+
+| Macro | Where | Nature |
+|-------|-------|--------|
+| `EJIT_DISABLE` | source guard | Manual define to compile EJIT out of a TU. |
+| `EJIT_SRE_ENABLE_EX` | implied by `EJIT_SRE_CODE_POOL` in CMake | RX-seal call; toggled with the code pool. |
+| `EJIT_SRE_SHARED_CODE_POINTERS` | CMake/build.sh shared-taskpool option | Allows non-owner cores to consume shared cache function pointers; keep explicit because it relies on same-VA mapping and per-core executable permission/coherency. |
+| `EJIT_CODE_POOL_4K_SEAL` | code-pool branch / CMake option when present | 4K sealing strategy switch; do not fold into profiles until platform validation is complete. |
+| `EJIT_SRE_TASKPOOL_TESTING` | taskpool unit tests | Test-only define. |
+| `EJIT_SRE_TASKPOOL_PLATFORM_IPC_LOCK` | taskpool source | Platform IPC-lock path; manual define. |
+| `EJIT_SRE_CODE_POOL_MID` | code-pool source | Manual define. |
+| `EJIT_FREESTANDING_MUTEX` | EJIT lib CMake option | Injects no-op mutex headers for toolchains lacking `<mutex>`. |
+
+---
+
+## 8. `build.sh` flag precedence (authoritative)
+
+`build.sh` parses flags **left to right**; for any switch that maps to the same
+underlying variable, **the last occurrence on the command line wins**. This is
+the only precedence rule and it applies uniformly to explicit flags and to the
+Phase-1 aggregate profiles.
+
+Consequences:
+
+- Aggregate profiles (`--ejit-sre-profile`, `--ejit-sre-async-profile`,
+  `--ejit-sre-code-pool-profile`) simply *set* the same `EJIT_SRE_*` variables
+  that the explicit flags set. They add **no** new macro and change **no** macro
+  meaning.
+- To override one feature of a profile, place the explicit flag **after** the
+  profile. Examples:
+
+  ```bash
+  # taskpool + code pool, but force code pool back off:
+  ./build.sh release aarch64 --ejit-sre-async-profile --no-sre-code-pool
+
+  # code pool only, but also enable taskpool:
+  ./build.sh release aarch64 --ejit-sre-code-pool-profile --sre-taskpool
+  ```
+
+- Old explicit flags remain fully supported and are the recommended way to be
+  unambiguous. Profiles are conveniences, not replacements.
+
+### 8.1 Aggregate profile expansions (Phase 1)
+
+| Aggregate flag | Expands to (existing switches only) |
+|----------------|-------------------------------------|
+| `--ejit-sre-code-pool-profile` | `EJIT_SRE_CODE_POOL=ON` |
+| `--ejit-sre-profile` | `EJIT_SRE_TASKPOOL=ON` |
+| `--ejit-sre-async-profile` | `EJIT_SRE_TASKPOOL=ON` + `EJIT_SRE_CODE_POOL=ON` |
+
+> **Async note**: sync vs async is a **runtime** choice (`ejit_set_compile_mode`
+> / `Config.compileMode`), not a build macro. `--ejit-sre-async-profile` only
+> bundles the *build* features typically needed for the async SRE bring-up
+> (taskpool scheduler + sealed code pool); it does not itself select async at
+> runtime and it defines no new macro.
+
+---
+
+## 9. Runtime behavior statement
+
+Phase 1 changes are **documentation** plus **pure `build.sh` convenience
+aliases**. No CMake option semantics change, no macro is added or removed, and
+the default build (`./build.sh <debug|release> <arch>` with no EJIT flags) is
+byte-for-byte identical to before. **Runtime behavior is unchanged.**

--- a/jit_design_doc/EJIT_MACRO_MATRIX.md
+++ b/jit_design_doc/EJIT_MACRO_MATRIX.md
@@ -1,7 +1,7 @@
 # EmbeddedJIT Macro / Build-Switch Matrix
 
-**Status**: Phase 2 — documentation + build-entry aggregation + centralized
-SRE default constants.
+**Status**: Phase 3 — documentation + build-entry aggregation + centralized
+SRE default constants + official SRE product profile.
 **Scope**: This document inventories the EmbeddedJIT (EJIT) compile-time macros
 and the `build.sh` / CMake switches that drive them, classifies them, and
 records why several macros cannot be deleted yet. It is intentionally
@@ -10,6 +10,10 @@ any macro, and does **not** alter the meaning of any existing CMake option.
 Phase 2 additionally centralizes SRE-facing default constants in
 `EJitSreConfig.h`, so adapter `.cpp` files do not each carry their own fallback
 `#ifndef` blocks.
+Phase 3 adds one stable product entry point, `EJIT_SRE_PROFILE`, for the SRE
+deployment shape that has now been validated: standard backend trim + SRE code
+pool + taskpool + shared taskpool. Lower-level macros remain available for
+bring-up, bisection, and platform validation.
 
 > **Baseline note (important)**: This document is based on `ejit_dev_spec4`,
 > which already contains the cross-core shared taskpool implementation. Shared
@@ -44,15 +48,15 @@ which defeats the size and freestanding goals of EmbeddedJIT.
 | Macro | Driven by | Why it must stay a compile-time macro |
 |-------|-----------|----------------------------------------|
 | `EJIT_FREESTANDING` | CMake `EJIT_FREESTANDING` (+ `build.sh --freestanding`) | Removes OS threads, file I/O, and logging; swaps in bare-metal mutex behavior and excludes `EJitSyncCompiler.cpp` / `EJitAsyncCompiler.cpp` from the library. It also flips `<future>`/`std::promise` guards in JITLink headers. A runtime flag cannot un-link `std::thread`. **52 `#ifdef` sites.** |
-| `EJIT_SRE_TASKPOOL` | CMake `EJIT_SRE_TASKPOOL` (+ `build.sh --sre-taskpool`) | Compiles the taskpool sources (`EJitTaskPool.cpp`, `EJitSreQueue.cpp`, `EJitWorker.cpp`, `EJitSreTask_*.cpp`) into the library and reroutes `ejit_compile_or_get`. Toggling it changes which translation units exist. **23 `#ifdef` sites.** |
-| `EJIT_SRE_SHARED_TASKPOOL` | CMake `EJIT_SRE_SHARED_TASKPOOL` (+ `build.sh --sre-shared-taskpool`) | Enables the cross-core shared taskpool layer: shared state, owner election, shared queue/cache/dedup/control state, and single-worker coordination. It requires `EJIT_SRE_TASKPOOL=ON` and changes runtime wiring, so it must remain compile-time until the shared path is fully productized. |
-| `EJIT_SRE_CODE_POOL` | CMake `EJIT_SRE_CODE_POOL` (+ `build.sh --sre-code-pool`) | Routes JIT code memory through the SRE 2 MiB code pools and (implicitly) enables `EJIT_SRE_ENABLE_EX` RX sealing. Changes the memory-manager path used to hand back executable pointers. **9 `#ifdef` sites.** |
-| `EJIT_TRIM_LLVM_BACKEND` | CMake `EJIT_TRIM_LLVM_BACKEND` | Disables heavyweight debug-info / GlobalISel / optional AArch64 SME-SVE passes at build time. Purely a link/size decision. |
+| `EJIT_SRE_TASKPOOL` | CMake `EJIT_SRE_TASKPOOL` (+ `build.sh --sre-taskpool`; implied by `EJIT_SRE_PROFILE`) | Compiles the taskpool sources (`EJitTaskPool.cpp`, `EJitSreQueue.cpp`, `EJitWorker.cpp`, `EJitSreTask_*.cpp`) into the library and reroutes `ejit_compile_or_get`. Toggling it changes which translation units exist. **23 `#ifdef` sites.** |
+| `EJIT_SRE_SHARED_TASKPOOL` | CMake `EJIT_SRE_SHARED_TASKPOOL` (+ `build.sh --sre-shared-taskpool`; implied by `EJIT_SRE_PROFILE`) | Enables the cross-core shared taskpool layer: shared state, owner election, shared queue/cache/dedup/control state, and single-worker coordination. It requires `EJIT_SRE_TASKPOOL=ON` and changes runtime wiring, so it remains compile-time even though it is now part of the product SRE profile. |
+| `EJIT_SRE_CODE_POOL` | CMake `EJIT_SRE_CODE_POOL` (+ `build.sh --sre-code-pool`; implied by `EJIT_SRE_PROFILE`) | Routes JIT code memory through the SRE 2 MiB code pools and (implicitly) enables `EJIT_SRE_ENABLE_EX` RX sealing. Changes the memory-manager path used to hand back executable pointers. **9 `#ifdef` sites.** |
+| `EJIT_TRIM_LLVM_BACKEND` | CMake `EJIT_TRIM_LLVM_BACKEND` (+ `build.sh --trim-llvm-backend`; implied by `EJIT_SRE_PROFILE`) | Disables heavyweight debug-info / GlobalISel / optional AArch64 SME-SVE passes at build time. Purely a link/size decision. |
 | `EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL` | CMake option (+ `build.sh --trim-llvm-backend-experimental`) | Bare-metal backend trim (non-ELF formats, non-AArch64 targets, DWARF/CFI). Implies `EJIT_TRIM_LLVM_BACKEND`. Build-time only. |
 | `EJIT_SRE_SHARED_TASKPOOL_PLATFORM` | CMake-derived define when `EJIT_SRE_SHARED_TASKPOOL=ON` and `EJIT_FREESTANDING=ON` | Selects the real platform-facing shared-taskpool hooks instead of host/test seams. It affects core-id/current-core behavior and shared-section expectations, so it is not a runtime flag. |
 | `EJIT_DEFAULT_TRIPLE` (from `EJIT_DEFAULT_TARGET_TRIPLE`) | EJIT lib CMake (+ `build.sh --target-triple=`) | Baked-in target triple that replaces host detection; required by freestanding. It is a compile-time string define on `LLVMEJIT`. |
 
-**Rule**: none of these may be deleted or runtime-ized in Phase 2.
+**Rule**: none of these may be deleted or runtime-ized in Phase 3.
 
 ---
 
@@ -73,31 +77,34 @@ runtime-ized in Phase 2.
 | `EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE` | CMake (+ `build.sh --sre-taskpool-worker-stack-size=`) | `1048576` | Shared worker stack size. It is already a build parameter but still participates in platform task creation and should not be changed by macro cleanup. |
 | `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS` | CMake `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS` | `16` | Fixed-slot shared cache size. Static shared-state layout depends on it. |
 
-**Rule**: leave as compile-time; do not runtime-ize a batch of these in Phase 2.
+**Rule**: leave as compile-time; do not runtime-ize a batch of these in Phase 3.
 
 ---
 
-## 4. Category C — Macros that could be ALIASED / AGGREGATED later
+## 4. Category C — Product profile and aggregate aliases
 
 These are not deletable, but callers frequently want to enable them **together**
-for a given bring-up scenario. Phase 1 added `build.sh` convenience aliases that
-bundle them (see [§6](#6-aggregate-convenience-switches-buildsh-only)); the
-underlying CMake options and macro semantics are unchanged.
+for the SRE product build. Phase 3 promotes that stable combination into the
+official `EJIT_SRE_PROFILE` CMake option and the matching
+`build.sh --ejit-sre-profile` entry.
 
 | Underlying CMake option | Existing explicit `build.sh` flag | Bundled by aggregate profile |
 |-------------------------|-----------------------------------|------------------------------|
-| `EJIT_SRE_CODE_POOL` | `--sre-code-pool` / `--no-sre-code-pool` | `--ejit-sre-code-pool-profile`, `--ejit-sre-async-profile` |
+| `EJIT_TRIM_LLVM_BACKEND` | `--trim-llvm-backend` | `--ejit-sre-profile`, `--ejit-sre-async-profile` |
+| `EJIT_SRE_CODE_POOL` | `--sre-code-pool` / `--no-sre-code-pool` | `--ejit-sre-code-pool-profile`, `--ejit-sre-profile`, `--ejit-sre-async-profile` |
 | `EJIT_SRE_TASKPOOL` | `--sre-taskpool` / `--no-sre-taskpool` | `--ejit-sre-profile`, `--ejit-sre-async-profile` |
-| `EJIT_SRE_SHARED_TASKPOOL` | `--sre-shared-taskpool` / `--no-sre-shared-taskpool` | Not bundled in Phase 2; enable explicitly so cross-core behavior is never switched on by surprise. |
-| `EJIT_SRE_SHARED_CODE_POINTERS` | `--sre-shared-code-pointers` / `--no-sre-shared-code-pointers` | Not bundled in Phase 2; requires platform same-VA and per-core executable permission/coherency validation. |
+| `EJIT_SRE_SHARED_TASKPOOL` | `--sre-shared-taskpool` / `--no-sre-shared-taskpool` | `--ejit-sre-profile`, `--ejit-sre-async-profile` |
+| `EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL` | `--trim-llvm-backend-experimental` | Not bundled; it is still a riskier trim for explicit size experiments. |
+| `EJIT_SRE_SHARED_CODE_POINTERS` | `--sre-shared-code-pointers` / `--no-sre-shared-code-pointers` | Not bundled; requires platform same-VA and per-core executable permission/coherency validation. |
 
 ---
 
 ## 5. Shared-taskpool cleanup boundary
 
 The shared taskpool exists in this baseline and has already been exercised on
-target hardware. That makes it a poor candidate for a first-round macro
-cleanup. In this phase:
+target hardware. In Phase 3 it is part of the stable SRE product profile, but
+the underlying implementation split remains intentionally unchanged. In this
+phase:
 
 - do not merge `EJitTaskPool` and `EJitSharedTaskPool`;
 - do not remove `EJIT_SRE_SHARED_TASKPOOL`;
@@ -106,9 +113,9 @@ cleanup. In this phase:
 - do not change owner election, shared queue, shared cache, dedup, activation
   state, worker startup, or code-permission behavior.
 
-Future cleanup can introduce a facade or higher-level build profile after the
-shared path has a stable product configuration, but that is intentionally out of
-scope for this conservative cleanup phase.
+Future cleanup can introduce a facade or merge plain taskpool/shared-taskpool
+internals after more product soak time. This phase only adds the high-level
+profile entry and keeps the working implementation shape intact.
 
 ---
 
@@ -191,21 +198,24 @@ Recorded for completeness; not wired to a CMake option and **not** changed here.
 
 `build.sh` parses flags **left to right**; for any switch that maps to the same
 underlying variable, **the last occurrence on the command line wins**. This is
-the only precedence rule and it applies uniformly to explicit flags and to the
-Phase-1 aggregate profiles.
+the normal precedence rule for explicit flags and aggregate profiles.
 
 Consequences:
 
-- Aggregate profiles (`--ejit-sre-profile`, `--ejit-sre-async-profile`,
-  `--ejit-sre-code-pool-profile`) simply *set* the same `EJIT_SRE_*` variables
-  that the explicit flags set. They add **no** new macro and change **no** macro
-  meaning.
+- `--ejit-sre-profile` is the SRE product profile. It sets
+  `EJIT_SRE_PROFILE=ON` and expands to the same stable product components:
+  standard backend trim, SRE code pool, taskpool, and shared taskpool.
+- `--ejit-sre-async-profile` is kept as a compatibility alias for the same
+  product profile. Sync vs async is still selected at runtime.
+- `--ejit-sre-code-pool-profile` remains a narrow code-pool-only alias for
+  bring-up.
 - To override one feature of a profile, place the explicit flag **after** the
-  profile. Examples:
+  profile. `build.sh` will then drop `EJIT_SRE_PROFILE=ON` and pass the
+  lower-level choices directly to CMake. Examples:
 
   ```bash
-  # taskpool + code pool, but force code pool back off:
-  ./build.sh release aarch64 --ejit-sre-async-profile --no-sre-code-pool
+  # product profile, but force shared taskpool back off for bisection:
+  ./build.sh release aarch64 --ejit-sre-profile --no-sre-shared-taskpool
 
   # code pool only, but also enable taskpool:
   ./build.sh release aarch64 --ejit-sre-code-pool-profile --sre-taskpool
@@ -214,26 +224,25 @@ Consequences:
 - Old explicit flags remain fully supported and are the recommended way to be
   unambiguous. Profiles are conveniences, not replacements.
 
-### 9.1 Aggregate profile expansions (Phase 1)
+### 9.1 Aggregate profile expansions (Phase 3)
 
-| Aggregate flag | Expands to (existing switches only) |
+| Aggregate flag | Expands to |
 |----------------|-------------------------------------|
 | `--ejit-sre-code-pool-profile` | `EJIT_SRE_CODE_POOL=ON` |
-| `--ejit-sre-profile` | `EJIT_SRE_TASKPOOL=ON` |
-| `--ejit-sre-async-profile` | `EJIT_SRE_TASKPOOL=ON` + `EJIT_SRE_CODE_POOL=ON` |
+| `--ejit-sre-profile` | `EJIT_SRE_PROFILE=ON`, `EJIT_TRIM_LLVM_BACKEND=ON`, `EJIT_SRE_CODE_POOL=ON`, `EJIT_SRE_TASKPOOL=ON`, `EJIT_SRE_SHARED_TASKPOOL=ON` |
+| `--ejit-sre-async-profile` | Compatibility alias for `--ejit-sre-profile` |
 
 > **Async note**: sync vs async is a **runtime** choice (`ejit_set_compile_mode`
 > / `Config.compileMode`), not a build macro. `--ejit-sre-async-profile` only
-> bundles the *build* features typically needed for the async SRE bring-up
-> (taskpool scheduler + sealed code pool); it does not itself select async at
-> runtime and it defines no new macro.
+> bundles the *build* features needed for the SRE product path; it does not
+> itself select async at runtime.
 
 ---
 
 ## 10. Runtime behavior statement
 
-Phase 2 changes are **documentation**, **pure `build.sh` convenience aliases**,
-and **centralized SRE default constants**. No CMake option semantics change, no
-macro is added or removed, and the default build (`./build.sh <debug|release>
-<arch>` with no EJIT flags) uses the same values as before. **Runtime behavior
-is unchanged.**
+Phase 3 changes add a product build entry point but do not delete the lower-level
+macros and do not change the default build (`./build.sh <debug|release> <arch>`
+with no EJIT flags). Runtime behavior changes only for builds that explicitly
+enable `EJIT_SRE_PROFILE` / `--ejit-sre-profile`, where the intended SRE product
+path is selected as a bundle.

--- a/jit_design_doc/EJIT_MACRO_MATRIX.md
+++ b/jit_design_doc/EJIT_MACRO_MATRIX.md
@@ -1,16 +1,20 @@
 # EmbeddedJIT Macro / Build-Switch Matrix
 
-**Status**: Phase 1 — documentation + build-entry aggregation only.
+**Status**: Phase 2 — documentation + build-entry aggregation + centralized
+SRE default constants.
 **Scope**: This document inventories the EmbeddedJIT (EJIT) compile-time macros
 and the `build.sh` / CMake switches that drive them, classifies them, and
 records why several macros cannot be deleted yet. It is intentionally
 non-invasive: it does **not** change any runtime behavior, does **not** remove
 any macro, and does **not** alter the meaning of any existing CMake option.
+Phase 2 additionally centralizes SRE-facing default constants in
+`EJitSreConfig.h`, so adapter `.cpp` files do not each carry their own fallback
+`#ifndef` blocks.
 
 > **Baseline note (important)**: This document is based on `ejit_dev_spec4`,
 > which already contains the cross-core shared taskpool implementation. Shared
 > taskpool macros are therefore documented as real, load-bearing bring-up
-> switches. Phase 1 does **not** delete, fold, runtime-ize, or otherwise alter
+> switches. Phase 2 does **not** delete, fold, runtime-ize, or otherwise alter
 > those paths.
 
 ---
@@ -48,7 +52,7 @@ which defeats the size and freestanding goals of EmbeddedJIT.
 | `EJIT_SRE_SHARED_TASKPOOL_PLATFORM` | CMake-derived define when `EJIT_SRE_SHARED_TASKPOOL=ON` and `EJIT_FREESTANDING=ON` | Selects the real platform-facing shared-taskpool hooks instead of host/test seams. It affects core-id/current-core behavior and shared-section expectations, so it is not a runtime flag. |
 | `EJIT_DEFAULT_TRIPLE` (from `EJIT_DEFAULT_TARGET_TRIPLE`) | EJIT lib CMake (+ `build.sh --target-triple=`) | Baked-in target triple that replaces host detection; required by freestanding. It is a compile-time string define on `LLVMEJIT`. |
 
-**Rule**: none of these may be deleted or runtime-ized in Phase 1.
+**Rule**: none of these may be deleted or runtime-ized in Phase 2.
 
 ---
 
@@ -56,8 +60,8 @@ which defeats the size and freestanding goals of EmbeddedJIT.
 
 These are integers that size fixed tables / pools. They could *in principle*
 migrate to a runtime config struct later, but only after the owning subsystem's
-data structures stop using them for static sizing. They are **not** touched in
-Phase 1.
+data structures stop using them for static sizing. They are **not**
+runtime-ized in Phase 2.
 
 | Macro | Driven by | Default | Future note |
 |-------|-----------|---------|-------------|
@@ -69,14 +73,14 @@ Phase 1.
 | `EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE` | CMake (+ `build.sh --sre-taskpool-worker-stack-size=`) | `1048576` | Shared worker stack size. It is already a build parameter but still participates in platform task creation and should not be changed by macro cleanup. |
 | `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS` | CMake `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS` | `16` | Fixed-slot shared cache size. Static shared-state layout depends on it. |
 
-**Rule**: leave as compile-time; do not runtime-ize a batch of these in Phase 1.
+**Rule**: leave as compile-time; do not runtime-ize a batch of these in Phase 2.
 
 ---
 
 ## 4. Category C — Macros that could be ALIASED / AGGREGATED later
 
 These are not deletable, but callers frequently want to enable them **together**
-for a given bring-up scenario. Phase 1 adds `build.sh` convenience aliases that
+for a given bring-up scenario. Phase 1 added `build.sh` convenience aliases that
 bundle them (see [§6](#6-aggregate-convenience-switches-buildsh-only)); the
 underlying CMake options and macro semantics are unchanged.
 
@@ -84,8 +88,8 @@ underlying CMake options and macro semantics are unchanged.
 |-------------------------|-----------------------------------|------------------------------|
 | `EJIT_SRE_CODE_POOL` | `--sre-code-pool` / `--no-sre-code-pool` | `--ejit-sre-code-pool-profile`, `--ejit-sre-async-profile` |
 | `EJIT_SRE_TASKPOOL` | `--sre-taskpool` / `--no-sre-taskpool` | `--ejit-sre-profile`, `--ejit-sre-async-profile` |
-| `EJIT_SRE_SHARED_TASKPOOL` | `--sre-shared-taskpool` / `--no-sre-shared-taskpool` | Not bundled in Phase 1; enable explicitly so cross-core behavior is never switched on by surprise. |
-| `EJIT_SRE_SHARED_CODE_POINTERS` | `--sre-shared-code-pointers` / `--no-sre-shared-code-pointers` | Not bundled in Phase 1; requires platform same-VA and per-core executable permission/coherency validation. |
+| `EJIT_SRE_SHARED_TASKPOOL` | `--sre-shared-taskpool` / `--no-sre-shared-taskpool` | Not bundled in Phase 2; enable explicitly so cross-core behavior is never switched on by surprise. |
+| `EJIT_SRE_SHARED_CODE_POINTERS` | `--sre-shared-code-pointers` / `--no-sre-shared-code-pointers` | Not bundled in Phase 2; requires platform same-VA and per-core executable permission/coherency validation. |
 
 ---
 
@@ -104,11 +108,30 @@ cleanup. In this phase:
 
 Future cleanup can introduce a facade or higher-level build profile after the
 shared path has a stable product configuration, but that is intentionally out of
-scope for this documentation/build-entry-only phase.
+scope for this conservative cleanup phase.
 
 ---
 
-## 6. Bring-up macros that CANNOT be deleted yet (justification)
+## 6. Centralized SRE defaults introduced in Phase 2
+
+`llvm/include/llvm/ExecutionEngine/EJIT/EJitSreConfig.h` is the single local
+header for SRE-facing default constants:
+
+- `EJIT_SRE_CODE_POOL_SIZE`
+- `EJIT_SRE_CODE_POOL_PTNO`
+- `EJIT_SRE_CODE_POOL_MID`
+- `EJIT_SRE_TASK_PRIORITY`
+- `EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE`
+- fixed page-size constants used by the SRE adapter (`2MiB`, `4KiB`)
+
+This is a code-layout cleanup only. The CMake cache variables and compile-time
+macros remain the source of values, and the generated binary sees the same
+constants as before. The goal is to avoid repeating fallback `#ifndef` blocks
+and magic defaults in multiple SRE adapter files.
+
+---
+
+## 7. Bring-up macros that CANNOT be deleted yet (justification)
 
 The task specifically asks why the following cannot be removed. Note that some
 are compile-time paths still under active bring-up and some are simply not
@@ -147,7 +170,7 @@ present here.
 
 ---
 
-## 7. Other compile-time defines observed (manual / test-only)
+## 8. Other compile-time defines observed (manual / test-only)
 
 Recorded for completeness; not wired to a CMake option and **not** changed here.
 
@@ -164,7 +187,7 @@ Recorded for completeness; not wired to a CMake option and **not** changed here.
 
 ---
 
-## 8. `build.sh` flag precedence (authoritative)
+## 9. `build.sh` flag precedence (authoritative)
 
 `build.sh` parses flags **left to right**; for any switch that maps to the same
 underlying variable, **the last occurrence on the command line wins**. This is
@@ -191,7 +214,7 @@ Consequences:
 - Old explicit flags remain fully supported and are the recommended way to be
   unambiguous. Profiles are conveniences, not replacements.
 
-### 8.1 Aggregate profile expansions (Phase 1)
+### 9.1 Aggregate profile expansions (Phase 1)
 
 | Aggregate flag | Expands to (existing switches only) |
 |----------------|-------------------------------------|
@@ -207,9 +230,10 @@ Consequences:
 
 ---
 
-## 9. Runtime behavior statement
+## 10. Runtime behavior statement
 
-Phase 1 changes are **documentation** plus **pure `build.sh` convenience
-aliases**. No CMake option semantics change, no macro is added or removed, and
-the default build (`./build.sh <debug|release> <arch>` with no EJIT flags) is
-byte-for-byte identical to before. **Runtime behavior is unchanged.**
+Phase 2 changes are **documentation**, **pure `build.sh` convenience aliases**,
+and **centralized SRE default constants**. No CMake option semantics change, no
+macro is added or removed, and the default build (`./build.sh <debug|release>
+<arch>` with no EJIT flags) uses the same values as before. **Runtime behavior
+is unchanged.**

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -564,6 +564,35 @@ if(EJIT_SRE_DIAG)
   add_definitions(-DEJIT_SRE_DIAG)
 endif()
 
+#===-- EmbeddedJIT SRE product profile -----------------------------------===#
+# Product profile for the currently validated SRE deployment shape. This is a
+# high-level build preset, not a replacement for the lower-level switches: the
+# individual options remain available for bring-up and bisecting.
+#
+# Included:
+#   - standard backend trimming for size
+#   - SRE code pool + enable_ex sealing
+#   - taskpool scheduler
+#   - cross-core shared taskpool
+#
+# Intentionally NOT included:
+#   - EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL (still a separate riskier trim)
+#   - EJIT_SRE_SHARED_CODE_POINTERS (requires platform same-VA/coherency proof)
+option(EJIT_SRE_PROFILE
+  "Enable the SRE product profile: backend trim + SRE code pool + shared taskpool" OFF)
+if(EJIT_SRE_PROFILE)
+  set(EJIT_TRIM_LLVM_BACKEND ON CACHE BOOL
+      "Trim LLVM backend pieces used by EJIT" FORCE)
+  set(EJIT_SRE_CODE_POOL ON CACHE BOOL
+      "Use the EmbeddedJIT SRE code pool" FORCE)
+  set(EJIT_SRE_TASKPOOL ON CACHE BOOL
+      "Enable the EmbeddedJIT SRE taskpool scheduler" FORCE)
+  set(EJIT_SRE_SHARED_TASKPOOL ON CACHE BOOL
+      "Enable the EmbeddedJIT cross-core shared taskpool" FORCE)
+  message(STATUS "EmbeddedJIT: SRE product profile enabled "
+                 "(backend trim + code pool + shared taskpool)")
+endif()
+
 option(EJIT_TRIM_LLVM_BACKEND "Trim LLVM backend pieces used by EJIT: disable heavyweight debug info, GlobalISel, and optional AArch64 SME/SVE passes" OFF)
 if(EJIT_TRIM_LLVM_BACKEND)
   add_definitions(-DEJIT_TRIM_LLVM_BACKEND)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreConfig.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreConfig.h
@@ -1,0 +1,66 @@
+//===-- EJitSreConfig.h - SRE build-time configuration ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITSRECONFIG_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITSRECONFIG_H
+
+#include <cstddef>
+#include <cstdint>
+
+#ifndef EJIT_SRE_CODE_POOL_SIZE
+#define EJIT_SRE_CODE_POOL_SIZE                                                \
+  (static_cast<unsigned long long>(2) * 1024 * 1024)
+#endif
+
+#ifndef EJIT_SRE_CODE_POOL_PTNO
+#define EJIT_SRE_CODE_POOL_PTNO 8
+#endif
+
+#ifndef EJIT_SRE_CODE_POOL_MID
+#define EJIT_SRE_CODE_POOL_MID 0
+#endif
+
+#ifndef EJIT_SRE_TASK_PRIORITY
+#define EJIT_SRE_TASK_PRIORITY 20u
+#endif
+
+#ifndef EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE
+#define EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE (1024u * 1024u)
+#endif
+
+namespace llvm {
+namespace ejit {
+namespace sre_config {
+
+constexpr std::size_t k2MiB = static_cast<std::size_t>(2) * 1024 * 1024;
+constexpr std::size_t k4KiB = static_cast<std::size_t>(4) * 1024;
+
+constexpr unsigned long long kCodePoolSize = EJIT_SRE_CODE_POOL_SIZE;
+constexpr unsigned char kCodePoolPtNo =
+    static_cast<unsigned char>(EJIT_SRE_CODE_POOL_PTNO);
+constexpr unsigned kCodePoolMid = static_cast<unsigned>(EJIT_SRE_CODE_POOL_MID);
+
+constexpr unsigned kTaskPriority = static_cast<unsigned>(EJIT_SRE_TASK_PRIORITY);
+constexpr std::uint32_t kWorkerStackSize =
+    static_cast<std::uint32_t>(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE);
+
+static_assert(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE > 0u,
+              "worker stack size must be non-zero");
+static_assert(
+    EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE % 16u == 0u,
+    "worker stack size must be 16-byte aligned (AArch64 SP alignment)");
+static_assert(
+    static_cast<unsigned long long>(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE) <=
+        0xFFFFFFFFull,
+    "worker stack size must fit the 32-bit TSK_INIT_PARAM_S.uwStackSize");
+
+} // namespace sre_config
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITSRECONFIG_H

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -22,30 +22,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
-
-#ifndef EJIT_SRE_CODE_POOL_SIZE
-#define EJIT_SRE_CODE_POOL_SIZE                                                \
-  (static_cast<unsigned long long>(2) * 1024 * 1024)
-#endif
-
-#ifndef EJIT_SRE_CODE_POOL_PTNO
-#define EJIT_SRE_CODE_POOL_PTNO 8
-#endif
-
-// Memory module id passed to SRE_MemDbgAlloc. Not architecturally significant
-// for the pool; overridable if a deployment needs a specific id.
-#ifndef EJIT_SRE_CODE_POOL_MID
-#define EJIT_SRE_CODE_POOL_MID 0
-#endif
-
-namespace {
-constexpr unsigned long long kSrePoolSize = EJIT_SRE_CODE_POOL_SIZE;
-constexpr unsigned char kSrePtNo =
-    static_cast<unsigned char>(EJIT_SRE_CODE_POOL_PTNO);
-constexpr unsigned kSreMid = static_cast<unsigned>(EJIT_SRE_CODE_POOL_MID);
-constexpr size_t k2MiB = static_cast<size_t>(2) * 1024 * 1024;
-constexpr size_t k4KiB = static_cast<size_t>(4) * 1024;
-} // namespace
+#include "llvm/ExecutionEngine/EJIT/EJitSreConfig.h"
 
 //===----------------------------------------------------------------------===//
 // Platform primitives (declaration only — defined by the platform/business)
@@ -75,21 +52,23 @@ extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
 std::unique_ptr<llvm::ejit::EJitCodePoolManager>
 llvm::ejit::makeSreCodePoolManager() {
   EJitCodePoolManager::Options Opts;
-  Opts.poolSize = static_cast<size_t>(kSrePoolSize);
-  Opts.poolAlign = k2MiB; // large-page / split granularity
+  Opts.poolSize = static_cast<size_t>(sre_config::kCodePoolSize);
+  Opts.poolAlign = sre_config::k2MiB; // large-page / split granularity
   Opts.minCodeAlign = 64;
   EJIT_DIAG("makeSreCodePoolManager: poolSize=%llu poolAlign=%zu",
-            kSrePoolSize, k2MiB);
+            sre_config::kCodePoolSize, sre_config::k2MiB);
 #ifdef EJIT_CODE_POOL_4K_SEAL
   // Adapt to the platform's 4K execute-permission interface: the 2MiB pool is
   // split into 4K mappings at creation and sealed one 4KiB page at a time.
   Opts.fourKSeal = true;
-  Opts.sealPageSize = k4KiB;
+  Opts.sealPageSize = sre_config::k4KiB;
 #endif
 
   auto RawAlloc = [](size_t Bytes) -> void * {
-    return SRE_MemDbgAlloc(kSreMid, kSrePtNo, static_cast<unsigned long>(Bytes),
-                           __func__, __LINE__);
+    return SRE_MemDbgAlloc(sre_config::kCodePoolMid,
+                           sre_config::kCodePoolPtNo,
+                           static_cast<unsigned long>(Bytes), __func__,
+                           __LINE__);
   };
 
   auto Seal = [](void *Va) -> unsigned {
@@ -130,7 +109,8 @@ bool llvm::ejit::prepareSreCodeForCurrentCore(const void *FnPtr) {
     return false;
   }
   const auto Address = reinterpret_cast<uintptr_t>(FnPtr);
-  const auto PoolBase = Address & ~(static_cast<uintptr_t>(k2MiB) - 1);
+  const auto PoolBase =
+      Address & ~(static_cast<uintptr_t>(sre_config::k2MiB) - 1);
   unsigned Rc = ejit_sre_enable_ex(1, static_cast<unsigned long long>(PoolBase));
   if (Rc != 0) {
     EJIT_DIAG("prepareSreCode FAIL: enable_ex poolBase=0x%llx rc=%u",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSreTask_sre.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSreTask_sre.cpp
@@ -1,6 +1,7 @@
 //===-- EJitSreTask_sre.cpp - SRE task implementation shim ---------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitSreConfig.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSreTask.h"
 
 #ifdef EJIT_FREESTANDING
@@ -27,28 +28,6 @@ struct TSK_INIT_PARAM_S {
 };
 
 namespace {
-
-#ifndef EJIT_SRE_TASK_PRIORITY
-#define EJIT_SRE_TASK_PRIORITY 20u
-#endif
-
-// Worker task stack size: the SINGLE source of truth is the CMake option
-// EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE (default 1 MiB, defined whenever
-// EJIT_SRE_TASKPOOL is ON). The LLVM optimize/codegen/ORC/JITLink pipeline runs
-// on THIS stack, so 64 KiB is not enough. The fallback below exists ONLY for a
-// non-CMake compile; CMake builds always pass -D so it is never used there.
-#ifndef EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE
-#define EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE (1024u * 1024u)
-#endif
-static_assert(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE > 0u,
-              "worker stack size must be non-zero");
-static_assert(
-    EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE % 16u == 0u,
-    "worker stack size must be 16-byte aligned (AArch64 SP alignment)");
-static_assert(
-    static_cast<unsigned long long>(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE) <=
-        0xFFFFFFFFull,
-    "worker stack size must fit the 32-bit TSK_INIT_PARAM_S.uwStackSize");
 
 constexpr uint32_t kSreOk = 0;
 constexpr const char kDefaultTaskName[] = "ejit_worker";
@@ -90,10 +69,10 @@ bool EJitSreTask::create(EJitSreTask &out, EntryFn entry, void *ctx,
 
   TSK_INIT_PARAM_S init{};
   init.pfnTaskEntry = &taskTrampoline;
-  init.usTaskPrio = static_cast<TSK_PRIOR_T>(EJIT_SRE_TASK_PRIORITY);
+  init.usTaskPrio = static_cast<TSK_PRIOR_T>(sre_config::kTaskPriority);
   init.auwArgs[0] = static_cast<TSK_ARG_T>(reinterpret_cast<uintptr_t>(entry));
   init.auwArgs[1] = static_cast<TSK_ARG_T>(reinterpret_cast<uintptr_t>(ctx));
-  init.uwStackSize = static_cast<uint32_t>(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE);
+  init.uwStackSize = sre_config::kWorkerStackSize;
   init.pcName = name ? name : kDefaultTaskName;
   EJIT_DIAG("platform task stack size=%u bytes",
             static_cast<unsigned>(init.uwStackSize));


### PR DESCRIPTION
## Summary / 摘要

This PR adds a conservative SRE build-profile cleanup on top of `ejit_dev_spec4`.

本 PR 在 `ejit_dev_spec4` 上做一组偏保守的 SRE 构建入口整理：不删除底层开关，不重写 taskpool/codepool 运行时，只增加稳定产品路径的一键入口，并集中默认参数。

## Changes / 改动

- Add `jit_design_doc/EJIT_MACRO_MATRIX.md` to document the current EJIT macro matrix and cleanup boundary.
- Add build.sh aggregate entries:
  - `--ejit-sre-code-pool-profile`
  - `--ejit-sre-profile`
  - `--ejit-sre-async-profile` as a compatibility alias.
- Add `EJitSreConfig.h` as the single local source for SRE default constants used by SRE adapters.
- Add CMake `EJIT_SRE_PROFILE`, the official SRE product profile:
  - `EJIT_TRIM_LLVM_BACKEND=ON`
  - `EJIT_SRE_CODE_POOL=ON`
  - `EJIT_SRE_TASKPOOL=ON`
  - `EJIT_SRE_SHARED_TASKPOOL=ON`
- Keep these explicitly opt-in:
  - `EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL`
  - `EJIT_SRE_SHARED_CODE_POINTERS`
- Make `build.sh --no-ccache` clear stale CMake compiler launcher cache entries.
- Cap build.sh internal Ninja invocations at `-j8`.

## Rationale / 背景

SRE bring-up now effectively uses the stable combination of shared taskpool + SRE code pool + standard backend trim. Rather than deleting the lower-level switches immediately, this PR introduces a product profile while preserving the individual knobs for debugging, bisection, and future bring-up.

当前 SRE 稳定路径基本是 shared taskpool + code pool + 普通 backend trim。这里先不急着删宏或合并实现，避免把已经跑通的路径改坏；先提供一个正式 profile，把产品构建入口收口起来。

## Validation / 验证

Configured with:

```bash
./build.sh release aarch64 -c --no-ccache --ejit-sre-profile
```

Built with `-j8`:

```bash
ninja -C build_release_aarch64 LLVMEJIT EJITTaskPoolTests EJITSharedTaskPoolTests EJITCodePoolTests -j8
```

Tests:

```bash
./build_release_aarch64/unittests/ExecutionEngine/EJIT/EJITTaskPoolTests        # 75/75 PASS
./build_release_aarch64/unittests/ExecutionEngine/EJIT/EJITSharedTaskPoolTests  # 53/53 PASS
./build_release_aarch64/unittests/ExecutionEngine/EJIT/EJITCodePoolTests        # 40/40 PASS
```

Also checked:

```bash
bash -n build.sh
git diff --check
```

## Notes / 说明

- Default build behavior remains unchanged unless `EJIT_SRE_PROFILE` / `--ejit-sre-profile` is explicitly enabled.
- `experimental trim` is intentionally not bundled into the product profile.
- shared code pointer consumption remains a separate explicit opt-in because it depends on platform same-VA and cache-coherency guarantees.