### PR TITLE
[EJIT] Use config copy in EJitCompileDriver initialization for ASYNC JIT

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -112,7 +112,7 @@ EJit::EJit(const Config &config) : config_(config) {
   EJitLogger *logger = nullptr;
 #endif
   compileDriver_ = std::make_unique<EJitCompileDriver>(
-      config, *cache_, *runtimeState_, *moduleLoader_, logger);
+      config_, *cache_, *runtimeState_, *moduleLoader_, logger);
 
   // Consume registration data from the staging store (constructor path).
   StoredData data = EJitRegistrationStore::instance().consume();


### PR DESCRIPTION
I've noticed that some `config` values aren't being propagated properly. I was working on some optimizations that involved using the value `config.optLevel`, and it was mostly garbage random values.

The worker thread starts during `ejit_init` but only reads `config_` when the actual compilation happens, which is triggered much later, after `ejit_init` returns. So the value dereferenced in [EJitCompileDriver.cpp](https://github.com/dongjianqiang2/llvm-project/blob/895ebf2bcc3ca94e07bbf5c5524ad5aee648638b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp#L352) is garbage by the time the worker thread reads it.

We should store a copy of `config` instead of binding a reference to the value passed to the constructor.