### PR TITLE
[EJIT] IR/ASM Diagnostic Dump, Extern Metadata Fix, Static Entry Linkag

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -53,6 +53,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/BinaryFormat/ELF.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 #include "llvm/IR/AttributeMask.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DataLayout.h"
@@ -5460,8 +5461,25 @@ llvm::Constant *CodeGenModule::GetAddrOfGlobalVar(const VarDecl *D,
     Ty = getTypes().ConvertTypeForMem(ASTTy);
 
   StringRef MangledName = getMangledName(D);
-  return GetOrCreateLLVMGlobal(MangledName, Ty, ASTTy.getAddressSpace(), D,
-                               IsForDefinition);
+  llvm::Constant *Addr = GetOrCreateLLVMGlobal(MangledName, Ty,
+                                               ASTTy.getAddressSpace(), D,
+                                               IsForDefinition);
+
+  // EmbeddedJIT: emit !ejit.metadata for ejit_period/ejit_period_arr globals
+  // on EXTERN DECLARATIONS too, not only definitions. Using TUs reference
+  // these globals via inlined accessors (e.g. getData(idx)); without metadata
+  // on the extern decl, the extracted bitcode's @g_ptr lacks it and the JIT
+  // struct-field pass cannot recognize the period variable (gvPeriodMap_
+  // empty → replaced=0). EmitGlobalVarDefinition attaches it on the
+  // definition; this covers the declaration path. Guarded so a global that
+  // already has metadata (e.g. the definition was emitted first) is not
+  // re-worked.
+  if (auto *GV = dyn_cast<llvm::GlobalVariable>(Addr))
+    if ((D->hasAttr<EjitPeriodAttr>() || D->hasAttr<EjitPeriodArrAttr>()) &&
+        !GV->hasMetadata(llvm::ejit::MD_EJIT_METADATA))
+      emitEjitGlobalMetadata(*this, D, GV);
+
+  return Addr;
 }
 
 /// CreateRuntimeVariable - Create a new runtime global variable with the

--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -22,6 +22,13 @@ Override with --cxx / --ld for cross-compilation.
 
 The resulting ejit.o (~30-40 MB) can replace all individual LLVM .a files
 when linking EJIT test binaries.
+
+When the EJIT ASM diagnostic dump (ejit_dump_func / ejit_print_dumped) is
+enabled on SRE, also add ejit_test/stubs/ejit_sre_format_stubs.o to the final
+SRE link/merge command alongside ejit.o. The assembly emitter formats text into
+an in-memory raw_svector_ostream and therefore needs working buffer formatting
+(snprintf/vsnprintf); that stub supplies it. It is intentionally NOT merged into
+ejit.o here so host builds keep using the platform libc.
 """
 
 import subprocess as sp, os, sys, re, argparse, struct, glob
@@ -348,7 +355,8 @@ def doit_gc_merge(args):
         "ejit_register_lifecycle", "ejit_register_funcindex",
         "ejit_taskpool_compile_or_get", "ejit_taskpool_release_read",
         "ejit_taskpool_set_instance_enabled", "ejit_taskpool_pending_count",
-        "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core"
+        "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
+        "ejit_taskpool_print_compiled", "ejit_dump_func", "ejit_print_dumped"
     ]
 
     defined = set()

--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -358,6 +358,11 @@ def doit_gc_merge(args):
         "ejit_register_period_array", "ejit_register_static_var",
         "ejit_clear_cache", "ejit_compile_or_get", "ejit_invalidate",
         "ejit_set_compile_mode", "ejit_get_compile_mode", "ejit_get_last_error",
+        # General diagnostics (always available — defined outside the
+        # EJIT_SRE_TASKPOOL ifdef in EJitRuntime.cpp).
+        "ejit_set_log_level", "ejit_get_log_level",
+        "ejit_print_registry", "ejit_print_func_meta",
+        "ejit_dump_all",
     ]
     optional_api = [
         "ejit_register_lifecycle", "ejit_register_funcindex",

--- a/ejit_test/stubs/ejit_sre_format_stubs.cpp
+++ b/ejit_test/stubs/ejit_sre_format_stubs.cpp
@@ -1,0 +1,436 @@
+//===-- ejit_sre_format_stubs.cpp - SRE buffer-formatting stubs -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Why this file exists
+// --------------------
+// EmbeddedJIT's on-demand ASM diagnostic dump (ejit_dump_func /
+// ejit_print_dumped) drives the LLVM code emitter down the human-readable
+// assembly path:
+//
+//     TargetMachine::addPassesToEmitFile(..., AssemblyFile)  ->  PM.run(M)
+//       -> AsmPrinter::emitFunctionBody
+//       -> AArch64AsmPrinter::emitInstruction
+//       -> MCAsmStreamer::emitInstruction
+//       -> AArch64InstPrinter::printInst
+//       -> raw_ostream::operator<<(llvm::format_object_base const&)
+//
+// The final step writes formatted text into an in-memory
+// raw_svector_ostream(AsmBuf). llvm::format_object_base implements that by
+// calling the C library snprintf()/vsnprintf() to render each field into a
+// scratch buffer. On SRE / bare-metal firmware those two functions are often
+// missing or non-functional, so the call crashes (the observed SRE stack ends
+// in raw_ostream::operator<<(format_object_base const&)).
+//
+// SRE_printf() alone cannot fix this: it prints to the device console and does
+// NOT populate AsmBuf. The missing capability is *buffer* formatting
+// (snprintf/vsnprintf-like), not console printing. This file provides exactly
+// that, isolated from the rest of EmbeddedJIT.
+//
+// How to use it on SRE / in the lipo flow
+// ---------------------------------------
+// This is a standalone optional object. It is NOT compiled into libLLVMEJIT.a
+// (so host builds keep using the real libc snprintf). When the SRE final image
+// is linked with ASM dump enabled, add this object to the final link / lipo
+// merge command so the emitter's snprintf/vsnprintf calls resolve here, e.g.:
+//
+//     clang++ --target=aarch64_be-... -std=c++17 -fno-exceptions -fno-rtti \
+//         -c ejit_test/stubs/ejit_sre_format_stubs.cpp -o ejit_sre_format_stubs.o
+//     <final-sre-link> ... ejit.o ejit_sre_format_stubs.o ...
+//
+// The libc-named definitions (::snprintf / ::vsnprintf) can be suppressed with
+// -DEJIT_SRE_FORMAT_STUBS_NO_LIBC_NAMES (used by the host unit test so it does
+// not clash with the platform libc). The core ejit_mini_* entry points are
+// always available.
+//
+// Deliberate limitations
+// ----------------------
+// This mini formatter targets what LLVM's AsmPrinter / AArch64InstPrinter need
+// for integer/pointer/text fields. It intentionally does NOT implement full
+// floating-point formatting; %f/%F/%e/%g consume their double argument (to keep
+// va_list alignment correct) and emit a coarse fixed-point approximation. It is
+// a diagnostic aid, not a conformant libc.
+//
+// Freestanding-friendly: no heap, no std::string / iostream / locale / mutex /
+// condition_variable / future, no exceptions / RTTI, no raw_ostream / errs() /
+// outs().
+//
+//===----------------------------------------------------------------------===//
+
+#include "ejit_sre_format_stubs.h"
+
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+
+// Sink that respects the caller-provided capacity while counting the full
+// (would-be) length, matching C99 vsnprintf return semantics.
+struct OutBuf {
+  char *buf;
+  size_t size;   // total capacity of buf (including NUL slot)
+  size_t pos;    // bytes written into buf so far (excluding NUL)
+  size_t total;  // bytes that would be written if buf were unbounded
+
+  void put(char c) {
+    if (buf && size > 0 && pos + 1 < size)
+      buf[pos++] = c;
+    ++total;
+  }
+};
+
+size_t mini_strlen(const char *s) {
+  size_t n = 0;
+  while (s[n])
+    ++n;
+  return n;
+}
+
+enum Length { LEN_NONE, LEN_L, LEN_LL, LEN_Z };
+
+struct Spec {
+  bool leftAlign = false;
+  bool zeroPad = false;
+  bool altForm = false; // '#'
+  bool plusSign = false;
+  bool spaceSign = false;
+  int width = 0;
+  int prec = -1; // negative => unspecified
+  Length length = LEN_NONE;
+};
+
+void pad(OutBuf &ob, char c, int n) {
+  for (int i = 0; i < n; ++i)
+    ob.put(c);
+}
+
+// Emit an unsigned magnitude in the given base, applying an optional textual
+// prefix (sign, "0x", ...) and width/zero-padding rules.
+void emit_unsigned(OutBuf &ob, unsigned long long val, unsigned base,
+                   bool upper, const Spec &s, const char *prefix) {
+  char tmp[64];
+  int n = 0;
+  const char *digits = upper ? "0123456789ABCDEF" : "0123456789abcdef";
+  if (val == 0) {
+    tmp[n++] = '0';
+  } else {
+    while (val > 0) {
+      tmp[n++] = digits[val % base];
+      val /= base;
+    }
+  }
+  // Precision on integers = minimum number of digits (zero-fill).
+  int precZeros = 0;
+  if (s.prec >= 0 && s.prec > n)
+    precZeros = s.prec - n;
+
+  int prefixLen = prefix ? (int)mini_strlen(prefix) : 0;
+  int bodyLen = prefixLen + precZeros + n;
+  int spaces = s.width > bodyLen ? s.width - bodyLen : 0;
+
+  // When zero-padding (and no explicit precision) the zeros go between the
+  // prefix and the digits; otherwise pad with spaces on the correct side.
+  bool zeroFill = s.zeroPad && !s.leftAlign && s.prec < 0;
+
+  if (!s.leftAlign && !zeroFill)
+    pad(ob, ' ', spaces);
+  for (int i = 0; i < prefixLen; ++i)
+    ob.put(prefix[i]);
+  if (zeroFill)
+    pad(ob, '0', spaces);
+  pad(ob, '0', precZeros);
+  for (int i = n - 1; i >= 0; --i)
+    ob.put(tmp[i]);
+  if (s.leftAlign)
+    pad(ob, ' ', spaces);
+}
+
+void emit_signed(OutBuf &ob, long long val, const Spec &s) {
+  bool neg = val < 0;
+  // Two's-complement safe magnitude (handles LLONG_MIN without UB).
+  unsigned long long mag =
+      neg ? (~static_cast<unsigned long long>(val) + 1ULL)
+          : static_cast<unsigned long long>(val);
+  const char *prefix = neg ? "-" : (s.plusSign ? "+" : (s.spaceSign ? " " : ""));
+  emit_unsigned(ob, mag, 10, false, s, prefix);
+}
+
+// Coarse fixed-point rendering of a double. Diagnostic-grade only.
+void emit_double(OutBuf &ob, double val, const Spec &s) {
+  const char *sign = "";
+  if (val < 0) {
+    sign = "-";
+    val = -val;
+  } else if (s.plusSign) {
+    sign = "+";
+  } else if (s.spaceSign) {
+    sign = " ";
+  }
+  int prec = s.prec >= 0 ? s.prec : 6;
+  unsigned long long intPart = (unsigned long long)val;
+  double frac = val - (double)intPart;
+
+  for (const char *p = sign; *p; ++p)
+    ob.put(*p);
+  // Integer part.
+  {
+    char tmp[32];
+    int n = 0;
+    if (intPart == 0) {
+      tmp[n++] = '0';
+    } else {
+      while (intPart > 0) {
+        tmp[n++] = (char)('0' + (int)(intPart % 10ULL));
+        intPart /= 10ULL;
+      }
+    }
+    for (int i = n - 1; i >= 0; --i)
+      ob.put(tmp[i]);
+  }
+  if (prec > 0) {
+    ob.put('.');
+    for (int i = 0; i < prec; ++i) {
+      frac *= 10.0;
+      int d = (int)frac;
+      if (d < 0)
+        d = 0;
+      if (d > 9)
+        d = 9;
+      ob.put((char)('0' + d));
+      frac -= (double)d;
+    }
+  }
+}
+
+int parse_int(const char *&f) {
+  int v = 0;
+  while (*f >= '0' && *f <= '9') {
+    v = v * 10 + (*f - '0');
+    ++f;
+  }
+  return v;
+}
+
+} // namespace
+
+extern "C" int ejit_mini_vsnprintf(char *buf, size_t size, const char *fmt,
+                                   va_list ap) {
+  OutBuf ob{buf, size, 0, 0};
+
+  for (const char *f = fmt; *f; ++f) {
+    if (*f != '%') {
+      ob.put(*f);
+      continue;
+    }
+    ++f; // consume '%'
+    if (*f == '%') {
+      ob.put('%');
+      continue;
+    }
+
+    Spec s;
+    // Flags.
+    for (;; ++f) {
+      if (*f == '-')
+        s.leftAlign = true;
+      else if (*f == '0')
+        s.zeroPad = true;
+      else if (*f == '#')
+        s.altForm = true;
+      else if (*f == '+')
+        s.plusSign = true;
+      else if (*f == ' ')
+        s.spaceSign = true;
+      else
+        break;
+    }
+    // Width (digits or '*').
+    if (*f == '*') {
+      s.width = va_arg(ap, int);
+      if (s.width < 0) {
+        s.leftAlign = true;
+        s.width = -s.width;
+      }
+      ++f;
+    } else {
+      s.width = parse_int(f);
+    }
+    // Precision.
+    if (*f == '.') {
+      ++f;
+      if (*f == '*') {
+        s.prec = va_arg(ap, int);
+        ++f;
+      } else {
+        s.prec = parse_int(f);
+      }
+      if (s.prec < 0)
+        s.prec = -1;
+    }
+    // Length modifiers.
+    if (*f == 'l') {
+      ++f;
+      if (*f == 'l') {
+        s.length = LEN_LL;
+        ++f;
+      } else {
+        s.length = LEN_L;
+      }
+    } else if (*f == 'z') {
+      s.length = LEN_Z;
+      ++f;
+    } else if (*f == 'h') {
+      ++f;
+      if (*f == 'h')
+        ++f; // 'hh' -> promoted to int anyway
+    } else if (*f == 'j' || *f == 't') {
+      s.length = LEN_LL;
+      ++f;
+    }
+
+    char conv = *f;
+    switch (conv) {
+    case 'd':
+    case 'i': {
+      long long v;
+      if (s.length == LEN_LL)
+        v = va_arg(ap, long long);
+      else if (s.length == LEN_L)
+        v = (long long)va_arg(ap, long);
+      else if (s.length == LEN_Z)
+        v = (long long)va_arg(ap, long);
+      else
+        v = (long long)va_arg(ap, int);
+      emit_signed(ob, v, s);
+      break;
+    }
+    case 'u':
+    case 'x':
+    case 'X':
+    case 'o': {
+      unsigned long long v;
+      if (s.length == LEN_LL)
+        v = va_arg(ap, unsigned long long);
+      else if (s.length == LEN_L)
+        v = va_arg(ap, unsigned long);
+      else if (s.length == LEN_Z)
+        v = (unsigned long long)va_arg(ap, size_t);
+      else
+        v = (unsigned long long)va_arg(ap, unsigned int);
+      unsigned base = (conv == 'o') ? 8 : (conv == 'u') ? 10 : 16;
+      bool upper = (conv == 'X');
+      const char *prefix = "";
+      if (s.altForm && v != 0) {
+        if (conv == 'x')
+          prefix = "0x";
+        else if (conv == 'X')
+          prefix = "0X";
+        else if (conv == 'o')
+          prefix = "0";
+      }
+      emit_unsigned(ob, v, base, upper, s, prefix);
+      break;
+    }
+    case 'p': {
+      void *ptr = va_arg(ap, void *);
+      uintptr_t v = (uintptr_t)ptr;
+      Spec ps = s;
+      emit_unsigned(ob, (unsigned long long)v, 16, false, ps, "0x");
+      break;
+    }
+    case 'c': {
+      char c = (char)va_arg(ap, int);
+      int spaces = s.width > 1 ? s.width - 1 : 0;
+      if (!s.leftAlign)
+        pad(ob, ' ', spaces);
+      ob.put(c);
+      if (s.leftAlign)
+        pad(ob, ' ', spaces);
+      break;
+    }
+    case 's': {
+      const char *str = va_arg(ap, const char *);
+      if (!str)
+        str = "(null)";
+      int len = 0;
+      if (s.prec >= 0) {
+        while (len < s.prec && str[len])
+          ++len;
+      } else {
+        len = (int)mini_strlen(str);
+      }
+      int spaces = s.width > len ? s.width - len : 0;
+      if (!s.leftAlign)
+        pad(ob, ' ', spaces);
+      for (int i = 0; i < len; ++i)
+        ob.put(str[i]);
+      if (s.leftAlign)
+        pad(ob, ' ', spaces);
+      break;
+    }
+    case 'f':
+    case 'F':
+    case 'e':
+    case 'E':
+    case 'g':
+    case 'G': {
+      double d = va_arg(ap, double);
+      emit_double(ob, d, s);
+      break;
+    }
+    case '\0':
+      // Trailing '%' at end of string: emit literally and stop.
+      ob.put('%');
+      --f; // let the loop's ++f land on the NUL and terminate
+      break;
+    default:
+      // Unknown specifier: emit verbatim so nothing is silently dropped.
+      ob.put('%');
+      ob.put(conv);
+      break;
+    }
+  }
+
+  if (ob.buf && ob.size > 0) {
+    size_t term = ob.pos < ob.size ? ob.pos : ob.size - 1;
+    ob.buf[term] = '\0';
+  }
+  return (int)ob.total;
+}
+
+extern "C" int ejit_mini_snprintf(char *buf, size_t size, const char *fmt,
+                                  ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int r = ejit_mini_vsnprintf(buf, size, fmt, ap);
+  va_end(ap);
+  return r;
+}
+
+//===----------------------------------------------------------------------===//
+// libc-named entry points that LLVM's format_object_base actually calls.
+// Suppressed under EJIT_SRE_FORMAT_STUBS_NO_LIBC_NAMES (host unit test) to
+// avoid clashing with the platform libc.
+//===----------------------------------------------------------------------===//
+#ifndef EJIT_SRE_FORMAT_STUBS_NO_LIBC_NAMES
+
+extern "C" int vsnprintf(char *buf, size_t size, const char *fmt, va_list ap) {
+  return ejit_mini_vsnprintf(buf, size, fmt, ap);
+}
+
+extern "C" int snprintf(char *buf, size_t size, const char *fmt, ...) {
+  // Route through vsnprintf so a single mini implementation backs both entry
+  // points. Variadic args cannot be forwarded to another variadic function.
+  va_list ap;
+  va_start(ap, fmt);
+  int r = vsnprintf(buf, size, fmt, ap);
+  va_end(ap);
+  return r;
+}
+
+#endif // EJIT_SRE_FORMAT_STUBS_NO_LIBC_NAMES

--- a/ejit_test/stubs/ejit_sre_format_stubs.h
+++ b/ejit_test/stubs/ejit_sre_format_stubs.h
@@ -1,0 +1,34 @@
+//===-- ejit_sre_format_stubs.h - SRE buffer-formatting stubs -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Declarations for the SRE buffer-formatting stubs. See
+// ejit_sre_format_stubs.cpp for the rationale and usage.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef EJIT_TEST_STUBS_EJIT_SRE_FORMAT_STUBS_H
+#define EJIT_TEST_STUBS_EJIT_SRE_FORMAT_STUBS_H
+
+#include <cstdarg>
+#include <cstddef>
+
+extern "C" {
+
+/// Self-contained mini vsnprintf: formats into \p buf (never allocates, always
+/// NUL-terminates when \p size > 0). Returns the number of characters that
+/// would have been written had the buffer been large enough (like the C
+/// standard vsnprintf), so callers such as LLVM's format_object_base can size
+/// their scratch buffer correctly.
+int ejit_mini_vsnprintf(char *buf, size_t size, const char *fmt, va_list ap);
+
+/// snprintf built on ejit_mini_vsnprintf.
+int ejit_mini_snprintf(char *buf, size_t size, const char *fmt, ...);
+
+} // extern "C"
+
+#endif // EJIT_TEST_STUBS_EJIT_SRE_FORMAT_STUBS_H

--- a/ejit_test/stubs/ejit_sre_format_stubs_test.cpp
+++ b/ejit_test/stubs/ejit_sre_format_stubs_test.cpp
@@ -1,0 +1,87 @@
+//===-- ejit_sre_format_stubs_test.cpp - mini vsnprintf unit test ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Host-side unit test for the bundled mini formatter. It exercises the
+// ejit_mini_snprintf() core directly (rather than the libc-named ::snprintf
+// wrapper) so it can link cleanly against the platform libc.
+//
+// Build/run:
+//   clang++ -std=c++17 -fno-exceptions -fno-rtti \
+//       -DEJIT_SRE_FORMAT_STUBS_NO_LIBC_NAMES \
+//       ejit_test/stubs/ejit_sre_format_stubs.cpp \
+//       ejit_test/stubs/ejit_sre_format_stubs_test.cpp \
+//       -o /tmp/ejit_sre_format_stubs_test
+//   /tmp/ejit_sre_format_stubs_test
+//
+//===----------------------------------------------------------------------===//
+
+#include "ejit_sre_format_stubs.h"
+
+#include <cstdio>
+#include <cstring>
+
+static int g_failures = 0;
+
+static void check(const char *expected, const char *got, const char *what) {
+  bool ok = std::strcmp(expected, got) == 0;
+  std::printf("[%s] %-28s expected=\"%s\" got=\"%s\"\n", ok ? "PASS" : "FAIL",
+              what, expected, got);
+  if (!ok)
+    ++g_failures;
+}
+
+int main() {
+  char b[128];
+
+  ejit_mini_snprintf(b, sizeof(b), "x=%08x", 0x12);
+  check("x=00000012", b, "%08x");
+
+  ejit_mini_snprintf(b, sizeof(b), "p=%p", (void *)0xdeadbeef);
+  check("p=0xdeadbeef", b, "%p");
+
+  ejit_mini_snprintf(b, sizeof(b), "s=%s c=%c d=%d u=%u ll=%016llx", "hi", 'Z',
+                     -42, 42u, (unsigned long long)0x1234ABCDULL);
+  check("s=hi c=Z d=-42 u=42 ll=000000001234abcd", b, "combined");
+
+  ejit_mini_snprintf(b, sizeof(b), "%% %d %i", 7, -7);
+  check("% 7 -7", b, "percent/d/i");
+
+  ejit_mini_snprintf(b, sizeof(b), "%5d|%-5d|%05d", 42, 42, 42);
+  check("   42|42   |00042", b, "width/left/zero");
+
+  ejit_mini_snprintf(b, sizeof(b), "%x %X %#x", 255, 255, 255);
+  check("ff FF 0xff", b, "hex forms");
+
+  ejit_mini_snprintf(b, sizeof(b), "%lu %llu %zu", 1000UL, 1000000000000ULL,
+                     (size_t)4096);
+  check("1000 1000000000000 4096", b, "length modifiers");
+
+  // Truncation: return value is the would-be length; buffer stays terminated.
+  char small[4];
+  int n = ejit_mini_snprintf(small, sizeof(small), "%s", "abcdef");
+  bool trunc_ok = (n == 6) && (std::strcmp(small, "abc") == 0);
+  std::printf("[%s] %-28s ret=%d buf=\"%s\"\n", trunc_ok ? "PASS" : "FAIL",
+              "truncation", n, small);
+  if (!trunc_ok)
+    ++g_failures;
+
+  // size==0 must not touch the buffer but still returns the would-be length.
+  char untouched = 'Q';
+  int n0 = ejit_mini_snprintf(&untouched, 0, "%d", 12345);
+  bool zero_ok = (n0 == 5) && (untouched == 'Q');
+  std::printf("[%s] %-28s ret=%d\n", zero_ok ? "PASS" : "FAIL", "size==0", n0);
+  if (!zero_ok)
+    ++g_failures;
+
+  if (g_failures == 0) {
+    std::printf("ALL PASS\n");
+    return 0;
+  }
+  std::printf("%d FAILURE(S)\n", g_failures);
+  return 1;
+}

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -121,6 +121,15 @@ public:
   /// diagnostics). Always constructed; valid for the lifetime of the instance.
   EJitModuleLoader &moduleLoader() { return *moduleLoader_; }
 
+  /// Print the registered registry (bitcodes, period arrays, static vars) and
+  /// funcIndex/lifecycle counts through EJIT_DIAG. For ejit_print_registry().
+  void printRegistry() const;
+
+  /// Print the !ejit.metadata parsed from \p funcName's registered bitcode
+  /// (ejit_entry marker, period_arr_ind slots, period arrays, may_const field
+  /// offsets). For ejit_print_func_meta(). Non-const: caches func metadata.
+  void printFuncMeta(const std::string &funcName);
+
 private:
   Config config_;
   std::unique_ptr<EJitRuntimeState> runtimeState_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -126,6 +126,10 @@ public:
   const EJitSharedTaskPool *sharedTaskPool() const;
 #endif
 
+  /// Access the module loader (for funcIndex → funcName resolution in
+  /// diagnostics). Always constructed; valid for the lifetime of the instance.
+  EJitModuleLoader &moduleLoader() { return *moduleLoader_; }
+
 private:
   Config config_;
   std::unique_ptr<EJitRuntimeState> runtimeState_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
@@ -17,10 +17,35 @@
 // through the platform-provided SRE_printf(); otherwise diagnostics use
 // std::printf.
 //
+// Runtime log levels (gEJitDiagLevel, default INFO):
+//   OFF(0)    — no output
+//   INFO(1)   — key events: init/shutdown, compile begin/OK/FAIL, cache
+//               HIT/MISS, activation, errors, registration consume summary
+//   VERBOSE(2)— per-item detail: each first-time registration, per-function
+//               struct-field stats, per-call compile_or_get, taskpool requests
+//   DEBUG(3)  — internals: idempotent registration skips, per-load replace
+//               failures, staging internals, funcMeta caching
+//
+// The level mirrors enum ejit_log_level in EJitRuntime.h; raise it at runtime
+// via ejit_set_log_level() to recover full detail without recompiling.  All
+// EJIT_DIAG* call sites are on cold paths (registration, compile, diagnostics),
+// so the single integer compare per call is negligible even on bare-metal.
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_EXECUTIONENGINE_EJIT_EJITDIAG_H
 #define LLVM_EXECUTIONENGINE_EJIT_EJITDIAG_H
+
+// Runtime log-level thresholds. Mirrored by enum ejit_log_level in
+// EJitRuntime.h (the public C ABI contract) — keep the two in sync.
+#define EJIT_LOG_LVL_OFF 0
+#define EJIT_LOG_LVL_INFO 1
+#define EJIT_LOG_LVL_VERBOSE 2
+#define EJIT_LOG_LVL_DEBUG 3
+
+// Process-wide runtime log level. Defined in EJitLogger.cpp (always compiled,
+// hosted and freestanding). Default INFO. Set via ejit_set_log_level().
+extern int gEJitDiagLevel;
 
 #ifdef EJIT_DIAG_ENABLE
 
@@ -30,18 +55,44 @@
 extern "C" int SRE_printf(const char *fmt, ...);
 
 // Keep diagnostics in a single call so the prefix and payload stay on one line.
-#define EJIT_DIAG(fmt, ...)                                                \
-  do {                                                                     \
-    SRE_printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,              \
-               ##__VA_ARGS__);                                             \
+#define EJIT_DIAG(fmt, ...)                                                  \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_INFO)                                 \
+      SRE_printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,               \
+                 ##__VA_ARGS__);                                             \
+  } while (0)
+#define EJIT_DIAG_VERBOSE(fmt, ...)                                          \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE)                              \
+      SRE_printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,               \
+                 ##__VA_ARGS__);                                             \
+  } while (0)
+#define EJIT_DIAG_DEBUG(fmt, ...)                                            \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_DEBUG)                                \
+      SRE_printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,               \
+                 ##__VA_ARGS__);                                             \
   } while (0)
 #else
 #include <cstdio>
 
-#define EJIT_DIAG(fmt, ...)                                                \
-  do {                                                                     \
-    std::printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,              \
-                ##__VA_ARGS__);                                            \
+#define EJIT_DIAG(fmt, ...)                                                  \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_INFO)                                 \
+      std::printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,              \
+                  ##__VA_ARGS__);                                            \
+  } while (0)
+#define EJIT_DIAG_VERBOSE(fmt, ...)                                          \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE)                              \
+      std::printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,              \
+                  ##__VA_ARGS__);                                            \
+  } while (0)
+#define EJIT_DIAG_DEBUG(fmt, ...)                                            \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_DEBUG)                                \
+      std::printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,              \
+                  ##__VA_ARGS__);                                            \
   } while (0)
 #endif
 
@@ -49,6 +100,8 @@ extern "C" int SRE_printf(const char *fmt, ...);
 
 // Expand to ((void)0) regardless of argument count by matching everything.
 #define EJIT_DIAG(...) ((void)0)
+#define EJIT_DIAG_VERBOSE(...) ((void)0)
+#define EJIT_DIAG_DEBUG(...) ((void)0)
 
 #endif // EJIT_DIAG_ENABLE
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -25,6 +25,20 @@ namespace ejit {
 class PeriodArrayRegistry;
 class EJitRuntimeState;
 
+/// Set a function-name filter for JIT IR+ASM diagnostic capture. When non-
+/// empty, the engine captures (saves in memory) the post-optimization IR and
+/// the emitted assembly of any specialization whose entry name exactly
+/// matches, the next time it is compiled. Empty/null disables further
+/// capture (already-captured entries are retained). Captured entries are
+/// printed on demand via printDumped(). Used for performance analysis.
+void setDumpFuncFilter(const std::string &name);
+
+/// Print the saved IR+ASM for \p name (or all saved entries when \p name is
+/// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no
+/// saved capture are reported as missing. Paired with setDumpFuncFilter():
+/// capture at compile time, print selectively later.
+void printDumped(const char *name);
+
 struct SpecializationContext {
   std::string fnName;
   uint64_t cacheKey = 0;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -24,6 +24,7 @@ namespace ejit {
 
 class PeriodArrayRegistry;
 class EJitRuntimeState;
+struct EJitSharedTaskPoolState;
 
 /// Set a function-name filter for JIT IR+ASM diagnostic capture. When non-
 /// empty, the engine captures (saves in memory) the post-optimization IR and
@@ -32,6 +33,12 @@ class EJitRuntimeState;
 /// capture (already-captured entries are retained). Captured entries are
 /// printed on demand via printDumped(). Used for performance analysis.
 void setDumpFuncFilter(const std::string &name);
+
+/// Bind the optional shared taskpool dump state. In a shared-taskpool build this
+/// lets any core set the dump filter and print the last worker-captured IR/ASM
+/// result. Passing nullptr disables the shared path and falls back to the local
+/// process-static dump store.
+void setDumpSharedState(EJitSharedTaskPoolState *state);
 
 /// Print the saved IR+ASM for \p name (or all saved entries when \p name is
 /// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -183,6 +183,7 @@ typedef struct {
 ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out);
 
 void ejit_taskpool_print_stats();
+void ejit_taskpool_print_compiled();
 uint32_t ejit_taskpool_get_worker_core();
 
 // Cache

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -188,8 +188,9 @@ uint32_t ejit_taskpool_get_worker_core();
 /// non-empty, the next time a specialization whose entry name exactly matches
 /// \p name is JIT-compiled, the engine saves (in memory) its post-optimization
 /// IR and emitted assembly for later printing. Pass NULL or "" to disable
-/// further capture (already-saved entries are retained). For performance
-/// analysis of individual functions.
+/// further capture (already-saved entries are retained). The special name "*"
+/// is a wildcard that captures EVERY specialization (see ejit_dump_all). For
+/// performance analysis of individual functions.
 void ejit_dump_func(const char *name);
 
 /// Print the saved IR+ASM for \p name (or all saved entries when \p name is
@@ -198,6 +199,18 @@ void ejit_dump_func(const char *name);
 /// reported as missing. Paired with ejit_dump_func(): capture at compile
 /// time, print selectively later.
 void ejit_print_dumped(const char *name);
+
+/// Convenience switch to capture IR+ASM for ALL JIT-compiled specializations
+/// (equivalent to ejit_dump_func("*")). When \p enable is true, every
+/// specialization's post-optimization IR and emitted assembly is saved (one
+/// entry per function name, overwritten on re-compile, so the store is bounded
+/// by the number of distinct entry functions); print later with
+/// ejit_print_dumped(NULL). When false, capture is disabled. NOTE: on a
+/// cross-core shared taskpool the captures live on the owner core (the one
+/// that runs the JIT worker); print from the owner core to see all entries,
+/// or use ejit_dump_func(name) for a single function whose capture is shared
+/// across cores.
+void ejit_dump_all(bool enable);
 
 // Cache
 void ejit_clear_cache(void);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -186,6 +186,21 @@ void ejit_taskpool_print_stats();
 void ejit_taskpool_print_compiled();
 uint32_t ejit_taskpool_get_worker_core();
 
+/// Enable name-filtered JIT IR+ASM capture. When \p name is non-null and
+/// non-empty, the next time a specialization whose entry name exactly matches
+/// \p name is JIT-compiled, the engine saves (in memory) its post-optimization
+/// IR and emitted assembly for later printing. Pass NULL or "" to disable
+/// further capture (already-saved entries are retained). For performance
+/// analysis of individual functions.
+void ejit_dump_func(const char *name);
+
+/// Print the saved IR+ASM for \p name (or all saved entries when \p name is
+/// NULL or "") through the platform log, one line per IR/ASM line, labeled
+/// "dump IR func=..." / "dump ASM func=...". Names with no saved capture are
+/// reported as missing. Paired with ejit_dump_func(): capture at compile
+/// time, print selectively later.
+void ejit_print_dumped(const char *name);
+
 // Cache
 void ejit_clear_cache(void);
 void ejit_invalidate(const char *periodName, uint8_t cellIdx);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -212,6 +212,41 @@ void ejit_print_dumped(const char *name);
 /// across cores.
 void ejit_dump_all(bool enable);
 
+/// Runtime diagnostic log level. Mirrors the EJIT_DIAG* macro thresholds.
+///   EJIT_LOG_OFF    — no diagnostic output
+///   EJIT_LOG_INFO   — key events (default): init, compile begin/OK/FAIL,
+///                      cache MISS, activation, errors, registration summary
+///   EJIT_LOG_VERBOSE — per-item detail: each registration, per-function
+///                      struct-field stats, per-call compile_or_get, taskpool
+///   EJIT_LOG_DEBUG  — internals: idempotent skips, per-load replacement
+///                      failures, dump mechanics
+typedef enum {
+  EJIT_LOG_OFF = 0,
+  EJIT_LOG_INFO = 1,
+  EJIT_LOG_VERBOSE = 2,
+  EJIT_LOG_DEBUG = 3,
+} ejit_log_level_t;
+
+/// Set the runtime diagnostic log level. Takes effect immediately for all
+/// subsequent EJIT_DIAG* output. Lower the level to reduce log volume in
+/// production; raise it to VERBOSE/DEBUG when diagnosing a problem.
+void ejit_set_log_level(ejit_log_level_t level);
+
+/// Current runtime diagnostic log level.
+ejit_log_level_t ejit_get_log_level(void);
+
+/// Print the registered registry through the platform log: every registered
+/// bitcode (funcIdx, name, size), period array (period, var, base, size),
+/// static var (var, addr), plus funcIndex/lifecycle counts. For verifying
+/// that AOT registration populated the runtime as expected.
+void ejit_print_registry(void);
+
+/// Print the !ejit.metadata of \p funcName (parsed from its registered
+/// bitcode): whether it is an ejit_entry, its period_arr_ind parameter slots,
+/// period arrays, and may_const field offsets. For diagnosing specialization
+/// parameter binding and constant-substitution eligibility.
+void ejit_print_func_meta(const char *funcName);
+
 // Cache
 void ejit_clear_cache(void);
 void ejit_invalidate(const char *periodName, uint8_t cellIdx);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntimeState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntimeState.h
@@ -44,6 +44,13 @@ public:
 
   const std::vector<PeriodArrayInfo> *getArrays(const std::string &periodName) const;
   const std::vector<StaticVarInfo> &getStaticVars() const { return staticVars_; }
+  /// All period arrays grouped by period name. For diagnostics
+  /// (ejit_print_registry): iterating this exposes every registered array
+  /// without needing to know period names up front.
+  const std::unordered_map<std::string, std::vector<PeriodArrayInfo>> &
+  arraysByPeriod() const {
+    return arraysByPeriod_;
+  }
   const PeriodArrayInfo *getArrayInfo(const std::string &varName) const;
   void *getStaticVarAddr(const std::string &varName) const;
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -160,6 +160,20 @@ public:
   void bind(EJitSharedTaskPoolState *state) { state_ = state; }
   EJitSharedTaskPoolState *state() const { return state_; }
 
+  /// Callback type for forEachCompiled: receives the funcIndex, its dim
+  /// identity (dimType:instanceId pairs, numDims entries), the compiled
+  /// function pointer, and the caller-provided context.
+  using CompiledFuncCallback = void (*)(uint32_t funcIndex,
+                                        const EJitDimPair *dims,
+                                        uint32_t numDims, void *fnPtr,
+                                        void *ctx);
+
+  /// Invoke \p cb once for every successfully compiled (Ready) cache entry.
+  /// For diagnostics (e.g. ejit_taskpool_print_compiled). Best-effort: a slot
+  /// mid-publish is skipped, and this is not a snapshot — concurrent publishes
+  /// may add entries during iteration.
+  void forEachCompiled(CompiledFuncCallback cb, void *ctx) const;
+
   //--- owner-only configuration (applied if this core wins election) ----------
   void setCompiler(CompileCallback fn, void *ctx) {
     compileFn_ = fn;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -70,6 +70,12 @@
 #ifndef EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS
 #define EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS 16u
 #endif
+#ifndef EJIT_SRE_SHARED_DUMP_NAME_BYTES
+#define EJIT_SRE_SHARED_DUMP_NAME_BYTES 128u
+#endif
+#ifndef EJIT_SRE_SHARED_DUMP_TEXT_BYTES
+#define EJIT_SRE_SHARED_DUMP_TEXT_BYTES 65536u
+#endif
 
 namespace llvm {
 namespace ejit {
@@ -84,6 +90,10 @@ constexpr uint32_t kEJitSharedCacheBuckets = EJIT_SRE_TASKPOOL_BUCKETS;
 constexpr uint32_t kEJitSharedCacheSlots = EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS;
 constexpr uint32_t kEJitSharedQueueSlots = EJIT_SRE_TASKPOOL_QUEUE_CAPACITY;
 constexpr uint32_t kEJitSharedPoolSlots = EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS;
+constexpr uint32_t kEJitSharedDumpNameBytes =
+    EJIT_SRE_SHARED_DUMP_NAME_BYTES;
+constexpr uint32_t kEJitSharedDumpTextBytes =
+    EJIT_SRE_SHARED_DUMP_TEXT_BYTES;
 constexpr uint32_t kEJitSharedCacheLine = 64u;
 /// Execute-permission seal granularity (the platform's per-page enable_ex unit)
 /// and the large-page / split granularity. Fixed platform constants.
@@ -196,6 +206,34 @@ struct EJitSharedPoolSplit {
 };
 
 //===----------------------------------------------------------------------===//
+// EJitSharedDumpState: fixed-size cross-core diagnostic exchange.
+//
+// The owner worker captures IR/ASM in its private ORC path, but shell/debug
+// requests can arrive on a different core. std::map/std::string cannot live in
+// shared memory, so the shared path uses one bounded filter + one bounded
+// captured result. It is diagnostic-only: long IR/ASM is truncated instead of
+// blocking normal JIT progress.
+//===----------------------------------------------------------------------===//
+struct alignas(kEJitSharedCacheLine) EJitSharedDumpState {
+  EJitAtomicU32 lock;          ///< 0 free, 1 locked by filter/capture/print
+  EJitAtomicU32 filterEnabled; ///< 1 => filterName is active
+  EJitAtomicU32 resultValid;   ///< 1 => resultName/ir/asm contain a capture
+  EJitAtomicU32 truncated;     ///< bit0 IR truncated, bit1 ASM truncated
+  uint32_t filterLen;
+  uint32_t resultNameLen;
+  uint32_t irSize;
+  uint32_t asmSize;
+  uint32_t keyHi;
+  uint32_t keyLo;
+  uint32_t reserved0;
+  uint32_t reserved1;
+  char filterName[kEJitSharedDumpNameBytes];
+  char resultName[kEJitSharedDumpNameBytes];
+  char ir[kEJitSharedDumpTextBytes];
+  char asmText[kEJitSharedDumpTextBytes];
+};
+
+//===----------------------------------------------------------------------===//
 // EJitSharedCounters: lock-free statistics, all monotonic.
 //===----------------------------------------------------------------------===//
 struct EJitSharedCounters {
@@ -263,6 +301,9 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
   alignas(kEJitSharedCacheLine)
       EJitSharedPoolSplit poolSplits[kEJitSharedPoolSlots];
 
+  //--- bounded cross-core IR/ASM dump diagnostics (own cache line)
+  alignas(kEJitSharedCacheLine) EJitSharedDumpState dump;
+
   //--- result cache (own cache line; each bucket is itself cache-line aligned)
   alignas(kEJitSharedCacheLine)
       EJitSharedCacheBucket buckets[kEJitSharedCacheBuckets];
@@ -310,6 +351,11 @@ static_assert(
         std::is_trivially_destructible<EJitSharedPoolSplit>::value &&
         std::is_trivially_default_constructible<EJitSharedPoolSplit>::value,
     "EJitSharedPoolSplit must be POD-style");
+static_assert(
+    std::is_standard_layout<EJitSharedDumpState>::value &&
+        std::is_trivially_destructible<EJitSharedDumpState>::value &&
+        std::is_trivially_default_constructible<EJitSharedDumpState>::value,
+    "EJitSharedDumpState must be POD-style");
 static_assert(alignof(EJitSharedTaskPoolState) == kEJitSharedCacheLine,
               "EJitSharedTaskPoolState must be cache-line aligned");
 static_assert(

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -2,6 +2,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJit.h"
 #include "llvm/Config/Targets.h"
+#include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCompileDriver.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitFuncRegistry.h"
@@ -11,6 +12,13 @@
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/TargetParser/Triple.h"
 
@@ -657,3 +665,98 @@ const EJitSharedTaskPool *EJit::sharedTaskPool() const {
   return compileDriver_ ? compileDriver_->sharedTaskPool() : nullptr;
 }
 #endif
+
+void EJit::printRegistry() const {
+  const PeriodArrayRegistry &reg = runtimeState_->getRegistry();
+  EJIT_DIAG("registry: funcIndexes=%u lifecycles=%u",
+            EJitFuncRegistry::instance().count(),
+            EJitLifecycleRegistry::instance().count());
+
+  EJIT_DIAG("registry: bitcodes (%u):", EJitFuncRegistry::instance().count());
+  for (uint32_t idx = 0; idx < EJitFuncRegistry::instance().count(); ++idx) {
+    const std::string &name = moduleLoader_->getFuncNameByFuncIdx(idx);
+    if (name.empty())
+      continue;
+    auto bc = moduleLoader_->getBitcodeByFuncIdx(idx);
+    size_t sz = bc ? bc->size() : 0;
+    if (!bc)
+      consumeError(bc.takeError());
+    EJIT_DIAG("  idx=%u name=%s size=%zu", idx, name.c_str(), sz);
+  }
+
+  EJIT_DIAG("registry: period arrays:");
+  for (const auto &kv : reg.arraysByPeriod())
+    for (const auto &info : kv.second)
+      EJIT_DIAG("  period=%s var=%s base=%p size=%zu", kv.first.c_str(),
+                info.varName.c_str(), info.baseAddr, info.arraySize);
+
+  EJIT_DIAG("registry: static vars (%zu):", reg.getStaticVars().size());
+  for (const auto &sv : reg.getStaticVars())
+    EJIT_DIAG("  var=%s addr=%p", sv.varName.c_str(), sv.varAddr);
+}
+
+void EJit::printFuncMeta(const std::string &funcName) {
+  uint32_t idx = EJitFuncRegistry::instance().lookup(funcName);
+  if (idx == kEJitInvalidFuncIndex) {
+    EJIT_DIAG("func_meta: name=%s not registered", funcName.c_str());
+    return;
+  }
+  auto bc = moduleLoader_->getBitcodeByFuncIdx(idx);
+  if (!bc) {
+    EJIT_DIAG("func_meta: name=%s funcIdx=%u bitcode lookup error",
+              funcName.c_str(), idx);
+    consumeError(bc.takeError());
+    return;
+  }
+  auto Ctx = std::make_unique<LLVMContext>();
+  auto Buf = MemoryBuffer::getMemBuffer(*bc, "meta_" + std::to_string(idx) + ".bc");
+  auto MOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
+  if (!MOrErr) {
+    EJIT_DIAG("func_meta: name=%s funcIdx=%u parse bitcode error",
+              funcName.c_str(), idx);
+    consumeError(MOrErr.takeError());
+    return;
+  }
+  Function *F = (*MOrErr)->getFunction(funcName);
+  EJIT_DIAG("func_meta name=%s funcIdx=%u found=%d", funcName.c_str(), idx,
+            F && !F->isDeclaration() ? 1 : 0);
+  if (!F || F->isDeclaration()) {
+    EJIT_DIAG("  (no definition in bitcode)");
+    return;
+  }
+  MDNode *MD = F->getMetadata(MD_EJIT_METADATA);
+  if (!MD) {
+    EJIT_DIAG("  (no !ejit.metadata)");
+    return;
+  }
+  EJIT_DIAG("  ejit_entry=%d",
+            hasMDStringEntry(MD, TAG_EJIT_ENTRY) ? 1 : 0);
+  for (const MDOperand &Op : MD->operands()) {
+    auto *Sub = dyn_cast<MDNode>(Op.get());
+    if (!Sub || Sub->getNumOperands() == 0)
+      continue;
+    auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
+    if (!Tag)
+      continue;
+    StringRef tag = Tag->getString();
+    // Render the remaining operands: MDString as their string, ConstantInt as
+    // its integer value, anything else as a placeholder.
+    std::string rest;
+    raw_string_ostream OS(rest);
+    for (unsigned i = 1; i < Sub->getNumOperands(); ++i) {
+      if (i > 1)
+        OS << ",";
+      if (auto *S = dyn_cast<MDString>(Sub->getOperand(i)))
+        OS << S->getString();
+      else if (auto *C = dyn_cast<ConstantAsMetadata>(Sub->getOperand(i)))
+        if (auto *CI = dyn_cast<ConstantInt>(C->getValue()))
+          OS << CI->getZExtValue();
+        else
+          OS << "?";
+      else
+        OS << "?";
+    }
+    OS.flush();
+    EJIT_DIAG("  %s %s", tag.str().c_str(), rest.c_str());
+  }
+}

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -99,9 +99,9 @@ void initializeEJitTargets() {
 } // namespace
 
 EJit::EJit(const Config &config) : config_(config) {
-  EJIT_DIAG("constructing: mode=%d opt=%d maxCache=%zu maxEntries=%u",
-            (int)config.compileMode, (int)config.optLevel, config.maxCacheSize,
-            (unsigned)config.maxCacheEntries);
+  EJIT_DIAG_VERBOSE("constructing: mode=%d opt=%d maxCache=%zu maxEntries=%u",
+                    (int)config.compileMode, (int)config.optLevel,
+                    config.maxCacheSize, (unsigned)config.maxCacheEntries);
 
   // Create all runtime components
   runtimeState_ = std::make_unique<EJitRuntimeState>();
@@ -272,8 +272,8 @@ EJit::EJit(const Config &config) : config_(config) {
   if (!initFailed_) {
     regPhase_ = RegistrationPhase::Frozen;
     if (config_.compileMode == CompileMode::Async) {
-      EJIT_DIAG("taskpool async init: engineReady=%u",
-                static_cast<unsigned>(engineReady));
+      EJIT_DIAG_VERBOSE("taskpool async init: engineReady=%u",
+                        static_cast<unsigned>(engineReady));
       if (!engineReady)
         recordInitError(EJIT_ERR_COMPILE_FAILED,
                         "Async mode requires a ready ORC engine", "");
@@ -292,7 +292,7 @@ EJit::EJit(const Config &config) : config_(config) {
       else
         EJIT_DIAG("taskpool async init complete: worker running");
     } else {
-      EJIT_DIAG("taskpool sync init complete: worker remains stopped");
+      EJIT_DIAG_VERBOSE("taskpool sync init complete: worker remains stopped");
     }
   }
 #else

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCache.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCache.cpp
@@ -34,7 +34,7 @@ void *EJitCache::getOrNull(uint64_t cacheKey) {
 bool EJitCache::put(uint64_t cacheKey, void *funcPtr,
                     size_t codeSize,
                     ArrayRef<std::string> periodDeps) {
-  EJIT_DIAG("cache put key=0x%016lx fn=%p size=%zu deps=%zu", cacheKey, funcPtr,
+  EJIT_DIAG_VERBOSE("cache put key=0x%016lx fn=%p size=%zu deps=%zu", cacheKey, funcPtr,
             codeSize, periodDeps.size());
   std::unique_lock<decltype(mutex_)> lock(mutex_);
 
@@ -83,14 +83,14 @@ bool EJitCache::put(uint64_t cacheKey, void *funcPtr,
 
 void EJitCache::invalidateByPeriod(const std::string &periodName,
                                    uint8_t cellIdx) {
-  EJIT_DIAG("cache invalidate begin period=%s cellIdx=%u", periodName.c_str(),
+  EJIT_DIAG_VERBOSE("cache invalidate begin period=%s cellIdx=%u", periodName.c_str(),
             cellIdx);
   std::unique_lock<decltype(mutex_)> lock(mutex_);
   std::string dep = periodName + "=" + std::to_string(cellIdx);
 
   auto it = periodIndex_.find(dep);
   if (it == periodIndex_.end()) {
-    EJIT_DIAG("cache invalidate period=%s cellIdx=%u: no matching entries",
+    EJIT_DIAG_DEBUG("cache invalidate period=%s cellIdx=%u: no matching entries",
               periodName.c_str(), cellIdx);
     return;
   }
@@ -107,7 +107,7 @@ void EJitCache::invalidateByPeriod(const std::string &periodName,
   }
   periodIndex_.erase(it);
 
-  EJIT_DIAG("cache invalidate period=%s cellIdx=%u: %zu entries removed",
+  EJIT_DIAG_VERBOSE("cache invalidate period=%s cellIdx=%u: %zu entries removed",
            periodName.c_str(), cellIdx, removed);
   (void)removed;
 }
@@ -119,7 +119,7 @@ void EJitCache::clear() {
   lruList_.clear();
   periodIndex_.clear();
   currentTotalSize_ = 0;
-  EJIT_DIAG("cache cleared: %zu entries", cleared);
+  EJIT_DIAG_VERBOSE("cache cleared: %zu entries", cleared);
   (void)cleared;
 }
 
@@ -175,6 +175,6 @@ void EJitCache::evictLRU() {
 
   cache_.erase(it);
   evictions_++;
-  EJIT_DIAG("cache evict LRU key=0x%016lx: size=%zu entries=%zu/%zu",
+  EJIT_DIAG_VERBOSE("cache evict LRU key=0x%016lx: size=%zu entries=%zu/%zu",
            key, currentTotalSize_, cache_.size(), maxEntries_);
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -46,9 +46,9 @@ EJitCodePoolManager::EJitCodePoolManager(Options Opts, RawAllocFn Alloc,
     if (Opts_.poolSize == 0)
       Opts_.poolSize = Opts_.poolAlign;
   }
-  EJIT_DIAG("code pool ctor: poolSize=%zu poolAlign=%zu minCodeAlign=%zu "
-            "fourKSeal=%u sealPage=%zu",
-            Opts_.poolSize, Opts_.poolAlign, Opts_.minCodeAlign,
+  EJIT_DIAG_VERBOSE("code pool ctor: poolSize=%zu poolAlign=%zu minCodeAlign=%zu "
+                    "fourKSeal=%u sealPage=%zu",
+                    Opts_.poolSize, Opts_.poolAlign, Opts_.minCodeAlign,
             static_cast<unsigned>(Opts_.fourKSeal), Opts_.sealPageSize);
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -266,7 +266,7 @@ void *EJitCompileDriver::getOrCompile(uint64_t cacheKey) {
 
   // ── Hot path: single hash find ───────────────────────────────────────────
   if (void *cached = cache_.getOrNull(cacheKey)) {
-    EJIT_DIAG("cache HIT key=0x%016lx", cacheKey);
+    EJIT_DIAG_VERBOSE("cache HIT key=0x%016lx", cacheKey);
     return cached;
   }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLogger.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLogger.cpp
@@ -3,6 +3,13 @@
 #include "llvm/ExecutionEngine/EJIT/EJitLogger.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 
+// Process-wide runtime log level (default INFO). Always defined, for both
+// hosted and freestanding builds. Raised via ejit_set_log_level() to recover
+// VERBOSE/DEBUG detail. Referenced by the EJIT_DIAG* macros; when
+// EJIT_DIAG_ENABLE is undefined the macros are no-ops and this symbol is
+// simply unused.
+int gEJitDiagLevel = EJIT_LOG_LVL_INFO;
+
 #ifndef EJIT_FREESTANDING
 
 #include <chrono>

--- a/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
@@ -49,8 +49,8 @@ bool EJitModuleLoader::registerBitcode(const std::string &funcName,
     // different payload is rejected (the original bitcode, funcIndex and any
     // live cache are kept) rather than silently swapped.
     if (It->second.data == data && It->second.size == size) {
-      EJIT_DIAG("bitcode register idempotent name=%s idx=%u", funcName.c_str(),
-                idx);
+      EJIT_DIAG_DEBUG("bitcode register idempotent name=%s idx=%u",
+                      funcName.c_str(), idx);
       return true;
     }
     EJIT_DIAG("bitcode register reject name=%s idx=%u: payload changed",
@@ -62,8 +62,9 @@ bool EJitModuleLoader::registerBitcode(const std::string &funcName,
   E.data = data;
   E.size = size;
   entriesByFuncIdx_.emplace(idx, std::move(E));
-  EJIT_DIAG("bitcode registered name=%s idx=%u data=%p size=%zu",
-            funcName.c_str(), idx, static_cast<const void *>(data), size);
+  EJIT_DIAG_VERBOSE("bitcode registered name=%s idx=%u data=%p size=%zu",
+                    funcName.c_str(), idx, static_cast<const void *>(data),
+                    size);
   return true;
 }
 
@@ -93,7 +94,7 @@ EJitModuleLoader::getOrCacheFuncMeta(uint32_t funcIdx) {
   if (it != funcMetaCache_.end())
     return it->second;
 
-  EJIT_DIAG("getOrCacheFuncMeta: building meta for funcIdx=%u", funcIdx);
+  EJIT_DIAG_DEBUG("getOrCacheFuncMeta: building meta for funcIdx=%u", funcIdx);
   FuncMeta &meta = funcMetaCache_[funcIdx];
   auto Eit = entriesByFuncIdx_.find(funcIdx);
   if (Eit == entriesByFuncIdx_.end()) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -74,18 +74,20 @@ void EJitOptimizer::clearAnalyses() {
 
 void EJitOptimizer::runPipeline(Module &M,
                                 const SpecializationContext &ctx) {
-  EJIT_DIAG("pipeline begin func=%s key=0x%016lx opt=%d dims=%zu module=%s",
-            ctx.fnName.c_str(), ctx.cacheKey, static_cast<int>(ctx.optLevel),
-            ctx.dimensions.size(), M.getName().str().c_str());
+  EJIT_DIAG_VERBOSE("pipeline begin func=%s key=0x%016lx opt=%d dims=%zu "
+                    "module=%s",
+                    ctx.fnName.c_str(), ctx.cacheKey,
+                    static_cast<int>(ctx.optLevel), ctx.dimensions.size(),
+                    M.getName().str().c_str());
 
   // 1. Parameter substitution: replace ejit_period_arr_ind args with constants
   preReplacePeriodIndices(M, ctx);
-  EJIT_DIAG("pipeline stage1 done: preReplacePeriodIndices");
+  EJIT_DIAG_DEBUG("pipeline stage1 done: preReplacePeriodIndices");
 
   // 2. InstCombine: fold constant GEP chains from substituted params
   //    so StructFieldPass can compute correct byte offsets.
   runInstCombine(M);
-  EJIT_DIAG("pipeline stage2 done: InstCombine");
+  EJIT_DIAG_DEBUG("pipeline stage2 done: InstCombine");
 
   // 3. Inline (L2+): currently disabled. The AOT pre-optimization in
   //    EJitRegisterBitcodePass already runs AlwaysInline + ModuleInliner(O2),
@@ -101,12 +103,12 @@ void EJitOptimizer::runPipeline(Module &M,
 
   // 4. StructFieldPass: replace may_const loads with runtime constants.
   runStructFieldPass(M);
-  EJIT_DIAG("pipeline stage4 done: StructFieldPass");
+  EJIT_DIAG_DEBUG("pipeline stage4 done: StructFieldPass");
 
   // 5. Core optimization at the configured level
   runOptimizationPipeline(M, ctx.optLevel);
-  EJIT_DIAG("pipeline done func=%s key=0x%016lx", ctx.fnName.c_str(),
-            ctx.cacheKey);
+  EJIT_DIAG_VERBOSE("pipeline done func=%s key=0x%016lx", ctx.fnName.c_str(),
+                    ctx.cacheKey);
 }
 
 void EJitOptimizer::preReplacePeriodIndices(
@@ -167,8 +169,8 @@ void EJitOptimizer::runStructFieldPass(Module &M) {
 
 void EJitOptimizer::runOptimizationPipeline(Module &M,
                                             OptimizationLevel level) {
-  EJIT_DIAG("pipeline stage5: core opt level=%d module=%s",
-            static_cast<int>(level), M.getName().str().c_str());
+  EJIT_DIAG_DEBUG("pipeline stage5: core opt level=%d module=%s",
+                  static_cast<int>(level), M.getName().str().c_str());
   // L1: SCCP + ADCE + SimplifyCFG — constant propagation, dead code
   // elimination, and CFG cleanup. Captures the vast majority of EJIT
   // performance gains (may_const load → constant → branch folding).

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -12,9 +12,14 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
+#include <map>
+#include <mutex>
 #include <map>
 
 #ifdef EJIT_SRE_CODE_POOL
@@ -50,7 +55,84 @@ struct EJitOrcEngine::Impl {
   std::string dumpJITDir;
   /// Persistent optimizer — analysis managers are registered once and reused.
   std::unique_ptr<EJitOptimizer> optimizer;
+  /// TargetMachine used for the name-filtered ASM diagnostic dump (created
+  /// once from the same JITTargetMachineBuilder the JIT compiles with, so the
+  /// emitted assembly matches the real JIT output). Null if creation failed.
+  std::unique_ptr<TargetMachine> dumpTM;
 };
+
+// Process-wide function-name filter for the IR+ASM diagnostic dump. Set via
+// ejit_dump_func() / setDumpFuncFilter(). Read in the IR transform layer.
+// A diagnostic: set before triggering the compile of interest; concurrent
+// set/read is benign (worst case a missed or extra dump).
+static std::string gDumpFuncFilter;
+
+void setDumpFuncFilter(const std::string &name) { gDumpFuncFilter = name; }
+
+/// Emit a multi-line blob (IR or ASM) through EJIT_DIAG, one line per call,
+/// under a labeled header. Bare-metal-safe (no file I/O — the existing
+/// dumpJITDir path uses raw_fd_ostream which crashes on SRE/bare-metal).
+static void dumpLines(const char *label, const std::string &s) {
+  EJIT_DIAG("=== %s ===", label);
+  StringRef rest(s);
+  while (!rest.empty()) {
+    auto [line, next] = rest.split('\n');
+    if (!line.empty())
+      EJIT_DIAG("  %.*s", static_cast<int>(line.size()), line.data());
+    rest = next;
+  }
+}
+
+/// Saved IR+ASM for a captured specialization (latest per function name).
+struct DumpEntry {
+  uint64_t cacheKey = 0;
+  std::string IR;
+  std::string ASM;
+};
+
+// Process-wide store of captured IR+ASM, filled by the IR transform layer
+// (worker thread) when the filter matches, read by ejit_print_dumped() (user
+// thread). Guarded by gDumpMutex.
+static std::mutex gDumpMutex;
+static std::map<std::string, DumpEntry> gDumpStore;
+
+/// Called from the IR transform layer when the filter matches: save the
+/// post-optimization IR and emitted ASM for later selective printing.
+static void captureDump(const std::string &fnName, uint64_t cacheKey,
+                        std::string IR, std::string ASM) {
+  std::lock_guard<std::mutex> lock(gDumpMutex);
+  gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
+}
+
+/// Print the saved IR+ASM for \p name (or all saved entries when \p name is
+/// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no
+/// saved capture are reported as missing.
+void printDumped(const char *name) {
+  std::lock_guard<std::mutex> lock(gDumpMutex);
+  auto emit = [&](const std::string &fnName, const DumpEntry &e) {
+    dumpLines(("dump IR func=" + fnName + " key=0x" +
+               Twine::utohexstr(e.cacheKey).str())
+                  .c_str(),
+              e.IR);
+    if (!e.ASM.empty())
+      dumpLines(("dump ASM func=" + fnName + " key=0x" +
+                 Twine::utohexstr(e.cacheKey).str())
+                    .c_str(),
+                e.ASM);
+  };
+  if (name && name[0]) {
+    auto it = gDumpStore.find(name);
+    if (it != gDumpStore.end())
+      emit(it->first, it->second);
+    else
+      EJIT_DIAG("print_dumped: no saved IR/ASM for func=%s", name);
+  } else {
+    if (gDumpStore.empty())
+      EJIT_DIAG("print_dumped: nothing saved");
+    for (auto &kv : gDumpStore)
+      emit(kv.first, kv.second);
+  }
+}
 
 EJitOrcEngine::EJitOrcEngine() : P(std::make_unique<Impl>()) {}
 EJitOrcEngine::~EJitOrcEngine() = default;
@@ -86,6 +168,14 @@ EJitOrcEngine::Create(const Config &config,
 
   // Use Large code model so JITLink can generate 64-bit absolute relocations.
   JTMBOrErr->setCodeModel(CodeModel::Large);
+
+  // Build a TargetMachine (same options the JIT compiles with) for the
+  // name-filtered ASM diagnostic dump. Failure is non-fatal — the dump is
+  // simply unavailable.
+  if (auto TMOrErr = JTMBOrErr->createTargetMachine())
+    engine->P->dumpTM = std::move(*TMOrErr);
+  else
+    consumeError(TMOrErr.takeError());
 
   orc::LLJITBuilder Builder;
   Builder.setJITTargetMachineBuilder(*JTMBOrErr);
@@ -205,6 +295,36 @@ EJitOrcEngine::Create(const Config &config,
             llvm::raw_fd_ostream OS(path, EC);
             if (!EC)
               M.print(OS, nullptr);
+          }
+
+          // Name-filtered IR+ASM capture for later selective printing. Filter
+          // set via ejit_dump_func(); captured entries printed on demand via
+          // ejit_print_dumped(). Bare-metal-safe (strings only, no
+          // raw_fd_ostream). Captures the post-optimization IR and the emitted
+          // assembly (from the same TargetMachine the JIT compiles with).
+          if (!gDumpFuncFilter.empty() && ctx->fnName == gDumpFuncFilter) {
+            std::string IR;
+            raw_string_ostream IOS(IR);
+            M.print(IOS, nullptr);
+            IOS.flush();
+
+            std::string Asm;
+            if (engine->P->dumpTM) {
+              SmallVector<char, 0> AsmBuf;
+              raw_svector_ostream AOS(AsmBuf);
+              legacy::PassManager PM;
+              if (!engine->P->dumpTM->addPassesToEmitFile(
+                      PM, AOS, /*DwoOut=*/nullptr,
+                      CodeGenFileType::AssemblyFile)) {
+                PM.run(M);
+                Asm.assign(AsmBuf.begin(), AsmBuf.end());
+              } else {
+                EJIT_DIAG("dump ASM func=%s: target cannot emit assembly",
+                          ctx->fnName.c_str());
+              }
+            }
+            captureDump(ctx->fnName, ctx->cacheKey, std::move(IR),
+                        std::move(Asm));
           }
         });
         return std::move(TSM);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -344,26 +344,31 @@ static void printOneDumpSafe(const char *requestedName,
 /// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no
 /// saved capture are reported as missing.
 void printDumped(const char *name) {
-  EJIT_DIAG("print_dumped enter name=%s &filter=%p &store=%p",
+  EJIT_DIAG_DEBUG("print_dumped enter name=%s &filter=%p &store=%p",
             (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
             (void *)&gDumpStore);
+  bool hasName = name && name[0];
 #ifdef EJIT_SRE_SHARED_TASKPOOL
-  if (printSharedDumped(name))
+  // A specific name may have been captured on another core: try the shared
+  // single-result first. For "print all" (name NULL/empty) skip the shared
+  // path — it holds only the latest capture — and iterate the local store,
+  // which keeps one entry per function name (every dump-all capture).
+  if (hasName && printSharedDumped(name))
     return;
 #endif
   std::lock_guard<DumpMutexType> lock(gDumpMutex);
-  EJIT_DIAG("print_dumped store_size=%u", (unsigned)gDumpStore.size());
-  if (name && name[0]) {
+  EJIT_DIAG_DEBUG("print_dumped store_size=%u", (unsigned)gDumpStore.size());
+  if (hasName) {
     auto it = gDumpStore.find(name);
     if (it != gDumpStore.end()) {
       printOneDumpSafe(name, it->first, it->second);
     } else {
-      EJIT_DIAG("print_dumped miss name=%s store_size=%u", name,
+      EJIT_DIAG_DEBUG("print_dumped miss name=%s store_size=%u", name,
                 (unsigned)gDumpStore.size());
       unsigned idx = 0;
       for (auto &kv : gDumpStore) {
         (void)kv;
-        EJIT_DIAG("stored[%u]=%s ir=%u asm=%u", idx, kv.first.c_str(),
+        EJIT_DIAG_DEBUG("stored[%u]=%s ir=%u asm=%u", idx, kv.first.c_str(),
                   (unsigned)kv.second.IR.size(),
                   (unsigned)kv.second.ASM.size());
         ++idx;
@@ -550,16 +555,22 @@ EJitOrcEngine::Create(const Config &config,
           // ejit_print_dumped(). Bare-metal-safe (strings only, no
           // raw_fd_ostream). Captures the post-optimization IR and the emitted
           // assembly (from the same TargetMachine the JIT compiles with).
+          // The filter value "*" is a wildcard: every specialization is captured
+          // (ejit_dump_all(true) sets it). The local gDumpStore keeps one entry
+          // per function name (overwritten on re-compile), so dump-all is
+          // bounded by the number of distinct entry functions; the cross-core
+          // shared result keeps only the latest capture (see ejit_print_dumped).
           {
             std::string DumpFilter;
             bool hasFilter = getActiveDumpFilter(DumpFilter);
-            bool match = hasFilter && ctx->fnName == DumpFilter;
-            EJIT_DIAG("dump check filter=%s fn=%s key_hi=0x%08x key_lo=0x%08x "
-                      "match=%d &filter=%p",
-                      hasFilter ? DumpFilter.c_str() : "(off)",
-                      ctx->fnName.c_str(), (uint32_t)(ctx->cacheKey >> 32),
-                      (uint32_t)(ctx->cacheKey & 0xffffffffu), match ? 1 : 0,
-                      (void *)&gDumpFuncFilter);
+            bool wildcard = hasFilter && DumpFilter == "*";
+            bool match = wildcard || (hasFilter && ctx->fnName == DumpFilter);
+            EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
+                            "key_lo=0x%08x match=%d wildcard=%d &filter=%p",
+                            hasFilter ? DumpFilter.c_str() : "(off)",
+                            ctx->fnName.c_str(), (uint32_t)(ctx->cacheKey >> 32),
+                            (uint32_t)(ctx->cacheKey & 0xffffffffu), match ? 1 : 0,
+                            wildcard ? 1 : 0, (void *)&gDumpFuncFilter);
             if (match) {
               // IR capture always runs first so it succeeds even if the ASM
               // diagnostic path is disabled or fails.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -243,6 +243,17 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     }
   }
 
+  // ejit_entry functions may have internal linkage (e.g. declared `static` in
+  // source). ORC's IR layer excludes local-linkage symbols from the JITDylib
+  // symbol table (Layer.cpp: hasLocalLinkage() skip), so a static entry is
+  // invisible to lookup ("symbol not found", no materialization). The function
+  // being compiled (origFnName) is the JIT lookup target — force it to
+  // external linkage so ORC registers and can materialize it. Spec JITDylibs
+  // are isolated, so this cannot collide with other specializations.
+  if (Function *EntryF = (*ModuleOrErr)->getFunction(origFnName))
+    if (!EntryF->isDeclaration() && EntryF->hasLocalLinkage())
+      EntryF->setLinkage(GlobalValue::ExternalLinkage);
+
   // Collect global variable addresses from the registry for symbols
   // that appear as external declarations in the bitcode module.
   orc::SymbolMap globalSymbols;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -19,8 +19,13 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
 #include <map>
+#include <string>
+
+#ifdef EJIT_FREESTANDING
+#include "llvm/ExecutionEngine/EJIT/EJitBareMetal.h"
+#else
 #include <mutex>
-#include <map>
+#endif
 
 #ifdef EJIT_SRE_CODE_POOL
 #include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
@@ -61,26 +66,28 @@ struct EJitOrcEngine::Impl {
   std::unique_ptr<TargetMachine> dumpTM;
 };
 
+namespace llvm {
+namespace ejit {
+
+// Mutex type for the dump store. On SRE/freestanding std::mutex is unsafe or
+// unavailable, so use the bare-metal no-op mutex (single-threaded).
+#ifdef EJIT_FREESTANDING
+using DumpMutexType = BareMetalMutex;
+#else
+using DumpMutexType = std::mutex;
+#endif
+
 // Process-wide function-name filter for the IR+ASM diagnostic dump. Set via
 // ejit_dump_func() / setDumpFuncFilter(). Read in the IR transform layer.
 // A diagnostic: set before triggering the compile of interest; concurrent
 // set/read is benign (worst case a missed or extra dump).
 static std::string gDumpFuncFilter;
 
-void setDumpFuncFilter(const std::string &name) { gDumpFuncFilter = name; }
-
-/// Emit a multi-line blob (IR or ASM) through EJIT_DIAG, one line per call,
-/// under a labeled header. Bare-metal-safe (no file I/O — the existing
-/// dumpJITDir path uses raw_fd_ostream which crashes on SRE/bare-metal).
-static void dumpLines(const char *label, const std::string &s) {
-  EJIT_DIAG("=== %s ===", label);
-  StringRef rest(s);
-  while (!rest.empty()) {
-    auto [line, next] = rest.split('\n');
-    if (!line.empty())
-      EJIT_DIAG("  %.*s", static_cast<int>(line.size()), line.data());
-    rest = next;
-  }
+void setDumpFuncFilter(const std::string &name) {
+  gDumpFuncFilter = name;
+  EJIT_DIAG("set_dump_filter value=%s &filter=%p",
+            gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
+            (void *)&gDumpFuncFilter);
 }
 
 /// Saved IR+ASM for a captured specialization (latest per function name).
@@ -92,47 +99,104 @@ struct DumpEntry {
 
 // Process-wide store of captured IR+ASM, filled by the IR transform layer
 // (worker thread) when the filter matches, read by ejit_print_dumped() (user
-// thread). Guarded by gDumpMutex.
-static std::mutex gDumpMutex;
+// thread). Guarded by gDumpMutex. These are ordinary process statics, not part
+// of the shared taskpool state; cross-core visibility depends on the worker
+// running in the same process image (addresses are logged to diagnose this).
+static DumpMutexType gDumpMutex;
 static std::map<std::string, DumpEntry> gDumpStore;
+
+/// Emit a multi-line blob (IR or ASM) through EJIT_DIAG. SRE-safe: no lambda,
+/// no Twine, no raw_fd_ostream. Splits on '\n' and chunks each line to a small
+/// fixed width so a single EJIT_DIAG/SRE_printf call stays bounded.
+static void dumpLinesSafe(const char *label, const std::string &s) {
+  EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)s.size());
+  const char *data = s.data();
+  size_t n = s.size();
+  size_t i = 0;
+  unsigned lineNo = 0;
+  while (i < n) {
+    size_t lineEnd = i;
+    while (lineEnd < n && data[lineEnd] != '\n')
+      ++lineEnd;
+    // Chunk this (possibly empty) line into <= 180-char pieces.
+    size_t pos = i;
+    do {
+      size_t chunk = lineEnd - pos;
+      if (chunk > 180)
+        chunk = 180;
+      EJIT_DIAG("%s:%u: %.*s", label, lineNo, (int)chunk, data + pos);
+      pos += chunk;
+    } while (pos < lineEnd);
+    ++lineNo;
+    i = lineEnd + 1; // skip the '\n'
+  }
+  EJIT_DIAG("=== %s end lines=%u ===", label, lineNo);
+}
 
 /// Called from the IR transform layer when the filter matches: save the
 /// post-optimization IR and emitted ASM for later selective printing.
 static void captureDump(const std::string &fnName, uint64_t cacheKey,
                         std::string IR, std::string ASM) {
-  std::lock_guard<std::mutex> lock(gDumpMutex);
+  EJIT_DIAG("capture enter func=%s ir_size=%u asm_size=%u &store=%p",
+            fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size(),
+            (void *)&gDumpStore);
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  EJIT_DIAG("capture store_size before=%u", (unsigned)gDumpStore.size());
   gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
+  EJIT_DIAG("capture store_size after=%u", (unsigned)gDumpStore.size());
+}
+
+/// Print one stored entry: header (name, key hi/lo, IR/ASM sizes) followed by
+/// the IR and ASM bodies. SRE-safe: no Twine, no lambda, no temporary label.
+static void printOneDumpSafe(const char *requestedName,
+                             const std::string &storedName,
+                             const DumpEntry &e) {
+  uint32_t keyHi = (uint32_t)(e.cacheKey >> 32);
+  uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
+  EJIT_DIAG("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
+            "key_lo=0x%08x ir_size=%u asm_size=%u",
+            requestedName ? requestedName : "(all)", storedName.c_str(), keyHi,
+            keyLo, (unsigned)e.IR.size(), (unsigned)e.ASM.size());
+  if (!e.IR.empty())
+    dumpLinesSafe("dump IR", e.IR);
+  if (!e.ASM.empty())
+    dumpLinesSafe("dump ASM", e.ASM);
 }
 
 /// Print the saved IR+ASM for \p name (or all saved entries when \p name is
 /// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no
 /// saved capture are reported as missing.
 void printDumped(const char *name) {
-  std::lock_guard<std::mutex> lock(gDumpMutex);
-  auto emit = [&](const std::string &fnName, const DumpEntry &e) {
-    dumpLines(("dump IR func=" + fnName + " key=0x" +
-               Twine::utohexstr(e.cacheKey).str())
-                  .c_str(),
-              e.IR);
-    if (!e.ASM.empty())
-      dumpLines(("dump ASM func=" + fnName + " key=0x" +
-                 Twine::utohexstr(e.cacheKey).str())
-                    .c_str(),
-                e.ASM);
-  };
+  EJIT_DIAG("print_dumped enter name=%s &filter=%p &store=%p",
+            (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
+            (void *)&gDumpStore);
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  EJIT_DIAG("print_dumped store_size=%u", (unsigned)gDumpStore.size());
   if (name && name[0]) {
     auto it = gDumpStore.find(name);
-    if (it != gDumpStore.end())
-      emit(it->first, it->second);
-    else
-      EJIT_DIAG("print_dumped: no saved IR/ASM for func=%s", name);
+    if (it != gDumpStore.end()) {
+      printOneDumpSafe(name, it->first, it->second);
+    } else {
+      EJIT_DIAG("print_dumped miss name=%s store_size=%u", name,
+                (unsigned)gDumpStore.size());
+      unsigned idx = 0;
+      for (auto &kv : gDumpStore) {
+        EJIT_DIAG("stored[%u]=%s ir=%u asm=%u", idx, kv.first.c_str(),
+                  (unsigned)kv.second.IR.size(),
+                  (unsigned)kv.second.ASM.size());
+        ++idx;
+      }
+    }
   } else {
     if (gDumpStore.empty())
       EJIT_DIAG("print_dumped: nothing saved");
     for (auto &kv : gDumpStore)
-      emit(kv.first, kv.second);
+      printOneDumpSafe(nullptr, kv.first, kv.second);
   }
 }
+
+} // namespace ejit
+} // namespace llvm
 
 EJitOrcEngine::EJitOrcEngine() : P(std::make_unique<Impl>()) {}
 EJitOrcEngine::~EJitOrcEngine() = default;
@@ -302,29 +366,53 @@ EJitOrcEngine::Create(const Config &config,
           // ejit_print_dumped(). Bare-metal-safe (strings only, no
           // raw_fd_ostream). Captures the post-optimization IR and the emitted
           // assembly (from the same TargetMachine the JIT compiles with).
-          if (!gDumpFuncFilter.empty() && ctx->fnName == gDumpFuncFilter) {
-            std::string IR;
-            raw_string_ostream IOS(IR);
-            M.print(IOS, nullptr);
-            IOS.flush();
+          {
+            bool match = !gDumpFuncFilter.empty() &&
+                         ctx->fnName == gDumpFuncFilter;
+            EJIT_DIAG("dump check filter=%s fn=%s key_hi=0x%08x key_lo=0x%08x "
+                      "match=%d &filter=%p",
+                      gDumpFuncFilter.empty() ? "(off)"
+                                              : gDumpFuncFilter.c_str(),
+                      ctx->fnName.c_str(), (uint32_t)(ctx->cacheKey >> 32),
+                      (uint32_t)(ctx->cacheKey & 0xffffffffu), match ? 1 : 0,
+                      (void *)&gDumpFuncFilter);
+            if (match) {
+              // IR capture always runs first so it succeeds even if the ASM
+              // diagnostic path is disabled or fails.
+              std::string IR;
+              raw_string_ostream IOS(IR);
+              M.print(IOS, nullptr);
+              IOS.flush();
 
-            std::string Asm;
-            if (engine->P->dumpTM) {
-              SmallVector<char, 0> AsmBuf;
-              raw_svector_ostream AOS(AsmBuf);
-              legacy::PassManager PM;
-              if (!engine->P->dumpTM->addPassesToEmitFile(
-                      PM, AOS, /*DwoOut=*/nullptr,
-                      CodeGenFileType::AssemblyFile)) {
-                PM.run(M);
-                Asm.assign(AsmBuf.begin(), AsmBuf.end());
-              } else {
-                EJIT_DIAG("dump ASM func=%s: target cannot emit assembly",
-                          ctx->fnName.c_str());
+              std::string Asm;
+              // ASM dump drives the LLVM assembly emitter, whose InstPrinter
+              // formats fields into AsmBuf via C-library snprintf/vsnprintf.
+              // On SRE those must be functional or the emit crashes in
+              // raw_ostream::operator<<(format_object_base). Link
+              // ejit_test/stubs/ejit_sre_format_stubs.cpp into the SRE/lipo
+              // image, or provide an equivalent platform vsnprintf.
+              if (engine->P->dumpTM) {
+                EJIT_DIAG("dump asm begin fn=%s", ctx->fnName.c_str());
+                SmallVector<char, 0> AsmBuf;
+                raw_svector_ostream AOS(AsmBuf);
+                legacy::PassManager PM;
+                if (!engine->P->dumpTM->addPassesToEmitFile(
+                        PM, AOS, /*DwoOut=*/nullptr,
+                        CodeGenFileType::AssemblyFile)) {
+                  EJIT_DIAG("dump asm PM.run begin fn=%s", ctx->fnName.c_str());
+                  PM.run(M);
+                  EJIT_DIAG("dump asm PM.run end fn=%s", ctx->fnName.c_str());
+                  Asm.assign(AsmBuf.begin(), AsmBuf.end());
+                  EJIT_DIAG("dump asm size=%u fn=%s", (unsigned)Asm.size(),
+                            ctx->fnName.c_str());
+                } else {
+                  EJIT_DIAG("dump asm addPassesToEmitFile failed fn=%s",
+                            ctx->fnName.c_str());
+                }
               }
+              captureDump(ctx->fnName, ctx->cacheKey, std::move(IR),
+                          std::move(Asm));
             }
-            captureDump(ctx->fnName, ctx->cacheKey, std::move(IR),
-                        std::move(Asm));
           }
         });
         return std::move(TSM);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -281,6 +281,10 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
 
   // Resolve undefined function symbols from user-registered table.
   // Required for bare-metal where dynamic lookup (dlsym) is unavailable.
+  // Throttle diagnostics: tally unresolved externals and emit a single
+  // summary line per load (below) instead of one line per symbol.
+  size_t unresolvedFuncs = 0;
+  size_t unresolvedGlobals = 0;
   for (Function &F : (*ModuleOrErr)->functions()) {
     if (!F.isDeclaration() || F.getName().empty())
       continue;
@@ -290,8 +294,7 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     auto it = P->userSymbols.find(name);
     if (it == P->userSymbols.end()) {
       if (!F.isIntrinsic())
-        EJIT_DIAG("loadBitcode: unresolved external func not registered: %s",
-                  name.c_str());
+        ++unresolvedFuncs;
       continue;
     }
     globalSymbols[P->J->mangleAndIntern(name)] =
@@ -306,14 +309,18 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
       continue;
     auto it = P->userSymbols.find(name);
     if (it == P->userSymbols.end()) {
-      EJIT_DIAG("loadBitcode: unresolved external global not registered: %s",
-                name.c_str());
+      ++unresolvedGlobals;
       continue;
     }
     globalSymbols[P->J->mangleAndIntern(name)] =
         orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(it->second),
                                JITSymbolFlags::Exported);
   }
+  if (unresolvedFuncs || unresolvedGlobals)
+    EJIT_DIAG("loadBitcode: %zu unresolved external(s) not registered "
+              "(%zu funcs, %zu globals)",
+              unresolvedFuncs + unresolvedGlobals, unresolvedFuncs,
+              unresolvedGlobals);
 
   // Provide codegen-synthesized runtime symbols (memset/memcpy/memmove/memcmp
   // and the stack-protector guard/fail) that the AOT symbol collector cannot

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -91,7 +91,7 @@ static std::string gDumpFuncFilter;
 
 void setDumpFuncFilter(const std::string &name) {
   gDumpFuncFilter = name;
-  EJIT_DIAG("set_dump_filter value=%s &filter=%p",
+  EJIT_DIAG_DEBUG("set_dump_filter value=%s &filter=%p",
             gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
             (void *)&gDumpFuncFilter);
 #ifdef EJIT_SRE_SHARED_TASKPOOL
@@ -116,7 +116,7 @@ void setDumpFuncFilter(const std::string &name) {
     D.truncated.storeRelease(0);
     D.filterEnabled.storeRelease(len ? 1u : 0u);
     D.lock.storeRelease(0);
-    EJIT_DIAG("set_dump_filter shared enabled=%u len=%u &shared=%p",
+    EJIT_DIAG_DEBUG("set_dump_filter shared enabled=%u len=%u &shared=%p",
               len ? 1u : 0u, len, (void *)gDumpSharedState);
   }
 #endif
@@ -125,7 +125,7 @@ void setDumpFuncFilter(const std::string &name) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 void setDumpSharedState(EJitSharedTaskPoolState *state) {
   gDumpSharedState = state;
-  EJIT_DIAG("set_dump_shared_state state=%p", (void *)state);
+  EJIT_DIAG_DEBUG("set_dump_shared_state state=%p", (void *)state);
 }
 
 static void sharedDumpLock(EJitSharedDumpState &D) {
@@ -256,7 +256,7 @@ static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
                            (asmTrunc ? 2u : 0u));
   D.resultValid.storeRelease(1);
   sharedDumpUnlock(D);
-  EJIT_DIAG("capture shared func=%s ir=%u asm=%u trunc=0x%x &shared=%p",
+  EJIT_DIAG_DEBUG("capture shared func=%s ir=%u asm=%u trunc=0x%x &shared=%p",
             fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size(),
             (nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) |
                 (asmTrunc ? 2u : 0u),
@@ -270,7 +270,7 @@ static bool printSharedDumped(const char *name) {
   sharedDumpLock(D);
   bool valid = D.resultValid.loadAcquire() != 0;
   if (!valid) {
-    EJIT_DIAG("print_dumped shared: nothing saved &shared=%p",
+    EJIT_DIAG_DEBUG("print_dumped shared: nothing saved &shared=%p",
               (void *)gDumpSharedState);
     sharedDumpUnlock(D);
     return false;
@@ -284,7 +284,7 @@ static bool printSharedDumped(const char *name) {
     match = (i == D.resultNameLen && name[i] == 0);
   }
   if (!match) {
-    EJIT_DIAG("print_dumped shared miss name=%s stored=%s ir=%u asm=%u",
+    EJIT_DIAG_DEBUG("print_dumped shared miss name=%s stored=%s ir=%u asm=%u",
               name ? name : "(null)", D.resultName, D.irSize, D.asmSize);
     sharedDumpUnlock(D);
     return false;
@@ -308,13 +308,13 @@ static bool printSharedDumped(const char *name) {
 /// post-optimization IR and emitted ASM for later selective printing.
 static void captureDump(const std::string &fnName, uint64_t cacheKey,
                         std::string IR, std::string ASM) {
-  EJIT_DIAG("capture enter func=%s ir_size=%u asm_size=%u &store=%p",
+  EJIT_DIAG_DEBUG("capture enter func=%s ir_size=%u asm_size=%u &store=%p",
             fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size(),
             (void *)&gDumpStore);
   std::lock_guard<DumpMutexType> lock(gDumpMutex);
-  EJIT_DIAG("capture store_size before=%u", (unsigned)gDumpStore.size());
+  EJIT_DIAG_DEBUG("capture store_size before=%u", (unsigned)gDumpStore.size());
   gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
-  EJIT_DIAG("capture store_size after=%u", (unsigned)gDumpStore.size());
+  EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   const DumpEntry &E = gDumpStore[fnName];
   captureSharedDump(fnName, cacheKey, E.IR, E.ASM);
@@ -393,9 +393,9 @@ Expected<std::unique_ptr<EJitOrcEngine>>
 EJitOrcEngine::Create(const Config &config,
                       PeriodArrayRegistry &periodReg,
                       EJitRuntimeState &runtimeState) {
-  EJIT_DIAG("create: opt=%d dump=%s",
-            static_cast<int>(config.optLevel),
-            config.dumpJITDir.empty() ? "(off)" : config.dumpJITDir.c_str());
+  EJIT_DIAG_VERBOSE("create: opt=%d dump=%s",
+                    static_cast<int>(config.optLevel),
+                    config.dumpJITDir.empty() ? "(off)" : config.dumpJITDir.c_str());
   auto engine = std::unique_ptr<EJitOrcEngine>(new EJitOrcEngine());
   engine->P->periodReg = &periodReg;
   engine->P->runtimeState = &runtimeState;
@@ -504,8 +504,8 @@ EJitOrcEngine::Create(const Config &config,
                   toString(std::move(Err)).c_str());
     }
   }
-  EJIT_DIAG("create: static vars registered=%zu",
-            periodReg.getStaticVars().size());
+  EJIT_DIAG_VERBOSE("create: static vars registered=%zu",
+                    periodReg.getStaticVars().size());
 
   // Set up IR transform layer: runs the specialization pipeline during
   // JIT compilation (parameter substitution → InstCombine → StructFieldPass
@@ -587,21 +587,21 @@ EJitOrcEngine::Create(const Config &config,
               // ejit_test/stubs/ejit_sre_format_stubs.cpp into the SRE/lipo
               // image, or provide an equivalent platform vsnprintf.
               if (engine->P->dumpTM) {
-                EJIT_DIAG("dump asm begin fn=%s", ctx->fnName.c_str());
+                EJIT_DIAG_DEBUG("dump asm begin fn=%s", ctx->fnName.c_str());
                 SmallVector<char, 0> AsmBuf;
                 raw_svector_ostream AOS(AsmBuf);
                 legacy::PassManager PM;
                 if (!engine->P->dumpTM->addPassesToEmitFile(
                         PM, AOS, /*DwoOut=*/nullptr,
                         CodeGenFileType::AssemblyFile)) {
-                  EJIT_DIAG("dump asm PM.run begin fn=%s", ctx->fnName.c_str());
+                  EJIT_DIAG_DEBUG("dump asm PM.run begin fn=%s", ctx->fnName.c_str());
                   PM.run(M);
-                  EJIT_DIAG("dump asm PM.run end fn=%s", ctx->fnName.c_str());
+                  EJIT_DIAG_DEBUG("dump asm PM.run end fn=%s", ctx->fnName.c_str());
                   Asm.assign(AsmBuf.begin(), AsmBuf.end());
-                  EJIT_DIAG("dump asm size=%u fn=%s", (unsigned)Asm.size(),
+                  EJIT_DIAG_DEBUG("dump asm size=%u fn=%s", (unsigned)Asm.size(),
                             ctx->fnName.c_str());
                 } else {
-                  EJIT_DIAG("dump asm addPassesToEmitFile failed fn=%s",
+                  EJIT_DIAG_DEBUG("dump asm addPassesToEmitFile failed fn=%s",
                             ctx->fnName.c_str());
                 }
               }
@@ -620,8 +620,8 @@ EJitOrcEngine::Create(const Config &config,
 Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
                                        uint64_t cacheKey,
                                        const std::string &origFnName) {
-  EJIT_DIAG("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
-            origFnName.c_str(), bitcodeData.size());
+  EJIT_DIAG_VERBOSE("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
+                    origFnName.c_str(), bitcodeData.size());
   auto Ctx = std::make_unique<LLVMContext>();
   auto Buf = MemoryBuffer::getMemBuffer(
       bitcodeData, ("spec_" + std::to_string(cacheKey) + ".bc"));
@@ -767,7 +767,8 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   }
 
   P->specDylibs[cacheKey] = &*JDOrErr;
-  EJIT_DIAG("loadBitcode OK key=0x%016lx func=%s", cacheKey, origFnName.c_str());
+  EJIT_DIAG_VERBOSE("loadBitcode OK key=0x%016lx func=%s", cacheKey,
+                    origFnName.c_str());
   return Error::success();
 }
 
@@ -811,8 +812,8 @@ Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
   }
 #endif
 
-  EJIT_DIAG("lookup OK key=0x%016lx name=%s ptr=%p", cacheKey, name.c_str(),
-            Ptr);
+  EJIT_DIAG_VERBOSE("lookup OK key=0x%016lx name=%s ptr=%p", cacheKey,
+                    name.c_str(), Ptr);
   return Ptr;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -32,6 +32,9 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #endif
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
+#endif
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -81,6 +84,9 @@ using DumpMutexType = std::mutex;
 // ejit_dump_func() / setDumpFuncFilter(). Read in the IR transform layer.
 // A diagnostic: set before triggering the compile of interest; concurrent
 // set/read is benign (worst case a missed or extra dump).
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+EJitSharedTaskPoolState *gDumpSharedState = nullptr;
+#endif
 static std::string gDumpFuncFilter;
 
 void setDumpFuncFilter(const std::string &name) {
@@ -88,6 +94,78 @@ void setDumpFuncFilter(const std::string &name) {
   EJIT_DIAG("set_dump_filter value=%s &filter=%p",
             gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
             (void *)&gDumpFuncFilter);
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (gDumpSharedState) {
+    EJitSharedDumpState &D = gDumpSharedState->dump;
+    uint32_t expected = 0;
+    while (!D.lock.compareExchange(expected, 1))
+      expected = 0;
+    uint32_t len = 0;
+    if (!name.empty()) {
+      while (len + 1 < kEJitSharedDumpNameBytes && len < name.size()) {
+        D.filterName[len] = name[len];
+        ++len;
+      }
+    }
+    D.filterName[len] = 0;
+    D.filterLen = len;
+    D.resultValid.storeRelease(0);
+    D.resultNameLen = 0;
+    D.irSize = 0;
+    D.asmSize = 0;
+    D.truncated.storeRelease(0);
+    D.filterEnabled.storeRelease(len ? 1u : 0u);
+    D.lock.storeRelease(0);
+    EJIT_DIAG("set_dump_filter shared enabled=%u len=%u &shared=%p",
+              len ? 1u : 0u, len, (void *)gDumpSharedState);
+  }
+#endif
+}
+
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+void setDumpSharedState(EJitSharedTaskPoolState *state) {
+  gDumpSharedState = state;
+  EJIT_DIAG("set_dump_shared_state state=%p", (void *)state);
+}
+
+static void sharedDumpLock(EJitSharedDumpState &D) {
+  uint32_t expected = 0;
+  while (!D.lock.compareExchange(expected, 1))
+    expected = 0;
+}
+
+static void sharedDumpUnlock(EJitSharedDumpState &D) {
+  D.lock.storeRelease(0);
+}
+
+static bool getSharedDumpFilter(std::string &out) {
+  if (!gDumpSharedState)
+    return false;
+  EJitSharedDumpState &D = gDumpSharedState->dump;
+  sharedDumpLock(D);
+  bool enabled = D.filterEnabled.loadAcquire() != 0;
+  if (enabled) {
+    uint32_t len = D.filterLen;
+    if (len >= kEJitSharedDumpNameBytes)
+      len = kEJitSharedDumpNameBytes - 1;
+    out.assign(D.filterName, D.filterName + len);
+  }
+  sharedDumpUnlock(D);
+  return enabled;
+}
+#else
+void setDumpSharedState(EJitSharedTaskPoolState * /*state*/) {}
+#endif
+
+static bool getActiveDumpFilter(std::string &out) {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (getSharedDumpFilter(out))
+    return true;
+#endif
+  if (gDumpFuncFilter.empty())
+    return false;
+  out = gDumpFuncFilter;
+  return true;
 }
 
 /// Saved IR+ASM for a captured specialization (latest per function name).
@@ -105,33 +183,126 @@ struct DumpEntry {
 static DumpMutexType gDumpMutex;
 static std::map<std::string, DumpEntry> gDumpStore;
 
-/// Emit a multi-line blob (IR or ASM) through EJIT_DIAG. SRE-safe: no lambda,
-/// no Twine, no raw_fd_ostream. Splits on '\n' and chunks each line to a small
-/// fixed width so a single EJIT_DIAG/SRE_printf call stays bounded.
-static void dumpLinesSafe(const char *label, const std::string &s) {
-  EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)s.size());
-  const char *data = s.data();
-  size_t n = s.size();
+static void dumpBytesSafe(const char *label, const char *data, size_t n) {
+  EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)n);
   size_t i = 0;
   unsigned lineNo = 0;
   while (i < n) {
     size_t lineEnd = i;
     while (lineEnd < n && data[lineEnd] != '\n')
       ++lineEnd;
-    // Chunk this (possibly empty) line into <= 180-char pieces.
     size_t pos = i;
-    do {
-      size_t chunk = lineEnd - pos;
-      if (chunk > 180)
-        chunk = 180;
-      EJIT_DIAG("%s:%u: %.*s", label, lineNo, (int)chunk, data + pos);
-      pos += chunk;
-    } while (pos < lineEnd);
+    if (pos == lineEnd) {
+      EJIT_DIAG("%s:%u: ", label, lineNo);
+    } else {
+      while (pos < lineEnd) {
+        size_t chunk = lineEnd - pos;
+        if (chunk > 180)
+          chunk = 180;
+        EJIT_DIAG("%s:%u: %.*s", label, lineNo, (int)chunk, data + pos);
+        pos += chunk;
+      }
+    }
     ++lineNo;
-    i = lineEnd + 1; // skip the '\n'
+    i = lineEnd + 1;
   }
+  (void)lineNo;
   EJIT_DIAG("=== %s end lines=%u ===", label, lineNo);
 }
+
+/// Emit a multi-line blob (IR or ASM) through EJIT_DIAG. SRE-safe: no lambda,
+/// no Twine, no raw_fd_ostream. Splits on '\n' and chunks each line to a small
+/// fixed width so a single EJIT_DIAG/SRE_printf call stays bounded.
+static void dumpLinesSafe(const char *label, const std::string &s) {
+  dumpBytesSafe(label, s.data(), s.size());
+}
+
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+static uint32_t copyDumpBytes(char *dst, uint32_t cap, const char *src,
+                              size_t size, bool &truncated) {
+  if (cap == 0)
+    return 0;
+  uint32_t n = 0;
+  while (n + 1 < cap && n < size) {
+    dst[n] = src[n];
+    ++n;
+  }
+  dst[n] = 0;
+  truncated = size >= cap;
+  return n;
+}
+
+static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
+                              const std::string &IR, const std::string &ASM) {
+  if (!gDumpSharedState)
+    return;
+  EJitSharedDumpState &D = gDumpSharedState->dump;
+  sharedDumpLock(D);
+  bool nameTrunc = false;
+  bool irTrunc = false;
+  bool asmTrunc = false;
+  D.resultValid.storeRelease(0);
+  D.resultNameLen =
+      copyDumpBytes(D.resultName, kEJitSharedDumpNameBytes, fnName.data(),
+                    fnName.size(), nameTrunc);
+  D.irSize =
+      copyDumpBytes(D.ir, kEJitSharedDumpTextBytes, IR.data(), IR.size(),
+                    irTrunc);
+  D.asmSize = copyDumpBytes(D.asmText, kEJitSharedDumpTextBytes, ASM.data(),
+                            ASM.size(), asmTrunc);
+  D.keyHi = (uint32_t)(cacheKey >> 32);
+  D.keyLo = (uint32_t)(cacheKey & 0xffffffffu);
+  D.truncated.storeRelease((nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) |
+                           (asmTrunc ? 2u : 0u));
+  D.resultValid.storeRelease(1);
+  sharedDumpUnlock(D);
+  EJIT_DIAG("capture shared func=%s ir=%u asm=%u trunc=0x%x &shared=%p",
+            fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size(),
+            (nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) |
+                (asmTrunc ? 2u : 0u),
+            (void *)gDumpSharedState);
+}
+
+static bool printSharedDumped(const char *name) {
+  if (!gDumpSharedState)
+    return false;
+  EJitSharedDumpState &D = gDumpSharedState->dump;
+  sharedDumpLock(D);
+  bool valid = D.resultValid.loadAcquire() != 0;
+  if (!valid) {
+    EJIT_DIAG("print_dumped shared: nothing saved &shared=%p",
+              (void *)gDumpSharedState);
+    sharedDumpUnlock(D);
+    return false;
+  }
+  bool hasName = name && name[0];
+  bool match = true;
+  if (hasName) {
+    uint32_t i = 0;
+    while (i < D.resultNameLen && name[i] && name[i] == D.resultName[i])
+      ++i;
+    match = (i == D.resultNameLen && name[i] == 0);
+  }
+  if (!match) {
+    EJIT_DIAG("print_dumped shared miss name=%s stored=%s ir=%u asm=%u",
+              name ? name : "(null)", D.resultName, D.irSize, D.asmSize);
+    sharedDumpUnlock(D);
+    return false;
+  }
+  uint32_t trunc = D.truncated.loadAcquire();
+  (void)trunc;
+  EJIT_DIAG("print_dumped shared hit requested=%s stored=%s key_hi=0x%08x "
+            "key_lo=0x%08x ir_size=%u asm_size=%u trunc=0x%x",
+            hasName ? name : "(all)", D.resultName, D.keyHi, D.keyLo, D.irSize,
+            D.asmSize, trunc);
+  if (D.irSize)
+    dumpBytesSafe("dump IR", D.ir, D.irSize);
+  if (D.asmSize)
+    dumpBytesSafe("dump ASM", D.asmText, D.asmSize);
+  sharedDumpUnlock(D);
+  return true;
+}
+#endif
 
 /// Called from the IR transform layer when the filter matches: save the
 /// post-optimization IR and emitted ASM for later selective printing.
@@ -144,6 +315,10 @@ static void captureDump(const std::string &fnName, uint64_t cacheKey,
   EJIT_DIAG("capture store_size before=%u", (unsigned)gDumpStore.size());
   gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
   EJIT_DIAG("capture store_size after=%u", (unsigned)gDumpStore.size());
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  const DumpEntry &E = gDumpStore[fnName];
+  captureSharedDump(fnName, cacheKey, E.IR, E.ASM);
+#endif
 }
 
 /// Print one stored entry: header (name, key hi/lo, IR/ASM sizes) followed by
@@ -153,6 +328,8 @@ static void printOneDumpSafe(const char *requestedName,
                              const DumpEntry &e) {
   uint32_t keyHi = (uint32_t)(e.cacheKey >> 32);
   uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
+  (void)keyHi;
+  (void)keyLo;
   EJIT_DIAG("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
             "key_lo=0x%08x ir_size=%u asm_size=%u",
             requestedName ? requestedName : "(all)", storedName.c_str(), keyHi,
@@ -170,6 +347,10 @@ void printDumped(const char *name) {
   EJIT_DIAG("print_dumped enter name=%s &filter=%p &store=%p",
             (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
             (void *)&gDumpStore);
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (printSharedDumped(name))
+    return;
+#endif
   std::lock_guard<DumpMutexType> lock(gDumpMutex);
   EJIT_DIAG("print_dumped store_size=%u", (unsigned)gDumpStore.size());
   if (name && name[0]) {
@@ -181,11 +362,13 @@ void printDumped(const char *name) {
                 (unsigned)gDumpStore.size());
       unsigned idx = 0;
       for (auto &kv : gDumpStore) {
+        (void)kv;
         EJIT_DIAG("stored[%u]=%s ir=%u asm=%u", idx, kv.first.c_str(),
                   (unsigned)kv.second.IR.size(),
                   (unsigned)kv.second.ASM.size());
         ++idx;
       }
+      (void)idx;
     }
   } else {
     if (gDumpStore.empty())
@@ -310,6 +493,7 @@ EJitOrcEngine::Create(const Config &config,
                                  JITSymbolFlags::Exported);
     if (!symMap.empty()) {
       size_t n = symMap.size();
+      (void)n;
       if (auto Err = JD.define(orc::absoluteSymbols(std::move(symMap))))
         EJIT_DIAG("create: define %zu static var(s) FAILED: %s", n,
                   toString(std::move(Err)).c_str());
@@ -367,12 +551,12 @@ EJitOrcEngine::Create(const Config &config,
           // raw_fd_ostream). Captures the post-optimization IR and the emitted
           // assembly (from the same TargetMachine the JIT compiles with).
           {
-            bool match = !gDumpFuncFilter.empty() &&
-                         ctx->fnName == gDumpFuncFilter;
+            std::string DumpFilter;
+            bool hasFilter = getActiveDumpFilter(DumpFilter);
+            bool match = hasFilter && ctx->fnName == DumpFilter;
             EJIT_DIAG("dump check filter=%s fn=%s key_hi=0x%08x key_lo=0x%08x "
                       "match=%d &filter=%p",
-                      gDumpFuncFilter.empty() ? "(off)"
-                                              : gDumpFuncFilter.c_str(),
+                      hasFilter ? DumpFilter.c_str() : "(off)",
                       ctx->fnName.c_str(), (uint32_t)(ctx->cacheKey >> 32),
                       (uint32_t)(ctx->cacheKey & 0xffffffffu), match ? 1 : 0,
                       (void *)&gDumpFuncFilter);
@@ -558,6 +742,7 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   // IR module so the JIT linker can resolve external references.
   if (!globalSymbols.empty()) {
     size_t nGlobals = globalSymbols.size();
+    (void)nGlobals;
     if (auto Err = JDOrErr->define(
             orc::absoluteSymbols(std::move(globalSymbols))))
       EJIT_DIAG("loadBitcode key=0x%016lx: define %zu global(s) FAILED: %s",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRegistrationStore.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRegistrationStore.cpp
@@ -14,8 +14,8 @@ EJitRegistrationStore &EJitRegistrationStore::instance() {
 
 void EJitRegistrationStore::registerBitcode(const std::string &funcName,
                                             const uint8_t *data, size_t size) {
-  EJIT_DIAG("regstore stage bitcode name=%s data=%p size=%zu",
-            funcName.c_str(), static_cast<const void *>(data), size);
+  EJIT_DIAG_DEBUG("regstore stage bitcode name=%s data=%p size=%zu",
+                  funcName.c_str(), static_cast<const void *>(data), size);
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   bitcodes_.push_back({funcName, data, size});
 }
@@ -24,24 +24,24 @@ void EJitRegistrationStore::registerPeriodArray(const std::string &periodName,
                                                 const std::string &varName,
                                                 void *baseAddr,
                                                 uint64_t arraySize) {
-  EJIT_DIAG("regstore stage periodArray period=%s var=%s base=%p size=%llu",
-            periodName.c_str(), varName.c_str(), baseAddr,
-            static_cast<unsigned long long>(arraySize));
+  EJIT_DIAG_DEBUG("regstore stage periodArray period=%s var=%s base=%p size=%llu",
+                  periodName.c_str(), varName.c_str(), baseAddr,
+                  static_cast<unsigned long long>(arraySize));
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   periodArrays_.push_back({periodName, varName, baseAddr, arraySize});
 }
 
 void EJitRegistrationStore::registerStaticVar(const std::string &varName,
                                               void *varAddr) {
-  EJIT_DIAG("regstore stage staticVar var=%s addr=%p", varName.c_str(),
-            varAddr);
+  EJIT_DIAG_DEBUG("regstore stage staticVar var=%s addr=%p", varName.c_str(),
+                  varAddr);
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   staticVars_.push_back({varName, varAddr});
 }
 
 void EJitRegistrationStore::registerSymbol(const std::string &name,
                                            void *addr) {
-  EJIT_DIAG("regstore stage symbol name=%s addr=%p", name.c_str(), addr);
+  EJIT_DIAG_DEBUG("regstore stage symbol name=%s addr=%p", name.c_str(), addr);
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   userSymbols_.push_back({name, addr});
 }
@@ -51,9 +51,9 @@ void EJitRegistrationStore::recordError(int code, const std::string &message,
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   // Preserve the first error so the earliest root cause is reported.
   if (error_.code != 0) {
-    EJIT_DIAG("regstore recordError suppressed (first error kept): code=%d "
-              "func=%s msg=%s",
-              code, funcName.c_str(), message.c_str());
+    EJIT_DIAG_DEBUG("regstore recordError suppressed (first error kept): "
+                    "code=%d func=%s msg=%s",
+                    code, funcName.c_str(), message.c_str());
     return;
   }
   error_.code = code;
@@ -73,8 +73,13 @@ RegistrationError EJitRegistrationStore::consumeError() {
   std::lock_guard<decltype(mutex_)> lock(mutex_);
   RegistrationError taken = error_;
   error_ = RegistrationError{};
-  EJIT_DIAG("regstore consumeError: code=%d func=%s", taken.code,
-            taken.funcName.c_str());
+  // Only surface at INFO when there was an actual error; the common no-error
+  // case (code=0) is DEBUG so it does not spam every init.
+  if (taken.code != 0)
+    EJIT_DIAG("regstore consumeError: code=%d func=%s", taken.code,
+              taken.funcName.c_str());
+  else
+    EJIT_DIAG_DEBUG("regstore consumeError: code=0 (no error)");
   return taken;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -660,6 +660,50 @@ void ejit_taskpool_print_stats() {
   EJIT_DIAG("  reserved         = %u", s.reserved);
 }
 
+void ejit_taskpool_print_compiled() {
+  if (!gEJIT) {
+    EJIT_DIAG("print_compiled: not initialized");
+    return;
+  }
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  EJitSharedTaskPool *sp = gEJIT->sharedTaskPool();
+  if (!sp || !sp->state()) {
+    EJIT_DIAG("print_compiled: no shared taskpool / state");
+    return;
+  }
+  EJitModuleLoader &loader = gEJIT->moduleLoader();
+  EJIT_DIAG("compiled functions:");
+  sp->forEachCompiled(
+      [](uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+         void *fnPtr, void *ctx) {
+#ifdef EJIT_DIAG_ENABLE
+        const auto &loader = *static_cast<EJitModuleLoader *>(ctx);
+        const std::string &name = loader.getFuncNameByFuncIdx(funcIndex);
+        EJIT_DIAG("  funcIdx=%u name=%s numDims=%u "
+                  "dims=[%u:%u,%u:%u,%u:%u,%u:%u] fn=%p",
+                  funcIndex, name.empty() ? "<unknown>" : name.c_str(), numDims,
+                  numDims > 0 ? dims[0].dimType : 0,
+                  numDims > 0 ? dims[0].instanceId : 0,
+                  numDims > 1 ? dims[1].dimType : 0,
+                  numDims > 1 ? dims[1].instanceId : 0,
+                  numDims > 2 ? dims[2].dimType : 0,
+                  numDims > 2 ? dims[2].instanceId : 0,
+                  numDims > 3 ? dims[3].dimType : 0,
+                  numDims > 3 ? dims[3].instanceId : 0, fnPtr);
+#else
+        (void)funcIndex;
+        (void)dims;
+        (void)numDims;
+        (void)fnPtr;
+        (void)ctx;
+#endif
+      },
+      &loader);
+#else
+  EJIT_DIAG("print_compiled: shared taskpool not enabled");
+#endif
+}
+
 // Sentinel returned when no owner core is elected (e.g. not initialized or the
 // shared taskpool has not bound state). Distinct from any valid core id.
 constexpr uint32_t kEJitInvalidOwnerCore = 0xFFFFFFFFu;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -743,4 +743,22 @@ uint32_t ejit_taskpool_get_worker_core() {
 }
 #endif // EJIT_SRE_TASKPOOL
 
+//===----------------------------------------------------------------------===//
+// General diagnostics (available in every build, not only taskpool).
+//===----------------------------------------------------------------------===//
+
+void ejit_dump_all(bool enable) {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (gEJIT) {
+    if (EJitSharedTaskPool *sp = gEJIT->sharedTaskPool())
+      setDumpSharedState(sp->state());
+  }
+#endif
+  // The "*" filter is a wildcard matched by every specialization in the IR
+  // transform layer (see getActiveDumpFilter / the capture condition). Capture
+  // is bounded by distinct function names; print with ejit_print_dumped(NULL).
+  EJIT_DIAG("dump_all enable=%u", enable ? 1u : 0u);
+  setDumpFuncFilter(enable ? std::string("*") : std::string());
+}
+
 } // extern "C"

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -7,6 +7,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitFuncRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLifecycleRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
+#include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #ifdef EJIT_SRE_TASKPOOL
@@ -702,6 +703,17 @@ void ejit_taskpool_print_compiled() {
 #else
   EJIT_DIAG("print_compiled: shared taskpool not enabled");
 #endif
+}
+
+void ejit_dump_func(const char *name) {
+  std::string filter = (name && name[0]) ? std::string(name) : std::string();
+  EJIT_DIAG("dump_func filter=%s", filter.empty() ? "(off)" : filter.c_str());
+  setDumpFuncFilter(filter);
+}
+
+void ejit_print_dumped(const char *name) {
+  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(all)");
+  printDumped(name);
 }
 
 // Sentinel returned when no owner core is elected (e.g. not initialized or the

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -761,4 +761,38 @@ void ejit_dump_all(bool enable) {
   setDumpFuncFilter(enable ? std::string("*") : std::string());
 }
 
+void ejit_set_log_level(ejit_log_level_t level) {
+  int v = static_cast<int>(level);
+  if (v < EJIT_LOG_LVL_OFF)
+    v = EJIT_LOG_LVL_OFF;
+  if (v > EJIT_LOG_LVL_DEBUG)
+    v = EJIT_LOG_LVL_DEBUG;
+  gEJitDiagLevel = v;
+  EJIT_DIAG("log_level=%d", gEJitDiagLevel);
+}
+
+ejit_log_level_t ejit_get_log_level(void) {
+  return static_cast<ejit_log_level_t>(gEJitDiagLevel);
+}
+
+void ejit_print_registry(void) {
+  if (!gEJIT) {
+    EJIT_DIAG("print_registry: not initialized");
+    return;
+  }
+  gEJIT->printRegistry();
+}
+
+void ejit_print_func_meta(const char *funcName) {
+  if (!funcName || !funcName[0]) {
+    EJIT_DIAG("print_func_meta: null/empty name");
+    return;
+  }
+  if (!gEJIT) {
+    EJIT_DIAG("print_func_meta: not initialized");
+    return;
+  }
+  gEJIT->printFuncMeta(funcName);
+}
+
 } // extern "C"

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -110,7 +110,8 @@ void ejit_shutdown(void) {
 }
 
 void ejit_register_symbol(const char *name, void *addr) {
-  EJIT_DIAG("register_symbol name=%s addr=%p", name ? name : "<null>", addr);
+  EJIT_DIAG_VERBOSE("register_symbol name=%s addr=%p", name ? name : "<null>",
+                    addr);
   if (gEJIT) {
     gEJIT->registerSymbol(name, addr);
   } else {
@@ -121,9 +122,9 @@ void ejit_register_symbol(const char *name, void *addr) {
 
 void ejit_register_bitcode(const char *funcName, const uint8_t *bitcodeData,
                            uint64_t bitcodeSize) {
-  EJIT_DIAG("register_bitcode name=%s size=%llu",
-            funcName ? funcName : "<null>",
-            static_cast<unsigned long long>(bitcodeSize));
+  EJIT_DIAG_VERBOSE("register_bitcode name=%s size=%llu",
+                    funcName ? funcName : "<null>",
+                    static_cast<unsigned long long>(bitcodeSize));
   if (gEJIT) {
     // Post-init runtime registration: the void ABI cannot return a status, so a
     // rejection (null/zero payload, funcIndex capacity, conflicting payload) is
@@ -144,9 +145,10 @@ void ejit_register_bitcode(const char *funcName, const uint8_t *bitcodeData,
 
 void ejit_register_period_array(const char *periodName, const char *varName,
                                 void *baseAddr, uint64_t arraySize) {
-  EJIT_DIAG("register_period_array period=%s var=%s size=%llu",
-            periodName ? periodName : "<null>", varName ? varName : "<null>",
-            static_cast<unsigned long long>(arraySize));
+  EJIT_DIAG_VERBOSE("register_period_array period=%s var=%s size=%llu",
+                    periodName ? periodName : "<null>",
+                    varName ? varName : "<null>",
+                    static_cast<unsigned long long>(arraySize));
   if (gEJIT) {
     // Post-init: rejected once registration is frozen (taskpool); the void ABI
     // records the failure for observability and mutates nothing.
@@ -164,8 +166,8 @@ void ejit_register_period_array(const char *periodName, const char *varName,
 }
 
 void ejit_register_static_var(const char *varName, void *varAddr) {
-  EJIT_DIAG("register_static_var var=%s addr=%p",
-            varName ? varName : "<null>", varAddr);
+  EJIT_DIAG_VERBOSE("register_static_var var=%s addr=%p",
+                    varName ? varName : "<null>", varAddr);
   if (gEJIT) {
     if (!gEJIT->registerStaticVar(varName, varAddr)) {
       EJitRegistrationStore::instance().recordError(
@@ -191,7 +193,7 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut) {
               (const void *)lifecycleName, (void *)slotOut);
     return;
   }
-  EJIT_DIAG("register_lifecycle name=%s", lifecycleName);
+  EJIT_DIAG_VERBOSE("register_lifecycle name=%s", lifecycleName);
 #ifdef EJIT_SRE_TASKPOOL
   // Once a taskpool init has frozen registration, the worker reads the registry
   // lock-free: refuse to mutate it (leave *slotOut and the registry unchanged).
@@ -214,7 +216,8 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut) {
     EJIT_DIAG("register_lifecycle FAIL name=%s: dimType capacity exhausted",
               lifecycleName);
   } else {
-    EJIT_DIAG("register_lifecycle OK name=%s slot=%u", lifecycleName, slot);
+    EJIT_DIAG_VERBOSE("register_lifecycle OK name=%s slot=%u", lifecycleName,
+                      slot);
   }
 }
 
@@ -228,7 +231,7 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
               (const void *)funcName, (void *)slotOut);
     return;
   }
-  EJIT_DIAG("register_funcindex name=%s", funcName);
+  EJIT_DIAG_VERBOSE("register_funcindex name=%s", funcName);
 #ifdef EJIT_SRE_TASKPOOL
   if (gEJIT && gEJIT->registrationFrozen()) {
     EJitRegistrationStore::instance().recordError(
@@ -248,7 +251,7 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
     EJIT_DIAG("register_funcindex FAIL name=%s: funcIndex capacity exhausted",
               funcName);
   } else {
-    EJIT_DIAG("register_funcindex OK name=%s idx=%u", funcName, idx);
+    EJIT_DIAG_VERBOSE("register_funcindex OK name=%s idx=%u", funcName, idx);
   }
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -22,6 +22,19 @@ using namespace llvm::ejit;
 
 static EJit *gEJIT = nullptr;
 
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+static void bindDumpSharedStateFromRuntime() {
+  if (!gEJIT) {
+    setDumpSharedState(nullptr);
+    return;
+  }
+  if (EJitSharedTaskPool *sp = gEJIT->sharedTaskPool())
+    setDumpSharedState(sp->state());
+  else
+    setDumpSharedState(nullptr);
+}
+#endif
+
 static void parseConfig(const ejit_config_t *src, Config &dst) {
   if (!src)
     return;
@@ -77,6 +90,9 @@ ejit_status_t ejit_init(const ejit_config_t *config) {
     return st;
   }
 
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  bindDumpSharedStateFromRuntime();
+#endif
   EJIT_DIAG("initialized: mode=%d opt=%d cache=%zu entries=%u",
             (int)cfg.compileMode, (int)cfg.optLevel, cfg.maxCacheSize,
             (unsigned)cfg.maxCacheEntries);
@@ -85,6 +101,9 @@ ejit_status_t ejit_init(const ejit_config_t *config) {
 
 void ejit_shutdown(void) {
   EJIT_DIAG("shutting down");
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  setDumpSharedState(nullptr);
+#endif
   delete gEJIT;
   gEJIT = nullptr;
   EJIT_DIAG("shutdown complete");
@@ -706,12 +725,24 @@ void ejit_taskpool_print_compiled() {
 }
 
 void ejit_dump_func(const char *name) {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (gEJIT) {
+    if (EJitSharedTaskPool *sp = gEJIT->sharedTaskPool())
+      setDumpSharedState(sp->state());
+  }
+#endif
   std::string filter = (name && name[0]) ? std::string(name) : std::string();
   EJIT_DIAG("dump_func filter=%s", filter.empty() ? "(off)" : filter.c_str());
   setDumpFuncFilter(filter);
 }
 
 void ejit_print_dumped(const char *name) {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (gEJIT) {
+    if (EJitSharedTaskPool *sp = gEJIT->sharedTaskPool())
+      setDumpSharedState(sp->state());
+  }
+#endif
   EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(all)");
   printDumped(name);
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -322,8 +322,8 @@ void *ejit_compile_or_get(uint64_t cacheKey, void **out_pfn) {
   if (out_pfn)
     *out_pfn = result;
 
-  EJIT_DIAG("compile_or_get(key=0x%016lx) → %s", cacheKey,
-            result ? "JIT" : "NULL");
+  EJIT_DIAG_VERBOSE("compile_or_get(key=0x%016lx) → %s", cacheKey,
+                    result ? "JIT" : "NULL");
   return result;
 }
 
@@ -441,7 +441,8 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     *outFn = nullptr;
   if (outBucket)
     *outBucket = 0;
-  EJIT_DIAG("taskpool_compile_or_get func=%u dims=%u", funcIndex, numDims);
+  EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u dims=%u", funcIndex,
+                    numDims);
   if (!gEJIT) {
     EJIT_DIAG("taskpool_compile_or_get reject func=%u: not initialized",
               funcIndex);
@@ -487,15 +488,15 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  EJIT_DIAG("taskpool_compile_or_get func=%u status=%u fn=%p", funcIndex,
-            static_cast<unsigned>(r.status), r.fnPtr);
+  EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u status=%u fn=%p",
+                    funcIndex, static_cast<unsigned>(r.status), r.fnPtr);
   return taskpoolStatus(r.status);
 }
 
 void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
                                         uint32_t enabled) {
-  EJIT_DIAG("taskpool_set_instance_enabled dim=%u inst=%u enabled=%u", dimType,
-            instanceId, enabled);
+  EJIT_DIAG_VERBOSE("taskpool_set_instance_enabled dim=%u inst=%u enabled=%u",
+                    dimType, instanceId, enabled);
   if (!gEJIT) {
     EJIT_DIAG("taskpool_set_instance_enabled reject: not initialized");
     return;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntimeState.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntimeState.cpp
@@ -10,8 +10,32 @@ using namespace llvm::ejit;
 void PeriodArrayRegistry::registerArray(const std::string &periodName,
                                         const std::string &varName,
                                         void *baseAddr, size_t size) {
-  EJIT_DIAG("registry registerArray period=%s var=%s base=%p size=%zu",
-            periodName.c_str(), varName.c_str(), baseAddr, size);
+  // Idempotent: the constructor path may register the same array twice
+  // (PASS1+PASS2 both add to global_ctors, or the static-registry walk
+  // revisits an entry). A repeat with identical (period, base, size) is a
+  // no-op (DEBUG only); a same-name conflict with different data is a clean
+  // rejection that keeps the first registration. This also prevents duplicate
+  // entries accumulating in arraysByPeriod_ (which would make activate fan out
+  // redundantly and getArrays() report ghosts).
+  auto existing = varNameIndex_.find(varName);
+  if (existing != varNameIndex_.end()) {
+    const PeriodArrayInfo &first = existing->second;
+    if (first.periodName == periodName && first.baseAddr == baseAddr &&
+        first.arraySize == size) {
+      EJIT_DIAG_DEBUG("registry registerArray idempotent skip period=%s "
+                      "var=%s base=%p size=%zu",
+                      periodName.c_str(), varName.c_str(), baseAddr, size);
+      return;
+    }
+    EJIT_DIAG("registry registerArray CONFLICT var=%s: kept first "
+              "(period=%s base=%p size=%zu), rejected (period=%s base=%p "
+              "size=%zu)",
+              varName.c_str(), first.periodName.c_str(), first.baseAddr,
+              first.arraySize, periodName.c_str(), baseAddr, size);
+    return;
+  }
+  EJIT_DIAG_VERBOSE("registry registerArray period=%s var=%s base=%p size=%zu",
+                    periodName.c_str(), varName.c_str(), baseAddr, size);
   PeriodArrayInfo info{varName, periodName, baseAddr, size};
   arraysByPeriod_[periodName].push_back(info);
   varNameIndex_[varName] = info;
@@ -20,8 +44,24 @@ void PeriodArrayRegistry::registerArray(const std::string &periodName,
 
 void PeriodArrayRegistry::registerStaticVar(const std::string &varName,
                                             void *varAddr) {
-  EJIT_DIAG("registry registerStaticVar var=%s addr=%p", varName.c_str(),
-            varAddr);
+  // Idempotent (see registerArray): a repeat with the same addr is a no-op;
+  // a same-name/different-addr conflict keeps the first registration and
+  // prevents staticVars_ from accumulating duplicates.
+  auto existing = staticVarIndex_.find(varName);
+  if (existing != staticVarIndex_.end()) {
+    if (existing->second == varAddr) {
+      EJIT_DIAG_DEBUG("registry registerStaticVar idempotent skip var=%s "
+                      "addr=%p",
+                      varName.c_str(), varAddr);
+      return;
+    }
+    EJIT_DIAG("registry registerStaticVar CONFLICT var=%s: kept addr=%p, "
+              "rejected addr=%p",
+              varName.c_str(), existing->second, varAddr);
+    return;
+  }
+  EJIT_DIAG_VERBOSE("registry registerStaticVar var=%s addr=%p",
+                    varName.c_str(), varAddr);
   staticVars_.push_back({varName, varAddr});
   staticVarIndex_[varName] = varAddr;
 }
@@ -60,8 +100,8 @@ PeriodArrayRegistry::getArrayByBaseAddr(void *addr) const {
 
 void EJitRuntimeState::activate(const std::string &periodName,
                                 uint8_t cellIdx) {
-  EJIT_DIAG("runtimeState activate period=%s cellIdx=%u", periodName.c_str(),
-            cellIdx);
+  EJIT_DIAG_DEBUG("runtimeState activate period=%s cellIdx=%u",
+                  periodName.c_str(), cellIdx);
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntimeState.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntimeState.cpp
@@ -116,8 +116,8 @@ void EJitRuntimeState::activate(const std::string &periodName,
 
 void EJitRuntimeState::deactivate(const std::string &periodName,
                                   uint8_t cellIdx) {
-  EJIT_DIAG("runtimeState deactivate period=%s cellIdx=%u", periodName.c_str(),
-            cellIdx);
+  EJIT_DIAG_DEBUG("runtimeState deactivate period=%s cellIdx=%u",
+                  periodName.c_str(), cellIdx);
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif
@@ -130,7 +130,7 @@ void EJitRuntimeState::deactivate(const std::string &periodName,
 }
 
 void EJitRuntimeState::activateAll(const std::string &periodName) {
-  EJIT_DIAG("runtimeState activateAll period=%s", periodName.c_str());
+  EJIT_DIAG_DEBUG("runtimeState activateAll period=%s", periodName.c_str());
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif
@@ -145,7 +145,7 @@ void EJitRuntimeState::activateAll(const std::string &periodName) {
 }
 
 void EJitRuntimeState::deactivateAll(const std::string &periodName) {
-  EJIT_DIAG("runtimeState deactivateAll period=%s", periodName.c_str());
+  EJIT_DIAG_DEBUG("runtimeState deactivateAll period=%s", periodName.c_str());
 #ifndef EJIT_FREESTANDING
   std::lock_guard<decltype(mutex_)> lock(mutex_);
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -85,6 +85,37 @@ uint32_t EJitSharedTaskPool::instanceVersion(uint32_t dimType,
   return state_->version[dimType][instanceId].loadAcquire();
 }
 
+void EJitSharedTaskPool::forEachCompiled(CompiledFuncCallback cb,
+                                         void *ctx) const {
+  if (!state_ || !cb)
+    return;
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
+    EJitSharedCacheBucket &B = state_->buckets[b];
+    // Acquire the per-bucket read lock; retry briefly if a writer is
+    // mid-publish, then skip the bucket if still contended (diagnostic — a
+    // missing entry here just means it was being updated this instant).
+    bool locked = false;
+    for (int retry = 0; retry < 16; ++retry) {
+      if (bucketTryRead(B)) {
+        locked = true;
+        break;
+      }
+      cpuRelax();
+    }
+    if (!locked)
+      continue;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      const EJitSharedCacheSlot &slot = B.slots[s];
+      if (static_cast<EJitSharedSlotState>(slot.state.loadAcquire()) !=
+          EJitSharedSlotState::Ready)
+        continue;
+      void *fn = reinterpret_cast<void *>(slot.fnPtr.loadAcquire());
+      cb(slot.funcIndex, slot.dims, slot.numDims, fn, ctx);
+    }
+    bucketReadRelease(B);
+  }
+}
+
 bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
                                             uint32_t instanceId, bool enabled) {
   if (!state_ || dimType >= kEJitSharedDimTypes ||

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -418,7 +418,7 @@ EJitSharedPoolSplit *EJitSharedTaskPool::findOrClaimPoolSlot(uintptr_t base) {
 bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
                                                        uintptr_t poolBase,
                                                        uint64_t poolSize) {
-  EJIT_DIAG("ensurePoolSplit: core=%u poolBase=0x%llx size=%llu", self,
+  EJIT_DIAG_VERBOSE("ensurePoolSplit: core=%u poolBase=0x%llx size=%llu", self,
             static_cast<unsigned long long>(poolBase),
             static_cast<unsigned long long>(poolSize));
   // Cores beyond the 64-bit memo width cannot record split state, so they must
@@ -433,7 +433,7 @@ bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
 
   EJitSharedPoolSplit *P = findOrClaimPoolSlot(poolBase);
   if (!P) {
-    EJIT_DIAG("ensurePoolSplit fallback: core=%u poolBase=0x%llx split table full",
+    EJIT_DIAG_VERBOSE("ensurePoolSplit fallback: core=%u poolBase=0x%llx split table full",
               self, static_cast<unsigned long long>(poolBase));
     return false; // table full -> clean fallback.
   }
@@ -458,7 +458,7 @@ bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
     }
     bool done = (P->splitDoneMask.loadAcquire() & Bit) != 0;
     if (!done)
-      EJIT_DIAG("ensurePoolSplit fallback: core=%u poolBase=0x%llx peer split "
+      EJIT_DIAG_VERBOSE("ensurePoolSplit fallback: core=%u poolBase=0x%llx peer split "
                 "did not publish done", self,
                 static_cast<unsigned long long>(poolBase));
     return done;
@@ -480,7 +480,7 @@ bool EJitSharedTaskPool::ensurePoolSplitForCurrentCore(uint32_t self,
 
 bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
                                                    uint32_t self) {
-  EJIT_DIAG("prepareExec: core=%u fn=%p codeStart=0x%llx codeSize=%llu "
+  EJIT_DIAG_VERBOSE("prepareExec: core=%u fn=%p codeStart=0x%llx codeSize=%llu "
             "poolBase=0x%llx fourK=%u", self, R.fn,
             static_cast<unsigned long long>(R.codeStart),
             static_cast<unsigned long long>(R.codeSize),
@@ -503,7 +503,7 @@ bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
   // 4K page seal needs the real executable extent. A slot with no recorded
   // range (or a malformed one) is a clean fallback, never a guessed seal.
   if (R.codeStart == 0 || R.codeSize == 0 || R.poolBase == 0 || R.poolSize == 0) {
-    EJIT_DIAG("prepareExec fallback: core=%u fn=%p malformed range "
+    EJIT_DIAG_VERBOSE("prepareExec fallback: core=%u fn=%p malformed range "
               "(codeStart=0x%llx codeSize=%llu poolBase=0x%llx poolSize=%llu)",
               self, R.fn, static_cast<unsigned long long>(R.codeStart),
               static_cast<unsigned long long>(R.codeSize),
@@ -512,16 +512,16 @@ bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
     return false;
   }
   if (R.codeStart + R.codeSize < R.codeStart) { // code range overflow
-    EJIT_DIAG("prepareExec fallback: core=%u code range overflow", self);
+    EJIT_DIAG_VERBOSE("prepareExec fallback: core=%u code range overflow", self);
     return false;
   }
   if (R.poolBase + R.poolSize < R.poolBase) { // pool range overflow
-    EJIT_DIAG("prepareExec fallback: core=%u pool range overflow", self);
+    EJIT_DIAG_VERBOSE("prepareExec fallback: core=%u pool range overflow", self);
     return false;
   }
   if (R.codeStart < R.poolBase ||
       R.codeStart + R.codeSize > R.poolBase + R.poolSize) {
-    EJIT_DIAG("prepareExec fallback: core=%u code not inside pool", self);
+    EJIT_DIAG_VERBOSE("prepareExec fallback: core=%u code not inside pool", self);
     return false; // code must lie wholly inside its pool.
   }
 
@@ -543,7 +543,7 @@ bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
                 self, static_cast<unsigned long long>(VA));
       return false; // any page failure -> no callable pointer is returned.
     }
-  EJIT_DIAG("prepareExec OK: core=%u fn=%p pages=[0x%llx,0x%llx)", self, R.fn,
+  EJIT_DIAG_VERBOSE("prepareExec OK: core=%u fn=%p pages=[0x%llx,0x%llx)", self, R.fn,
             static_cast<unsigned long long>(PageStart),
             static_cast<unsigned long long>(PageEnd));
   return true;
@@ -891,10 +891,10 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                  uint32_t numDims, void *fallback) {
   CompileOrGetResult R;
   R.fnPtr = fallback;
-  EJIT_DIAG("shared taskpool request func=%u dims=%u fallback=%p", funcIndex,
+  EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p", funcIndex,
             numDims, fallback);
   if (!state_ || state_->initState.loadAcquire() != kReady) {
-    EJIT_DIAG("shared taskpool fallback func=%u: not Ready", funcIndex);
+    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: not Ready", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode; // not Ready → clean fallback.
     return R;
   }
@@ -908,7 +908,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   for (uint32_t i = 0; i < numDims; ++i)
     if (!isInstanceEnabled(dims[i].dimType, dims[i].instanceId)) {
       state_->counters.instanceDisabled.fetchAdd(1);
-      EJIT_DIAG("shared taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex,
+      EJIT_DIAG_VERBOSE("shared taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex,
                 i, dims[i].dimType, dims[i].instanceId);
       R.status = EJitCompileOrGetStatus::InstanceDisabled;
       return R;
@@ -921,14 +921,14 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.fnPtr = Hit.fnPtr;
     R.bucketIndex = Hit.bucketIndex;
     R.hasReadToken = true;
-    EJIT_DIAG("shared taskpool hit func=%u bucket=%u fn=%p", funcIndex,
+    EJIT_DIAG_VERBOSE("shared taskpool hit func=%u bucket=%u fn=%p", funcIndex,
               Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
   if (Hit.readyButNotShareable) {
     // The work is already done but this core may not read the cross-core
     // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
-    EJIT_DIAG("shared taskpool fallback func=%u: ready but not shareable on this core",
+    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: ready but not shareable on this core",
               funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;
     R.readyButNotShareable = true;
@@ -937,7 +937,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   // Off mode (§5.2 step 2).
   if (state_->mode.loadAcquire() ==
       static_cast<uint32_t>(EJitCompileMode::Off)) {
-    EJIT_DIAG("shared taskpool fallback func=%u: mode off", funcIndex);
+    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: mode off", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;
     return R;
   }
@@ -955,7 +955,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   switch (dedupMark(funcIndex, gen)) {
   case EJitDedupResult::AlreadyPending:
     state_->counters.alreadyPending.fetchAdd(1);
-    EJIT_DIAG("shared taskpool coalesced func=%u: already pending", funcIndex);
+    EJIT_DIAG_VERBOSE("shared taskpool coalesced func=%u: already pending", funcIndex);
     R.status = EJitCompileOrGetStatus::AlreadyPending;
     return R;
   case EJitDedupResult::InvalidFuncIndex:
@@ -973,7 +973,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     return R;
   }
   state_->counters.asyncEnqueues.fetchAdd(1);
-  EJIT_DIAG("shared taskpool enqueued func=%u gen=%u", funcIndex, gen);
+  EJIT_DIAG_VERBOSE("shared taskpool enqueued func=%u gen=%u", funcIndex, gen);
   R.status = EJitCompileOrGetStatus::EnqueuedPending;
   return R;
 }
@@ -982,7 +982,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
 // Consumer path (§5.3) — runs on the single owner worker (or a test driver).
 //===----------------------------------------------------------------------===//
 void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
-  EJIT_DIAG("shared worker compile begin func=%u dims=%u gen=%u", req.funcIndex,
+  EJIT_DIAG_VERBOSE("shared worker compile begin func=%u dims=%u gen=%u", req.funcIndex,
             req.numDims, req.generation);
   // Checkpoint 0 (spec §11): generation guard. A request enqueued under an
   // earlier generation (owner re-init in between) is dropped before compiling.
@@ -1036,7 +1036,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   case EJitPublishStatus::Published:
     state_->counters.asyncCompiles.fetchAdd(1);
     dedupClear(req.funcIndex, req.generation);
-    EJIT_DIAG("shared worker publish ok func=%u fn=%p", req.funcIndex, fn);
+    EJIT_DIAG_VERBOSE("shared worker publish ok func=%u fn=%p", req.funcIndex, fn);
     return;
   case EJitPublishStatus::VersionMismatch:
     if (releaseFn_)
@@ -1092,13 +1092,13 @@ EJitWorkerStep EJitSharedTaskPool::workerPollOnce() {
   case EJitSharedInitState::Failed:
   case EJitSharedInitState::Stopping:
   default:
-    EJIT_DIAG("shared worker exit: state=%u", st);
+    EJIT_DIAG_DEBUG("shared worker exit: state=%u", st);
     return EJitWorkerStep::Exit;
   }
 }
 
 void EJitSharedTaskPool::runWorkerLoop() {
-  EJIT_DIAG("shared worker loop enter");
+  EJIT_DIAG_VERBOSE("shared worker loop enter");
   // Loop until a terminal state. The worker is a PRODUCTION-lifetime task: it
   // never exits just because the owner is slightly slow to publish Ready (no
   // spin budget). On every non-consuming iteration — waiting through
@@ -1115,7 +1115,7 @@ void EJitSharedTaskPool::runWorkerLoop() {
       workerIdle();
     // Consumed: loop immediately, more work is likely queued.
   }
-  EJIT_DIAG("shared worker loop leave");
+  EJIT_DIAG_VERBOSE("shared worker loop leave");
 }
 
 void EJitSharedTaskPool::workerIdle() {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -702,6 +702,26 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
     st->poolSplits[i].splitDoneMask.storeRelaxed(0);
     st->poolSplits[i].splitPreparingMask.storeRelaxed(0);
   }
+  st->dump.lock.storeRelaxed(0);
+  st->dump.filterEnabled.storeRelaxed(0);
+  st->dump.resultValid.storeRelaxed(0);
+  st->dump.truncated.storeRelaxed(0);
+  st->dump.filterLen = 0;
+  st->dump.resultNameLen = 0;
+  st->dump.irSize = 0;
+  st->dump.asmSize = 0;
+  st->dump.keyHi = 0;
+  st->dump.keyLo = 0;
+  st->dump.reserved0 = 0;
+  st->dump.reserved1 = 0;
+  for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i) {
+    st->dump.filterName[i] = 0;
+    st->dump.resultName[i] = 0;
+  }
+  for (uint32_t i = 0; i < kEJitSharedDumpTextBytes; ++i) {
+    st->dump.ir[i] = 0;
+    st->dump.asmText[i] = 0;
+  }
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     st->buckets[b].writeFlag.storeRelaxed(0);
     st->buckets[b].readers.storeRelaxed(0);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -78,8 +78,8 @@ llvm::ejit::makeSreCodePoolManager() {
   Opts.poolSize = static_cast<size_t>(kSrePoolSize);
   Opts.poolAlign = k2MiB; // large-page / split granularity
   Opts.minCodeAlign = 64;
-  EJIT_DIAG("makeSreCodePoolManager: poolSize=%llu poolAlign=%zu",
-            kSrePoolSize, k2MiB);
+  EJIT_DIAG_VERBOSE("makeSreCodePoolManager: poolSize=%llu poolAlign=%zu",
+                    kSrePoolSize, k2MiB);
 #ifdef EJIT_CODE_POOL_4K_SEAL
   // Adapt to the platform's 4K execute-permission interface: the 2MiB pool is
   // split into 4K mappings at creation and sealed one 4KiB page at a time.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -72,6 +72,12 @@ void EJitStructFieldPass::initFromModule(Module &M) {
   }
 
   mapsBuilt_ = true;
+#ifdef EJIT_DIAG_ENABLE
+  EJIT_DIAG("struct-field initFromModule module=%s globals=%zu "
+            "gvPeriod=%zu mayConstField=%zu",
+            M.getName().str().c_str(), M.global_size(), gvPeriodMap_.size(),
+            mayConstFieldMap_.size());
+#endif
 }
 
 //===----------------------------------------------------------------------===//
@@ -326,6 +332,44 @@ tryReplaceIndirect(LoadInst *LI, const Value *PtrOp,
 // Public interface
 //===----------------------------------------------------------------------===//
 
+#ifdef EJIT_DIAG_ENABLE
+/// Classify why a may_const load was NOT replaced by any pattern, for
+/// diagnostics. One EJIT_DIAG line per failed load. Reasons:
+///   no-root-gv        — pointer not rooted at a GlobalVariable (opaque/indirect)
+///   gv-not-in-map     — root GV has no ejit.metadata (not a period var)
+///   base-unresolved   — GV is a period var but not registered at runtime
+///   non-const-offset  — GEP index not folded to a constant
+///   unsupported-type  — createConstantFromMemory cannot build the load type
+static void logReplaceFailure(LoadInst *LI, const GVPeriodMap &gvMap,
+                              PeriodArrayRegistry &reg,
+                              const DataLayout &DL) {
+  Value *Ptr = LI->getPointerOperand();
+  const GlobalVariable *GV = findRootGV(Ptr);
+  if (!GV) {
+    EJIT_DIAG("  may_const load NOT replaced: no-root-gv");
+    return;
+  }
+  auto it = gvMap.find(GV);
+  if (it == gvMap.end()) {
+    EJIT_DIAG("  may_const load NOT replaced: gv-not-in-map gv=%s",
+              GV->getName().str().c_str());
+    return;
+  }
+  if (!resolveBase(GV, it->second, reg)) {
+    EJIT_DIAG("  may_const load NOT replaced: base-unresolved gv=%s",
+              GV->getName().str().c_str());
+    return;
+  }
+  if (!accumulateFullOffset(DL, Ptr)) {
+    EJIT_DIAG("  may_const load NOT replaced: non-const-offset gv=%s",
+              GV->getName().str().c_str());
+    return;
+  }
+  EJIT_DIAG("  may_const load NOT replaced: unsupported-type gv=%s",
+            GV->getName().str().c_str());
+}
+#endif
+
 PreservedAnalyses
 EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
   Module *M = F.getParent();
@@ -347,15 +391,24 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
   // 2. Scan all loads and collect replacements.
   struct Replacement { LoadInst *LI; Constant *ConstVal; };
   SmallVector<Replacement, 16> replacements;
+#ifdef EJIT_DIAG_ENABLE
+  size_t totalLoads = 0, mayConstLoads = 0;
+#endif
 
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
       auto *LI = dyn_cast<LoadInst>(&I);
       if (!LI)
         continue;
+#ifdef EJIT_DIAG_ENABLE
+      ++totalLoads;
+#endif
 
       if (!isMayConstLoad(LI, mayConstFieldMap_, DL))
         continue;
+#ifdef EJIT_DIAG_ENABLE
+      ++mayConstLoads;
+#endif
 
       Value *PtrOp = LI->getPointerOperand();
 
@@ -376,6 +429,10 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
 
       if (C)
         replacements.push_back({LI, C});
+#ifdef EJIT_DIAG_ENABLE
+      else
+        logReplaceFailure(LI, gvPeriodMap_, registry_, DL);
+#endif
     }
   }
 
@@ -389,6 +446,10 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
 
   EJIT_DIAG("struct-field run func=%s replaced=%zu", F.getName().str().c_str(),
             replacements.size());
+#ifdef EJIT_DIAG_ENABLE
+  EJIT_DIAG("  loads total=%zu may_const=%zu replaced=%zu", totalLoads,
+            mayConstLoads, replacements.size());
+#endif
   LLVM_DEBUG(if (changed) dbgs() << "ejit-struct-field: replaced "
                                  << replacements.size() << " load(s) in "
                                  << F.getName() << "\n");

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -22,8 +22,8 @@ using namespace llvm::ejit;
 #define DEBUG_TYPE "ejit-struct-field"
 
 void EJitStructFieldPass::initFromModule(Module &M) {
-  EJIT_DIAG("struct-field initFromModule module=%s globals=%zu",
-            M.getName().str().c_str(), M.global_size());
+  EJIT_DIAG_VERBOSE("struct-field initFromModule module=%s globals=%zu",
+                    M.getName().str().c_str(), M.global_size());
   // Build GV period map.
   for (GlobalVariable &GV : M.globals()) {
     MDNode *MD = GV.getMetadata(MD_EJIT_METADATA);
@@ -73,10 +73,10 @@ void EJitStructFieldPass::initFromModule(Module &M) {
 
   mapsBuilt_ = true;
 #ifdef EJIT_DIAG_ENABLE
-  EJIT_DIAG("struct-field initFromModule module=%s globals=%zu "
-            "gvPeriod=%zu mayConstField=%zu",
-            M.getName().str().c_str(), M.global_size(), gvPeriodMap_.size(),
-            mayConstFieldMap_.size());
+  EJIT_DIAG_DEBUG("struct-field initFromModule module=%s globals=%zu "
+                  "gvPeriod=%zu mayConstField=%zu",
+                  M.getName().str().c_str(), M.global_size(), gvPeriodMap_.size(),
+                  mayConstFieldMap_.size());
 #endif
 }
 
@@ -346,27 +346,27 @@ static void logReplaceFailure(LoadInst *LI, const GVPeriodMap &gvMap,
   Value *Ptr = LI->getPointerOperand();
   const GlobalVariable *GV = findRootGV(Ptr);
   if (!GV) {
-    EJIT_DIAG("  may_const load NOT replaced: no-root-gv");
+    EJIT_DIAG_VERBOSE("  may_const load NOT replaced: no-root-gv");
     return;
   }
   auto it = gvMap.find(GV);
   if (it == gvMap.end()) {
-    EJIT_DIAG("  may_const load NOT replaced: gv-not-in-map gv=%s",
-              GV->getName().str().c_str());
+    EJIT_DIAG_VERBOSE("  may_const load NOT replaced: gv-not-in-map gv=%s",
+                      GV->getName().str().c_str());
     return;
   }
   if (!resolveBase(GV, it->second, reg)) {
-    EJIT_DIAG("  may_const load NOT replaced: base-unresolved gv=%s",
-              GV->getName().str().c_str());
+    EJIT_DIAG_VERBOSE("  may_const load NOT replaced: base-unresolved gv=%s",
+                      GV->getName().str().c_str());
     return;
   }
   if (!accumulateFullOffset(DL, Ptr)) {
-    EJIT_DIAG("  may_const load NOT replaced: non-const-offset gv=%s",
-              GV->getName().str().c_str());
+    EJIT_DIAG_VERBOSE("  may_const load NOT replaced: non-const-offset gv=%s",
+                      GV->getName().str().c_str());
     return;
   }
-  EJIT_DIAG("  may_const load NOT replaced: unsupported-type gv=%s",
-            GV->getName().str().c_str());
+  EJIT_DIAG_VERBOSE("  may_const load NOT replaced: unsupported-type gv=%s",
+                    GV->getName().str().c_str());
 }
 #endif
 
@@ -374,11 +374,10 @@ PreservedAnalyses
 EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
   Module *M = F.getParent();
   if (!M) {
-    EJIT_DIAG("struct-field run SKIP func=%s: no parent module",
-              F.getName().str().c_str());
+    EJIT_DIAG_VERBOSE("struct-field run SKIP func=%s: no parent module",
+                      F.getName().str().c_str());
     return PreservedAnalyses::all();
   }
-  EJIT_DIAG("struct-field run func=%s", F.getName().str().c_str());
 
   assert(mapsBuilt_ && "EJitStructFieldPass::initFromModule() must be "
                        "called before run()");
@@ -393,6 +392,13 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
   SmallVector<Replacement, 16> replacements;
 #ifdef EJIT_DIAG_ENABLE
   size_t totalLoads = 0, mayConstLoads = 0;
+  // Only the ejit_entry function (or any function that actually has may_const
+  // activity / replacements) is worth a per-function diagnostic block. Silent
+  // for the common case of an auxiliary callee with no may_const loads, which
+  // is the dominant source of struct-field log noise on a specialization
+  // module that contains many non-entry callees.
+  bool isEjitEntry =
+      hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY);
 #endif
 
   for (BasicBlock &BB : F) {
@@ -444,11 +450,20 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
     changed = true;
   }
 
-  EJIT_DIAG("struct-field run func=%s replaced=%zu", F.getName().str().c_str(),
-            replacements.size());
 #ifdef EJIT_DIAG_ENABLE
-  EJIT_DIAG("  loads total=%zu may_const=%zu replaced=%zu", totalLoads,
-            mayConstLoads, replacements.size());
+  // Gate the per-function block: emit for the ejit_entry function (always
+  // interesting — it is the specialization target) or for any function where a
+  // may_const load was seen or a replacement actually happened. Auxiliary
+  // callees with no may_const activity stay silent, eliminating the bulk of
+  // the struct-field log volume while preserving locatability for the
+  // functions that matter. Raise the log level to VERBOSE to see this detail.
+  if (isEjitEntry || mayConstLoads > 0 || !replacements.empty()) {
+    EJIT_DIAG_VERBOSE("struct-field run func=%s entry=%d replaced=%zu",
+                      F.getName().str().c_str(), isEjitEntry ? 1 : 0,
+                      replacements.size());
+    EJIT_DIAG_VERBOSE("  loads total=%zu may_const=%zu replaced=%zu",
+                      totalLoads, mayConstLoads, replacements.size());
+  }
 #endif
   LLVM_DEBUG(if (changed) dbgs() << "ejit-struct-field: replaced "
                                  << replacements.size() << " load(s) in "

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -318,7 +318,7 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                            uint32_t numDims, void *fallback) {
   CompileOrGetResult R;
   R.fnPtr = fallback;
-  EJIT_DIAG("taskpool request func=%u dims=%u fallback=%p", funcIndex, numDims,
+  EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex, numDims,
             fallback);
 
   // 1. Parameter check.
@@ -334,7 +334,7 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   for (uint32_t i = 0; i < numDims; ++i) {
     if (!switch_.isInstanceEnabled(dims[i].dimType, dims[i].instanceId)) {
       counters_.instanceDisabled.fetchAdd(1);
-      EJIT_DIAG("taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex, i,
+      EJIT_DIAG_VERBOSE("taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex, i,
                 dims[i].dimType, dims[i].instanceId);
       R.status = EJitCompileOrGetStatus::InstanceDisabled;
       return R;
@@ -352,14 +352,14 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.fnPtr = Hit.fnPtr;
     R.bucketIndex = Hit.bucketIndex;
     R.hasReadToken = true;
-    EJIT_DIAG("taskpool hit func=%u bucket=%u fn=%p", funcIndex,
+    EJIT_DIAG_VERBOSE("taskpool hit func=%u bucket=%u fn=%p", funcIndex,
               Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
 
   // 4. Off mode (§5.2 step 2) — fall back, never enqueue/compile.
   if (switch_.getMode() == EJitCompileMode::Off) {
-    EJIT_DIAG("taskpool fallback func=%u: mode off", funcIndex);
+    EJIT_DIAG_VERBOSE("taskpool fallback func=%u: mode off", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;
     return R;
   }
@@ -378,13 +378,13 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   EJitTaskQueue::EnqueueResult EQ = queue_.tryEnqueue(Req);
   if (EQ == EJitTaskQueue::EnqueueResult::Enqueued) {
     counters_.asyncEnqueues.fetchAdd(1);
-    EJIT_DIAG("taskpool enqueued func=%u", funcIndex);
+    EJIT_DIAG_VERBOSE("taskpool enqueued func=%u", funcIndex);
     R.status = EJitCompileOrGetStatus::EnqueuedPending;
     return R;
   }
   if (EQ == EJitTaskQueue::EnqueueResult::AlreadyPending) {
     counters_.alreadyPending.fetchAdd(1);
-    EJIT_DIAG("taskpool coalesced func=%u: already pending", funcIndex);
+    EJIT_DIAG_VERBOSE("taskpool coalesced func=%u: already pending", funcIndex);
     R.status = EJitCompileOrGetStatus::AlreadyPending;
     return R;
   }
@@ -411,7 +411,7 @@ bool EJitTaskPool::versionsMatch(const EJitCompileRequest &req) const {
 }
 
 void EJitTaskPool::runCompile(const EJitCompileRequest &req) {
-  EJIT_DIAG("worker compile begin func=%u dims=%u", req.funcIndex, req.numDims);
+  EJIT_DIAG_VERBOSE("worker compile begin func=%u dims=%u", req.funcIndex, req.numDims);
   // Checkpoint 1 (§5.3): drop a request invalidated before compilation started.
   if (!versionsMatch(req)) {
     queue_.release(req.funcIndex);
@@ -451,7 +451,7 @@ void EJitTaskPool::runCompile(const EJitCompileRequest &req) {
   case EJitPublishStatus::Published:
     counters_.asyncCompiles.fetchAdd(1);
     queue_.release(req.funcIndex);
-    EJIT_DIAG("worker publish ok func=%u fn=%p", req.funcIndex, fn);
+    EJIT_DIAG_VERBOSE("worker publish ok func=%u fn=%p", req.funcIndex, fn);
     return;
   case EJitPublishStatus::VersionMismatch:
     // Rejected at the commit gate: retire the stale code, do not overwrite any

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
@@ -13,3 +13,10 @@ cl::opt<bool> EnableEJitGlobalCtors(
     "enable-ejit-global-ctors", cl::init(true), cl::Hidden,
     cl::desc("Generate llvm.global_ctors for auto-registration "
              "(disable for bare-metal / testing)"));
+
+cl::opt<std::string> EJitDumpBitcodeDir(
+    "ejit-dump-bitcode-dir", cl::init(""), cl::Hidden,
+    cl::desc("Directory to dump extracted EmbeddedJIT bitcode (.bc and .ll) "
+             "at AOT compile time, for debugging symbol extraction. Each TU "
+             "writes a PID + module-named file so parallel -j builds do not "
+             "collide or serialize."));

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -31,6 +31,8 @@
 #include "llvm/Transforms/Utils/Mem2Reg.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 
@@ -38,6 +40,7 @@ using namespace llvm;
 using namespace llvm::ejit;
 
 extern cl::opt<bool> EnableEJitGlobalCtors;
+extern cl::opt<std::string> EJitDumpBitcodeDir;
 
 #define DEBUG_TYPE "ejit-register-bitcode"
 
@@ -239,6 +242,40 @@ static void preOptimizeBitcode(Module &M) {
 static void preOptimizeBitcode(Module &) {}
 #endif
 
+/// Dump the extracted bitcode module to EJitDumpBitcodeDir (if set) for
+/// debugging — e.g. to confirm an ejit_entry function is emitted as a
+/// definition rather than just a declaration. Parallel-safe under -j: the
+/// filename embeds the process id (distinct per concurrent clang) and the
+/// sanitized module name, so no two invocations share a file and writes
+/// never serialize. Writes both .ll (readable: grep "define @Fn" vs
+/// "declare @Fn") and .bc.
+static void dumpExtractedBitcode(const Module &M, StringRef Dir) {
+  if (Dir.empty())
+    return;
+  if (std::error_code EC = sys::fs::create_directories(Dir))
+    return;
+  std::string Stem;
+  StringRef Name = M.getName();
+  if (Name.empty())
+    Name = "ejit_module";
+  auto IsAlnum = [](char C) {
+    return (C >= 'a' && C <= 'z') || (C >= 'A' && C <= 'Z') ||
+           (C >= '0' && C <= '9');
+  };
+  for (char C : Name)
+    Stem.push_back(IsAlnum(C) ? C : '_');
+  unsigned Pid = sys::Process::getProcessId();
+  std::string Base = (Twine(Dir) + "/" + Twine(Pid) + "_" + Stem).str();
+
+  std::error_code EC;
+  raw_fd_ostream LL(Base + ".ll", EC);
+  if (!EC)
+    M.print(LL, nullptr);
+  raw_fd_ostream BC(Base + ".bc", EC);
+  if (!EC)
+    WriteBitcodeToFile(M, BC);
+}
+
 static std::string extractAndSerialize(Module &M,
     const SetVector<Function *> &Funcs,
     const SetVector<GlobalVariable *> &Globals) {
@@ -291,6 +328,12 @@ static std::string extractAndSerialize(Module &M,
     GV.setInitializer(nullptr);
     GV.setLinkage(GlobalValue::ExternalLinkage);
   }
+
+  // Optionally dump the extracted module for debugging (e.g. to confirm an
+  // ejit_entry function is emitted as a definition, not a declaration).
+  // Parallel-safe: filename embeds PID + module name (see dumpExtractedBitcode).
+  if (!EJitDumpBitcodeDir.empty())
+    dumpExtractedBitcode(*Extracted, EJitDumpBitcodeDir);
 
   std::string Bitcode;
   raw_string_ostream OS(Bitcode);

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -276,12 +276,43 @@ static void dumpExtractedBitcode(const Module &M, StringRef Dir) {
     WriteBitcodeToFile(M, BC);
 }
 
+/// Diagnostic: count globals carrying !ejit.metadata, and within that the
+/// period_arr / may_const_field tags. Gated on EJitDumpBitcodeDir so it only
+/// runs when the dump is enabled. Used to pinpoint where the struct-field
+/// pass's GV metadata is lost during extraction (clone → preOptimize →
+/// externalization).
+static void logEJitGlobalMeta(const char *label, const Module &M) {
+  if (EJitDumpBitcodeDir.empty())
+    return;
+  unsigned withMeta = 0, periodArr = 0, mayConstField = 0;
+  for (const GlobalVariable &GV : M.globals()) {
+    MDNode *MD = GV.getMetadata(MD_EJIT_METADATA);
+    if (!MD)
+      continue;
+    ++withMeta;
+    for (const MDOperand &Op : MD->operands()) {
+      auto *Sub = dyn_cast<MDNode>(Op.get());
+      if (!Sub || Sub->getNumOperands() < 2)
+        continue;
+      if (auto *Tag = dyn_cast<MDString>(Sub->getOperand(0))) {
+        if (Tag->getString() == TAG_EJIT_PERIOD_ARR)
+          ++periodArr;
+        else if (Tag->getString() == TAG_EJIT_MAY_CONST_FIELD)
+          ++mayConstField;
+      }
+    }
+  }
+  errs() << "ejit-register-bitcode: " << label
+         << " globals=" << M.global_size() << " withMeta=" << withMeta
+         << " periodArr=" << periodArr << " mayConstField=" << mayConstField
+         << "\n";
+}
+
 static std::string extractAndSerialize(Module &M,
     const SetVector<Function *> &Funcs,
     const SetVector<GlobalVariable *> &Globals) {
 
   auto Extracted = CloneModule(M);
-
   DenseSet<StringRef> FuncNames;
   for (Function *F : Funcs)
     FuncNames.insert(F->getName());
@@ -316,7 +347,9 @@ static std::string extractAndSerialize(Module &M,
   // Pre-optimize the extracted bitcode to reduce JIT compilation pressure.
   // InstCombine + Mem2Reg + SimplifyCFG folds constant chains, promotes
   // allocas, and cleans up dead branches before serialization.
+  logEJitGlobalMeta("extract-after-clone", *Extracted);
   preOptimizeBitcode(*Extracted);
+  logEJitGlobalMeta("extract-after-preOpt", *Extracted);
 
   // Convert kept non-constant global definitions to external declarations
   // so the JIT linker resolves them from the host process. Constants (e.g.
@@ -328,6 +361,7 @@ static std::string extractAndSerialize(Module &M,
     GV.setInitializer(nullptr);
     GV.setLinkage(GlobalValue::ExternalLinkage);
   }
+  logEJitGlobalMeta("extract-after-extern", *Extracted);
 
   // Optionally dump the extracted module for debugging (e.g. to confirm an
   // ejit_entry function is emitted as a definition, not a declaration).

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -469,6 +469,59 @@ TEST(PeriodArrayRegistry, MultipleArraysSamePeriod) {
   EXPECT_EQ(arrs->size(), 2u);
 }
 
+// Idempotent registration: the constructor path may register the same array
+// twice (PASS1+PASS2 both add to global_ctors, or the static-registry walk
+// revisits an entry). A repeat with identical (period, base, size) must be a
+// no-op — it must NOT append a second entry to arraysByPeriod_ (which would
+// make activate fan out redundantly and getArrays() report ghosts).
+TEST(PeriodArrayRegistry, RegisterArrayIsIdempotent) {
+  PeriodArrayRegistry reg;
+  int data[4];
+  reg.registerArray("cell", "g_arr", data, 4);
+  reg.registerArray("cell", "g_arr", data, 4); // identical duplicate
+  reg.registerArray("cell", "g_arr", data, 4); // identical duplicate
+
+  const auto *arrs = reg.getArrays("cell");
+  ASSERT_NE(arrs, nullptr);
+  EXPECT_EQ(arrs->size(), 1u); // no duplicate entries
+  EXPECT_EQ(reg.getArrayInfo("g_arr")->baseAddr, (void *)data);
+}
+
+// A same-name conflict with a different base/size is rejected: the first
+// registration is kept and the second does not create a duplicate entry.
+TEST(PeriodArrayRegistry, RegisterArrayConflictKeepsFirst) {
+  PeriodArrayRegistry reg;
+  int a[4], b[4];
+  reg.registerArray("cell", "g_arr", a, 4);
+  reg.registerArray("cell", "g_arr", b, 4); // different base — conflict
+
+  const auto *arrs = reg.getArrays("cell");
+  ASSERT_NE(arrs, nullptr);
+  EXPECT_EQ(arrs->size(), 1u); // no duplicate
+  EXPECT_EQ(reg.getArrayInfo("g_arr")->baseAddr, (void *)a); // first kept
+}
+
+TEST(PeriodArrayRegistry, RegisterStaticVarIsIdempotent) {
+  PeriodArrayRegistry reg;
+  int val = 0;
+  reg.registerStaticVar("g_sv", &val);
+  reg.registerStaticVar("g_sv", &val); // identical duplicate
+  reg.registerStaticVar("g_sv", &val); // identical duplicate
+
+  EXPECT_EQ(reg.getStaticVars().size(), 1u); // no duplicate entries
+  EXPECT_EQ(reg.getStaticVarAddr("g_sv"), (void *)&val);
+}
+
+TEST(PeriodArrayRegistry, RegisterStaticVarConflictKeepsFirst) {
+  PeriodArrayRegistry reg;
+  int a = 0, b = 0;
+  reg.registerStaticVar("g_sv", &a);
+  reg.registerStaticVar("g_sv", &b); // different addr — conflict
+
+  EXPECT_EQ(reg.getStaticVars().size(), 1u); // no duplicate
+  EXPECT_EQ(reg.getStaticVarAddr("g_sv"), (void *)&a); // first kept
+}
+
 //===----------------------------------------------------------------------===//
 // EJitRuntimeState tests (T3-11)
 //===----------------------------------------------------------------------===//
@@ -751,6 +804,11 @@ extern void ejit_register_period_array(const char *, const char *, void *,
 extern void ejit_register_bitcode(const char *, const uint8_t *, uint64_t);
 extern void ejit_register_static_var(const char *, void *);
 extern void ejit_register_lifecycle(const char *, uint32_t *);
+extern void ejit_set_log_level(int level);
+extern int ejit_get_log_level(void);
+extern void ejit_dump_all(bool enable);
+extern void ejit_print_registry(void);
+extern void ejit_print_func_meta(const char *funcName);
 }
 
 // The "runtime-dynamic cellIdx" C-API tests below exercise the LEGACY model:
@@ -2833,4 +2891,51 @@ TEST(EJitCacheLifecycle, ReputAfterInvalidate) {
   int newVal = 99;
   cache.put(777, &newVal, 64, deps);
   EXPECT_EQ(cache.getOrNull(777), &newVal);
+}
+
+//===----------------------------------------------------------------------===//
+// Log level + diagnostics C-API (ejit_set_log_level, ejit_dump_all,
+// ejit_print_registry, ejit_print_func_meta)
+//===----------------------------------------------------------------------===//
+
+TEST(EJitDiagLogLevel, SetAndGet) {
+  // Default level is INFO (1).
+  EXPECT_EQ(ejit_get_log_level(), 1);
+  ejit_set_log_level(3); // DEBUG
+  EXPECT_EQ(ejit_get_log_level(), 3);
+  ejit_set_log_level(0); // OFF
+  EXPECT_EQ(ejit_get_log_level(), 0);
+  ejit_set_log_level(2); // VERBOSE
+  EXPECT_EQ(ejit_get_log_level(), 2);
+  // Restore the default so subsequent tests are unaffected.
+  ejit_set_log_level(1);
+  EXPECT_EQ(ejit_get_log_level(), 1);
+}
+
+TEST(EJitDiagLogLevel, ClampsOutOfRange) {
+  ejit_set_log_level(-5);
+  EXPECT_EQ(ejit_get_log_level(), 0);
+  ejit_set_log_level(99);
+  EXPECT_EQ(ejit_get_log_level(), 3);
+  ejit_set_log_level(1); // restore
+}
+
+// ejit_dump_all must not crash whether or not the runtime is initialized.
+TEST(EJitDumpAll, ToggleWithoutCrash) {
+  ejit_dump_all(true);
+  ejit_dump_all(false);
+}
+
+// Registry / func-meta prints must not crash on an uninitialized runtime and on
+// a missing name. (Output goes through EJIT_DIAG, which is a no-op when
+// EJIT_DIAG_ENABLE is undefined — the test only asserts it does not crash.)
+TEST(EJitDiagnostics, PrintRegistryUninitialized) {
+  // Not initialized: should report and return, not crash.
+  ejit_print_registry();
+}
+
+TEST(EJitDiagnostics, PrintFuncMetaMissingName) {
+  ejit_print_func_meta(nullptr); // null
+  ejit_print_func_meta("");      // empty
+  ejit_print_func_meta("does_not_exist");
 }


### PR DESCRIPTION
1. add runtime diag functions: dump IR/asm、print Compiled functions.
2. add diag option: dump bitcode.  `-ejit-dump-bitcode-dir=<dir>`
3. fix ejit.metadata loss of extern variable.
4. fix symbol registerd loss of static functions.
