### PR TITLE
[EJIT] Add new attribute spellings + UPPER_CASE macros, keep old as aliases

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -5224,14 +5224,16 @@ def OpenACCRoutineDecl :InheritableAttr {
 
 // Marks a struct member as potentially constant within a time window
 def EjitMayConst : InheritableAttr {
-  let Spellings = [Clang<"ejit_may_const">];
+  let Spellings = [Clang<"ejit_period_const">,
+                   Clang<"ejit_may_const">];
   let Subjects = SubjectList<[Field]>;
   let Documentation = [EjitMayConstDocs];
 }
 
 // Marks the time window a global variable belongs to
 def EjitPeriod : InheritableAttr {
-  let Spellings = [Clang<"ejit_period">];
+  let Spellings = [Clang<"ejit_in_period">,
+                   Clang<"ejit_period">];
   let Args = [StringArgument<"PeriodName">];
   let Subjects = SubjectList<[Var]>;
   let Documentation = [EjitPeriodDocs];
@@ -5239,7 +5241,8 @@ def EjitPeriod : InheritableAttr {
 
 // Marks the time window array a global array belongs to
 def EjitPeriodArr : InheritableAttr {
-  let Spellings = [Clang<"ejit_period_arr">];
+  let Spellings = [Clang<"ejit_in_period_array">,
+                   Clang<"ejit_period_arr">];
   let Args = [StringArgument<"PeriodName">];
   let Subjects = SubjectList<[Var]>;
   let Documentation = [EjitPeriodArrDocs];
@@ -5247,7 +5250,8 @@ def EjitPeriodArr : InheritableAttr {
 
 // Marks a function parameter as a specialization dimension index
 def EjitPeriodArrInd : InheritableParamAttr {
-  let Spellings = [Clang<"ejit_period_arr_ind">];
+  let Spellings = [Clang<"ejit_dim">,
+                   Clang<"ejit_period_arr_ind">];
   let Args = [StringArgument<"PeriodName">];
   let Subjects = SubjectList<[ParmVar]>;
   let Documentation = [EjitPeriodArrIndDocs];
@@ -5262,7 +5266,8 @@ def EjitEntry : InheritableAttr {
 
 // Marks a time window lifecycle management function
 def EjitPeriodLc : InheritableAttr {
-  let Spellings = [Clang<"ejit_period_lc">];
+  let Spellings = [Clang<"ejit_period_guard">,
+                   Clang<"ejit_period_lc">];
   let Args = [StringArgument<"PeriodName">];
   let Subjects = SubjectList<[Function]>;
   let Documentation = [EjitPeriodLcDocs];

--- a/clang/test/CodeGen/ejit_new_attr_spellings.c
+++ b/clang/test/CodeGen/ejit_new_attr_spellings.c
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -emit-llvm -o - %s 2>&1 | FileCheck %s
+// New attribute spellings: verify metadata is emitted correctly.
+
+struct CellConfig {
+  __attribute__((ejit_period_const)) int cellType;
+  int xx;
+};
+
+// CHECK: @g_boardCfg = {{.*}} !ejit.metadata
+__attribute__((ejit_in_period("static"))) struct CellConfig g_boardCfg;
+
+// CHECK: @g_cellCfg = {{.*}} !ejit.metadata
+__attribute__((ejit_in_period_array("cell"))) struct CellConfig g_cellCfg[16];
+
+// CHECK: define {{.*}} @jit_entry({{.*}} !ejit.metadata
+__attribute__((ejit_entry))
+void jit_entry(__attribute__((ejit_dim("cell"))) int cellIdx) {
+  // CHECK: !ejit.may_const
+  if (g_cellCfg[cellIdx].cellType == 2) { }
+}
+
+// CHECK: define {{.*}} @lc_func({{.*}} !ejit.metadata
+__attribute__((ejit_period_guard("cell")))
+void lc_func(__attribute__((ejit_dim("cell"))) int cellIdx) {
+  g_cellCfg[cellIdx].xx = 42;
+}
+
+// Metadata tags use canonical names.
+// CHECK-DAG: !{!"ejit_period_arr", !"cell", i32 16}
+// CHECK-DAG: !{!"ejit_entry"}
+// CHECK-DAG: !{!"ejit_period_arr_ind", !"cell", i32 0}
+// CHECK-DAG: !{!"ejit_period_lc", !"cell"}

--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -184,6 +184,7 @@ ALL_TESTS=(
   ejit_manual_register_test
   ejit_multi_tu_test
   ejit_baremetal_link_test
+  ejit_new_attr_test
   ejit_sync_mode_test
   ejit_perf_bench
   ejit_ptr_period_test
@@ -241,6 +242,7 @@ TEST_ARGS[ejit_ptr_period_test]="0 1 3"
 TEST_ARGS[ejit_multi_tu_test]="0 3"
 TEST_ARGS[ejit_baremetal_link_test]="0 3"
 TEST_ARGS[ejit_sync_mode_test]="0"
+TEST_ARGS[ejit_new_attr_test]="0"
 
 if [[ ${#SELECTED[@]} -eq 0 ]]; then
   SELECTED=("${ALL_TESTS[@]}")

--- a/ejit_test/ejit_new_attr_test.c
+++ b/ejit_test/ejit_new_attr_test.c
@@ -1,0 +1,95 @@
+/**
+ * EmbeddedJIT New Attribute Macro Test
+ *
+ * Verifies all 6 new UPPER_CASE attribute macros compile and JIT correctly.
+ * Uses the new naming convention exclusively (no legacy compat aliases).
+ *
+ *   EJIT_PERIOD_CONST       ← was ejit_may_const
+ *   EJIT_IN_PERIOD(x)       ← was ejit_period(x)
+ *   EJIT_IN_PERIOD_ARRAY(x) ← was ejit_period_arr(x)
+ *   EJIT_DIM(x)             ← was ejit_period_arr_ind(x)
+ *   EJIT_ENTRY              ← was ejit_entry (new UPPER_CASE form)
+ *   EJIT_PERIOD_GUARD(x)    ← was ejit_period_lc(x)
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ejit_test_helpers.h"
+
+//===-- Structs using EJIT_PERIOD_CONST -----------------------------------===//
+
+struct BoardCfg {
+    EJIT_PERIOD_CONST uint32_t boardType;
+    uint32_t _pad;
+};
+
+struct CellCfg {
+    EJIT_PERIOD_CONST uint32_t cellType;
+    uint32_t traffic;
+};
+
+//===-- Globals using EJIT_IN_PERIOD / EJIT_IN_PERIOD_ARRAY ---------------===//
+
+EJIT_IN_PERIOD(static)  struct BoardCfg g_board;
+EJIT_IN_PERIOD_ARRAY(cell) struct CellCfg g_cells[8];
+
+//===-- JIT functions using EJIT_ENTRY / EJIT_DIM / EJIT_PERIOD_GUARD -----===//
+
+EJIT_ENTRY uint32_t check_cell(EJIT_DIM(cell) uint8_t ci) {
+    if (g_cells[ci].cellType == 42) return 100;
+    if (g_cells[ci].cellType == 99) return 200;
+    return 0;
+}
+
+EJIT_PERIOD_GUARD(cell)
+void update_cell(EJIT_DIM(cell) uint8_t ci) {
+    g_cells[ci].cellType = 99;
+}
+
+//===-- Main --------------------------------------------------------------===//
+
+int main(int argc, char **argv) {
+    uint8_t ci = (uint8_t)(argc > 1 ? (uint8_t)(argv[1][0] - '0') : 0);
+    int failures = 0;
+
+    printf("=== EJIT New Attribute Test ===\n");
+    printf("cellIdx=%u\n\n", ci);
+
+    // Init
+    ejit_config_t cfg;
+    ejit_default_config(&cfg);
+    int rc = (int)ejit_init(&cfg);
+    if (rc != 0) { printf("FAIL: init\n"); return 1; }
+    printf("--- init OK ---\n");
+
+    // Test 1: JIT compile with EJIT_PERIOD_CONST
+    printf("\n--- 1. EJIT_PERIOD_CONST in struct ---\n");
+    g_cells[ci].cellType = 42;
+    ejit_activate("cell", ci);
+    ejit_drain_taskpool();
+    uint32_t r = check_cell(ci);
+    if (r != 100) { printf("  FAIL: check_cell=%u (expected 100)\n", r); failures++; }
+    else printf("  OK: check_cell=%u\n", r);
+
+    // Test 2: EJIT_PERIOD_GUARD with EJIT_DIM
+    printf("\n--- 2. EJIT_PERIOD_GUARD + EJIT_DIM ---\n");
+    update_cell(ci);
+    ejit_drain_taskpool();
+    r = check_cell(ci);
+    if (r != 200) { printf("  FAIL: after guard, check_cell=%u (expected 200)\n", r); failures++; }
+    else printf("  OK: after guard, check_cell=%u\n", r);
+
+    // Test 3: EJIT_IN_PERIOD static always active
+    printf("\n--- 3. EJIT_IN_PERIOD(static) ---\n");
+    g_board.boardType = 7;
+    // static period is always active — no explicit activate needed
+    // This just verifies the attribute compiles and the global is accessible
+    printf("  OK: boardCfg.boardType=%u\n", g_board.boardType);
+
+    printf("\n=== Result: %d failures ===\n", failures);
+    ejit_shutdown();
+    return failures > 0 ? 1 : 0;
+}

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -30,19 +30,33 @@
 //===----------------------------------------------------------------------===//
 
 #ifdef EJIT_DISABLE
+#define EJIT_PERIOD_CONST
 #define ejit_may_const
+#define EJIT_IN_PERIOD(x)
 #define ejit_period(x)
+#define EJIT_IN_PERIOD_ARRAY(x)
 #define ejit_period_arr(x)
+#define EJIT_DIM(x)
 #define ejit_period_arr_ind(x)
+#define EJIT_ENTRY
 #define ejit_entry
+#define EJIT_PERIOD_GUARD(x)
 #define ejit_period_lc(x)
 #else
-#define ejit_may_const          __attribute__((ejit_may_const))
-#define ejit_period(x)          __attribute__((ejit_period(#x)))
-#define ejit_period_arr(x)      __attribute__((ejit_period_arr(#x)))
-#define ejit_period_arr_ind(x)  __attribute__((ejit_period_arr_ind(#x)))
-#define ejit_entry              __attribute__((ejit_entry))
-#define ejit_period_lc(x)       __attribute__((ejit_period_lc(#x)))
+// New names (preferred)
+#define EJIT_PERIOD_CONST       __attribute__((ejit_period_const))
+#define EJIT_IN_PERIOD(x)       __attribute__((ejit_in_period(#x)))
+#define EJIT_IN_PERIOD_ARRAY(x) __attribute__((ejit_in_period_array(#x)))
+#define EJIT_DIM(x)             __attribute__((ejit_dim(#x)))
+#define EJIT_ENTRY              __attribute__((ejit_entry))
+#define EJIT_PERIOD_GUARD(x)    __attribute__((ejit_period_guard(#x)))
+// Old names (aliases — use new macros to avoid double expansion)
+#define ejit_may_const          EJIT_PERIOD_CONST
+#define ejit_period(x)          EJIT_IN_PERIOD(x)
+#define ejit_period_arr(x)      EJIT_IN_PERIOD_ARRAY(x)
+#define ejit_period_arr_ind(x)  EJIT_DIM(x)
+#define ejit_entry              EJIT_ENTRY
+#define ejit_period_lc(x)       EJIT_PERIOD_GUARD(x)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Attr.td: each attribute now lists both spellings (new first, old second):
      ejit_period_const  (was ejit_may_const)
      ejit_in_period(x)  (was ejit_period(x))
      ejit_in_period_array(x) (was ejit_period_arr(x))
      ejit_dim(x)        (was ejit_period_arr_ind(x))
      ejit_period_guard(x) (was ejit_period_lc(x))
    
    EJitRuntime.h: new UPPER_CASE macros (EJIT_PERIOD_CONST, EJIT_IN_PERIOD,
    EJIT_IN_PERIOD_ARRAY, EJIT_DIM, EJIT_ENTRY, EJIT_PERIOD_GUARD). Old
    lowercase macros become aliases of the new ones to avoid preprocessor
    double-expansion when used together.
