### PR TITLE
[EJIT] Specialize shared taskpool cache lookup hot paths

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -367,6 +367,9 @@ def doit_gc_merge(args):
     optional_api = [
         "ejit_register_lifecycle", "ejit_register_funcindex",
         "ejit_taskpool_compile_or_get", "ejit_taskpool_release_read",
+        "ejit_taskpool_compile_or_get_0d", "ejit_taskpool_compile_or_get_1d",
+        "ejit_taskpool_compile_or_get_2d", "ejit_taskpool_compile_or_get_3d",
+        "ejit_taskpool_compile_or_get_4d",
         "ejit_taskpool_set_instance_enabled", "ejit_taskpool_pending_count",
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_dump_func", "ejit_print_dumped"

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -59,6 +59,18 @@ constexpr const char *FN_REGISTER_LIFECYCLE = "ejit_register_lifecycle";
 constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
+// Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper
+// when -ejit-wrapper-fixed-dim-entry is enabled and the entry has <= 4 dims.
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_0D =
+    "ejit_taskpool_compile_or_get_0d";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_1D =
+    "ejit_taskpool_compile_or_get_1d";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_2D =
+    "ejit_taskpool_compile_or_get_2d";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_3D =
+    "ejit_taskpool_compile_or_get_3d";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_4D =
+    "ejit_taskpool_compile_or_get_4d";
 constexpr const char *FN_TASKPOOL_RELEASE_READ = "ejit_taskpool_release_read";
 // Lifecycle activation is keyed by period/lifecycle name + instance index only.
 // PASS4 emits these name-level calls at ejit_period_lc entry/exit; there is no

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -161,6 +161,36 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                                            const ejit_dim_pair_t *dims,
                                            uint32_t numDims, void **outFn,
                                            uint32_t *outBucket);
+
+// Fixed-dimension fast paths (0-4 dims). Additive alternatives to
+// ejit_taskpool_compile_or_get that pass the dim identity as scalar arguments
+// instead of an ejit_dim_pair_t* + numDims pair, trimming the cache-hit path
+// (no numDims bound/null checks, no variable-length validation loop, dims built
+// directly on the stack). Return status and outFn/outBucket semantics are
+// identical to ejit_taskpool_compile_or_get with the matching numDims; on a
+// cache hit the caller still owns the read token and must call
+// ejit_taskpool_release_read(*outBucket). 4 dims is the maximum; callers with
+// more dims use the generic entry above.
+ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
+                                              uint32_t *outBucket);
+ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, void **outFn,
+                                              uint32_t *outBucket);
+ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, uint32_t dim1,
+                                              uint32_t inst1, void **outFn,
+                                              uint32_t *outBucket);
+ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, uint32_t dim1,
+                                              uint32_t inst1, uint32_t dim2,
+                                              uint32_t inst2, void **outFn,
+                                              uint32_t *outBucket);
+ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, uint32_t dim1,
+                                              uint32_t inst1, uint32_t dim2,
+                                              uint32_t inst2, uint32_t dim3,
+                                              uint32_t inst3, void **outFn,
+                                              uint32_t *outBucket);
 void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
                                         uint32_t enabled);
 void ejit_taskpool_release_read(uint32_t bucketIndex);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -298,6 +298,29 @@ public:
   /// calls this so the ordering/counters/semantics stay identical.
   CompileOrGetResult tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
                                  uint32_t numDims);
+  /// Fixed-dimension fast cache-hit entries (0-4 dims). Same terminal
+  /// semantics as tryCacheHit() but the instance-enabled check is unrolled and
+  /// the dim identity is built directly on the stack (no numDims loop / no
+  /// variable-length array handling), so the C ABI fixed-dimension entries
+  /// (ejit_taskpool_compile_or_get_Nd) reach the cache lookup with the least
+  /// overhead. The cache lookup itself is still the shared generic
+  /// cacheLookup(). 4 is the maximum dimension count (numDims > 4 is rejected
+  /// by the C ABI); higher-dimension callers keep using tryCacheHit().
+  CompileOrGetResult tryCacheHit0D(uint32_t funcIndex);
+  CompileOrGetResult tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0);
+  CompileOrGetResult tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0, uint32_t dim1,
+                                   uint32_t inst1);
+  CompileOrGetResult tryCacheHit3D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0, uint32_t dim1,
+                                   uint32_t inst1, uint32_t dim2,
+                                   uint32_t inst2);
+  CompileOrGetResult tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0, uint32_t dim1,
+                                   uint32_t inst1, uint32_t dim2,
+                                   uint32_t inst2, uint32_t dim3,
+                                   uint32_t inst3);
   void releaseRead(uint32_t bucketIndex);
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read
@@ -358,6 +381,13 @@ private:
                         uint32_t numDims) const;
   SharedLookup cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
                            uint32_t numDims);
+  /// Convert a shared cache lookup outcome into a CompileOrGetResult with the
+  /// fast-path terminal classification (CacheHit / readyButNotShareable /
+  /// miss). Shared by tryCacheHit() and the fixed-dimension entries so the
+  /// cache-hit counter is incremented exactly once and the semantics stay
+  /// identical. Does NOT perform the Ready or instance-enabled checks (the
+  /// callers do those first).
+  CompileOrGetResult classifyHit(const SharedLookup &Hit);
   EJitPublishStatus cachePublish(const EJitCompileRequest &req, void *fnPtr,
                                  const EJitCompiledCodeInfo *info);
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -150,6 +150,14 @@ public:
     /// cross-core pointer (code sharing not platform-validated): a clean
     /// fallback that did NOT re-enqueue.
     bool readyButNotShareable = false;
+    /// Set by tryCacheHit() when the request was fully resolved on the fast
+    /// cache-hit path (a cache hit, a disabled instance, a not-yet-Ready pool,
+    /// or a ready-but-not-shareable fallback). When true the caller returns
+    /// this result directly and MUST NOT enter the compileOrGet() slow path.
+    /// When false the request is a true miss that still needs compileOrGet().
+    /// This flag is an internal control signal; it does not affect status
+    /// mapping or the C ABI.
+    bool fastPathTerminal = false;
   };
 
   EJitSharedTaskPool() = default;
@@ -274,6 +282,22 @@ public:
   //--- producer path ----------------------------------------------------------
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                   uint32_t numDims, void *fallback);
+  /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
+  /// terminal front half of compileOrGet(): the Ready check, the
+  /// instance-enabled check, and the cache lookup, then classifies the outcome:
+  ///   * CacheHit           — returns fnPtr + bucketIndex + a held read token
+  ///                          (caller releases via releaseRead), cacheHits++.
+  ///   * InstanceDisabled   — a disabled dim, instanceDisabled++.
+  ///   * OffMode            — the pool is not Ready (clean fallback).
+  ///   * OffMode + readyButNotShareable — Ready code this core may not read;
+  ///                          NO enqueue / dedup.
+  /// Each of the above sets fastPathTerminal = true; the caller returns the
+  /// result directly and never enters the slow path. A true miss (Ready,
+  /// enabled, no shareable cached code) returns fastPathTerminal = false and
+  /// the caller must fall through to compileOrGet(). compileOrGet() itself
+  /// calls this so the ordering/counters/semantics stay identical.
+  CompileOrGetResult tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                                 uint32_t numDims);
   void releaseRead(uint32_t bucketIndex);
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -381,6 +381,39 @@ private:
                         uint32_t numDims) const;
   SharedLookup cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
                            uint32_t numDims);
+  /// Fixed-dimension specializations of cacheLookup() (0-4 dims). Identity
+  /// hashing, slot identity comparison, and version comparison are all unrolled
+  /// (no numDims loops, no dims[] indexing), so a cache hit reaches the shared
+  /// slot resolution with the least per-hit work. Behavior is identical to
+  /// cacheLookup() with the matching numDims. The cross-core fnPtr gate and the
+  /// cold non-owner preparation are shared via resolveMatchedSlot() /
+  /// peerPrepareSlot(), so these stay small on the hot path.
+  SharedLookup cacheLookup0D(uint32_t funcIndex);
+  SharedLookup cacheLookup1D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0);
+  SharedLookup cacheLookup2D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                             uint32_t dim1, uint32_t inst1);
+  SharedLookup cacheLookup3D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                             uint32_t dim1, uint32_t inst1, uint32_t dim2,
+                             uint32_t inst2);
+  SharedLookup cacheLookup4D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                             uint32_t dim1, uint32_t inst1, uint32_t dim2,
+                             uint32_t inst2, uint32_t dim3, uint32_t inst3);
+  /// Resolve a cache slot whose identity + versions already matched, with the
+  /// bucket read lock HELD on entry. Applies the cross-core fnPtr gate and
+  /// returns the hit (with the read token held) for the owner core or a core
+  /// that has already memoized execute permission; a core that may not read the
+  /// pointer gets a clean readyButNotShareable fallback (lock released). The
+  /// rare non-owner first-touch case is delegated to peerPrepareSlot(). Shared
+  /// by cacheLookup() and all fixed-dimension specializations.
+  SharedLookup resolveMatchedSlot(EJitSharedCacheBucket &bucket,
+                                  uint32_t bucketIndex, uint32_t slotIndex);
+  /// Cold non-owner first-touch execute-permission preparation for a matched
+  /// slot, with the bucket read lock HELD on entry (this function releases it).
+  /// Snapshots the slot, drops the lock for the per-core platform seal, then
+  /// re-validates before handing back the prepared pointer. Kept out-of-line
+  /// (noinline) so it never bloats the hit path in cacheLookup()/cacheLookupNd.
+  SharedLookup peerPrepareSlot(EJitSharedCacheBucket &bucket,
+                               uint32_t bucketIndex, uint32_t slotIndex);
   /// Convert a shared cache lookup outcome into a CompileOrGetResult with the
   /// fast-path terminal classification (CacheHit / readyButNotShareable /
   /// miss). Shared by tryCacheHit() and the fixed-dimension entries so the

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -328,6 +328,28 @@ public:
   CompileOrGetResult tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
                                  uint32_t numDims);
 
+  /// Fixed-dimension fast cache-hit entries (0-4 dims). Same terminal
+  /// semantics as tryCacheHit() but the instance-enabled check is unrolled and
+  /// the dim identity is built directly on the stack (no numDims loop), so the
+  /// C ABI fixed-dimension entries (ejit_taskpool_compile_or_get_Nd) reach the
+  /// shared cache lookup with the least overhead. 4 is the maximum dimension
+  /// count; higher-dimension callers keep using tryCacheHit().
+  CompileOrGetResult tryCacheHit0D(uint32_t funcIndex);
+  CompileOrGetResult tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0);
+  CompileOrGetResult tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0, uint32_t dim1,
+                                   uint32_t inst1);
+  CompileOrGetResult tryCacheHit3D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0, uint32_t dim1,
+                                   uint32_t inst1, uint32_t dim2,
+                                   uint32_t inst2);
+  CompileOrGetResult tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
+                                   uint32_t inst0, uint32_t dim1,
+                                   uint32_t inst1, uint32_t dim2,
+                                   uint32_t inst2, uint32_t dim3,
+                                   uint32_t inst3);
+
   bool pollOne();
   unsigned pollBudget(unsigned maxItems);
 
@@ -345,6 +367,12 @@ public:
 private:
   bool versionsMatch(const EJitCompileRequest &req) const;
   void runCompile(const EJitCompileRequest &req);
+  /// Convert a cache lookup outcome into a CompileOrGetResult with the
+  /// fast-path terminal classification (CacheHit / miss). Shared by
+  /// tryCacheHit() and the fixed-dimension entries so the cache-hit counter is
+  /// incremented exactly once and the semantics stay identical. Does NOT
+  /// perform the instance-enabled check (the callers do that first).
+  CompileOrGetResult classifyHit(const EJitCacheLookupResult &Hit);
 
   EJitSwitchController switch_;
   EJitTaskQueue queue_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -283,6 +283,13 @@ public:
     void *fnPtr = nullptr;
     uint32_t bucketIndex = 0;
     bool hasReadToken = false;
+    /// Set by tryCacheHit() when the request was fully resolved on the fast
+    /// cache-hit path (a cache hit or a disabled instance). When true the
+    /// caller returns this result directly and MUST NOT enter the
+    /// compileOrGet() slow path; when false the request is a true miss that
+    /// still needs compileOrGet(). Internal control signal only — it does not
+    /// affect status mapping or the C ABI.
+    bool fastPathTerminal = false;
   };
 
   explicit EJitTaskPool(
@@ -306,6 +313,20 @@ public:
 
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                   uint32_t numDims, void *fallback);
+
+  /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
+  /// terminal front half of compileOrGet(): the instance-enabled check and the
+  /// cache lookup, then classifies the outcome:
+  ///   * CacheHit         — returns fnPtr + bucketIndex + a held read token
+  ///                        (caller releases via releaseRead), cacheHits++.
+  ///   * InstanceDisabled — a disabled dim, instanceDisabled++.
+  /// Both set fastPathTerminal = true; the caller returns the result directly
+  /// and never enters the slow path. A true miss (enabled, no cached code)
+  /// returns fastPathTerminal = false and the caller must fall through to
+  /// compileOrGet(). compileOrGet() itself calls this so the
+  /// ordering/counters/semantics stay identical.
+  CompileOrGetResult tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                                 uint32_t numDims);
 
   bool pollOne();
   unsigned pollBudget(unsigned maxItems);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -488,6 +488,198 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
   return taskpoolStatus(r.status);
 }
 
+//===----------------------------------------------------------------------===//
+// Fixed-dimension C ABI fast paths (0-4 dims).
+//
+// Additive entry points that pass the dim identity as scalar arguments instead
+// of an EJitDimPair* + numDims pair. They skip the generic entry's numDims
+// bound check, null-dims check, and variable-length validation loop, and drive
+// the pool's unrolled tryCacheHitNd() so a cache hit reaches the cache lookup
+// with the least overhead. Semantics (status mapping, read-token / outBucket
+// ownership, InstanceDisabled / OffMode / readyButNotShareable, and the
+// fall-through to compileOrGet on a true miss) are identical to
+// ejit_taskpool_compile_or_get with the matching numDims. The original generic
+// entry is retained unchanged as the fallback for >4 dims and existing wrapper
+// output.
+//===----------------------------------------------------------------------===//
+namespace {
+inline bool ejitTaskpoolDimInRange(uint32_t dimType, uint32_t instanceId) {
+  return dimType < EJitSwitchController::MAX_DIM_TYPES &&
+         instanceId < EJitSwitchController::MAX_INSTANCES;
+}
+} // namespace
+
+ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
+                                              uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+
+  auto fast = tp->tryCacheHit0D(funcIndex);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  auto r = tp->compileOrGet(funcIndex, nullptr, 0, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, void **outFn,
+                                              uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+  if (!ejitTaskpoolDimInRange(dim0, inst0))
+    return EJIT_ERR_INVALID_PARAM;
+
+  auto fast = tp->tryCacheHit1D(funcIndex, dim0, inst0);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  const EJitDimPair dims[1] = {{dim0, inst0}};
+  auto r = tp->compileOrGet(funcIndex, dims, 1, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, uint32_t dim1,
+                                              uint32_t inst1, void **outFn,
+                                              uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+  if (!ejitTaskpoolDimInRange(dim0, inst0) ||
+      !ejitTaskpoolDimInRange(dim1, inst1))
+    return EJIT_ERR_INVALID_PARAM;
+
+  auto fast = tp->tryCacheHit2D(funcIndex, dim0, inst0, dim1, inst1);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
+  auto r = tp->compileOrGet(funcIndex, dims, 2, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, uint32_t dim1,
+                                              uint32_t inst1, uint32_t dim2,
+                                              uint32_t inst2, void **outFn,
+                                              uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+  if (!ejitTaskpoolDimInRange(dim0, inst0) ||
+      !ejitTaskpoolDimInRange(dim1, inst1) ||
+      !ejitTaskpoolDimInRange(dim2, inst2))
+    return EJIT_ERR_INVALID_PARAM;
+
+  auto fast =
+      tp->tryCacheHit3D(funcIndex, dim0, inst0, dim1, inst1, dim2, inst2);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
+  auto r = tp->compileOrGet(funcIndex, dims, 3, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
+                                              uint32_t inst0, uint32_t dim1,
+                                              uint32_t inst1, uint32_t dim2,
+                                              uint32_t inst2, uint32_t dim3,
+                                              uint32_t inst3, void **outFn,
+                                              uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+  if (!ejitTaskpoolDimInRange(dim0, inst0) ||
+      !ejitTaskpoolDimInRange(dim1, inst1) ||
+      !ejitTaskpoolDimInRange(dim2, inst2) ||
+      !ejitTaskpoolDimInRange(dim3, inst3))
+    return EJIT_ERR_INVALID_PARAM;
+
+  auto fast = tp->tryCacheHit4D(funcIndex, dim0, inst0, dim1, inst1, dim2,
+                                inst2, dim3, inst3);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  const EJitDimPair dims[4] = {
+      {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
+  auto r = tp->compileOrGet(funcIndex, dims, 4, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+
 void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
                                         uint32_t enabled) {
   EJIT_DIAG_VERBOSE("taskpool_set_instance_enabled dim=%u inst=%u enabled=%u",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -456,8 +456,28 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
 
   // ejit_dim_pair_t and EJitDimPair share the same layout; pass through
   // to avoid a stack copy of up to 4 dim pairs.
-  auto r = tp->compileOrGet(funcIndex,
-                            reinterpret_cast<const EJitDimPair *>(dims), numDims,
+  const EJitDimPair *dimsCast = reinterpret_cast<const EJitDimPair *>(dims);
+
+  // Flattened fast cache-hit path: resolve the common terminal outcomes (cache
+  // hit, disabled instance, not-Ready / ready-but-not-shareable fallback)
+  // without entering the full compileOrGet slow path. tryCacheHit preserves the
+  // exact compileOrGet hot-path semantics (ordering, counters, read tokens),
+  // so a hit still hands back outBucket for ejit_taskpool_release_read and a
+  // disabled instance never returns stale code. A true miss falls through to
+  // compileOrGet unchanged (enqueue/dedup/compile).
+  auto fast = tp->tryCacheHit(funcIndex, dimsCast, numDims);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u fast status=%u fn=%p",
+                      funcIndex, static_cast<unsigned>(fast.status),
+                      fast.fnPtr);
+    return taskpoolStatus(fast.status);
+  }
+
+  auto r = tp->compileOrGet(funcIndex, dimsCast, numDims,
                             /*fallback=*/nullptr);
   if (outFn)
     *outFn = r.fnPtr;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -275,109 +275,359 @@ EJitSharedTaskPool::cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
       }
     if (!versionsOk)
       break; // identity matched but stale → miss, token off.
-
-    // fnPtr cross-core gate (§11 prerequisites): a non-owner core may read the
-    // pointer only when code sharing is platform-validated (same VA, sealed,
-    // I/D-cache coherent). Otherwise CLEAN-REJECT — never hand back a pointer
-    // this core may not legally execute.
-    uint32_t self = EJitCoreId::current();
-    uint32_t owner = state_->ownerCoreId.loadAcquire();
-    bool mayReadPtr =
-        (state_->codeSharingEnabled.loadAcquire() != 0) || (self == owner);
-    if (!mayReadPtr) {
-      bucketReadRelease(B);
-      R.readyButNotShareable = true;
-      return R;
-    }
-    void *fn = reinterpret_cast<void *>(Slot.fnPtr.loadAcquire());
-    if (!fn)
-      break;
-
-    // The owner already has execute permission (it sealed the code before
-    // publishing). Return directly while holding the read token.
-    if (self == owner) {
-      R.fnPtr = fn;
-      R.bucketIndex = bucket;
-      R.hasReadToken = true;
-      return R;
-    }
-
-    // Non-owner: execute permission is a per-core property on the target. If
-    // this core has already prepared THIS slot's code (memoized bit), return
-    // immediately under the read lock — no platform call.
-    const bool CanMemoize = self < kEJitSharedMaxMemoCores;
-    const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : uint64_t{0};
-    if (CanMemoize && (Slot.executableCoreMask.loadAcquire() & CoreBit) != 0) {
-      R.fnPtr = fn;
-      R.bucketIndex = bucket;
-      R.hasReadToken = true;
-      return R;
-    }
-
-    // Not prepared yet. Snapshot the identity + the REAL code range, then DROP
-    // the bucket read lock: the per-core platform split/enable_ex calls
-    // (potentially slow) must never run while holding a cross-core bucket lock,
-    // or a concurrent owner publish (which spins for readers==0) would stall.
-    PeerCodeRange Snap;
-    Snap.fn = fn;
-    Snap.slotIndex = s;
-    Snap.bucket = bucket;
-    Snap.funcIndex = Slot.funcIndex;
-    Snap.numDims = Slot.numDims;
-    Snap.generation = Slot.generation;
-    for (uint32_t i = 0; i < Snap.numDims && i < 4; ++i) {
-      Snap.dims[i] = Slot.dims[i];
-      Snap.versions[i] = Slot.versions[i];
-    }
-    Snap.codeStart = Slot.codeStart;
-    Snap.codeSize = Slot.codeSize;
-    Snap.poolBase = Slot.poolBase;
-    Snap.poolSize = Slot.poolSize;
-    bucketReadRelease(B);
-
-    if (!prepareExecForCurrentCore(Snap, self)) {
-      state_->counters.executePrepareFailed.fetchAdd(1);
-      R.readyButNotShareable = true;
-      return R; // clean fallback: no token, no shared pointer handed back.
-    }
-
-    // Re-acquire the read lock and RE-VALIDATE the slot: a publish may have
-    // overwritten it (new code/generation) while we prepared. Only a slot that
-    // is still Ready, same generation + identity + fnPtr, with current
-    // versions, may hand back the prepared pointer; otherwise clean fallback so
-    // a replaced/stale pointer is never returned (spec §11 / §8).
-    if (!bucketTryRead(B)) {
-      R.readyButNotShareable = true;
-      return R;
-    }
-    EJitSharedCacheSlot &S2 = B.slots[Snap.slotIndex];
-    uint32_t curGen2 = state_->generation.loadAcquire();
-    bool stillValid =
-        S2.state.loadAcquire() ==
-            static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
-        S2.generation == curGen2 && S2.generation == Snap.generation &&
-        slotIdentityMatches(S2, Snap.funcIndex, Snap.dims, Snap.numDims) &&
-        reinterpret_cast<void *>(S2.fnPtr.loadAcquire()) == Snap.fn;
-    if (stillValid)
-      for (uint32_t i = 0; i < Snap.numDims; ++i)
-        if (S2.versions[i] !=
-            instanceVersion(Snap.dims[i].dimType, Snap.dims[i].instanceId)) {
-          stillValid = false;
-          break;
-        }
-    if (!stillValid) {
-      bucketReadRelease(B);
-      R.readyButNotShareable = true;
-      return R;
-    }
-    if (CanMemoize)
-      S2.executableCoreMask.fetchOr(CoreBit);
-    R.fnPtr = Snap.fn;
-    R.bucketIndex = Snap.bucket;
-    R.hasReadToken = true;
-    return R; // token held (re-acquired); caller releases after using fnPtr.
+    // Identity + versions match: resolve the fnPtr gate (owner/memoized fast
+    // return, clean reject, or cold peer preparation). Terminal — a bucket
+    // holds at most one slot per identity.
+    return resolveMatchedSlot(B, bucket, s);
   }
 
+  bucketReadRelease(B);
+  return R;
+}
+
+//===----------------------------------------------------------------------===//
+// Shared slot resolution: applied once a slot's identity + versions have
+// matched (bucket read lock held). Dimension-independent, so cacheLookup() and
+// every fixed-dimension cacheLookupNd() share it. The owner core and any core
+// that already memoized execute permission return the hit here with the read
+// token held; a core that may not legally read the cross-core pointer gets a
+// clean readyButNotShareable fallback; the rare non-owner first touch is
+// delegated to the out-of-line peerPrepareSlot().
+//===----------------------------------------------------------------------===//
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
+                                       uint32_t bucket, uint32_t slotIndex) {
+  SharedLookup R;
+  EJitSharedCacheSlot &Slot = B.slots[slotIndex];
+  // fnPtr cross-core gate (§11 prerequisites): a non-owner core may read the
+  // pointer only when code sharing is platform-validated (same VA, sealed,
+  // I/D-cache coherent). Otherwise CLEAN-REJECT — never hand back a pointer
+  // this core may not legally execute.
+  uint32_t self = EJitCoreId::current();
+  uint32_t owner = state_->ownerCoreId.loadAcquire();
+  bool mayReadPtr =
+      (state_->codeSharingEnabled.loadAcquire() != 0) || (self == owner);
+  if (!mayReadPtr) {
+    bucketReadRelease(B);
+    R.readyButNotShareable = true;
+    return R;
+  }
+  void *fn = reinterpret_cast<void *>(Slot.fnPtr.loadAcquire());
+  if (!fn) {
+    bucketReadRelease(B);
+    return R; // identity matched but no pointer yet → miss.
+  }
+
+  // The owner already has execute permission (it sealed the code before
+  // publishing). Return directly while holding the read token.
+  if (self == owner) {
+    R.fnPtr = fn;
+    R.bucketIndex = bucket;
+    R.hasReadToken = true;
+    return R;
+  }
+
+  // Non-owner: execute permission is a per-core property on the target. If this
+  // core has already prepared THIS slot's code (memoized bit), return
+  // immediately under the read lock — no platform call.
+  const bool CanMemoize = self < kEJitSharedMaxMemoCores;
+  const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : uint64_t{0};
+  if (CanMemoize && (Slot.executableCoreMask.loadAcquire() & CoreBit) != 0) {
+    R.fnPtr = fn;
+    R.bucketIndex = bucket;
+    R.hasReadToken = true;
+    return R;
+  }
+
+  // Cold: this core has never prepared this code. Delegate to the out-of-line
+  // helper so the hit path stays small.
+  return peerPrepareSlot(B, bucket, slotIndex);
+}
+
+//===----------------------------------------------------------------------===//
+// Cold non-owner first-touch execute-permission preparation. Out-of-line
+// (noinline) so it never inflates the cache-hit path. Bucket read lock held on
+// entry; released here.
+//===----------------------------------------------------------------------===//
+__attribute__((noinline)) EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
+                                    uint32_t slotIndex) {
+  SharedLookup R;
+  EJitSharedCacheSlot &Slot = B.slots[slotIndex];
+  uint32_t self = EJitCoreId::current();
+  void *fn = reinterpret_cast<void *>(Slot.fnPtr.loadAcquire());
+
+  // Snapshot the identity + the REAL code range, then DROP the bucket read
+  // lock: the per-core platform split/enable_ex calls (potentially slow) must
+  // never run while holding a cross-core bucket lock, or a concurrent owner
+  // publish (which spins for readers==0) would stall.
+  PeerCodeRange Snap;
+  Snap.fn = fn;
+  Snap.slotIndex = slotIndex;
+  Snap.bucket = bucket;
+  Snap.funcIndex = Slot.funcIndex;
+  Snap.numDims = Slot.numDims;
+  Snap.generation = Slot.generation;
+  for (uint32_t i = 0; i < Snap.numDims && i < 4; ++i) {
+    Snap.dims[i] = Slot.dims[i];
+    Snap.versions[i] = Slot.versions[i];
+  }
+  Snap.codeStart = Slot.codeStart;
+  Snap.codeSize = Slot.codeSize;
+  Snap.poolBase = Slot.poolBase;
+  Snap.poolSize = Slot.poolSize;
+  bucketReadRelease(B);
+
+  if (!prepareExecForCurrentCore(Snap, self)) {
+    state_->counters.executePrepareFailed.fetchAdd(1);
+    R.readyButNotShareable = true;
+    return R; // clean fallback: no token, no shared pointer handed back.
+  }
+
+  // Re-acquire the read lock and RE-VALIDATE the slot: a publish may have
+  // overwritten it (new code/generation) while we prepared. Only a slot that is
+  // still Ready, same generation + identity + fnPtr, with current versions, may
+  // hand back the prepared pointer; otherwise clean fallback so a
+  // replaced/stale pointer is never returned (spec §11 / §8).
+  if (!bucketTryRead(B)) {
+    R.readyButNotShareable = true;
+    return R;
+  }
+  EJitSharedCacheSlot &S2 = B.slots[Snap.slotIndex];
+  uint32_t curGen2 = state_->generation.loadAcquire();
+  bool stillValid =
+      S2.state.loadAcquire() ==
+          static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
+      S2.generation == curGen2 && S2.generation == Snap.generation &&
+      slotIdentityMatches(S2, Snap.funcIndex, Snap.dims, Snap.numDims) &&
+      reinterpret_cast<void *>(S2.fnPtr.loadAcquire()) == Snap.fn;
+  if (stillValid)
+    for (uint32_t i = 0; i < Snap.numDims; ++i)
+      if (S2.versions[i] !=
+          instanceVersion(Snap.dims[i].dimType, Snap.dims[i].instanceId)) {
+        stillValid = false;
+        break;
+      }
+  if (!stillValid) {
+    bucketReadRelease(B);
+    R.readyButNotShareable = true;
+    return R;
+  }
+  const bool CanMemoize = self < kEJitSharedMaxMemoCores;
+  const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : uint64_t{0};
+  if (CanMemoize)
+    S2.executableCoreMask.fetchOr(CoreBit);
+  R.fnPtr = Snap.fn;
+  R.bucketIndex = Snap.bucket;
+  R.hasReadToken = true;
+  return R; // token held (re-acquired); caller releases after using fnPtr.
+}
+
+//===----------------------------------------------------------------------===//
+// Fixed-dimension cacheLookup specializations (0-4 dims). Identity hashing,
+// slot identity comparison, and version comparison are unrolled — no numDims
+// loop, no dims[] indirection, no generic numDims>4 guard. The matched-slot
+// fnPtr gate and cold peer preparation are shared via resolveMatchedSlot(), so
+// each specialization stays small. Results are identical to cacheLookup() with
+// the matching numDims. kHashMul mirrors the mixing constant in hashIdentity().
+//===----------------------------------------------------------------------===//
+static constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex); // hashIdentity(fi, _, 0)
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  if (!bucketTryRead(B))
+    return R;
+  uint32_t curGen = state_->generation.loadAcquire();
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() !=
+        static_cast<uint32_t>(EJitSharedSlotState::Ready))
+      continue;
+    if (Slot.generation != curGen)
+      continue;
+    if (Slot.identityHash != key)
+      continue;
+    if (Slot.funcIndex != funcIndex || Slot.numDims != 0)
+      continue;
+    // 0D: no dims, no versions to compare.
+    return resolveMatchedSlot(B, bucket, s);
+  }
+  bucketReadRelease(B);
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookup1D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  if (!bucketTryRead(B))
+    return R;
+  uint32_t curGen = state_->generation.loadAcquire();
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() !=
+        static_cast<uint32_t>(EJitSharedSlotState::Ready))
+      continue;
+    if (Slot.generation != curGen)
+      continue;
+    if (Slot.identityHash != key)
+      continue;
+    if (Slot.funcIndex != funcIndex || Slot.numDims != 1)
+      continue;
+    if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+      continue;
+    if (Slot.versions[0] != instanceVersion(dim0, inst0))
+      break; // identity matched but stale → miss.
+    return resolveMatchedSlot(B, bucket, s);
+  }
+  bucketReadRelease(B);
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookup2D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0, uint32_t dim1,
+                                  uint32_t inst1) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  if (!bucketTryRead(B))
+    return R;
+  uint32_t curGen = state_->generation.loadAcquire();
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() !=
+        static_cast<uint32_t>(EJitSharedSlotState::Ready))
+      continue;
+    if (Slot.generation != curGen)
+      continue;
+    if (Slot.identityHash != key)
+      continue;
+    if (Slot.funcIndex != funcIndex || Slot.numDims != 2)
+      continue;
+    if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+      continue;
+    if (Slot.dims[1].dimType != dim1 || Slot.dims[1].instanceId != inst1)
+      continue;
+    if (Slot.versions[0] != instanceVersion(dim0, inst0))
+      break;
+    if (Slot.versions[1] != instanceVersion(dim1, inst1))
+      break;
+    return resolveMatchedSlot(B, bucket, s);
+  }
+  bucketReadRelease(B);
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookup3D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0, uint32_t dim1, uint32_t inst1,
+                                  uint32_t dim2, uint32_t inst2) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim2) << 32) | static_cast<uint64_t>(inst2);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  if (!bucketTryRead(B))
+    return R;
+  uint32_t curGen = state_->generation.loadAcquire();
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() !=
+        static_cast<uint32_t>(EJitSharedSlotState::Ready))
+      continue;
+    if (Slot.generation != curGen)
+      continue;
+    if (Slot.identityHash != key)
+      continue;
+    if (Slot.funcIndex != funcIndex || Slot.numDims != 3)
+      continue;
+    if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+      continue;
+    if (Slot.dims[1].dimType != dim1 || Slot.dims[1].instanceId != inst1)
+      continue;
+    if (Slot.dims[2].dimType != dim2 || Slot.dims[2].instanceId != inst2)
+      continue;
+    if (Slot.versions[0] != instanceVersion(dim0, inst0))
+      break;
+    if (Slot.versions[1] != instanceVersion(dim1, inst1))
+      break;
+    if (Slot.versions[2] != instanceVersion(dim2, inst2))
+      break;
+    return resolveMatchedSlot(B, bucket, s);
+  }
+  bucketReadRelease(B);
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookup4D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0, uint32_t dim1, uint32_t inst1,
+                                  uint32_t dim2, uint32_t inst2, uint32_t dim3,
+                                  uint32_t inst3) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim2) << 32) | static_cast<uint64_t>(inst2);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim3) << 32) | static_cast<uint64_t>(inst3);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  if (!bucketTryRead(B))
+    return R;
+  uint32_t curGen = state_->generation.loadAcquire();
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() !=
+        static_cast<uint32_t>(EJitSharedSlotState::Ready))
+      continue;
+    if (Slot.generation != curGen)
+      continue;
+    if (Slot.identityHash != key)
+      continue;
+    if (Slot.funcIndex != funcIndex || Slot.numDims != 4)
+      continue;
+    if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+      continue;
+    if (Slot.dims[1].dimType != dim1 || Slot.dims[1].instanceId != inst1)
+      continue;
+    if (Slot.dims[2].dimType != dim2 || Slot.dims[2].instanceId != inst2)
+      continue;
+    if (Slot.dims[3].dimType != dim3 || Slot.dims[3].instanceId != inst3)
+      continue;
+    if (Slot.versions[0] != instanceVersion(dim0, inst0))
+      break;
+    if (Slot.versions[1] != instanceVersion(dim1, inst1))
+      break;
+    if (Slot.versions[2] != instanceVersion(dim2, inst2))
+      break;
+    if (Slot.versions[3] != instanceVersion(dim3, inst3))
+      break;
+    return resolveMatchedSlot(B, bucket, s);
+  }
   bucketReadRelease(B);
   return R;
 }
@@ -886,7 +1136,7 @@ void EJitSharedTaskPool::ownerShutdown() {
 //===----------------------------------------------------------------------===//
 // Producer path (§5.2).
 //===----------------------------------------------------------------------===//
-EJitSharedTaskPool::CompileOrGetResult
+__attribute__((always_inline)) EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   CompileOrGetResult R;
   if (Hit.hasReadToken && Hit.fnPtr) {
@@ -960,7 +1210,7 @@ EJitSharedTaskPool::tryCacheHit0D(uint32_t funcIndex) {
     R.fastPathTerminal = true;
     return R;
   }
-  return classifyHit(cacheLookup(funcIndex, nullptr, 0));
+  return classifyHit(cacheLookup0D(funcIndex));
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -978,8 +1228,7 @@ EJitSharedTaskPool::tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
-  const EJitDimPair dims[1] = {{dim0, inst0}};
-  return classifyHit(cacheLookup(funcIndex, dims, 1));
+  return classifyHit(cacheLookup1D(funcIndex, dim0, inst0));
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -998,8 +1247,7 @@ EJitSharedTaskPool::tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
-  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
-  return classifyHit(cacheLookup(funcIndex, dims, 2));
+  return classifyHit(cacheLookup2D(funcIndex, dim0, inst0, dim1, inst1));
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -1019,8 +1267,8 @@ EJitSharedTaskPool::tryCacheHit3D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
-  const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
-  return classifyHit(cacheLookup(funcIndex, dims, 3));
+  return classifyHit(
+      cacheLookup3D(funcIndex, dim0, inst0, dim1, inst1, dim2, inst2));
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -1041,9 +1289,8 @@ EJitSharedTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
-  const EJitDimPair dims[4] = {
-      {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
-  return classifyHit(cacheLookup(funcIndex, dims, 4));
+  return classifyHit(cacheLookup4D(funcIndex, dim0, inst0, dim1, inst1, dim2,
+                                   inst2, dim3, inst3));
 }
 
 EJitSharedTaskPool::CompileOrGetResult

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -887,6 +887,32 @@ void EJitSharedTaskPool::ownerShutdown() {
 // Producer path (§5.2).
 //===----------------------------------------------------------------------===//
 EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
+  CompileOrGetResult R;
+  if (Hit.hasReadToken && Hit.fnPtr) {
+    state_->counters.cacheHits.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::CacheHit;
+    R.fnPtr = Hit.fnPtr;
+    R.bucketIndex = Hit.bucketIndex;
+    R.hasReadToken = true;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  if (Hit.readyButNotShareable) {
+    // The work is already done but this core may not read the cross-core
+    // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
+    R.status = EJitCompileOrGetStatus::OffMode;
+    R.readyButNotShareable = true;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  // True miss (Ready, enabled, no shareable cached code): the caller must fall
+  // through to the compileOrGet() slow path (Off / Sync / Async).
+  R.fastPathTerminal = false;
+  return R;
+}
+
+EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
                                 uint32_t numDims) {
   CompileOrGetResult R;
@@ -915,34 +941,109 @@ EJitSharedTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
 
   // Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
   // compiled entry is still served even when the pool is globally Off.
-  EJitSharedTaskPool::SharedLookup Hit = cacheLookup(funcIndex, dims, numDims);
-  if (Hit.hasReadToken && Hit.fnPtr) {
-    state_->counters.cacheHits.fetchAdd(1);
-    R.status = EJitCompileOrGetStatus::CacheHit;
-    R.fnPtr = Hit.fnPtr;
-    R.bucketIndex = Hit.bucketIndex;
-    R.hasReadToken = true;
-    R.fastPathTerminal = true;
-    EJIT_DIAG_VERBOSE("shared taskpool hit func=%u bucket=%u fn=%p", funcIndex,
-                      Hit.bucketIndex, Hit.fnPtr);
-    return R;
-  }
-  if (Hit.readyButNotShareable) {
-    // The work is already done but this core may not read the cross-core
-    // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
-    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: ready but not "
-                      "shareable on this core",
-                      funcIndex);
-    R.status = EJitCompileOrGetStatus::OffMode;
-    R.readyButNotShareable = true;
-    R.fastPathTerminal = true;
-    return R;
-  }
+  return classifyHit(cacheLookup(funcIndex, dims, numDims));
+}
 
-  // True miss (Ready, enabled, no shareable cached code): the caller must fall
-  // through to the compileOrGet() slow path (Off / Sync / Async).
-  R.fastPathTerminal = false;
-  return R;
+//===----------------------------------------------------------------------===//
+// Fixed-dimension fast cache-hit entries (§5.2 steps 0-1, unrolled). Each
+// shares the Ready gate + classifyHit() with tryCacheHit() but the
+// instance-enabled check is unrolled and the dim identity is built directly on
+// the stack, so the C ABI fixed-dimension entries reach the shared
+// cacheLookup() without a numDims loop or variable-length array setup.
+// Semantics are identical to tryCacheHit() with the matching numDims.
+//===----------------------------------------------------------------------===//
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::tryCacheHit0D(uint32_t funcIndex) {
+  CompileOrGetResult R;
+  if (!state_ || state_->initState.loadAcquire() != kReady) {
+    R.status = EJitCompileOrGetStatus::OffMode;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  return classifyHit(cacheLookup(funcIndex, nullptr, 0));
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0) {
+  CompileOrGetResult R;
+  if (!state_ || state_->initState.loadAcquire() != kReady) {
+    R.status = EJitCompileOrGetStatus::OffMode;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  if (!isInstanceEnabled(dim0, inst0)) {
+    state_->counters.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  const EJitDimPair dims[1] = {{dim0, inst0}};
+  return classifyHit(cacheLookup(funcIndex, dims, 1));
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0, uint32_t dim1,
+                                  uint32_t inst1) {
+  CompileOrGetResult R;
+  if (!state_ || state_->initState.loadAcquire() != kReady) {
+    R.status = EJitCompileOrGetStatus::OffMode;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  if (!isInstanceEnabled(dim0, inst0) || !isInstanceEnabled(dim1, inst1)) {
+    state_->counters.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
+  return classifyHit(cacheLookup(funcIndex, dims, 2));
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::tryCacheHit3D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0, uint32_t dim1, uint32_t inst1,
+                                  uint32_t dim2, uint32_t inst2) {
+  CompileOrGetResult R;
+  if (!state_ || state_->initState.loadAcquire() != kReady) {
+    R.status = EJitCompileOrGetStatus::OffMode;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  if (!isInstanceEnabled(dim0, inst0) || !isInstanceEnabled(dim1, inst1) ||
+      !isInstanceEnabled(dim2, inst2)) {
+    state_->counters.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
+  return classifyHit(cacheLookup(funcIndex, dims, 3));
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
+                                  uint32_t inst0, uint32_t dim1, uint32_t inst1,
+                                  uint32_t dim2, uint32_t inst2, uint32_t dim3,
+                                  uint32_t inst3) {
+  CompileOrGetResult R;
+  if (!state_ || state_->initState.loadAcquire() != kReady) {
+    R.status = EJitCompileOrGetStatus::OffMode;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  if (!isInstanceEnabled(dim0, inst0) || !isInstanceEnabled(dim1, inst1) ||
+      !isInstanceEnabled(dim2, inst2) || !isInstanceEnabled(dim3, inst3)) {
+    state_->counters.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  const EJitDimPair dims[4] = {
+      {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
+  return classifyHit(cacheLookup(funcIndex, dims, 4));
 }
 
 EJitSharedTaskPool::CompileOrGetResult

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -887,29 +887,34 @@ void EJitSharedTaskPool::ownerShutdown() {
 // Producer path (§5.2).
 //===----------------------------------------------------------------------===//
 EJitSharedTaskPool::CompileOrGetResult
-EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                                 uint32_t numDims, void *fallback) {
+EJitSharedTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                                uint32_t numDims) {
   CompileOrGetResult R;
-  R.fnPtr = fallback;
-  EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p", funcIndex,
-            numDims, fallback);
+  // Parameter check already done by the C API layer.
+
+  // Ready check (§5.2 step 0): a not-yet-Ready pool is a clean fallback and
+  // never reads the queue/cache.
   if (!state_ || state_->initState.loadAcquire() != kReady) {
     EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: not Ready", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode; // not Ready → clean fallback.
+    R.fastPathTerminal = true;
     return R;
   }
-  // Parameter check already done by the C API layer.
 
-  // Instance-enabled check (§5.2 step 0).
+  // Instance-enabled check (§5.2 step 0): a disabled dim falls back and never
+  // reaches the cache, so a deactivated instance is never served stale code.
   for (uint32_t i = 0; i < numDims; ++i)
     if (!isInstanceEnabled(dims[i].dimType, dims[i].instanceId)) {
       state_->counters.instanceDisabled.fetchAdd(1);
-      EJIT_DIAG_VERBOSE("shared taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex,
-                i, dims[i].dimType, dims[i].instanceId);
+      EJIT_DIAG_VERBOSE("shared taskpool disabled func=%u dim[%u]=(%u,%u)",
+                        funcIndex, i, dims[i].dimType, dims[i].instanceId);
       R.status = EJitCompileOrGetStatus::InstanceDisabled;
+      R.fastPathTerminal = true;
       return R;
     }
-  // Cache lookup (§5.2 step 1).
+
+  // Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
+  // compiled entry is still served even when the pool is globally Off.
   EJitSharedTaskPool::SharedLookup Hit = cacheLookup(funcIndex, dims, numDims);
   if (Hit.hasReadToken && Hit.fnPtr) {
     state_->counters.cacheHits.fetchAdd(1);
@@ -917,19 +922,48 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.fnPtr = Hit.fnPtr;
     R.bucketIndex = Hit.bucketIndex;
     R.hasReadToken = true;
+    R.fastPathTerminal = true;
     EJIT_DIAG_VERBOSE("shared taskpool hit func=%u bucket=%u fn=%p", funcIndex,
-              Hit.bucketIndex, Hit.fnPtr);
+                      Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
   if (Hit.readyButNotShareable) {
     // The work is already done but this core may not read the cross-core
     // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
-    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: ready but not shareable on this core",
-              funcIndex);
+    EJIT_DIAG_VERBOSE("shared taskpool fallback func=%u: ready but not "
+                      "shareable on this core",
+                      funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;
     R.readyButNotShareable = true;
+    R.fastPathTerminal = true;
     return R;
   }
+
+  // True miss (Ready, enabled, no shareable cached code): the caller must fall
+  // through to the compileOrGet() slow path (Off / Sync / Async).
+  R.fastPathTerminal = false;
+  return R;
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
+                                 uint32_t numDims, void *fallback) {
+  EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p",
+                    funcIndex, numDims, fallback);
+  // Parameter check already done by the C API layer.
+
+  // Fast cache-hit path (§5.2 steps 0-1). On any terminal outcome (hit,
+  // disabled instance, not-Ready, or ready-but-not-shareable) return directly.
+  CompileOrGetResult R = tryCacheHit(funcIndex, dims, numDims);
+  if (R.fastPathTerminal) {
+    // Non-hit terminals surface the caller's fallback pointer (a hit already
+    // carries the cached fnPtr + read token).
+    if (R.status != EJitCompileOrGetStatus::CacheHit)
+      R.fnPtr = fallback;
+    return R;
+  }
+  // True miss: continue the slow path with the caller's fallback.
+  R.fnPtr = fallback;
   // Off mode (§5.2 step 2).
   if (state_->mode.loadAcquire() ==
       static_cast<uint32_t>(EJitCompileMode::Off)) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -314,12 +314,9 @@ EJitTaskPool::~EJitTaskPool() {
 }
 
 EJitTaskPool::CompileOrGetResult
-EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                           uint32_t numDims, void *fallback) {
+EJitTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
+                          uint32_t numDims) {
   CompileOrGetResult R;
-  R.fnPtr = fallback;
-  EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex, numDims,
-            fallback);
 
   // Parameter check already done by the C API layer (ejit_taskpool_compile_or_get).
 
@@ -331,14 +328,15 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       EJIT_DIAG_VERBOSE("taskpool disabled func=%u dim[%u]=(%u,%u)", funcIndex, i,
                 dims[i].dimType, dims[i].instanceId);
       R.status = EJitCompileOrGetStatus::InstanceDisabled;
+      R.fastPathTerminal = true;
       return R;
     }
   }
 
-  // 3. Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
+  // 2. Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
   //    compiled entry is still served while the pool is globally Off (the spec
   //    orders cache lookup ahead of the Off check). A disabled instance was
-  //    already rejected in step 2 and never reaches here.
+  //    already rejected above and never reaches here.
   EJitCacheLookupResult Hit = cache_.lookup(funcIndex, dims, numDims);
   if (Hit.hasReadToken && Hit.fnPtr) {
     counters_.cacheHits.fetchAdd(1);
@@ -346,12 +344,41 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.fnPtr = Hit.fnPtr;
     R.bucketIndex = Hit.bucketIndex;
     R.hasReadToken = true;
+    R.fastPathTerminal = true;
     EJIT_DIAG_VERBOSE("taskpool hit func=%u bucket=%u fn=%p", funcIndex,
               Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
 
-  // 4. Off mode (§5.2 step 2) — fall back, never enqueue/compile.
+  // True miss (enabled, no cached code): the caller must fall through to the
+  // compileOrGet() slow path (Off / Sync / Async).
+  R.fastPathTerminal = false;
+  return R;
+}
+
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
+                           uint32_t numDims, void *fallback) {
+  EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex,
+                    numDims, fallback);
+
+  // Parameter check already done by the C API layer
+  // (ejit_taskpool_compile_or_get).
+
+  // Fast cache-hit path (§5.2 steps 0-1). On a terminal outcome (hit or a
+  // disabled instance) return directly.
+  CompileOrGetResult R = tryCacheHit(funcIndex, dims, numDims);
+  if (R.fastPathTerminal) {
+    // Non-hit terminals surface the caller's fallback pointer (a hit already
+    // carries the cached fnPtr + read token).
+    if (R.status != EJitCompileOrGetStatus::CacheHit)
+      R.fnPtr = fallback;
+    return R;
+  }
+  // True miss: continue the slow path with the caller's fallback.
+  R.fnPtr = fallback;
+
+  // 3. Off mode (§5.2 step 2) — fall back, never enqueue/compile.
   if (switch_.getMode() == EJitCompileMode::Off) {
     EJIT_DIAG_VERBOSE("taskpool fallback func=%u: mode off", funcIndex);
     R.status = EJitCompileOrGetStatus::OffMode;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -314,6 +314,24 @@ EJitTaskPool::~EJitTaskPool() {
 }
 
 EJitTaskPool::CompileOrGetResult
+EJitTaskPool::classifyHit(const EJitCacheLookupResult &Hit) {
+  CompileOrGetResult R;
+  if (Hit.hasReadToken && Hit.fnPtr) {
+    counters_.cacheHits.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::CacheHit;
+    R.fnPtr = Hit.fnPtr;
+    R.bucketIndex = Hit.bucketIndex;
+    R.hasReadToken = true;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  // True miss (enabled, no cached code): the caller must fall through to the
+  // compileOrGet() slow path (Off / Sync / Async).
+  R.fastPathTerminal = false;
+  return R;
+}
+
+EJitTaskPool::CompileOrGetResult
 EJitTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
                           uint32_t numDims) {
   CompileOrGetResult R;
@@ -337,23 +355,83 @@ EJitTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
   //    compiled entry is still served while the pool is globally Off (the spec
   //    orders cache lookup ahead of the Off check). A disabled instance was
   //    already rejected above and never reaches here.
-  EJitCacheLookupResult Hit = cache_.lookup(funcIndex, dims, numDims);
-  if (Hit.hasReadToken && Hit.fnPtr) {
-    counters_.cacheHits.fetchAdd(1);
-    R.status = EJitCompileOrGetStatus::CacheHit;
-    R.fnPtr = Hit.fnPtr;
-    R.bucketIndex = Hit.bucketIndex;
-    R.hasReadToken = true;
+  return classifyHit(cache_.lookup(funcIndex, dims, numDims));
+}
+
+//===----------------------------------------------------------------------===//
+// Fixed-dimension fast cache-hit entries (§5.2 steps 0-1, unrolled). Each
+// shares classifyHit() with tryCacheHit() but the instance-enabled check is
+// unrolled and the dim identity is built directly on the stack, so the C ABI
+// fixed-dimension entries reach the shared cache lookup without a numDims loop.
+// Semantics are identical to tryCacheHit() with the matching numDims.
+//===----------------------------------------------------------------------===//
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::tryCacheHit0D(uint32_t funcIndex) {
+  return classifyHit(cache_.lookup(funcIndex, nullptr, 0));
+}
+
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::tryCacheHit1D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0) {
+  CompileOrGetResult R;
+  if (!switch_.isInstanceEnabled(dim0, inst0)) {
+    counters_.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
     R.fastPathTerminal = true;
-    EJIT_DIAG_VERBOSE("taskpool hit func=%u bucket=%u fn=%p", funcIndex,
-              Hit.bucketIndex, Hit.fnPtr);
     return R;
   }
+  const EJitDimPair dims[1] = {{dim0, inst0}};
+  return classifyHit(cache_.lookup(funcIndex, dims, 1));
+}
 
-  // True miss (enabled, no cached code): the caller must fall through to the
-  // compileOrGet() slow path (Off / Sync / Async).
-  R.fastPathTerminal = false;
-  return R;
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::tryCacheHit2D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                            uint32_t dim1, uint32_t inst1) {
+  CompileOrGetResult R;
+  if (!switch_.isInstanceEnabled(dim0, inst0) ||
+      !switch_.isInstanceEnabled(dim1, inst1)) {
+    counters_.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
+  return classifyHit(cache_.lookup(funcIndex, dims, 2));
+}
+
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::tryCacheHit3D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                            uint32_t dim1, uint32_t inst1, uint32_t dim2,
+                            uint32_t inst2) {
+  CompileOrGetResult R;
+  if (!switch_.isInstanceEnabled(dim0, inst0) ||
+      !switch_.isInstanceEnabled(dim1, inst1) ||
+      !switch_.isInstanceEnabled(dim2, inst2)) {
+    counters_.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
+  return classifyHit(cache_.lookup(funcIndex, dims, 3));
+}
+
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                            uint32_t dim1, uint32_t inst1, uint32_t dim2,
+                            uint32_t inst2, uint32_t dim3, uint32_t inst3) {
+  CompileOrGetResult R;
+  if (!switch_.isInstanceEnabled(dim0, inst0) ||
+      !switch_.isInstanceEnabled(dim1, inst1) ||
+      !switch_.isInstanceEnabled(dim2, inst2) ||
+      !switch_.isInstanceEnabled(dim3, inst3)) {
+    counters_.instanceDisabled.fetchAdd(1);
+    R.status = EJitCompileOrGetStatus::InstanceDisabled;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  const EJitDimPair dims[4] = {
+      {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
+  return classifyHit(cache_.lookup(funcIndex, dims, 4));
 }
 
 EJitTaskPool::CompileOrGetResult

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -43,6 +43,17 @@ static cl::opt<bool> EJitNoInlineEntry(
     cl::desc("Add noinline attribute to ejit_entry functions to prevent the "
              "CGSCC inliner from duplicating the JIT wrapper into callers"));
 
+// Temporary opt-in: emit the fixed-dimension taskpool fast-path C ABI calls
+// (ejit_taskpool_compile_or_get_Nd, N = dim count) for entries with <= 4 dims
+// instead of the generic ejit_taskpool_compile_or_get. Default OFF so existing
+// wrapper output / lit tests are unaffected; entries with > 4 dims always use
+// the generic entry.
+static cl::opt<bool> EJitWrapperFixedDimEntry(
+    "ejit-wrapper-fixed-dim-entry", cl::init(false), cl::Hidden,
+    cl::desc("Emit fixed-dimension taskpool fast-path calls "
+             "(ejit_taskpool_compile_or_get_Nd) for ejit_entry functions with "
+             "<= 4 dims instead of the generic ejit_taskpool_compile_or_get"));
+
 // Wrapper generation now unconditionally uses the unified taskpool API
 // (ejit_taskpool_compile_or_get + ejit_taskpool_release_read). Both Sync
 // and Async modes are runtime-configurable — the AOT wrapper code is
@@ -470,9 +481,15 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // invalid, branch straight to the AOT fallback without entering either
     // compile path.
     IRBuilder<> Builder(JitEntry);
+    // Emit the fixed-dimension fast-path C API for entries with <= 4 dims when
+    // the opt-in flag is set; otherwise keep the generic ejit_taskpool_compile_
+    // or_get with the dim array on the stack.
+    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 4;
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
-    Value *DimsAlloca =
-        Builder.CreateAlloca(ArrayType::get(DimPairTy, 4), nullptr, "ejit_dims");
+    Value *DimsAlloca = UseFixed
+                            ? nullptr
+                            : Builder.CreateAlloca(ArrayType::get(DimPairTy, 4),
+                                                   nullptr, "ejit_dims");
     Value *OutFnAlloca =
         Builder.CreateAlloca(PtrTy, nullptr, "ejit_out_fn");
     Value *OutBucketAlloca =
@@ -483,40 +500,76 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
     Builder.CreateCondBr(IdxValid, JitCall, JitFallback);
 
-    // jit_call: unified taskpool API (ejit_taskpool_compile_or_get). Both
-    // Sync and Async modes share the same AOT wrapper — the runtime compile
-    // mode controls whether compilation is inline or via a background worker.
+    // jit_call: unified taskpool API. Both Sync and Async modes share the same
+    // AOT wrapper — the runtime compile mode controls whether compilation is
+    // inline or via a background worker.
     Builder.SetInsertPoint(JitCall);
-    for (unsigned I = 0; I < DimCount; ++I) {
-      Value *Idxs[] = {ConstantInt::get(I32Ty, 0), ConstantInt::get(I32Ty, I)};
-      Value *PairPtr = Builder.CreateInBoundsGEP(ArrayType::get(DimPairTy, 4),
-                                                 DimsAlloca, Idxs);
-      Value *DimTypePtr =
-          Builder.CreateStructGEP(DimPairTy, PairPtr, 0, "dim_type_ptr");
-      Value *InstancePtr =
-          Builder.CreateStructGEP(DimPairTy, PairPtr, 1, "instance_ptr");
-      Value *DimTypeVal = Builder.CreateLoad(
-          I32Ty, DimTypeGlobals[PeriodInds[I].PeriodName], "ejit_dimtype");
-      Builder.CreateStore(DimTypeVal, DimTypePtr);
 
+    // Load each dim's (dimType, instanceId) as i32. Shared by both emitters.
+    auto emitDimTypeVal = [&](unsigned I) {
+      return Builder.CreateLoad(I32Ty, DimTypeGlobals[PeriodInds[I].PeriodName],
+                                "ejit_dimtype");
+    };
+    auto emitInstanceVal = [&](unsigned I) -> Value * {
       Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
       unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
-      Value *InstanceId = ArgVal;
       if (BW > 32)
-        InstanceId = Builder.CreateTrunc(ArgVal, I32Ty);
-      else if (BW < 32)
-        InstanceId = Builder.CreateZExt(ArgVal, I32Ty);
-      Builder.CreateStore(InstanceId, InstancePtr);
-    }
+        return Builder.CreateTrunc(ArgVal, I32Ty);
+      if (BW < 32)
+        return Builder.CreateZExt(ArgVal, I32Ty);
+      return ArgVal;
+    };
 
-    Value *DimsPtr =
-        DimCount > 0 ? Builder.CreatePointerCast(DimsAlloca, PtrTy)
-                     : ConstantPointerNull::get(PtrTy);
-    Value *Status = Builder.CreateCall(
-        M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
-        {FuncIdx, DimsPtr, ConstantInt::get(I32Ty, DimCount),
-         Builder.CreatePointerCast(OutFnAlloca, PtrTy),
-         Builder.CreatePointerCast(OutBucketAlloca, PtrTy)});
+    Value *OutFnArg = Builder.CreatePointerCast(OutFnAlloca, PtrTy);
+    Value *OutBucketArg = Builder.CreatePointerCast(OutBucketAlloca, PtrTy);
+    Value *Status = nullptr;
+    if (UseFixed) {
+      // ejit_taskpool_compile_or_get_Nd(i32 funcIndex,
+      //     [i32 dimType, i32 instanceId] * N, ptr outFn, ptr outBucket)
+      static const char *const FixedNames[] = {
+          FN_TASKPOOL_COMPILE_OR_GET_0D, FN_TASKPOOL_COMPILE_OR_GET_1D,
+          FN_TASKPOOL_COMPILE_OR_GET_2D, FN_TASKPOOL_COMPILE_OR_GET_3D,
+          FN_TASKPOOL_COMPILE_OR_GET_4D};
+      SmallVector<Type *, 12> ParamTys;
+      SmallVector<Value *, 12> Args;
+      ParamTys.push_back(I32Ty);
+      Args.push_back(FuncIdx);
+      for (unsigned I = 0; I < DimCount; ++I) {
+        Value *DimTypeVal = emitDimTypeVal(I);
+        Value *InstanceId = emitInstanceVal(I);
+        ParamTys.push_back(I32Ty);
+        ParamTys.push_back(I32Ty);
+        Args.push_back(DimTypeVal);
+        Args.push_back(InstanceId);
+      }
+      ParamTys.push_back(PtrTy);
+      ParamTys.push_back(PtrTy);
+      Args.push_back(OutFnArg);
+      Args.push_back(OutBucketArg);
+      FunctionCallee FixedFn = M.getOrInsertFunction(
+          FixedNames[DimCount], FunctionType::get(I32Ty, ParamTys, false));
+      Status = Builder.CreateCall(FixedFn, Args);
+    } else {
+      for (unsigned I = 0; I < DimCount; ++I) {
+        Value *Idxs[] = {ConstantInt::get(I32Ty, 0),
+                         ConstantInt::get(I32Ty, I)};
+        Value *PairPtr = Builder.CreateInBoundsGEP(ArrayType::get(DimPairTy, 4),
+                                                   DimsAlloca, Idxs);
+        Value *DimTypePtr =
+            Builder.CreateStructGEP(DimPairTy, PairPtr, 0, "dim_type_ptr");
+        Value *InstancePtr =
+            Builder.CreateStructGEP(DimPairTy, PairPtr, 1, "instance_ptr");
+        Builder.CreateStore(emitDimTypeVal(I), DimTypePtr);
+        Builder.CreateStore(emitInstanceVal(I), InstancePtr);
+      }
+      Value *DimsPtr = DimCount > 0
+                           ? Builder.CreatePointerCast(DimsAlloca, PtrTy)
+                           : ConstantPointerNull::get(PtrTy);
+      Status = Builder.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
+                                  {FuncIdx, DimsPtr,
+                                   ConstantInt::get(I32Ty, DimCount), OutFnArg,
+                                   OutBucketArg});
+    }
     Value *OutFn = Builder.CreateLoad(PtrTy, OutFnAlloca, "ejit_fn");
     Value *HitStatus =
         Builder.CreateICmpEQ(Status, ConstantInt::get(I32Ty, 0));

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -481,10 +481,17 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // invalid, branch straight to the AOT fallback without entering either
     // compile path.
     IRBuilder<> Builder(JitEntry);
-    // Emit the fixed-dimension fast-path C API for entries with <= 4 dims when
-    // the opt-in flag is set; otherwise keep the generic ejit_taskpool_compile_
-    // or_get with the dim array on the stack.
-    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 4;
+    // Emit the fixed-dimension fast-path C API only for 0/1/2-dim entries when
+    // the opt-in flag is set. Rationale (measured on aarch64, -Os): 0D/1D/2D
+    // pass funcIndex + up to 4 dim scalars + 2 out pointers, which still fit in
+    // the 8 integer argument registers (no stack spill) and hit a specialized
+    // cacheLookupNd with the numDims/identity/version loops fully unrolled. A
+    // 3D call needs 9 and a 4D call 11 integer arguments, spilling to the stack
+    // at every call site, which cancels the lookup saving — so 3D/4D keep using
+    // the generic ejit_taskpool_compile_or_get (one dim-array pointer). The
+    // fixed 3D/4D C APIs still exist and are semantically correct for direct
+    // callers; the wrapper just does not select them.
+    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
     Value *DimsAlloca = UseFixed
                             ? nullptr

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-fixed-dim.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-fixed-dim.ll
@@ -1,0 +1,31 @@
+; Default (flag OFF): the wrapper keeps the generic variable-dimension entry.
+; RUN: opt -passes=ejit-wrapper-gen -S %s \
+; RUN:   | FileCheck %s --check-prefix=GENERIC
+; Flag ON: entries with <= 4 dims call the matching fixed-dimension fast path.
+; RUN: opt -passes=ejit-wrapper-gen -ejit-wrapper-fixed-dim-entry -S %s \
+; RUN:   | FileCheck %s --check-prefix=FIXED
+
+; GENERIC: jit_call:
+; GENERIC: call i32 @ejit_taskpool_compile_or_get(i32 {{.*}}, ptr {{.*}}, i32 2, ptr {{.*}}, ptr {{.*}})
+; GENERIC-NOT: @ejit_taskpool_compile_or_get_2d
+
+; The fixed 2D entry receives the dim identity as scalar (dimType, instanceId)
+; args instead of a stack EJitDimPair array + numDims.
+; FIXED: jit_call:
+; FIXED: call i32 @ejit_taskpool_compile_or_get_2d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+; FIXED-NOT: call i32 @ejit_taskpool_compile_or_get(i32
+; FIXED-NOT: alloca [4 x { i32, i32 }]
+
+define i32 @multi_dim_entry(i32 %idx1, i32 %idx2) !ejit.metadata !0 {
+entry:
+  %v1 = load i32, ptr @data
+  %v2 = load i32, ptr @data2
+  ret i32 0
+}
+
+@data = global i32 0, !ejit.metadata !10
+@data2 = global i32 0, !ejit.metadata !11
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
+!11 = distinct !{!{!"ejit_period_arr", !"trp", i32 32}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-fixed-dim.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-fixed-dim.ll
@@ -1,31 +1,52 @@
 ; Default (flag OFF): the wrapper keeps the generic variable-dimension entry.
 ; RUN: opt -passes=ejit-wrapper-gen -S %s \
 ; RUN:   | FileCheck %s --check-prefix=GENERIC
-; Flag ON: entries with <= 4 dims call the matching fixed-dimension fast path.
+; Flag ON: 0/1/2-dim entries call the matching fixed fast path; 3/4-dim entries
+; keep using the generic entry (their fixed calling convention would spill args
+; on aarch64, cancelling the specialized-lookup saving).
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-wrapper-fixed-dim-entry -S %s \
 ; RUN:   | FileCheck %s --check-prefix=FIXED
 
-; GENERIC: jit_call:
+; --- 2D entry: fixed under the flag, generic by default. ---
+; GENERIC-LABEL: define i32 @two_dim_entry(
 ; GENERIC: call i32 @ejit_taskpool_compile_or_get(i32 {{.*}}, ptr {{.*}}, i32 2, ptr {{.*}}, ptr {{.*}})
 ; GENERIC-NOT: @ejit_taskpool_compile_or_get_2d
 
-; The fixed 2D entry receives the dim identity as scalar (dimType, instanceId)
-; args instead of a stack EJitDimPair array + numDims.
-; FIXED: jit_call:
+; FIXED-LABEL: define i32 @two_dim_entry(
 ; FIXED: call i32 @ejit_taskpool_compile_or_get_2d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
-; FIXED-NOT: call i32 @ejit_taskpool_compile_or_get(i32
-; FIXED-NOT: alloca [4 x { i32, i32 }]
 
-define i32 @multi_dim_entry(i32 %idx1, i32 %idx2) !ejit.metadata !0 {
+define i32 @two_dim_entry(i32 %idx1, i32 %idx2) !ejit.metadata !0 {
 entry:
   %v1 = load i32, ptr @data
   %v2 = load i32, ptr @data2
   ret i32 0
 }
 
+; --- 3D entry: generic in BOTH modes (fixed 3D not selected by the wrapper). ---
+; GENERIC-LABEL: define i32 @three_dim_entry(
+; GENERIC: call i32 @ejit_taskpool_compile_or_get(i32 {{.*}}, ptr {{.*}}, i32 3, ptr {{.*}}, ptr {{.*}})
+
+; FIXED-LABEL: define i32 @three_dim_entry(
+; FIXED: call i32 @ejit_taskpool_compile_or_get(i32 {{.*}}, ptr {{.*}}, i32 3, ptr {{.*}}, ptr {{.*}})
+
+define i32 @three_dim_entry(i32 %a, i32 %b, i32 %c) !ejit.metadata !1 {
+entry:
+  %v1 = load i32, ptr @data
+  %v2 = load i32, ptr @data2
+  %v3 = load i32, ptr @data3
+  ret i32 0
+}
+
+; No fixed 3D/4D calls are ever emitted.
+; FIXED-NOT: @ejit_taskpool_compile_or_get_3d
+; FIXED-NOT: @ejit_taskpool_compile_or_get_4d
+
 @data = global i32 0, !ejit.metadata !10
 @data2 = global i32 0, !ejit.metadata !11
+@data3 = global i32 0, !ejit.metadata !12
 
 !0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}, !{!"ejit_period_arr_ind", !"grp", i32 2}}
 !10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
 !11 = distinct !{!{!"ejit_period_arr", !"trp", i32 32}}
+!12 = distinct !{!{!"ejit_period_arr", !"grp", i32 48}}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2059,4 +2059,87 @@ TEST_F(SharedTaskPoolTest, FixedDimReadyButNotShareableCleanFallback) {
   EXPECT_EQ(fast.fnPtr, nullptr);
 }
 
+// The specialized cacheLookupNd behind each fixed entry must agree with the
+// generic tryCacheHit()/cacheLookup() for the same identity: same fnPtr, same
+// bucket, same CacheHit status across 0D..4D.
+TEST_F(SharedTaskPoolTest, FixedDimCacheLookupMatchesGenericAllDims) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(0, 1, true);
+  owner.setInstanceEnabled(1, 2, true);
+  owner.setInstanceEnabled(2, 3, true);
+  owner.setInstanceEnabled(3, 4, true);
+  EJitDimPair d1[1] = {dim(0, 1)};
+  EJitDimPair d2[2] = {dim(0, 1), dim(1, 2)};
+  EJitDimPair d3[3] = {dim(0, 1), dim(1, 2), dim(2, 3)};
+  EJitDimPair d4[4] = {dim(0, 1), dim(1, 2), dim(2, 3), dim(3, 4)};
+  auto publishDims = [&](uint32_t fi, const EJitDimPair *d, uint32_t n) {
+    ASSERT_EQ(owner.compileOrGet(fi, d, n, codeFor(fi)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(owner.pollOne());
+  };
+  publish(owner, 60);
+  publishDims(61, d1, 1);
+  publishDims(62, d2, 2);
+  publishDims(63, d3, 3);
+  publishDims(64, d4, 4);
+
+  auto cmp = [&](EJitSharedTaskPool::CompileOrGetResult fixed, uint32_t fi,
+                 const EJitDimPair *d, uint32_t n) {
+    auto gen = owner.tryCacheHit(fi, d, n);
+    EXPECT_EQ(fixed.status, EJitCompileOrGetStatus::CacheHit);
+    EXPECT_EQ(fixed.status, gen.status);
+    EXPECT_EQ(fixed.fnPtr, gen.fnPtr);
+    EXPECT_EQ(fixed.bucketIndex, gen.bucketIndex);
+    owner.releaseRead(fixed.bucketIndex);
+    owner.releaseRead(gen.bucketIndex);
+  };
+  cmp(owner.tryCacheHit0D(60), 60, nullptr, 0);
+  cmp(owner.tryCacheHit1D(61, 0, 1), 61, d1, 1);
+  cmp(owner.tryCacheHit2D(62, 0, 1, 1, 2), 62, d2, 2);
+  cmp(owner.tryCacheHit3D(63, 0, 1, 1, 2, 2, 3), 63, d3, 3);
+  cmp(owner.tryCacheHit4D(64, 0, 1, 1, 2, 2, 3, 3, 4), 64, d4, 4);
+}
+
+// Version mismatch: a stale instance version (bumped by a deactivate/activate
+// cycle after publish) must miss on the fixed path exactly as on the generic
+// path — never returning the stale cached pointer.
+TEST_F(SharedTaskPoolTest, FixedDimVersionMismatchMisses) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(0, 1, true);
+  owner.setInstanceEnabled(1, 2, true);
+
+  // 1D
+  EJitDimPair d1[1] = {dim(0, 1)};
+  ASSERT_EQ(owner.compileOrGet(70, d1, 1, codeFor(70)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  // Bump the version while leaving the instance ENABLED (disable then enable).
+  owner.setInstanceEnabled(0, 1, false);
+  owner.setInstanceEnabled(0, 1, true);
+  auto genMiss = owner.tryCacheHit(70, d1, 1);
+  auto fixedMiss = owner.tryCacheHit1D(70, 0, 1);
+  EXPECT_FALSE(genMiss.fastPathTerminal);   // stale version → miss
+  EXPECT_FALSE(fixedMiss.fastPathTerminal); // same on the fixed path
+  EXPECT_NE(fixedMiss.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(fixedMiss.hasReadToken);
+
+  // 2D: bump only the second dim's version.
+  EJitDimPair d2[2] = {dim(0, 1), dim(1, 2)};
+  ASSERT_EQ(owner.compileOrGet(71, d2, 2, codeFor(71)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  auto hit2 = owner.tryCacheHit2D(71, 0, 1, 1, 2); // sanity: hits before bump
+  ASSERT_EQ(hit2.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(hit2.bucketIndex);
+  owner.setInstanceEnabled(1, 2, false);
+  owner.setInstanceEnabled(1, 2, true);
+  auto fixedMiss2 = owner.tryCacheHit2D(71, 0, 1, 1, 2);
+  EXPECT_FALSE(fixedMiss2.fastPathTerminal);
+  EXPECT_FALSE(fixedMiss2.hasReadToken);
+}
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1878,4 +1878,185 @@ TEST_F(SharedTaskPoolTest, TryCacheHitServesHitEvenWhenModeOff) {
   owner.releaseRead(fast.bucketIndex);
 }
 
+//===----------------------------------------------------------------------===//
+// Fixed-dimension fast cache-hit entries (tryCacheHit0D..4D): the unrolled
+// front-halves the C ABI ejit_taskpool_compile_or_get_Nd entries drive. Each
+// must match the generic tryCacheHit() semantics for the matching numDims.
+//===----------------------------------------------------------------------===//
+
+// 0D/1D/2D/3D/4D cache hit: fnPtr + bucket + read token, no enqueue/dedup.
+TEST_F(SharedTaskPoolTest, FixedDimEntriesServeCacheHit) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(0, 1, true);
+  owner.setInstanceEnabled(1, 2, true);
+  owner.setInstanceEnabled(2, 3, true);
+  owner.setInstanceEnabled(3, 4, true);
+
+  auto publishDims = [&](uint32_t fi, const EJitDimPair *d, uint32_t n) {
+    ASSERT_EQ(owner.compileOrGet(fi, d, n, codeFor(fi)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(owner.pollOne());
+  };
+
+  // 0D
+  publish(owner, 1);
+  auto h0 = owner.tryCacheHit0D(1);
+  EXPECT_TRUE(h0.fastPathTerminal);
+  EXPECT_EQ(h0.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h0.fnPtr, codeFor(1));
+  EXPECT_TRUE(h0.hasReadToken);
+  EXPECT_GT(state_->buckets[h0.bucketIndex].readers.loadAcquire(), 0u);
+  owner.releaseRead(h0.bucketIndex);
+
+  // 1D
+  EJitDimPair d1[1] = {dim(0, 1)};
+  publishDims(2, d1, 1);
+  auto h1 = owner.tryCacheHit1D(2, 0, 1);
+  ASSERT_EQ(h1.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h1.fnPtr, codeFor(2));
+  EXPECT_TRUE(h1.hasReadToken);
+  owner.releaseRead(h1.bucketIndex);
+
+  // 2D
+  EJitDimPair d2[2] = {dim(0, 1), dim(1, 2)};
+  publishDims(3, d2, 2);
+  auto h2 = owner.tryCacheHit2D(3, 0, 1, 1, 2);
+  ASSERT_EQ(h2.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h2.fnPtr, codeFor(3));
+  owner.releaseRead(h2.bucketIndex);
+
+  // 3D
+  EJitDimPair d3[3] = {dim(0, 1), dim(1, 2), dim(2, 3)};
+  publishDims(4, d3, 3);
+  auto h3 = owner.tryCacheHit3D(4, 0, 1, 1, 2, 2, 3);
+  ASSERT_EQ(h3.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h3.fnPtr, codeFor(4));
+  owner.releaseRead(h3.bucketIndex);
+
+  // 4D
+  EJitDimPair d4[4] = {dim(0, 1), dim(1, 2), dim(2, 3), dim(3, 4)};
+  publishDims(5, d4, 4);
+  auto h4 = owner.tryCacheHit4D(5, 0, 1, 1, 2, 2, 3, 3, 4);
+  ASSERT_EQ(h4.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h4.fnPtr, codeFor(5));
+  owner.releaseRead(h4.bucketIndex);
+
+  // Cache hits do not enqueue/dedup.
+  EJitSharedDiagnostics d;
+  owner.getDiagnostics(d);
+  EXPECT_EQ(d.queueDepth, 0u);
+  EXPECT_EQ(d.pendingCount, 0u);
+}
+
+// A fixed-dim entry matches the generic path exactly for the same identity.
+TEST_F(SharedTaskPoolTest, FixedDim1DMatchesGeneric) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(2, 5, true);
+  EJitDimPair d1[1] = {dim(2, 5)};
+  ASSERT_EQ(owner.compileOrGet(7, d1, 1, codeFor(7)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  auto generic = owner.tryCacheHit(7, d1, 1);
+  ASSERT_EQ(generic.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(generic.bucketIndex);
+  auto fixed = owner.tryCacheHit1D(7, 2, 5);
+  ASSERT_EQ(fixed.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed.fnPtr, generic.fnPtr);
+  EXPECT_EQ(fixed.bucketIndex, generic.bucketIndex);
+  owner.releaseRead(fixed.bucketIndex);
+}
+
+// Disabled instance: fixed entry returns InstanceDisabled, no stale code, no
+// enqueue — including when only a later dim is disabled.
+TEST_F(SharedTaskPoolTest, FixedDimDisabledInstanceReturnsDisabled) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(0, 1, true);
+  owner.setInstanceEnabled(1, 2, true);
+  EJitDimPair d2[2] = {dim(0, 1), dim(1, 2)};
+  ASSERT_EQ(owner.compileOrGet(9, d2, 2, codeFor(9)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  // Disable the SECOND dim only.
+  owner.setInstanceEnabled(1, 2, false);
+  EJitSharedDiagnostics before;
+  owner.getDiagnostics(before);
+  auto fast = owner.tryCacheHit2D(9, 0, 1, 1, 2);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::InstanceDisabled);
+  EXPECT_EQ(fast.fnPtr, nullptr);
+  EXPECT_FALSE(fast.hasReadToken);
+  EJitSharedDiagnostics after;
+  owner.getDiagnostics(after);
+  EXPECT_EQ(after.instanceDisabled, before.instanceDisabled + 1);
+  EXPECT_EQ(after.queueDepth, before.queueDepth);
+}
+
+// Miss: fixed entry is not terminal and does not enqueue; the slow path still
+// enqueues.
+TEST_F(SharedTaskPoolTest, FixedDimMissFallsThrough) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(0, 1, true);
+
+  auto fast = owner.tryCacheHit1D(15, 0, 1);
+  EXPECT_FALSE(fast.fastPathTerminal);
+  EXPECT_NE(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(fast.hasReadToken);
+  EJitSharedDiagnostics d;
+  owner.getDiagnostics(d);
+  EXPECT_EQ(d.asyncEnqueues, 0u);
+  EXPECT_EQ(d.queueDepth, 0u);
+
+  EJitDimPair d1[1] = {dim(0, 1)};
+  EXPECT_EQ(owner.compileOrGet(15, d1, 1, codeFor(15)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  owner.getDiagnostics(d);
+  EXPECT_EQ(d.queueDepth, 1u);
+}
+
+// Mode Off still serves an existing cache hit via a fixed entry.
+TEST_F(SharedTaskPoolTest, FixedDimServesHitEvenWhenModeOff) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 40);
+  owner.setSharedMode(EJitCompileMode::Off);
+  EJitCoreId::setCurrentForTest(0);
+  auto fast = owner.tryCacheHit0D(40);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fast.fnPtr, codeFor(40));
+  EXPECT_TRUE(fast.hasReadToken);
+  owner.releaseRead(fast.bucketIndex);
+}
+
+// readyButNotShareable: a peer core that may not read the pointer gets a clean
+// OffMode fallback with no read token and no enqueue via a fixed entry.
+TEST_F(SharedTaskPoolTest, FixedDimReadyButNotShareableCleanFallback) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/false);
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.compileOrGet(50, nullptr, 0, codeFor(50)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  EJitSharedTaskPool peer;
+  peer.bind(state_.get());
+  EJitCoreId::setCurrentForTest(9);
+  auto fast = peer.tryCacheHit0D(50);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(fast.readyButNotShareable);
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(fast.fnPtr, nullptr);
+}
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1726,4 +1726,156 @@ TEST_F(SharedTaskPoolTest, FourKReinitForcesPeerToReSplit) {
   EXPECT_EQ(fourK.splits[1].second, 3u);
 }
 
+//===----------------------------------------------------------------------===//
+// tryCacheHit(): the flattened fast cache-hit path the C API drives before the
+// compileOrGet slow path. It must preserve every compileOrGet hot-path
+// semantic (ordering, counters, read tokens) while NEVER enqueuing/deduping.
+//===----------------------------------------------------------------------===//
+
+// 1/ A cache hit is served entirely on the fast path: fnPtr + bucket + a held
+//    read token, fastPathTerminal set, and NO enqueue/dedup side effects.
+TEST_F(SharedTaskPoolTest, TryCacheHitServesHitWithoutEnqueue) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(0);
+  EJitSharedDiagnostics before;
+  owner.getDiagnostics(before);
+
+  auto fast = owner.tryCacheHit(1, nullptr, 0);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fast.fnPtr, codeFor(1));
+  EXPECT_TRUE(fast.hasReadToken);
+  EXPECT_FALSE(fast.readyButNotShareable);
+  // A held read token keeps readers > 0 (same ownership contract as
+  // compileOrGet — the caller must release through releaseRead).
+  EXPECT_GT(state_->buckets[fast.bucketIndex].readers.loadAcquire(), 0u);
+
+  EJitSharedDiagnostics after;
+  owner.getDiagnostics(after);
+  EXPECT_EQ(after.cacheHits, before.cacheHits + 1);     // counted exactly once
+  EXPECT_EQ(after.asyncEnqueues, before.asyncEnqueues); // no enqueue
+  EXPECT_EQ(after.queueDepth, 0u);                      // no dedup slot
+  EXPECT_EQ(after.pendingCount, 0u);
+
+  owner.releaseRead(fast.bucketIndex);
+  EXPECT_EQ(state_->buckets[fast.bucketIndex].readers.loadAcquire(), 0u);
+}
+
+// 2/ A true miss is NOT terminal on the fast path (no enqueue), and the slow
+//    path (compileOrGet) still enqueues/compiles exactly as before.
+TEST_F(SharedTaskPoolTest, TryCacheHitMissFallsThroughToCompileOrGet) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  EJitCoreId::setCurrentForTest(0);
+
+  auto fast = owner.tryCacheHit(5, nullptr, 0);
+  EXPECT_FALSE(fast.fastPathTerminal); // must fall through
+  EXPECT_NE(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(fast.hasReadToken);
+
+  EJitSharedDiagnostics d;
+  owner.getDiagnostics(d);
+  EXPECT_EQ(d.asyncEnqueues, 0u); // fast path never enqueues
+  EXPECT_EQ(d.queueDepth, 0u);
+  EXPECT_EQ(d.pendingCount, 0u);
+
+  // The slow path still enqueues the async request unchanged.
+  auto slow = owner.compileOrGet(5, nullptr, 0, codeFor(5));
+  EXPECT_EQ(slow.status, EJitCompileOrGetStatus::EnqueuedPending);
+  owner.getDiagnostics(d);
+  EXPECT_EQ(d.asyncEnqueues, 1u);
+  EXPECT_EQ(d.queueDepth, 1u);
+  EXPECT_EQ(d.pendingCount, 1u);
+}
+
+// 3/ A disabled instance returns InstanceDisabled on the fast path and NEVER
+//    hands back cached code, even though a Ready entry exists (deactivate must
+//    not serve stale code). No enqueue.
+TEST_F(SharedTaskPoolTest, TryCacheHitDisabledInstanceReturnsDisabled) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  owner.setInstanceEnabled(1, 4, true);
+  EJitDimPair d0[1] = {dim(1, 4)};
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.compileOrGet(11, d0, 1, codeFor(11)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  // Sanity: while enabled the entry is a real hit.
+  auto sane = owner.tryCacheHit(11, d0, 1);
+  ASSERT_EQ(sane.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(sane.bucketIndex);
+
+  // Deactivate the instance, then the fast path must reject before the cache.
+  owner.setInstanceEnabled(1, 4, false);
+  EJitSharedDiagnostics before;
+  owner.getDiagnostics(before);
+
+  auto fast = owner.tryCacheHit(11, d0, 1);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::InstanceDisabled);
+  EXPECT_EQ(fast.fnPtr, nullptr); // no stale cached code
+  EXPECT_FALSE(fast.hasReadToken);
+
+  EJitSharedDiagnostics after;
+  owner.getDiagnostics(after);
+  EXPECT_EQ(after.instanceDisabled, before.instanceDisabled + 1);
+  EXPECT_EQ(after.queueDepth, before.queueDepth); // no enqueue
+  EXPECT_EQ(after.asyncEnqueues, before.asyncEnqueues);
+}
+
+// 4/ readyButNotShareable: a peer core that may not read the cross-core pointer
+//    gets a clean OffMode fallback with readyButNotShareable set, no read
+//    token, and NO enqueue/dedup.
+TEST_F(SharedTaskPoolTest, TryCacheHitReadyButNotShareableCleanFallback) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/false);
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.compileOrGet(20, nullptr, 0, codeFor(20)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  EJitSharedTaskPool peer;
+  peer.bind(state_.get());
+  EJitCoreId::setCurrentForTest(9);
+  EJitSharedDiagnostics before;
+  peer.getDiagnostics(before);
+
+  auto fast = peer.tryCacheHit(20, nullptr, 0);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::OffMode);
+  EXPECT_TRUE(fast.readyButNotShareable);
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(fast.fnPtr, nullptr);
+
+  EJitSharedDiagnostics after;
+  peer.getDiagnostics(after);
+  EXPECT_EQ(after.queueDepth, before.queueDepth); // no enqueue/dedup
+  EXPECT_EQ(after.asyncEnqueues, before.asyncEnqueues);
+  EXPECT_EQ(after.pendingCount, before.pendingCount);
+}
+
+// 5/ Mode Off still returns an existing cache hit on the fast path — the cache
+//    lookup is ordered ahead of the Off check, matching compileOrGet.
+TEST_F(SharedTaskPoolTest, TryCacheHitServesHitEvenWhenModeOff) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true); // comes up Async
+  publish(owner, 30);
+
+  // Flip the cross-core mode to Off after the entry is Ready.
+  owner.setSharedMode(EJitCompileMode::Off);
+  EXPECT_EQ(owner.getSharedMode(), EJitCompileMode::Off);
+
+  EJitCoreId::setCurrentForTest(0);
+  auto fast = owner.tryCacheHit(30, nullptr, 0);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fast.fnPtr, codeFor(30));
+  EXPECT_TRUE(fast.hasReadToken);
+  owner.releaseRead(fast.bucketIndex);
+}
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
@@ -953,6 +953,72 @@ TEST(EJitTaskPoolTest, DisabledInstanceWithExistingCacheFallsBack) {
   EXPECT_EQ(r.fnPtr, fb);
 }
 
+//===----------------------------------------------------------------------===//
+// tryCacheHit(): the flattened fast cache-hit path the C API drives before the
+// compileOrGet slow path. On the private pool it performs the instance-enabled
+// check + cache lookup only; it must match compileOrGet's front-half semantics
+// and never enqueue.
+//===----------------------------------------------------------------------===//
+
+// A cache hit is served on the fast path with a held read token and NO enqueue.
+TEST(EJitTaskPoolTest, TryCacheHitServesHitWithoutEnqueue) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair D[1] = {{0, 1}};
+  P.compileOrGet(40, D, 1, nullptr);
+  EXPECT_TRUE(P.pollOne()); // populate cache
+  ASSERT_EQ(P.pendingCount(), 0u);
+
+  auto fast = P.tryCacheHit(40, D, 1);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_TRUE(fast.hasReadToken);
+  EXPECT_NE(fast.fnPtr, nullptr);
+  EXPECT_EQ(P.pendingCount(), 0u); // no enqueue/dedup on the fast path
+  P.releaseRead(fast.bucketIndex);
+}
+
+// A true miss is NOT terminal on the fast path; the slow path still enqueues.
+TEST(EJitTaskPoolTest, TryCacheHitMissFallsThroughToCompileOrGet) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair D[1] = {{0, 1}};
+
+  auto fast = P.tryCacheHit(41, D, 1);
+  EXPECT_FALSE(fast.fastPathTerminal);
+  EXPECT_NE(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(P.pendingCount(), 0u); // fast path never enqueues
+
+  auto slow = P.compileOrGet(41, D, 1, nullptr);
+  EXPECT_EQ(slow.status, EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(P.pendingCount(), 1u);
+}
+
+// A disabled instance returns InstanceDisabled on the fast path and never
+// serves cached code.
+TEST(EJitTaskPoolTest, TryCacheHitDisabledInstanceReturnsDisabled) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair D[1] = {{0, 1}};
+  P.compileOrGet(42, D, 1, nullptr);
+  EXPECT_TRUE(P.pollOne()); // cache now holds func 42
+  P.switchController().setEnabled(0, 1, false);
+
+  auto fast = P.tryCacheHit(42, D, 1);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::InstanceDisabled);
+  EXPECT_EQ(fast.fnPtr, nullptr); // no stale cached code
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(P.pendingCount(), 0u);
+}
+
 TEST(EJitTaskPoolTest, SameFuncDifferentDimsAlreadyPending) {
   EJitTaskPool P(16, false);
   P.switchController().setMode(EJitCompileMode::Async);

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
@@ -1019,6 +1019,123 @@ TEST(EJitTaskPoolTest, TryCacheHitDisabledInstanceReturnsDisabled) {
   EXPECT_EQ(P.pendingCount(), 0u);
 }
 
+//===----------------------------------------------------------------------===//
+// Fixed-dimension fast cache-hit entries (tryCacheHit0D..4D) on the private
+// pool. Same semantics as tryCacheHit() with the matching numDims.
+//===----------------------------------------------------------------------===//
+TEST(EJitTaskPoolTest, FixedDimEntriesServeCacheHit) {
+  EJitTaskPool P(16, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+
+  auto publishDims = [&](uint32_t fi, const EJitDimPair *d, uint32_t n) {
+    ASSERT_EQ(P.compileOrGet(fi, d, n, nullptr).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(P.pollOne());
+  };
+
+  // 0D
+  publishDims(1, nullptr, 0);
+  auto h0 = P.tryCacheHit0D(1);
+  EXPECT_TRUE(h0.fastPathTerminal);
+  EXPECT_EQ(h0.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h0.fnPtr, reinterpret_cast<void *>(C.base + 1));
+  EXPECT_TRUE(h0.hasReadToken);
+  P.releaseRead(h0.bucketIndex);
+
+  // 1D
+  EJitDimPair d1[1] = {{0, 1}};
+  publishDims(2, d1, 1);
+  auto h1 = P.tryCacheHit1D(2, 0, 1);
+  ASSERT_EQ(h1.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h1.fnPtr, reinterpret_cast<void *>(C.base + 2));
+  P.releaseRead(h1.bucketIndex);
+
+  // 2D
+  EJitDimPair d2[2] = {{0, 1}, {1, 2}};
+  publishDims(3, d2, 2);
+  auto h2 = P.tryCacheHit2D(3, 0, 1, 1, 2);
+  ASSERT_EQ(h2.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h2.fnPtr, reinterpret_cast<void *>(C.base + 3));
+  P.releaseRead(h2.bucketIndex);
+
+  // 3D
+  EJitDimPair d3[3] = {{0, 1}, {1, 2}, {2, 3}};
+  publishDims(4, d3, 3);
+  auto h3 = P.tryCacheHit3D(4, 0, 1, 1, 2, 2, 3);
+  ASSERT_EQ(h3.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h3.fnPtr, reinterpret_cast<void *>(C.base + 4));
+  P.releaseRead(h3.bucketIndex);
+
+  // 4D
+  EJitDimPair d4[4] = {{0, 1}, {1, 2}, {2, 3}, {3, 4}};
+  publishDims(5, d4, 4);
+  auto h4 = P.tryCacheHit4D(5, 0, 1, 1, 2, 2, 3, 3, 4);
+  ASSERT_EQ(h4.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(h4.fnPtr, reinterpret_cast<void *>(C.base + 5));
+  P.releaseRead(h4.bucketIndex);
+
+  EXPECT_EQ(P.pendingCount(), 0u); // hits never enqueue
+}
+
+// Disabled instance: fixed entry returns InstanceDisabled, no cached code, no
+// enqueue — including when only a later dim is disabled.
+TEST(EJitTaskPoolTest, FixedDimDisabledInstanceReturnsDisabled) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair d2[2] = {{0, 1}, {1, 2}};
+  P.compileOrGet(60, d2, 2, nullptr);
+  EXPECT_TRUE(P.pollOne());
+  P.switchController().setEnabled(1, 2, false); // disable second dim
+
+  auto fast = P.tryCacheHit2D(60, 0, 1, 1, 2);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::InstanceDisabled);
+  EXPECT_EQ(fast.fnPtr, nullptr);
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(P.pendingCount(), 0u);
+}
+
+// Miss: fixed entry not terminal, no enqueue; slow path still enqueues.
+TEST(EJitTaskPoolTest, FixedDimMissFallsThrough) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+
+  auto fast = P.tryCacheHit1D(61, 0, 1);
+  EXPECT_FALSE(fast.fastPathTerminal);
+  EXPECT_NE(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(fast.hasReadToken);
+  EXPECT_EQ(P.pendingCount(), 0u);
+
+  EJitDimPair d1[1] = {{0, 1}};
+  EXPECT_EQ(P.compileOrGet(61, d1, 1, nullptr).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(P.pendingCount(), 1u);
+}
+
+// Cache lookup precedes the Off check for fixed entries too.
+TEST(EJitTaskPoolTest, FixedDimServesHitEvenWhenModeOff) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  P.setCompiler(&MockCompiler::compile, &C);
+  EJitDimPair d1[1] = {{0, 1}};
+  P.compileOrGet(62, d1, 1, nullptr);
+  EXPECT_TRUE(P.pollOne());
+  P.switchController().setMode(EJitCompileMode::Off);
+
+  auto fast = P.tryCacheHit1D(62, 0, 1);
+  EXPECT_TRUE(fast.fastPathTerminal);
+  EXPECT_EQ(fast.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_TRUE(fast.hasReadToken);
+  P.releaseRead(fast.bucketIndex);
+}
+
 TEST(EJitTaskPoolTest, SameFuncDifferentDimsAlreadyPending) {
   EJitTaskPool P(16, false);
   P.switchController().setMode(EJitCompileMode::Async);


### PR DESCRIPTION
## Summary

Specialize the shared taskpool cache-hit lookup path for fixed dimensions.

This is the higher-risk performance follow-up to the fixed-dimension API PR #61. GitHub cross-fork stacked PRs cannot use a branch from the fork as the base, so this PR targets `ejit_dev_spec4` and may show #61's commits in the full diff until #61 lands.

Review-only diff for this PR's own change:

https://github.com/ChenRuan/llvm-project/compare/codex/ejit-taskpool-fixed-dim-api...codex/ejit-taskpool-cachelookup-specialized?expand=1

Please review the `[EJIT] Specialize taskpool cache-hit lookup paths` commit for the cache lookup specialization itself.

## Why

After the C API front-path and fixed-dim API work, the shared cache-hit head was still dominated by generic `cacheLookup()`:

- identity hash loop;
- slot identity loop;
- per-dim version loop;
- cold non-owner peer prepare body inlined into the same hot function.

The old shared `cacheLookup` measured around 341 static AArch64 instructions.

## What Changed

- Split hot/cold parts:
  - `resolveMatchedSlot()` handles the dimension-independent fnPtr gate;
  - `peerPrepareSlot()` is noinline for the cold non-owner first-touch path.
- Add fixed lookup helpers:
  - `cacheLookup0D/1D/2D/3D/4D`
  - `tryCacheHit0D/1D/2D/3D/4D`
- Unroll identity hash, slot identity compare, and version checks for fixed dimensions.
- Keep wrapper fixed-path selection limited to 0D/1D/2D.
- Keep 3D/4D fixed APIs and lookup helpers correct/tested, but do not select them from the wrapper because the AArch64 call-site argument spill cancels the lookup saving.

## Measured Impact

Measured from release/-Os AArch64 objdump.

| Path | Static instructions | Notes |
|---|---:|---|
| old generic `cacheLookup` | 341 | loops + cold peer prepare inline |
| new generic `cacheLookup` | 129 | cold tail extracted |
| `cacheLookup0D` | 68 | unrolled identity/version checks |
| `cacheLookup1D` | 109 | unrolled identity/version checks |
| `cacheLookup2D` | 138 | unrolled identity/version checks |
| `cacheLookup3D` | 180 | correct/tested, not wrapper-selected |
| `cacheLookup4D` | 220 | correct/tested, not wrapper-selected |
| `resolveMatchedSlot` | 56 | executed on hit |
| `peerPrepareSlot` | 140 | cold path for first peer prepare |

Conservative owner-hit estimate including `resolveMatchedSlot`:

| Dim | Before | After | Approx saving |
|---|---:|---:|---:|
| 0D | 341 | 68 + 56 = 124 | ~217 instr |
| 1D | 341 | 109 + 56 = 165 | ~176 instr |
| 2D | 341 | 138 + 56 = 194 | ~147 instr |

This does not claim the full C API-to-return path is below 100 instructions. It specifically reduces the shared cache lookup head, which was the dominant hot function body.

## Risk / Compatibility

- Generic API remains unchanged.
- Fixed-dim APIs remain additive from #61.
- Wrapper fixed-dim emission remains opt-in.
- Wrapper only selects fixed paths for 0D/1D/2D.
- Cache semantics are preserved:
  - read token / `outBucket` ownership unchanged;
  - `ejit_taskpool_release_read` still required after hit;
  - version mismatch still misses;
  - disabled instance never returns stale code;
  - peer prepare path still handles non-owner execute-permission readiness.

Main review focus should be identity/version equality, read-lock release, and the owner/peer prepare split.

## Validation

Reported from the split branch:

- `ninja -C build_release_aarch64 LLVMEJIT EJITSharedTaskPoolTests EJITTaskPoolTests -j8` passed
- `EJITSharedTaskPoolTests`: 66/66 passed
- `EJITTaskPoolTests`: 82/82 passed
- No remaining pre-existing `InvalidParam` failure on the current `ejit_dev_spec4` base

## Notes

This PR intentionally does not try to force the complete C API owner-hit path below 100 instructions. That likely requires a separate design such as hot-slot hints or call-site local caches, with different correctness tradeoffs around generation/version/read-token/peer execute permission.