### PR TITLE
[EJIT] default period instances to inactive, require explicit ejit_ac…

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -318,11 +318,12 @@ bool EJit::activate(const std::string &periodName, uint8_t cellIdx) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
     // Cross-core: activation is a SHARED fact. Write the shared enabled/version
     // (visible to the owner worker, which compiles on a different core). The
-    // owner-private runtimeState_ is NOT the JIT gate's source of truth here —
-    // in an owner!=producer split the owner never calls activate_all, so its
-    // private state would be empty and every compile would be gated out. The
-    // shared SwitchController defaults to active; setEnabled(true) is a no-op
-    // until a prior deactivate flipped the bit.
+    // owner-private runtimeState_ is NOT the JIT gate's source of truth here.
+    // The shared SwitchController defaults to INACTIVE (enabled=0), so the
+    // producer MUST call ejit_activate before the owner will compile a given
+    // period instance. setEnabled(true) flips 0->1 + bumps version on first
+    // activate; it is a no-op while already active, until a deactivate flips
+    // the bit back.
     if (EJitSharedTaskPool *sp = sharedTaskPool())
       sp->setInstanceEnabled(dt, cellIdx, /*enabled=*/true);
 #else

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -317,13 +317,13 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, bool storeLru) {
   for (unsigned i = 0; i < dimCount; ++i) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
     // Cross-core: gate on the SHARED enabled bit (the one the producer's
-    // ejit_activate writes), NOT the owner-private runtimeState_. In an
-    // owner!=producer split the worker compiles on the owner core, whose
-    // private runtimeState_ is empty (the owner never calls activate_all), so
-    // the legacy gate would reject every compile. The shared SwitchController
-    // defaults to active; a deactivate flips the bit + bumps version. Race
-    // protection during compilation is handled by runCompile's version
-    // checkpoints (cp1/cp2), not this gate.
+    // ejit_activate writes), NOT the owner-private runtimeState_. The shared
+    // SwitchController defaults to INACTIVE (initSharedStorage sets enabled=0),
+    // matching the non-shared path: a period instance must be explicitly
+    // ejit_activate'd before the JIT will compile it. activate flips 0->1 +
+    // bumps version; deactivate flips 1->0 + bumps version. Race protection
+    // during compilation is handled by runCompile's version checkpoints
+    // (cp1/cp2), not this gate.
     uint32_t dt = meta.dimTypes[i];
     if (dt == kEJitInvalidDimType || !sharedPool_.isInstanceActive(dt, dims[i])) {
       EJIT_DIAG("compile SKIP key=0x%016lx func=%s: period %s[%u] not active",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -633,10 +633,15 @@ void EJitSharedTaskPool::releaseRead(uint32_t bucketIndex) {
 namespace {
 // Field-by-field init so it is correct on raw, uninitialized shared memory
 // (never relies on a C++ constructor having run on the blob).
+//
+// enabled defaults to 0 (inactive): a period instance must be explicitly
+// activated via ejit_activate before the JIT will compile it. This matches
+// the non-shared EJitRuntimeState::isActive default (no entry => inactive).
+// setInstanceEnabled(true) flips 0->1 and bumps version on first activate.
 void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
   for (uint32_t d = 0; d < kEJitSharedDimTypes; ++d)
     for (uint32_t i = 0; i < kEJitSharedInstances; ++i) {
-      st->enabled[d][i].storeRelaxed(1);
+      st->enabled[d][i].storeRelaxed(0);
       st->version[d][i].storeRelaxed(0);
     }
   st->mode.storeRelaxed(mode);


### PR DESCRIPTION
…tivate

initSharedStorage initialized the shared SwitchController enabled bit to 1 (active), so every period instance was JIT-compilable immediately after ejit_init — any ejit_entry call triggered compilation without a prior ejit_activate. This also diverged from the non-shared path (EJitRuntimeState::isActive returns false when no activate entry exists).

Flip the default to 0 (inactive) so a period instance must be explicitly ejit_activate'd before the JIT compile gate (compileCold) will compile it; otherwise the wrapper falls back to the AOT body. setInstanceEnabled already flips 0->1 and bumps the version on first activate, so cache invalidation semantics are unchanged. As a side benefit, unactivated periods no longer enter the compile path, avoiding the failed-compile JITDylib leaks that contributed to the OOM in run1.log.

Update the two stale "defaults to active" comments in EJit.cpp and EJitCompileDriver.cpp.