### PR TITLE
[EJIT] Keep IR/ASM dump payloads worker-local

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -66,7 +66,12 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// (codeStart/codeSize/poolBase/poolSize/poolId) and the shared state gains a
 /// per-core, per-pool 4K split-readiness table, so a non-owner core in 4K-seal
 /// mode can split its pool once and seal exactly the pages the code covers.
-constexpr uint32_t kEJitSharedAbiVersion = 5u;
+/// v6: EJitSharedDumpState no longer carries the large ir[]/asmText[] buffers.
+/// Full IR/ASM dump text stays worker-local (private std::map); the shared blob
+/// keeps only small dump metadata (hasDump, workerCore, cacheKey, resultName,
+/// irSize, asmSize, status). This shrinks the shared region and removes silent
+/// text truncation.
+constexpr uint32_t kEJitSharedAbiVersion = 6u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -73,20 +73,6 @@
 #ifndef EJIT_SRE_SHARED_DUMP_NAME_BYTES
 #define EJIT_SRE_SHARED_DUMP_NAME_BYTES 128u
 #endif
-// Per-slot IR/ASM text capacity in the cross-core dump table (each slot holds
-// one captured function's name + IR + ASM, truncated to this size per text).
-#ifndef EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES
-#define EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES 8192u
-#endif
-// Number of per-name result slots in the cross-core dump table. Each captured
-// specialization occupies one slot keyed by entry name; when full, the oldest
-// slot is round-robin evicted. Covers this many distinct functions for
-// cross-core ejit_print_dumped(name) retrieval. NOTE: the table lives in the
-// fixed shared section, so sizeof(EJitSharedTaskPoolState) scales with
-// SLOT_COUNT * (2 * SLOT_TEXT_BYTES); resize the linker section accordingly.
-#ifndef EJIT_SRE_SHARED_DUMP_SLOT_COUNT
-#define EJIT_SRE_SHARED_DUMP_SLOT_COUNT 50u
-#endif
 
 namespace llvm {
 namespace ejit {
@@ -103,10 +89,6 @@ constexpr uint32_t kEJitSharedQueueSlots = EJIT_SRE_TASKPOOL_QUEUE_CAPACITY;
 constexpr uint32_t kEJitSharedPoolSlots = EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS;
 constexpr uint32_t kEJitSharedDumpNameBytes =
     EJIT_SRE_SHARED_DUMP_NAME_BYTES;
-constexpr uint32_t kEJitSharedDumpSlotTextBytes =
-    EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES;
-constexpr uint32_t kEJitSharedDumpSlotCount =
-    EJIT_SRE_SHARED_DUMP_SLOT_COUNT;
 constexpr uint32_t kEJitSharedCacheLine = 64u;
 /// Execute-permission seal granularity (the platform's per-page enable_ex unit)
 /// and the large-page / split granularity. Fixed platform constants.
@@ -219,41 +201,33 @@ struct EJitSharedPoolSplit {
 };
 
 //===----------------------------------------------------------------------===//
-// EJitSharedDumpState: fixed-size cross-core diagnostic exchange.
+// EJitSharedDumpState: fixed-size cross-core diagnostic metadata.
 //
-// The owner worker captures IR/ASM in its private ORC path, but shell/debug
-// requests can arrive on a different core. std::map/std::string cannot live in
-// shared memory, so the shared path uses one bounded filter plus a bounded
-// per-name result TABLE: each captured specialization occupies one slot keyed
-// by entry name; when the table is full the oldest slot is round-robin
-// evicted. This lets a non-owner core retrieve any recently-captured function
-// by name (not just the latest). It is diagnostic-only: long IR/ASM is
-// truncated (per-slot) instead of blocking normal JIT progress; the full,
-// untruncated IR/ASM remains available on the owner core via the per-core
-// gDumpStore + ejit_print_dumped(NULL).
+// The owner worker captures full IR/ASM in its private ORC path (a
+// std::map<std::string, DumpEntry> that lives ONLY in that core's private
+// heap). std::map/std::string cannot live in shared memory, and copying large
+// IR/ASM text into a fixed shared buffer wastes cross-core memory and silently
+// truncates. So this shared struct holds ONLY small metadata: which core owns
+// the capture, its cache key, the requested filter, and the IR/ASM sizes. A
+// core that misses its private store uses this metadata to tell the user which
+// worker core to re-run ejit_print_dumped() on. The full text is NEVER copied
+// here.
 //===----------------------------------------------------------------------===//
-struct alignas(kEJitSharedCacheLine) EJitSharedDumpSlot {
-  EJitAtomicU32 valid;       ///< 1 => name/ir/asm hold a capture
-  EJitAtomicU32 truncated;   ///< bit0 IR, bit1 ASM, bit2 name truncated
-  uint32_t nameLen;
-  uint32_t irSize;
-  uint32_t asmSize;
-  uint32_t keyHi;
-  uint32_t keyLo;
-  uint32_t reserved0;
-  char name[kEJitSharedDumpNameBytes];
-  char ir[kEJitSharedDumpSlotTextBytes];
-  char asmText[kEJitSharedDumpSlotTextBytes];
-};
-
 struct alignas(kEJitSharedCacheLine) EJitSharedDumpState {
   EJitAtomicU32 lock;          ///< 0 free, 1 locked by filter/capture/print
   EJitAtomicU32 filterEnabled; ///< 1 => filterName is active
+  EJitAtomicU32 hasDump;       ///< 1 => metadata describes a worker-local dump
+  EJitAtomicU32 status;        ///< bit0 IR truncated, bit1 ASM truncated
   uint32_t filterLen;
-  uint32_t nextSlot;           ///< round-robin eviction cursor (under lock)
+  uint32_t resultNameLen;
+  uint32_t irSize;    ///< bytes of IR text kept worker-local (not stored here)
+  uint32_t asmSize;   ///< bytes of ASM text kept worker-local (not stored here)
+  uint32_t keyHi;
+  uint32_t keyLo;
+  uint32_t workerCore; ///< core that captured (kEJitInvalidCoreId if unknown)
   uint32_t reserved0;
   char filterName[kEJitSharedDumpNameBytes];
-  EJitSharedDumpSlot slots[kEJitSharedDumpSlotCount];
+  char resultName[kEJitSharedDumpNameBytes];
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -170,15 +170,12 @@ void setDumpFuncFilter(const std::string &name) {
     }
     D.filterName[len] = 0;
     D.filterLen = len;
-    // A filter change invalidates all captured slots so stale results don't
-    // surface after re-arming.
-    for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-      D.slots[s].valid.storeRelease(0);
-      D.slots[s].nameLen = 0;
-      D.slots[s].irSize = 0;
-      D.slots[s].asmSize = 0;
-    }
-    D.nextSlot = 0;
+    D.hasDump.storeRelease(0);
+    D.resultNameLen = 0;
+    D.irSize = 0;
+    D.asmSize = 0;
+    D.workerCore = kEJitInvalidCoreId;
+    D.status.storeRelease(0);
     D.filterEnabled.storeRelease(len ? 1u : 0u);
     D.lock.storeRelease(0);
     EJIT_DIAG_DEBUG("set_dump_filter shared enabled=%u len=%u &shared=%p",
@@ -304,95 +301,83 @@ static uint32_t copyDumpBytes(char *dst, uint32_t cap, const char *src,
   return n;
 }
 
-static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
-                              const std::string &IR, const std::string &ASM) {
+static void captureSharedDumpMetadata(const std::string &fnName,
+                                      uint64_t cacheKey, size_t irSize,
+                                      size_t asmSize) {
   if (!gDumpSharedState)
     return;
   EJitSharedDumpState &D = gDumpSharedState->dump;
+  uint32_t core = EJitCoreId::current();
   sharedDumpLock(D);
-  // Find an existing slot for fnName (overwrite it in place). Distinct names
-  // accumulate; a repeat re-capture refreshes the same slot rather than
-  // consuming another.
-  uint32_t target = kEJitSharedDumpSlotCount;
-  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-    if (D.slots[s].valid.loadRelaxed() != 0 &&
-        D.slots[s].nameLen == fnName.size() &&
-        std::memcmp(D.slots[s].name, fnName.data(), fnName.size()) == 0) {
-      target = s;
-      break;
-    }
-  }
-  if (target == kEJitSharedDumpSlotCount) {
-    // New name: prefer a free slot, else round-robin evict the oldest.
-    target = D.nextSlot;
-    for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-      uint32_t idx = (D.nextSlot + s) % kEJitSharedDumpSlotCount;
-      if (D.slots[idx].valid.loadRelaxed() == 0) {
-        target = idx;
-        break;
-      }
-    }
-    D.nextSlot = (target + 1) % kEJitSharedDumpSlotCount;
-  }
-  EJitSharedDumpSlot &Slot = D.slots[target];
-  bool nameTrunc = false, irTrunc = false, asmTrunc = false;
-  Slot.valid.storeRelease(0); // invalidate while writing (readers hold the lock)
-  Slot.nameLen = copyDumpBytes(Slot.name, kEJitSharedDumpNameBytes,
-                               fnName.data(), fnName.size(), nameTrunc);
-  Slot.irSize = copyDumpBytes(Slot.ir, kEJitSharedDumpSlotTextBytes, IR.data(),
-                              IR.size(), irTrunc);
-  Slot.asmSize = copyDumpBytes(Slot.asmText, kEJitSharedDumpSlotTextBytes,
-                               ASM.data(), ASM.size(), asmTrunc);
-  Slot.keyHi = (uint32_t)(cacheKey >> 32);
-  Slot.keyLo = (uint32_t)(cacheKey & 0xffffffffu);
-  Slot.truncated.storeRelease((nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) |
-                              (asmTrunc ? 2u : 0u));
-  Slot.valid.storeRelease(1);
+  bool nameTrunc = false;
+  D.hasDump.storeRelease(0);
+  D.resultNameLen = copyDumpBytes(D.resultName, kEJitSharedDumpNameBytes,
+                                  fnName.data(), fnName.size(), nameTrunc);
+  D.irSize = (irSize > 0xffffffffu) ? 0xffffffffu : (uint32_t)irSize;
+  D.asmSize = (asmSize > 0xffffffffu) ? 0xffffffffu : (uint32_t)asmSize;
+  D.keyHi = (uint32_t)(cacheKey >> 32);
+  D.keyLo = (uint32_t)(cacheKey & 0xffffffffu);
+  D.workerCore = core;
+  D.status.storeRelease(nameTrunc ? 4u : 0u);
+  D.hasDump.storeRelease(1);
   sharedDumpUnlock(D);
-  EJIT_DIAG_DEBUG("capture shared func=%s slot=%u ir=%u asm=%u trunc=0x%x &shared=%p",
-            fnName.c_str(), target, (unsigned)IR.size(), (unsigned)ASM.size(),
-            (nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) | (asmTrunc ? 2u : 0u),
+  EJIT_DIAG("capture shared metadata func=%s core=%u ir=%u asm=%u &shared=%p",
+            fnName.c_str(), core, (unsigned)irSize, (unsigned)asmSize,
             (void *)gDumpSharedState);
 }
 
-static bool printSharedDumped(const char *name) {
+/// A core that misses its private gDumpStore consults the shared metadata: if a
+/// worker core captured a matching dump, tell the user which core to re-run
+/// ejit_print_dumped() on. IR/ASM text is NEVER stored here, so it is never
+/// printed from the shared path — only the small metadata (worker core, sizes,
+/// cache key) is surfaced.
+static bool printSharedDumpHint(const char *name) {
   if (!gDumpSharedState)
     return false;
   EJitSharedDumpState &D = gDumpSharedState->dump;
-  bool hasName = name && name[0];
   sharedDumpLock(D);
-  bool any = false;
-  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-    EJitSharedDumpSlot &Slot = D.slots[s];
-    if (Slot.valid.loadAcquire() == 0)
-      continue;
-    bool match = true;
-    if (hasName) {
-      uint32_t i = 0;
-      while (i < Slot.nameLen && name[i] && name[i] == Slot.name[i])
-        ++i;
-      match = (i == Slot.nameLen && name[i] == 0);
-    }
-    if (!match)
-      continue;
-    uint32_t trunc = Slot.truncated.loadAcquire();
-    EJIT_DIAG("print_dumped shared hit requested=%s stored=%s slot=%u "
-              "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u trunc=0x%x",
-              hasName ? name : "(all)", Slot.name, s, Slot.keyHi, Slot.keyLo,
-              Slot.irSize, Slot.asmSize, trunc);
-    if (Slot.irSize)
-      dumpBytesSafe("dump IR", Slot.ir, Slot.irSize);
-    if (Slot.asmSize)
-      dumpBytesSafe("dump ASM", Slot.asmText, Slot.asmSize);
-    any = true;
-    if (hasName)
-      break; // single-name query: done after the first match
+  bool has = D.hasDump.loadAcquire() != 0;
+  if (!has) {
+    sharedDumpUnlock(D);
+    return false;
   }
+  bool hasName = name && name[0];
+  bool match = true;
+  if (hasName) {
+    uint32_t i = 0;
+    while (i < D.resultNameLen && name[i] && name[i] == D.resultName[i])
+      ++i;
+    match = (i == D.resultNameLen && name[i] == 0);
+  }
+  if (!match) {
+    sharedDumpUnlock(D);
+    return false;
+  }
+  uint32_t workerCore = D.workerCore;
+  uint32_t irSize = D.irSize;
+  uint32_t asmSize = D.asmSize;
+  uint32_t keyHi = D.keyHi;
+  uint32_t keyLo = D.keyLo;
+  char stored[kEJitSharedDumpNameBytes];
+  uint32_t sn = D.resultNameLen;
+  if (sn >= kEJitSharedDumpNameBytes)
+    sn = kEJitSharedDumpNameBytes - 1;
+  for (uint32_t i = 0; i < sn; ++i)
+    stored[i] = D.resultName[i];
+  stored[sn] = 0;
   sharedDumpUnlock(D);
-  if (!any)
-    EJIT_DIAG_DEBUG("print_dumped shared miss name=%s &shared=%p",
-                    hasName ? name : "(all)", (void *)gDumpSharedState);
-  return any;
+  if (workerCore == kEJitInvalidCoreId) {
+    EJIT_DIAG("print_dumped: dump for \"%s\" is stored on the worker core "
+              "(core id unknown); please run ejit_print_dumped(\"%s\") on that "
+              "core. ir_size=%u asm_size=%u key_hi=0x%08x key_lo=0x%08x",
+              stored, stored, irSize, asmSize, keyHi, keyLo);
+  } else {
+    EJIT_DIAG("print_dumped: dump for \"%s\" is stored on worker core %u; "
+              "please run ejit_print_dumped(\"%s\") on that core. ir_size=%u "
+              "asm_size=%u key_hi=0x%08x key_lo=0x%08x",
+              stored, workerCore, stored, irSize, asmSize, keyHi, keyLo);
+  }
+  return true;
 }
 #endif
 
@@ -408,8 +393,10 @@ static void captureDump(const std::string &fnName, uint64_t cacheKey,
   gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
   EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
+  // Publish only small metadata to shared memory. The full IR/ASM text stays
+  // worker-local in gDumpStore above; it is never copied cross-core.
   const DumpEntry &E = gDumpStore[fnName];
-  captureSharedDump(fnName, cacheKey, E.IR, E.ASM);
+  captureSharedDumpMetadata(fnName, cacheKey, E.IR.size(), E.ASM.size());
 #endif
 }
 
@@ -458,18 +445,17 @@ void printDumped(const char *name) {
     }
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
-  // Local miss / empty (e.g. a non-owner core, whose per-core gDumpStore is
-  // empty): serve from the cross-core shared per-name table. The table holds
-  // the last N captured functions (truncated to the slot text size); a specific
-  // name retrieves its slot, NULL lists all of them.
-  if (printSharedDumped(name))
+  // Local miss / empty (e.g. a non-owner core): point the user to the worker
+  // core that owns the full worker-local IR/ASM text.
+  if (printSharedDumpHint(name))
     return;
 #endif
-  if (hasName)
-    EJIT_DIAG_DEBUG("print_dumped miss name=%s store_size=%u", name,
-                    (unsigned)gDumpStore.size());
-  else
+  if (hasName) {
+    EJIT_DIAG("print_dumped miss name=%s store_size=%u", name,
+              (unsigned)gDumpStore.size());
+  } else {
     EJIT_DIAG("print_dumped: nothing saved");
+  }
 }
 
 } // namespace ejit

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -973,27 +973,19 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
   }
   st->dump.lock.storeRelaxed(0);
   st->dump.filterEnabled.storeRelaxed(0);
+  st->dump.hasDump.storeRelaxed(0);
+  st->dump.status.storeRelaxed(0);
   st->dump.filterLen = 0;
-  st->dump.nextSlot = 0;
+  st->dump.resultNameLen = 0;
+  st->dump.irSize = 0;
+  st->dump.asmSize = 0;
+  st->dump.keyHi = 0;
+  st->dump.keyLo = 0;
+  st->dump.workerCore = kEJitInvalidCoreId;
   st->dump.reserved0 = 0;
-  for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
+  for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i) {
     st->dump.filterName[i] = 0;
-  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-    EJitSharedDumpSlot &Slot = st->dump.slots[s];
-    Slot.valid.storeRelaxed(0);
-    Slot.truncated.storeRelaxed(0);
-    Slot.nameLen = 0;
-    Slot.irSize = 0;
-    Slot.asmSize = 0;
-    Slot.keyHi = 0;
-    Slot.keyLo = 0;
-    Slot.reserved0 = 0;
-    for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
-      Slot.name[i] = 0;
-    for (uint32_t i = 0; i < kEJitSharedDumpSlotTextBytes; ++i) {
-      Slot.ir[i] = 0;
-      Slot.asmText[i] = 0;
-    }
+    st->dump.resultName[i] = 0;
   }
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     st->buckets[b].writeFlag.storeRelaxed(0);

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -252,6 +252,40 @@ TEST_F(SharedTaskPoolTest, SharedStateRequiresNoDynamicInitialization) {
 }
 
 //===----------------------------------------------------------------------===//
+// Dump metadata: the shared blob keeps ONLY small dump metadata. Full IR/ASM
+// text is worker-local (a private std::map in EJitOrcEngine.cpp) and must never
+// be copied into shared memory. Guard against a regression that re-adds a large
+// fixed ir[]/asmText[] buffer to EJitSharedDumpState.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, DumpStateHoldsOnlySmallMetadata) {
+  EXPECT_TRUE(std::is_standard_layout<EJitSharedDumpState>::value);
+  EXPECT_TRUE(std::is_trivially_destructible<EJitSharedDumpState>::value);
+  EXPECT_TRUE(
+      std::is_trivially_default_constructible<EJitSharedDumpState>::value);
+
+  // Two bounded name arrays plus a handful of scalars. If a large IR/ASM text
+  // buffer (previously kEJitSharedDumpTextBytes each) is ever re-introduced,
+  // this bound blows up immediately.
+  EXPECT_LE(sizeof(EJitSharedDumpState),
+            static_cast<size_t>(2 * kEJitSharedDumpNameBytes + 256))
+      << "EJitSharedDumpState must not carry large IR/ASM text buffers";
+}
+
+// After owner init, the dump metadata is cleared: no captured dump, worker core
+// unknown, and both text sizes zero.
+TEST_F(SharedTaskPoolTest, DumpMetadataClearedOnInit) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const EJitSharedDumpState &D = state_->dump;
+  EXPECT_EQ(D.hasDump.loadAcquire(), 0u);
+  EXPECT_EQ(D.filterEnabled.loadAcquire(), 0u);
+  EXPECT_EQ(D.workerCore, kEJitInvalidCoreId);
+  EXPECT_EQ(D.irSize, 0u);
+  EXPECT_EQ(D.asmSize, 0u);
+  EXPECT_EQ(D.resultNameLen, 0u);
+}
+
+//===----------------------------------------------------------------------===//
 // 1/ Owner election: exactly one owner across simulated cores.
 //===----------------------------------------------------------------------===//
 TEST_F(SharedTaskPoolTest, ExactlyOneOwnerAcrossCores) {
@@ -1575,7 +1609,7 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
 // naturally-aligned scalars (read back by value — endian-safe), and the
 // pool-split table is POD.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 5u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 6u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(


### PR DESCRIPTION
## Summary

Keep large IR/ASM dump payloads local to the worker core instead of copying them into the shared taskpool state.

The previous shared dump path copied fixed-size IR/ASM buffers into `EJitSharedDumpState`, which made the shared blob much larger and still truncated larger dumps. This PR keeps the full payload in the worker-local `gDumpStore` and uses the shared state only for small metadata.

## What changed

- Remove the large shared `ir[]` / `asmText[]` buffers from `EJitSharedDumpState`.
- Keep only small metadata in shared state:
  - filter/result names
  - cache key
  - worker core
  - IR/ASM sizes
  - status bits
- Keep full IR/ASM strings only in worker-local `std::map<std::string, DumpEntry> gDumpStore`.
- When another core calls `ejit_print_dumped(name)` and only shared metadata is available, print a hint telling the user to run `ejit_print_dumped("name")` on the worker core instead of trying to read cross-core dump text.
- Bump shared ABI version because the shared blob layout changed.

## Behavior

- Worker core / local store hit: prints full IR/ASM as before.
- Non-worker core / local miss / shared metadata hit: prints a message like:
  - dump is stored on worker core X; please run `ejit_print_dumped("name")` on that core
- No shared malloc is introduced.
- No cross-core large text reads are attempted.

## Validation reported locally

- `git diff --check`: clean
- `ninja -C build_release_aarch64 LLVMEJIT -j8`: passed
- `ninja -C build_release_aarch64 EJITSharedTaskPoolTests -j8`: passed
- `EJITSharedTaskPoolTests`: 49 passed

Known note: 6 shared-taskpool tests were already failing on the baseline and were confirmed unrelated by the author of this change.

## Motivation

This avoids making the shared taskpool state carry large diagnostic payloads. The shared state now acts only as a small cross-core locator/metadata channel; the actual dump payload stays with the worker that generated it.