### PR TITLE
[EJIT] Collapse EJitOptimizer optimization levels into a single pipeline

### DIFF
--- a/ejit_test/ejit_opt_level_test.c
+++ b/ejit_test/ejit_opt_level_test.c
@@ -1,13 +1,16 @@
 /**
- * EJIT 优化等级测试 — 覆盖 L1 / L2 / L3
+ * EJIT 优化等级测试 — L1 / L2 / L3
  *
- * 每个等级独立进程 (EJitRegistrationStore 只能 consume 一次),
- * 验证 JIT 编译成功 (entries > 0) 且结果正确。
+ * NOTE: the L1/L2/L3 optimizer tiers have been collapsed into a single fixed
+ * pipeline. optLevel is still accepted (ABI compatibility) but no longer selects
+ * a pipeline — every level runs the full specialization and must produce the
+ * same correct result. This test therefore verifies that JIT compilation
+ * succeeds and the result is correct for whichever level is passed.
+ *
+ * 每个等级独立进程 (EJitRegistrationStore 只能 consume 一次)。
  *
  * 用法:
- *   ./ejit_opt_level L1    # 测试 L1 (SCCP + ADCE + SimplifyCFG)
- *   ./ejit_opt_level L2    # 测试 L2 (L1 + AlwaysInliner + SimplifyCFG)
- *   ./ejit_opt_level L3    # 测试 L3 (L2 + LoopSimplify + LoopFullUnroll + Promote)
+ *   ./ejit_opt_level L1|L2|L3   # all run the same collapsed pipeline
  *
  * 编译:
  *   build/bin/clang -O2 -c ejit_test/ejit_opt_level_test.c -o /tmp/opt_level.o

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -51,8 +51,12 @@ private:
   /// Run EJitStructFieldPass on all functions.
   void runStructFieldPass(Module &M);
 
-  /// Run core optimization: L1 = SCCP+ADCE+SimplifyCFG,
-  /// L2 = + AlwaysInliner + cleanup, L3 = + LoopUnroll + cleanup.
+  /// Run the EJIT optimization pipeline: a single fused sequence that exploits
+  /// the just-substituted period-index / may_const constants to their fixed
+  /// point (scalar fold/propagate/simplify), folds loops whose bounds became
+  /// constant, re-specializes the array accesses that unrolling turns into
+  /// constant-index GEPs, then does a final cleanup. `level` is accepted for ABI
+  /// compatibility and does not affect the pipeline.
   void runOptimizationPipeline(Module &M, OptimizationLevel level);
 
   PeriodArrayRegistry &registry_;
@@ -64,10 +68,13 @@ private:
   CGSCCAnalysisManager CGAM_;
   ModuleAnalysisManager MAM_;
 
-  // Cached pass pipelines — created once, reused across compilations.
-  FunctionPassManager L1FPM_;   // SCCP + ADCE + SimplifyCFG (always runs)
-  FunctionPassManager L2FPM_;   // SimplifyCFG only (L2 inline cleanup)
-  FunctionPassManager L3FPM_;   // LoopSimplify + LoopFullUnroll + Promote + SimplifyCFG
+  // Cached pass managers, built once and reused across compilations:
+  //   mainFPM_    scalar fold/propagate/simplify to a fixed point, then loop
+  //               fold-to-constant (Phases 2-3).
+  //   cleanupFPM_ fold/propagate/simplify after unrolling re-exposes constant
+  //               array accesses and the second StructFieldPass (Phase 4).
+  FunctionPassManager mainFPM_;
+  FunctionPassManager cleanupFPM_;
 
   // Grant the unit-test accessor visibility into the private pipeline steps.
   // runPipeline() remains the only production entry point; this friend keeps

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -35,34 +35,52 @@ EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
   EJitPassBuilder::registerModuleAnalyses(MAM_);
   EJitPassBuilder::crossRegisterProxies(LAM_, FAM_, CGAM_, MAM_);
 
-  // Pre-build cached pass pipelines.
-  // L1: SCCP + ADCE + SimplifyCFG (always runs).
-  L1FPM_.addPass(SCCPPass());
-  L1FPM_.addPass(ADCEPass());
-  L1FPM_.addPass(SimplifyCFGPass());
-
-  // L2: reserved for post-inline cleanup.
-  // TODO: populate once inlining is re-enabled in runPipeline.
-
-  // L3: LoopSimplify → FullUnroll → IndVarSimplify → LoopDeletion →
-  //     Promote → SCCP → SimplifyCFG.
+  // Pre-build the two cached FunctionPassManagers of the optimization pipeline.
   //
-  // FullUnroll handles small bounded loops (budget ~150 instructions).
-  // For larger loops whose trip count is a may_const, IndVarSimplify uses SCEV
-  // to replace the accumulator phi with a closed-form exit value, then
-  // LoopDeletion removes the now-dead loop.  A second SCCP pass propagates the
-  // freshly-computed loop-exit constants through the rest of the function.
-  L3FPM_.addPass(LoopSimplifyPass());
+  // By the time these run, runPipeline has turned the period-index argument and
+  // every may_const field into a compile-time constant. The pipeline's whole job
+  // is to exploit those constants maximally, so it is structured as a fold →
+  // propagate → simplify fixed point followed by loop folding.
+  //
+  // mainFPM_ — Phase 2 (scalar) then Phase 3 (loops):
+  //
+  //   Phase 2 drives the substituted constants to a fixed point. The first round
+  //   peephole-folds the constants (InstCombine), propagates them and folds the
+  //   now-constant branches (SCCP), and deletes the unreachable blocks
+  //   (SimplifyCFG). Folding a branch merges blocks and exposes fresh constants
+  //   and dead code, so a second InstCombine + SimplifyCFG round catches that
+  //   cascade; ADCE then removes whatever became dead.
+  mainFPM_.addPass(InstCombinePass());
+  mainFPM_.addPass(SCCPPass());
+  mainFPM_.addPass(SimplifyCFGPass());
+  mainFPM_.addPass(InstCombinePass());
+  mainFPM_.addPass(SimplifyCFGPass());
+  mainFPM_.addPass(ADCEPass());
+  //   Phase 3 folds loops whose bounds became constant (a no-op on loopless
+  //   functions). LoopSimplify canonicalizes; LoopFullUnroll unrolls small
+  //   bounded loops; IndVarSimplify uses SCEV to replace a larger loop's
+  //   accumulator phi with its closed-form exit value; LoopDeletion removes the
+  //   emptied loop; Promote returns any loop-created allocas to SSA.
+  mainFPM_.addPass(LoopSimplifyPass());
   {
     LoopPassManager LPM;
     LPM.addPass(LoopFullUnrollPass());
     LPM.addPass(IndVarSimplifyPass());
     LPM.addPass(LoopDeletionPass());
-    L3FPM_.addPass(createFunctionToLoopPassAdaptor(std::move(LPM)));
+    mainFPM_.addPass(createFunctionToLoopPassAdaptor(std::move(LPM)));
   }
-  L3FPM_.addPass(PromotePass());
-  L3FPM_.addPass(SCCPPass());
-  L3FPM_.addPass(SimplifyCFGPass());
+  mainFPM_.addPass(PromotePass());
+
+  // cleanupFPM_ — Phase 4, run after the second StructFieldPass. Unrolling turns
+  // a loop-variant array access g_arr[k].field into constant-index GEPs
+  // (g_arr[0]/[1]/...), which only then become substitutable. Once
+  // StructFieldPass replaces them, this fold/propagate/simplify pass collapses
+  // the freshly-constant values and drops what became dead — the same treatment
+  // Phase 2 gave the first wave of constants.
+  cleanupFPM_.addPass(InstCombinePass());
+  cleanupFPM_.addPass(SCCPPass());
+  cleanupFPM_.addPass(SimplifyCFGPass());
+  cleanupFPM_.addPass(ADCEPass());
 }
 
 void EJitOptimizer::clearAnalyses() {
@@ -80,32 +98,26 @@ void EJitOptimizer::runPipeline(Module &M,
                     static_cast<int>(ctx.optLevel), ctx.dimensions.size(),
                     M.getName().str().c_str());
 
-  // 1. Parameter substitution: replace ejit_period_arr_ind args with constants
+  // Phase 1 — specialize: turn the period index and every may_const field into
+  // a compile-time constant.
+  //   (a) Substitute the ejit_period_arr_ind argument with its constant index.
   preReplacePeriodIndices(M, ctx);
-  EJIT_DIAG_DEBUG("pipeline stage1 done: preReplacePeriodIndices");
-
-  // 2. InstCombine: fold constant GEP chains from substituted params
-  //    so StructFieldPass can compute correct byte offsets.
+  EJIT_DIAG_DEBUG("pipeline phase1a done: preReplacePeriodIndices");
+  //   (b) Fold the constant GEP chains that exposes so StructFieldPass can
+  //       compute the byte offset of each may_const field access.
   runInstCombine(M);
-  EJIT_DIAG_DEBUG("pipeline stage2 done: InstCombine");
-
-  // 3. Inline (L2+): currently disabled. The AOT pre-optimization in
-  //    EJitRegisterBitcodePass already runs AlwaysInline + ModuleInliner(O2),
-  //    so callee bodies are already expanded in the embedded bitcode and
-  //    their may_const GEP chains are directly traceable to global variables.
-  //    Skipping this saves JIT compile time at the cost of missing inlines
-  //    that only become profitable after parameter substitution.
-  // if (static_cast<int>(ctx.optLevel) >= 2) {
-  //   ModulePassManager MPM;
-  //   MPM.addPass(AlwaysInlinerPass());
-  //   MPM.run(M, MAM_);
-  // }
-
-  // 4. StructFieldPass: replace may_const loads with runtime constants.
+  EJIT_DIAG_DEBUG("pipeline phase1b done: InstCombine");
+  // Inlining is intentionally not run here: the AOT pre-optimization
+  // (EJitRegisterBitcodePass: AlwaysInline + ModuleInliner(O2)) already expanded
+  // callee bodies in the embedded bitcode, so their may_const GEP chains are
+  // already traceable to the global.
+  //   (c) Replace the may_const loads with their runtime constant values.
   runStructFieldPass(M);
-  EJIT_DIAG_DEBUG("pipeline stage4 done: StructFieldPass");
+  EJIT_DIAG_DEBUG("pipeline phase1c done: StructFieldPass");
 
-  // 5. Core optimization at the configured level
+  // Phases 2-4 — exploit those constants (scalar fixed point → loops →
+  // re-specialize → cleanup). ctx.optLevel is accepted for ABI compatibility
+  // and does not affect the pipeline.
   runOptimizationPipeline(M, ctx.optLevel);
   EJIT_DIAG_VERBOSE("pipeline done func=%s key=0x%016lx", ctx.fnName.c_str(),
                     ctx.cacheKey);
@@ -169,34 +181,21 @@ void EJitOptimizer::runStructFieldPass(Module &M) {
 
 void EJitOptimizer::runOptimizationPipeline(Module &M,
                                             OptimizationLevel level) {
-  EJIT_DIAG_DEBUG("pipeline stage5: core opt level=%d module=%s",
-                  static_cast<int>(level), M.getName().str().c_str());
-  // L1: SCCP + ADCE + SimplifyCFG — constant propagation, dead code
-  // elimination, and CFG cleanup. Captures the vast majority of EJIT
-  // performance gains (may_const load → constant → branch folding).
-  // L1FPM_ is pre-built in the constructor and reused across compilations.
+  // One fixed pipeline; `level` does not affect it.
+  (void)level;
+  EJIT_DIAG_DEBUG("pipeline stage5: optimization pipeline module=%s",
+                  M.getName().str().c_str());
+
+  // Phases 2-3: scalar fold/propagate/simplify fixed point, then loop folding.
   for (Function &F : M.functions())
     if (!F.isDeclaration())
-      L1FPM_.run(F, FAM_);
+      mainFPM_.run(F, FAM_);
 
-  // L2: SimplifyCFG cleanup. Inline now runs in runPipeline (before
-  // StructFieldPass), so no need to re-run StructFieldPass here.
-  if (static_cast<int>(level) >= 2) {
-    for (Function &F : M.functions())
-      if (!F.isDeclaration())
-        L2FPM_.run(F, FAM_);
-  }
-
-  // L3: Unroll small loops with may_const-dependent bodies. Re-run
-  // StructFieldPass because loop unrolling can turn loop-variant GEP
-  // indices into constants (e.g. g_cfg[i].field → g_cfg[0].field,
-  // g_cfg[1].field after unrolling).
-  if (static_cast<int>(level) >= 3) {
-    for (Function &F : M.functions())
-      if (!F.isDeclaration())
-        L3FPM_.run(F, FAM_);
-
-    runStructFieldPass(M);
-    runInstCombine(M);
-  }
+  // Phase 4: unrolling exposed new constant-index array accesses
+  // (g_arr[k].field → g_arr[0].field, g_arr[1].field, ...). Substitute them,
+  // then fold/propagate/simplify the freshly-constant values.
+  runStructFieldPass(M);
+  for (Function &F : M.functions())
+    if (!F.isDeclaration())
+      cleanupFPM_.run(F, FAM_);
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -34,6 +34,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 #ifndef EJIT_FREESTANDING
 #include <thread>
@@ -2209,6 +2210,49 @@ TEST(EJitOptimizer, OptimizationL3LoopUnroll) {
 }
 
 //===----------------------------------------------------------------------===//
+// Pipeline-collapse proof tests
+//
+// The L1/L2/L3 optimizer tiers were collapsed into one fixed pipeline. These
+// prove the collapse is behavior-preserving:
+//   * level-equivalence — optimizing the SAME module at L1, L2, and L3 yields
+//     byte-identical IR (the optimizer no longer branches on the level);
+//   * no-regression — that IR is the fully optimized form the old L3 produced
+//     (the loop is unrolled and folded to the constant 6). Pre-collapse the L1
+//     output would still contain the loop, so this would have failed.
+//===----------------------------------------------------------------------===//
+
+// Optimize a fresh copy of createLoopFunc at `lvl` and return the printed IR.
+static std::string optimizeLoopFnAt(llvm::ejit::OptimizationLevel lvl) {
+  LLVMContext Ctx;
+  auto M = createTestModule(Ctx, "collapse_equiv");
+  createLoopFunc(Ctx, *M);
+  PeriodArrayRegistry reg;
+  EJitOptimizerTestAccess opt(reg);
+  opt.runInstCombine(*M);
+  opt.runOptimizationPipeline(*M, lvl);
+  std::string Out;
+  raw_string_ostream OS(Out);
+  M->print(OS, nullptr);
+  return Out;
+}
+
+TEST(EJitOptimizer, PipelineCollapseLevelEquivalence) {
+  std::string L1 = optimizeLoopFnAt(llvm::ejit::OptimizationLevel::L1);
+  std::string L2 = optimizeLoopFnAt(llvm::ejit::OptimizationLevel::L2);
+  std::string L3 = optimizeLoopFnAt(llvm::ejit::OptimizationLevel::L3);
+
+  // Collapse proof: every level runs the identical single pipeline.
+  EXPECT_EQ(L1, L2) << "L1 vs L2 IR differs — the tiers were not collapsed";
+  EXPECT_EQ(L2, L3) << "L2 vs L3 IR differs — the tiers were not collapsed";
+
+  // No-regression proof: the single pipeline still fully optimizes at EVERY
+  // level (loop unrolled + folded to constant 6 — the old L3 outcome). Under the
+  // old tiers, L1 kept the loop and this find() would fail.
+  EXPECT_NE(L1.find("ret i32 6"), std::string::npos)
+      << "collapsed pipeline did not fold the loop at L1 (regressed vs old L3)";
+}
+
+//===----------------------------------------------------------------------===//
 // End-to-end tests
 //===----------------------------------------------------------------------===//
 
@@ -2303,6 +2347,44 @@ TEST(EJitEndToEnd, BranchFolding) {
   ASSERT_NE(RetVal, nullptr);
   // mock.val = 1 => branch taken => result = 100
   EXPECT_EQ(RetVal->getSExtValue(), 100);
+}
+
+// Second collapse-proof, on a different function shape: a may_const field
+// driving a branch (not a loop). Specialize it through the full pipeline at L1,
+// L2, and L3 and confirm the output IR is byte-identical (level does not change
+// the pipeline) and fully folded (branch resolved to the constant 100).
+static std::string specializeBranchAt(llvm::ejit::OptimizationLevel lvl) {
+  LLVMContext Ctx;
+  auto M = std::make_unique<Module>("branch_equiv", Ctx);
+  M->setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+  createBranchOnMayConstFunc(Ctx, *M);
+
+  struct MockCfg {
+    int32_t val;
+  } mock = {1}; // non-zero → "then" branch → result 100
+  PeriodArrayRegistry reg;
+  reg.registerStaticVar("g_branch_cfg", &mock);
+
+  EJitOptimizerTestAccess opt(reg);
+  opt.runInstCombine(*M);
+  opt.runStructFieldPass(*M);
+  opt.runOptimizationPipeline(*M, lvl);
+
+  std::string Out;
+  raw_string_ostream OS(Out);
+  M->print(OS, nullptr);
+  return Out;
+}
+
+TEST(EJitEndToEnd, PipelineLevelEquivalenceBranch) {
+  std::string L1 = specializeBranchAt(llvm::ejit::OptimizationLevel::L1);
+  std::string L2 = specializeBranchAt(llvm::ejit::OptimizationLevel::L2);
+  std::string L3 = specializeBranchAt(llvm::ejit::OptimizationLevel::L3);
+
+  EXPECT_EQ(L1, L2) << "L1 vs L2 IR differs — level changed the pipeline";
+  EXPECT_EQ(L2, L3) << "L2 vs L3 IR differs — level changed the pipeline";
+  EXPECT_NE(L1.find("ret i32 100"), std::string::npos)
+      << "pipeline did not fold the may_const branch to the constant 100";
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Currently, we have 3 different optimization levels in the EJitOptimizer pipeline.

We can collapse all of these levels (L1/L2/L3) into a single optimization pipeline. The time taken to run these optimizations is negligible, so using L1 over L3, for example, doesn't improve compile time.

The proposed new EJIT optimizer pipeline (one fixed run, no levels) is:
```
  Phase 1  specialize:   preReplacePeriodIndices → InstCombine → StructFieldPass
  Phase 2  scalar:       InstCombine → SCCP → SimplifyCFG
                         InstCombine → SimplifyCFG   (2nd round for the cascade)
                         ADCE
  Phase 3  loops:        LoopSimplify → [LoopFullUnroll → IndVarSimplify →
                         LoopDeletion] → Promote      (no-op if loopless)
  Phase 4  re-specialize: StructFieldPass → InstCombine → SCCP → SimplifyCFG → ADCE
```

The single pipeline is mostly the old L3 path, so anything that compiled at L3 is unchanged for the most part, and L1/L2 callers just get the full specialization pipeline.