### PR TITLE
[EJIT] Flatten taskpool C API cache-hit front path

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -150,6 +150,14 @@ public:
     /// cross-core pointer (code sharing not platform-validated): a clean
     /// fallback that did NOT re-enqueue.
     bool readyButNotShareable = false;
+    /// Set by tryCacheHit() when the request was fully resolved on the fast
+    /// cache-hit path (a cache hit, a disabled instance, a not-yet-Ready pool,
+    /// or a ready-but-not-shareable fallback). When true the caller returns
+    /// this result directly and MUST NOT enter the compileOrGet() slow path.
+    /// When false the request is a true miss that still needs compileOrGet().
+    /// This flag is an internal control signal; it does not affect status
+    /// mapping or the C ABI.
+    bool fastPathTerminal = false;
   };
 
   EJitSharedTaskPool() = default;
@@ -274,6 +282,22 @@ public:
   //--- producer path ----------------------------------------------------------
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                   uint32_t numDims, void *fallback);
+  /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
+  /// terminal front half of compileOrGet(): the Ready check, the
+  /// instance-enabled check, and the cache lookup, then classifies the outcome:
+  ///   * CacheHit           — returns fnPtr + bucketIndex + a held read token
+  ///                          (caller releases via releaseRead), cacheHits++.
+  ///   * InstanceDisabled   — a disabled dim, instanceDisabled++.
+  ///   * OffMode            — the pool is not Ready (clean fallback).
+  ///   * OffMode + readyButNotShareable — Ready code this core may not read;
+  ///                          NO enqueue / dedup.
+  /// Each of the above sets fastPathTerminal = true; the caller returns the
+  /// result directly and never enters the slow path. A true miss (Ready,
+  /// enabled, no shareable cached code) returns fastPathTerminal = false and
+  /// the caller must fall through to compileOrGet(). compileOrGet() itself
+  /// calls this so the ordering/counters/semantics stay identical.
+  CompileOrGetResult tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                                 uint32_t numDims);
   void releaseRead(uint32_t bucketIndex);
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -283,6 +283,13 @@ public:
     void *fnPtr = nullptr;
     uint32_t bucketIndex = 0;
     bool hasReadToken = false;
+    /// Set by tryCacheHit() when the request was fully resolved on the fast
+    /// cache-hit path (a cache hit or a disabled instance). When true the
+    /// caller returns this result directly and MUST NOT enter the
+    /// compileOrGet() slow path; when false the request is a true miss that
+    /// still needs compileOrGet(). Internal control signal only — it does not
+    /// affect status mapping or the C ABI.
+    bool fastPathTerminal = false;
   };
 
   explicit EJitTaskPool(
@@ -306,6 +313,20 @@ public:
 
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                   uint32_t numDims, void *fallback);
+
+  /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
+  /// terminal front half of compileOrGet(): the instance-enabled check and the
+  /// cache lookup, then classifies the outcome:
+  ///   * CacheHit         — returns fnPtr + bucketIndex + a held read token
+  ///                        (caller releases via releaseRead), cacheHits++.
+  ///   * InstanceDisabled — a disabled dim, instanceDisabled++.
+  /// Both set fastPathTerminal = true; the caller returns the result directly
+  /// and never enters the slow path. A true miss (enabled, no cached code)
+  /// returns fastPathTerminal = false and the caller must fall through to
+  /// compileOrGet(). compileOrGet() itself calls this so the
+  /// ordering/counters/semantics stay identical.
+  CompileOrGetResult tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                                 uint32_t numDims);
 
   bool pollOne();
   unsigned pollBudget(unsigned maxItems);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -456,8 +456,28 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
 
   // ejit_dim_pair_t and EJitDimPair share the same layout; pass through
   // to avoid a stack copy of up to 4 dim pairs.
-  auto r = tp->compileOrGet(funcIndex,
-                            reinterpret_cast<const EJitDimPair *>(dims), numDims,
+  const EJitDimPair *dimsCast = reinterpret_cast<const EJitDimPair *>(dims);
+
+  // Flattened fast cache-hit path: resolve the common terminal outcomes (cache
+  // hit, disabled instance, not-Ready / ready-but-not-shareable fallback)
+  // without entering the full compileOrGet slow path. tryCacheHit preserves the
+  // exact compileOrGet hot-path semantics (ordering, counters, read tokens),
+  // so a hit still hands back outBucket for ejit_taskpool_release_read and a
+  // disabled instance never returns stale code. A true miss falls through to
+  // compileOrGet unchanged (enqueue/dedup/compile).
+  auto fast = tp->tryCacheHit(funcIndex, dimsCast, numDims);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u fast status=%u fn=%p",
+                      funcIndex, static_cast<unsigned>(fast.status),
+                      fast.fnPtr);
+    return taskpoolStatus(fast.status);
+  }
+
+  auto r = tp->compileOrGet(funcIndex, dimsCast, numDims,
                             /*fallback=*/nullptr);
   if (outFn)
     *outFn = r.fnPtr;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -887,29 +887,34 @@ void EJitSharedTaskPool::ownerShutdown() {
 // Producer path (§5.2).
 //===----------------------------------------------------------------------===//
 EJitSharedTaskPool::CompileOrGetResult
-EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                                 uint32_t numDims, void *fallback) {
+EJitSharedTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                                uint32_t numDims) {
   CompileOrGetResult R;
-  R.fnPtr = fallback;
-  EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p", funcIndex,
-            numDims, fallback);
+  // Parameter check already done by the C API layer.
+
+  // Ready check (§5.2 step 0): a not-yet-Ready pool is a clean fallback and
+  // never reads the queue/cache.
   if (!state_ || state_->initState.loadAcquire() != kReady) {
     EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: not Ready", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode; // not Ready → clean fallback.
+    R.fastPathTerminal = true;
     return R;
   }
-  // Parameter check already done by the C API layer.
 
-  // Instance-enabled check (§5.2 step 0).
+  // Instance-enabled check (§5.2 step 0): a disabled dim falls back and never
+  // reaches the cache, so a deactivated instance is never served stale code.
   for (uint32_t i = 0; i < numDims; ++i)
     if (!isInstanceEnabled(dims[i].dimType, dims[i].instanceId)) {
       state_->counters.instanceDisabled.fetchAdd(1);
-      EJIT_DIAG_VERBOSE("shared taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex,
-                i, dims[i].dimType, dims[i].instanceId);
+      EJIT_DIAG_VERBOSE("shared taskpool disabled func=%u dim[%u]=(%u,%u)",
+                        funcIndex, i, dims[i].dimType, dims[i].instanceId);
       R.status = EJitCompileOrGetStatus::InstanceDisabled;
+      R.fastPathTerminal = true;
       return R;
     }
-  // Cache lookup (§5.2 step 1).
+
+  // Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
+  // compiled entry is still served even when the pool is globally Off.
   EJitSharedTaskPool::SharedLookup Hit = cacheLookup(funcIndex, dims, numDims);
   if (Hit.hasReadToken && Hit.fnPtr) {
     state_->counters.cacheHits.fetchAdd(1);
@@ -917,19 +922,48 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.fnPtr = Hit.fnPtr;
     R.bucketIndex = Hit.bucketIndex;
     R.hasReadToken = true;
+    R.fastPathTerminal = true;
     EJIT_DIAG_VERBOSE("shared taskpool hit func=%u bucket=%u fn=%p", funcIndex,
-              Hit.bucketIndex, Hit.fnPtr);
+                      Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
   if (Hit.readyButNotShareable) {
     // The work is already done but this core may not read the cross-core
     // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
-    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: ready but not shareable on this core",
-              funcIndex);
+    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: ready but not "
+                      "shareable on this core",
+                      funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;
     R.readyButNotShareable = true;
+    R.fastPathTerminal = true;
     return R;
   }
+
+  // True miss (Ready, enabled, no shareable cached code): the caller must fall
+  // through to the compileOrGet() slow path (Off / Sync / Async).
+  R.fastPathTerminal = false;
+  return R;
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
+                                 uint32_t numDims, void *fallback) {
+  EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p",
+                    funcIndex, numDims, fallback);
+  // Parameter check already done by the C API layer.
+
+  // Fast cache-hit path (§5.2 steps 0-1). On any terminal outcome (hit,
+  // disabled instance, not-Ready, or ready-but-not-shareable) return directly.
+  CompileOrGetResult R = tryCacheHit(funcIndex, dims, numDims);
+  if (R.fastPathTerminal) {
+    // Non-hit terminals surface the caller's fallback pointer (a hit already
+    // carries the cached fnPtr + read token).
+    if (R.status != EJitCompileOrGetStatus::CacheHit)
+      R.fnPtr = fallback;
+    return R;
+  }
+  // True miss: continue the slow path with the caller's fallback.
+  R.fnPtr = fallback;
   // Off mode (§5.2 step 2).
   if (state_->mode.loadAcquire() ==
       static_cast<uint32_t>(EJitCompileMode::Off)) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -314,12 +314,9 @@ EJitTaskPool::~EJitTaskPool() {
 }
 
 EJitTaskPool::CompileOrGetResult
-EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                           uint32_t numDims, void *fallback) {
+EJitTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                          uint32_t numDims) {
   CompileOrGetResult R;
-  R.fnPtr = fallback;
-  EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex, numDims,
-            fallback);
 
   // Parameter check already done by the C API layer (ejit_taskpool_compile_or_get).
 
@@ -331,14 +328,15 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       EJIT_DIAG_VERBOSE("taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex, i,
                 dims[i].dimType, dims[i].instanceId);
       R.status = EJitCompileOrGetStatus::InstanceDisabled;
+      R.fastPathTerminal = true;
       return R;
     }
   }
 
-  // 3. Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
+  // 2. Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
   //    compiled entry is still served while the pool is globally Off (the spec
   //    orders cache lookup ahead of the Off check). A disabled instance was
-  //    already rejected in step 2 and never reaches here.
+  //    already rejected above and never reaches here.
   EJitCacheLookupResult Hit = cache_.lookup(funcIndex, dims, numDims);
   if (Hit.hasReadToken && Hit.fnPtr) {
     counters_.cacheHits.fetchAdd(1);
@@ -346,12 +344,41 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.fnPtr = Hit.fnPtr;
     R.bucketIndex = Hit.bucketIndex;
     R.hasReadToken = true;
+    R.fastPathTerminal = true;
     EJIT_DIAG_VERBOSE("taskpool hit func=%u bucket=%u fn=%p", funcIndex,
               Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
 
-  // 4. Off mode (§5.2 step 2) — fall back, never enqueue/compile.
+  // True miss (enabled, no cached code): the caller must fall through to the
+  // compileOrGet() slow path (Off / Sync / Async).
+  R.fastPathTerminal = false;
+  return R;
+}
+
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
+                           uint32_t numDims, void *fallback) {
+  EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex,
+                    numDims, fallback);
+
+  // Parameter check already done by the C API layer
+  // (ejit_taskpool_compile_or_get).
+
+  // Fast cache-hit path (§5.2 steps 0-1). On a terminal outcome (hit or a
+  // disabled instance) return directly.
+  CompileOrGetResult R = tryCacheHit(funcIndex, dims, numDims);
+  if (R.fastPathTerminal) {
+    // Non-hit terminals surface the caller's fallback pointer (a hit already
+    // carries the cached fnPtr + read token).
+    if (R.status != EJitCompileOrGetStatus::CacheHit)
+      R.fnPtr = fallback;
+    return R;
+  }
+  // True miss: continue the slow path with the caller's fallback.
+  R.fnPtr = fallback;
+
+  // 3. Off mode (§5.2 step 2) — fall back, never enqueue/compile.
   if (switch_.getMode() == EJitCompileMode::Off) {
     EJIT_DIAG_VERBOSE("taskpool fallback func=%u: mode off", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1726,4 +1726,156 @@ TEST_F(SharedTaskPoolTest, FourKReinitForcesPeerToReSplit) {
   EXPECT_EQ(fourK.splits[1].second, 3u);
 }
 
+//===----------------------------------------------------------------------===//
+// tryCacheHit(): the flattened fast cache-hit path the C API drives before the
+// compileOrGet slow path. It must preserve every compileOrGet hot-path
+// semantic (ordering, counters, read tokens) while NEVER enqueuing/deduping.
+//===----------------------------------------------------------------------===//
+
+// 1/ A cache hit is served entirely on the fast path: fnPtr + bucket + a held
+//    read token, fastPathTerminal set, and NO enqueue/dedup side effects.
+TEST_F(SharedTaskPoolTest, TryCacheHitServesHitWithoutEnqueue) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(0);
+  EJitSharedDiagnostics before;
+  owner.getDiagnostics(before);
+
+  auto fast = owner.tryCacheHit(1, nullptr, 0);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fast.fnPtr, codeFor(1));
+  EXPECT_TRUE(fast.hasReadToken);
+  EXPECT_FALSE(fast.readyButNotShareable);
+  // A held read token keeps readers > 0 (same ownership contract as
+  // compileOrGet — the caller must release through releaseRead).
+  EXPECT_GT(state_->buckets[fast.bucketIndex].readers.loadAcquire(), 0u);
+
+  EJitSharedDiagnostics after;
+  owner.getDiagnostics(after);
+  EXPECT_EQ(after.cacheHits, before.cacheHits + 1);     // counted exactly once
+  EXPECT_EQ(after.asyncEnqueues, before.asyncEnqueues); // no enqueue
+  EXPECT_EQ(after.queueDepth, 0u);                      // no dedup slot
+  EXPECT_EQ(after.pendingCount, 0u);
+
+  owner.releaseRead(fast.bucketIndex);
+  EXPECT_EQ(state_->buckets[fast.bucketIndex].readers.loadAcquire(), 0u);
+}
+
+// 2/ A true miss is NOT terminal on the fast path (no enqueue), and the slow
+//    path (compileOrGet) still enqueues/compiles exactly as before.
+TEST_F(SharedTaskPoolTest, TryCacheHitMissFallsThroughToCompileOrGet) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  EJitCoreId::setCurrentForTest(0);
+
+  auto fast = owner.tryCacheHit(5, nullptr, 0);
+  EXPECT_FALSE(fast.fastPathTerminal); // must fall through
+  EXPECT_NE(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(fast.hasReadToken);
+
+  EJitSharedDiagnostics d;
+  owner.getDiagnostics(d);
+  EXPECT_EQ(d.asyncEnqueues, 0u); // fast path never enqueues
+  EXPECT_EQ(d.queueDepth, 0u);
+  EXPECT_EQ(d.pendingCount, 0u);
+
+  // The slow path still enqueues the async request unchanged.
+  auto slow = owner.compileOrGet(5, nullptr, 0, codeFor(5));
+  EXPECT_EQ(slow.status, EJitCompileOrGetStatus::EnqueuedPending);
+  owner.getDiagnostics(d);
+  EXPECT_EQ(d.asyncEnqueues, 1u);
+  EXPECT_EQ(d.queueDepth, 1u);
+  EXPECT_EQ(d.pendingCount, 1u);
+}
+
+// 3/ A disabled instance returns InstanceDisabled on the fast path and NEVER
+//    hands back cached code, even though a Ready entry exists (deactivate must
+//    not serve stale code). No enqueue.
+TEST_F(SharedTaskPoolTest, TryCacheHitDisabledInstanceReturnsDisabled) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  owner.setInstanceEnabled(1, 4, true);
+  EJitDimPair d0[1] = {dim(1, 4)};
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.compileOrGet(11, d0, 1, codeFor(11)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  // Sanity: while enabled the entry is a real hit.
+  auto sane = owner.tryCacheHit(11, d0, 1);
+  ASSERT_EQ(sane.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(sane.bucketIndex);
+
+  // Deactivate the instance, then the fast path must reject before the cache.
+  owner.setInstanceEnabled(1, 4, false);
+  EJitSharedDiagnostics before;
+  owner.getDiagnostics(before);
+
+  auto fast = owner.tryCacheHit(11, d0, 1);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::InstanceDisabled);
+  EXPECT_EQ(fast.fnPtr, nullptr); // no stale cached code
+  EXPECT_FALSE(fast.hasReadToken);
+
+  EJitSharedDiagnostics after;
+  owner.getDiagnostics(after);
+  EXPECT_EQ(after.instanceDisabled, before.instanceDisabled + 1);
+  EXPECT_EQ(after.queueDepth, before.queueDepth); // no enqueue
+  EXPECT_EQ(after.asyncEnqueues, before.asyncEnqueues);
+}
+
+// 4/ readyButNotShareable: a peer core that may not read the cross-core pointer
+//    gets a clean OffMode fallback with readyButNotShareable set, no read
+//    token, and NO enqueue/dedup.
+TEST_F(SharedTaskPoolTest, TryCacheHitReadyButNotShareableCleanFallback) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/false);
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.compileOrGet(20, nullptr, 0, codeFor(20)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  EJitSharedTaskPool peer;
+  peer.bind(state_.get());
+  EJitCoreId::setCurrentForTest(9);
+  EJitSharedDiagnostics before;
+  peer.getDiagnostics(before);
+
+  auto fast = peer.tryCacheHit(20, nullptr, 0);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(fast.readyButNotShareable);
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(fast.fnPtr, nullptr);
+
+  EJitSharedDiagnostics after;
+  peer.getDiagnostics(after);
+  EXPECT_EQ(after.queueDepth, before.queueDepth); // no enqueue/dedup
+  EXPECT_EQ(after.asyncEnqueues, before.asyncEnqueues);
+  EXPECT_EQ(after.pendingCount, before.pendingCount);
+}
+
+// 5/ Mode Off still returns an existing cache hit on the fast path — the cache
+//    lookup is ordered ahead of the Off check, matching compileOrGet.
+TEST_F(SharedTaskPoolTest, TryCacheHitServesHitEvenWhenModeOff) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true); // comes up Async
+  publish(owner, 30);
+
+  // Flip the cross-core mode to Off after the entry is Ready.
+  owner.setSharedMode(EJitCompileMode::Off);
+  EXPECT_EQ(owner.getSharedMode(), EJitCompileMode::Off);
+
+  EJitCoreId::setCurrentForTest(0);
+  auto fast = owner.tryCacheHit(30, nullptr, 0);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fast.fnPtr, codeFor(30));
+  EXPECT_TRUE(fast.hasReadToken);
+  owner.releaseRead(fast.bucketIndex);
+}
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
@@ -955,6 +955,72 @@ TEST(EJitTaskPoolTest, DisabledInstanceWithExistingCacheFallsBack) {
   EXPECT_EQ(r.fnPtr, fb);
 }
 
+//===----------------------------------------------------------------------===//
+// tryCacheHit(): the flattened fast cache-hit path the C API drives before the
+// compileOrGet slow path. On the private pool it performs the instance-enabled
+// check + cache lookup only; it must match compileOrGet's front-half semantics
+// and never enqueue.
+//===----------------------------------------------------------------------===//
+
+// A cache hit is served on the fast path with a held read token and NO enqueue.
+TEST(EJitTaskPoolTest, TryCacheHitServesHitWithoutEnqueue) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair D[1] = {{0, 1}};
+  P.compileOrGet(40, D, 1, nullptr);
+  EXPECT_TRUE(P.pollOne()); // populate cache
+  ASSERT_EQ(P.pendingCount(), 0u);
+
+  auto fast = P.tryCacheHit(40, D, 1);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_TRUE(fast.hasReadToken);
+  EXPECT_NE(fast.fnPtr, nullptr);
+  EXPECT_EQ(P.pendingCount(), 0u); // no enqueue/dedup on the fast path
+  P.releaseRead(fast.bucketIndex);
+}
+
+// A true miss is NOT terminal on the fast path; the slow path still enqueues.
+TEST(EJitTaskPoolTest, TryCacheHitMissFallsThroughToCompileOrGet) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair D[1] = {{0, 1}};
+
+  auto fast = P.tryCacheHit(41, D, 1);
+  EXPECT_FALSE(fast.fastPathTerminal);
+  EXPECT_NE(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(P.pendingCount(), 0u); // fast path never enqueues
+
+  auto slow = P.compileOrGet(41, D, 1, nullptr);
+  EXPECT_EQ(slow.status, EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(P.pendingCount(), 1u);
+}
+
+// A disabled instance returns InstanceDisabled on the fast path and never
+// serves cached code.
+TEST(EJitTaskPoolTest, TryCacheHitDisabledInstanceReturnsDisabled) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair D[1] = {{0, 1}};
+  P.compileOrGet(42, D, 1, nullptr);
+  EXPECT_TRUE(P.pollOne()); // cache now holds func 42
+  P.switchController().setEnabled(0, 1, false);
+
+  auto fast = P.tryCacheHit(42, D, 1);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::InstanceDisabled);
+  EXPECT_EQ(fast.fnPtr, nullptr); // no stale cached code
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(P.pendingCount(), 0u);
+}
+
 TEST(EJitTaskPoolTest, SameFuncDifferentDimsAlreadyPending) {
   EJitTaskPool P(16, false);
   P.switchController().setMode(EJitCompileMode::Async);


### PR DESCRIPTION
## Summary

This PR adds a low-risk cache-hit front path for the EJIT taskpool C API.

Before this change, `ejit_taskpool_compile_or_get` always entered the full `compileOrGet` path, even when the requested function was already present in the taskpool cache. This PR adds `tryCacheHit()` so the C API can return terminal cache-hit style results before falling into the miss/enqueue/compile slow path.

## What Changed

- Add `tryCacheHit()` to shared and private taskpool implementations.
- Refactor `compileOrGet()` to reuse the same terminal front-half logic.
- Update `ejit_taskpool_compile_or_get` to call `tryCacheHit()` first.
- Preserve status mapping, `outFn`, `outBucket`, and release-read ownership.
- Add tests for shared/private cache-hit fast path behavior.

## Semantics Preserved

- Cache hit still returns a read token / bucket index, and callers must still call `ejit_taskpool_release_read`.
- Cache lookup still happens before Off-mode fallback, matching existing behavior.
- Disabled instances do not return stale code.
- Ready-but-not-shareable peer cases still avoid enqueueing invalid work.
- Misses still fall through to the existing `compileOrGet()` path.

## Validation

Reported validation from the branch work:

- `EJITSharedTaskPoolTests`: passed with the new fast-hit coverage
- `EJITTaskPoolTests`: passed with the new fast-hit coverage, excluding the known pre-existing direct-null `InvalidParam` crash noted separately
- `git diff --check`: clean

## Follow-up

A separate PR will handle the more aggressive fixed-dimension C API and shared `cacheLookup` specialization. That change is intentionally split out because it is a different risk/performance tradeoff from this front-path refactor.