### PR TITLE
[EJIT] Register extern const globals so the JIT can resolve them

### DIFF
--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -434,13 +434,18 @@ static void generateSymbolRegisters(
             }
           }
         }
-        // External global variable references. Skip constants (compiler-
-        // generated strings etc.) — they're embedded in the bitcode. Resolve
-        // through bitcasts/GEPs via rootGlobal so every global the collector
-        // kept in the extracted bitcode is actually registered here.
+        // External global variable references. A const global *with a local
+        // definition* (initializer) is embedded in the extracted bitcode by
+        // extractAndSerialize, so it needs no registration. A const global that
+        // is only a *declaration* (extern const, no initializer in this TU)
+        // cannot be embedded and must be resolved from the host process at JIT
+        // link time, so it MUST be registered — dropping it leaves an
+        // unresolved external that fails JITLink. Resolve through bitcasts/GEPs
+        // via rootGlobal so every global the collector kept in the extracted
+        // bitcode is actually registered here.
         for (Use &U : I.operands()) {
           auto *GV = rootGlobal(U.get(), DL);
-          if (!GV || GV->isConstant())
+          if (!GV || (GV->isConstant() && !GV->isDeclaration()))
             continue;
           if (GV->isDeclaration() || !isPeriodVar(*GV)) {
             std::string Name = GV->getName().str();
@@ -581,7 +586,11 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
         for (const Value *Op : I.operands()) {
           const GlobalVariable *GV =
               rootGlobal(const_cast<Value *>(Op), DL);
-          if (!GV || GV->isConstant() || GV->getName().starts_with("llvm."))
+          // Skip const globals that have a local definition (they're embedded
+          // in the bitcode), but keep const *declarations* (extern const) so
+          // they get registered and resolved from the host at JIT link time.
+          if (!GV || (GV->isConstant() && !GV->isDeclaration()) ||
+              GV->getName().starts_with("llvm."))
             continue;
           if (!GVsDone.insert(GV).second)
             continue;

--- a/llvm/test/Transforms/EmbeddedJIT/extern-const-symbol-registration.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/extern-const-symbol-registration.ll
@@ -1,0 +1,36 @@
+; RUN: opt -passes=ejit-register-bitcode -S %s | FileCheck %s
+
+; Regression test for extern-const global registration.
+;
+; An ejit_entry function that reads an `extern const` global must cause that
+; global to be registered with the JIT (ejit_register_symbol). extractAndSerialize
+; keeps a const *declaration* (extern const, no initializer in this TU) as an
+; external declaration in the extracted bitcode — it cannot be embedded, so it
+; must be resolved from the host process at JIT link time. The symbol
+; collectors previously skipped every const global (isConstant()), which left
+; extern-const declarations unregistered and made JITLink fail with
+; "Symbols not found". Only a const global *with a local definition* (embedded
+; in the bitcode) should be skipped.
+
+; extern const — the case that was broken.
+@g_extern_const = external constant i32
+
+; extern non-const — control; this one was already registered.
+@g_extern_mut = external global i32
+
+define i32 @ejit_entry_fn() !ejit.metadata !1 {
+; CHECK-LABEL: define i32 @ejit_entry_fn()
+  %a = load i32, ptr @g_extern_const
+  %b = load i32, ptr @g_extern_mut
+  %s = add i32 %a, %b
+  ret i32 %s
+}
+
+; The auto-register function must emit ejit_register_symbol for BOTH externals
+; referenced by the closure — including the const one.
+; CHECK: define internal void @ejit_auto_register()
+; CHECK-DAG: call void @ejit_register_symbol({{.*}}@g_extern_const)
+; CHECK-DAG: call void @ejit_register_symbol({{.*}}@g_extern_mut)
+
+!0 = !{!"ejit_entry"}
+!1 = !{!0}


### PR DESCRIPTION
An ejit_entry function that reads an `extern const` global caused JIT compilation to fail with "Symbols not found: [ <global> ]" and, on bare-metal systems that treat a JIT compile failure as fatal, a system reset.

extractAndSerialize keeps a const global that is only a *declaration* (extern const, no initializer in this TU) as an external declaration in the extracted bitcode — it cannot be embedded, so it must be resolved from the host process at JIT link time. But both symbol-registration paths in EJitRegisterBitcode skipped every const global via `GV->isConstant()`:
  - generateSymbolRegisters (global_ctors -> ejit_register_symbol)
  - generateRegistryTable (.ejit_bitcode section, used on bare-metal) so extern const declarations were never registered, leaving them unresolved.

The skip is only correct for const globals that have a local definition (initializer embedded in the bitcode). Refine both guards to `(GV->isConstant() && !GV->isDeclaration())` so const *declarations* (extern const) are registered while const *definitions* (embedded) stay skipped.

Add a lit test: an ejit_entry function reading an extern const global must emit ejit_register_symbol for it.