### PR TITLE
[EJIT] Use dynamic shared IR/ASM dump payloads

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -365,7 +365,6 @@ def doit_gc_merge(args):
         # EJIT_SRE_TASKPOOL ifdef in EJitRuntime.cpp).
         "ejit_set_log_level", "ejit_get_log_level",
         "ejit_print_registry", "ejit_print_func_meta",
-        "ejit_dump_all",
         "ejit_get_code_pool_stats", "ejit_print_code_pool_stats",
         "ejit_print_active",
     ]

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -581,7 +581,7 @@ if(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
 endif()
 
 # Re-enable textual assembly (.s) emission for the JIT IR/ASM diagnostic dump
-# (ejit_dump_func / ejit_dump_all) even in an EJIT_TRIM_LLVM_BACKEND build.
+# (ejit_dump_func / ejit_print_dumped) even in an EJIT_TRIM_LLVM_BACKEND build.
 # The trim normally #ifdef's out the AssemblyFile codegen path
 # (CodeGenTargetMachineImpl::createMCStreamer) to save image size; this option
 # overrides that so ejit_print_dumped can produce ASM on target. Cost: the

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -248,29 +248,14 @@ uint32_t ejit_taskpool_get_worker_core();
 /// non-empty, the next time a specialization whose entry name exactly matches
 /// \p name is JIT-compiled, the engine saves (in memory) its post-optimization
 /// IR and emitted assembly for later printing. Pass NULL or "" to disable
-/// further capture (already-saved entries are retained). The special name "*"
-/// is a wildcard that captures EVERY specialization (see ejit_dump_all). For
-/// performance analysis of individual functions.
+/// further capture (already-saved entries are retained). Capture is exact-name
+/// only, and shared IR/ASM payloads are allocated to the generated text size.
 void ejit_dump_func(const char *name);
 
-/// Print the saved IR+ASM for \p name (or all saved entries when \p name is
-/// NULL or "") through the platform log, one line per IR/ASM line, labeled
-/// "dump IR func=..." / "dump ASM func=...". Names with no saved capture are
-/// reported as missing. Paired with ejit_dump_func(): capture at compile
-/// time, print selectively later.
+/// Print the saved IR+ASM for \p name through the platform log, one line per
+/// IR/ASM line. Names with no saved capture are reported as missing. Passing
+/// NULL or "" only lists captured names; it does not dump all payloads.
 void ejit_print_dumped(const char *name);
-
-/// Convenience switch to capture IR+ASM for ALL JIT-compiled specializations
-/// (equivalent to ejit_dump_func("*")). When \p enable is true, every
-/// specialization's post-optimization IR and emitted assembly is saved (one
-/// entry per function name, overwritten on re-compile, so the store is bounded
-/// by the number of distinct entry functions); print later with
-/// ejit_print_dumped(NULL). When false, capture is disabled. NOTE: on a
-/// cross-core shared taskpool the captures live on the owner core (the one
-/// that runs the JIT worker); print from the owner core to see all entries,
-/// or use ejit_dump_func(name) for a single function whose capture is shared
-/// across cores.
-void ejit_dump_all(bool enable);
 
 /// Runtime diagnostic log level. Mirrors the EJIT_DIAG* macro thresholds.
 ///   EJIT_LOG_OFF    — no diagnostic output

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -66,7 +66,9 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// (codeStart/codeSize/poolBase/poolSize/poolId) and the shared state gains a
 /// per-core, per-pool 4K split-readiness table, so a non-owner core in 4K-seal
 /// mode can split its pool once and seal exactly the pages the code covers.
-constexpr uint32_t kEJitSharedAbiVersion = 5u;
+/// v6: dump slots carry dynamic IR/ASM payload pointers instead of fixed text
+/// buffers.
+constexpr uint32_t kEJitSharedAbiVersion = 6u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -73,17 +73,11 @@
 #ifndef EJIT_SRE_SHARED_DUMP_NAME_BYTES
 #define EJIT_SRE_SHARED_DUMP_NAME_BYTES 128u
 #endif
-// Per-slot IR/ASM text capacity in the cross-core dump table (each slot holds
-// one captured function's name + IR + ASM, truncated to this size per text).
-#ifndef EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES
-#define EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES 8192u
-#endif
 // Number of per-name result slots in the cross-core dump table. Each captured
 // specialization occupies one slot keyed by entry name; when full, the oldest
 // slot is round-robin evicted. Covers this many distinct functions for
-// cross-core ejit_print_dumped(name) retrieval. NOTE: the table lives in the
-// fixed shared section, so sizeof(EJitSharedTaskPoolState) scales with
-// SLOT_COUNT * (2 * SLOT_TEXT_BYTES); resize the linker section accordingly.
+// cross-core ejit_print_dumped(name) retrieval. The table stores pointers to
+// dynamically allocated IR/ASM payloads, not fixed text buffers.
 #ifndef EJIT_SRE_SHARED_DUMP_SLOT_COUNT
 #define EJIT_SRE_SHARED_DUMP_SLOT_COUNT 50u
 #endif
@@ -103,8 +97,6 @@ constexpr uint32_t kEJitSharedQueueSlots = EJIT_SRE_TASKPOOL_QUEUE_CAPACITY;
 constexpr uint32_t kEJitSharedPoolSlots = EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS;
 constexpr uint32_t kEJitSharedDumpNameBytes =
     EJIT_SRE_SHARED_DUMP_NAME_BYTES;
-constexpr uint32_t kEJitSharedDumpSlotTextBytes =
-    EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES;
 constexpr uint32_t kEJitSharedDumpSlotCount =
     EJIT_SRE_SHARED_DUMP_SLOT_COUNT;
 constexpr uint32_t kEJitSharedCacheLine = 64u;
@@ -219,31 +211,28 @@ struct EJitSharedPoolSplit {
 };
 
 //===----------------------------------------------------------------------===//
-// EJitSharedDumpState: fixed-size cross-core diagnostic exchange.
+// EJitSharedDumpState: cross-core diagnostic exchange.
 //
 // The owner worker captures IR/ASM in its private ORC path, but shell/debug
 // requests can arrive on a different core. std::map/std::string cannot live in
 // shared memory, so the shared path uses one bounded filter plus a bounded
 // per-name result TABLE: each captured specialization occupies one slot keyed
 // by entry name; when the table is full the oldest slot is round-robin
-// evicted. This lets a non-owner core retrieve any recently-captured function
-// by name (not just the latest). It is diagnostic-only: long IR/ASM is
-// truncated (per-slot) instead of blocking normal JIT progress; the full,
-// untruncated IR/ASM remains available on the owner core via the per-core
-// gDumpStore + ejit_print_dumped(NULL).
+// evicted. IR/ASM payloads are allocated dynamically to their actual text size,
+// and the slot stores shared-visible pointers plus sizes.
 //===----------------------------------------------------------------------===//
 struct alignas(kEJitSharedCacheLine) EJitSharedDumpSlot {
   EJitAtomicU32 valid;       ///< 1 => name/ir/asm hold a capture
-  EJitAtomicU32 truncated;   ///< bit0 IR, bit1 ASM, bit2 name truncated
+  EJitAtomicU32 truncated;   ///< bit2 name truncated
   uint32_t nameLen;
   uint32_t irSize;
   uint32_t asmSize;
   uint32_t keyHi;
   uint32_t keyLo;
   uint32_t reserved0;
+  uintptr_t irPtr;
+  uintptr_t asmPtr;
   char name[kEJitSharedDumpNameBytes];
-  char ir[kEJitSharedDumpSlotTextBytes];
-  char asmText[kEJitSharedDumpSlotTextBytes];
 };
 
 struct alignas(kEJitSharedCacheLine) EJitSharedDumpState {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -23,9 +23,14 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <string>
+
+#ifdef EJIT_FREESTANDING
+extern "C" uint32_t SRE_TaskDelay(uint32_t tick);
+#endif
 
 #ifdef EJIT_FREESTANDING
 #include "llvm/ExecutionEngine/EJIT/EJitBareMetal.h"
@@ -141,17 +146,40 @@ using DumpMutexType = DumpSpinLock;
 using DumpMutexType = std::mutex;
 #endif
 
+#ifndef EJIT_DUMP_PRINT_THROTTLE_LINES
+#define EJIT_DUMP_PRINT_THROTTLE_LINES 16
+#endif
+
+#ifndef EJIT_DUMP_PRINT_THROTTLE_TICKS
+#define EJIT_DUMP_PRINT_THROTTLE_TICKS 1
+#endif
+
+static void throttleDumpPrint(unsigned printedLines) {
+#if defined(EJIT_FREESTANDING) && EJIT_DUMP_PRINT_THROTTLE_LINES > 0 &&        \
+    EJIT_DUMP_PRINT_THROTTLE_TICKS > 0
+  if (printedLines != 0 &&
+      (printedLines % EJIT_DUMP_PRINT_THROTTLE_LINES) == 0)
+    (void)SRE_TaskDelay(EJIT_DUMP_PRINT_THROTTLE_TICKS);
+#else
+  (void)printedLines;
+#endif
+}
+
 // Process-wide function-name filter for the IR+ASM diagnostic dump. Set via
 // ejit_dump_func() / setDumpFuncFilter(). Read in the IR transform layer.
 // A diagnostic: set before triggering the compile of interest; concurrent
 // set/read is benign (worst case a missed or extra dump).
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 EJitSharedTaskPoolState *gDumpSharedState = nullptr;
+static void clearSharedDumpSlots(EJitSharedDumpState &D);
 #endif
 static std::string gDumpFuncFilter;
+static void clearLocalDumpStore();
 
 void setDumpFuncFilter(const std::string &name) {
   gDumpFuncFilter = name;
+  if (name.empty())
+    clearLocalDumpStore();
   EJIT_DIAG_DEBUG("set_dump_filter value=%s &filter=%p",
             gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
             (void *)&gDumpFuncFilter);
@@ -171,14 +199,8 @@ void setDumpFuncFilter(const std::string &name) {
     D.filterName[len] = 0;
     D.filterLen = len;
     // A filter change invalidates all captured slots so stale results don't
-    // surface after re-arming.
-    for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-      D.slots[s].valid.storeRelease(0);
-      D.slots[s].nameLen = 0;
-      D.slots[s].irSize = 0;
-      D.slots[s].asmSize = 0;
-    }
-    D.nextSlot = 0;
+    // surface after re-arming. It also releases dynamic dump payloads.
+    clearSharedDumpSlots(D);
     D.filterEnabled.storeRelease(len ? 1u : 0u);
     D.lock.storeRelease(0);
     EJIT_DIAG_DEBUG("set_dump_filter shared enabled=%u len=%u &shared=%p",
@@ -191,8 +213,8 @@ void setDumpFuncFilter(const std::string &name) {
 void setDumpSharedState(EJitSharedTaskPoolState *state) {
   gDumpSharedState = state;
   EJIT_DIAG_DEBUG("set_dump_shared_state state=%p", (void *)state);
-  // If a filter was set before the shared state was bound — e.g. ejit_dump_all
-  // or ejit_dump_func called during the init_array phase, before ejit_init —
+  // If a filter was set before the shared state was bound — e.g. ejit_dump_func
+  // called during the init_array phase, before ejit_init —
   // propagate it into the now-bound shared state. Otherwise the owner worker
   // (possibly a different core) sees an empty shared filter and never captures,
   // even though the producer thinks dump is armed.
@@ -255,10 +277,16 @@ struct DumpEntry {
 static DumpMutexType gDumpMutex;
 static std::map<std::string, DumpEntry> gDumpStore;
 
+static void clearLocalDumpStore() {
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  gDumpStore.clear();
+}
+
 static void dumpBytesSafe(const char *label, const char *data, size_t n) {
   EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)n);
   size_t i = 0;
   unsigned lineNo = 0;
+  unsigned printedLines = 0;
   while (i < n) {
     size_t lineEnd = i;
     while (lineEnd < n && data[lineEnd] != '\n')
@@ -275,6 +303,7 @@ static void dumpBytesSafe(const char *label, const char *data, size_t n) {
         pos += chunk;
       }
     }
+    throttleDumpPrint(++printedLines);
     ++lineNo;
     i = lineEnd + 1;
   }
@@ -304,10 +333,70 @@ static uint32_t copyDumpBytes(char *dst, uint32_t cap, const char *src,
   return n;
 }
 
+static void freeSharedDumpPayload(EJitSharedDumpSlot &Slot) {
+  if (Slot.irPtr)
+    std::free(reinterpret_cast<void *>(Slot.irPtr));
+  if (Slot.asmPtr)
+    std::free(reinterpret_cast<void *>(Slot.asmPtr));
+  Slot.irPtr = 0;
+  Slot.asmPtr = 0;
+  Slot.irSize = 0;
+  Slot.asmSize = 0;
+}
+
+static void clearSharedDumpSlots(EJitSharedDumpState &D) {
+  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
+    EJitSharedDumpSlot &Slot = D.slots[s];
+    Slot.valid.storeRelease(0);
+    Slot.truncated.storeRelease(0);
+    Slot.nameLen = 0;
+    freeSharedDumpPayload(Slot);
+    Slot.keyHi = 0;
+    Slot.keyLo = 0;
+    Slot.reserved0 = 0;
+    for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
+      Slot.name[i] = 0;
+  }
+  D.nextSlot = 0;
+}
+
+static bool allocSharedDumpPayload(const std::string &Text, uintptr_t &Ptr,
+                                   uint32_t &Size) {
+  Ptr = 0;
+  Size = 0;
+  if (Text.empty())
+    return true;
+  if (Text.size() > 0xffffffffu)
+    return false;
+  char *Buf = static_cast<char *>(std::malloc(Text.size() + 1));
+  if (!Buf)
+    return false;
+  std::memcpy(Buf, Text.data(), Text.size());
+  Buf[Text.size()] = 0;
+  Ptr = reinterpret_cast<uintptr_t>(Buf);
+  Size = static_cast<uint32_t>(Text.size());
+  return true;
+}
+
 static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
                               const std::string &IR, const std::string &ASM) {
   if (!gDumpSharedState)
     return;
+  uintptr_t NewIR = 0;
+  uintptr_t NewASM = 0;
+  uint32_t NewIRSize = 0;
+  uint32_t NewASMSize = 0;
+  if (!allocSharedDumpPayload(IR, NewIR, NewIRSize) ||
+      !allocSharedDumpPayload(ASM, NewASM, NewASMSize)) {
+    if (NewIR)
+      std::free(reinterpret_cast<void *>(NewIR));
+    if (NewASM)
+      std::free(reinterpret_cast<void *>(NewASM));
+    EJIT_DIAG("capture shared failed func=%s ir=%u asm=%u: alloc failed",
+              fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size());
+    return;
+  }
+
   EJitSharedDumpState &D = gDumpSharedState->dump;
   sharedDumpLock(D);
   // Find an existing slot for fnName (overwrite it in place). Distinct names
@@ -335,23 +424,23 @@ static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
     D.nextSlot = (target + 1) % kEJitSharedDumpSlotCount;
   }
   EJitSharedDumpSlot &Slot = D.slots[target];
-  bool nameTrunc = false, irTrunc = false, asmTrunc = false;
+  bool nameTrunc = false;
   Slot.valid.storeRelease(0); // invalidate while writing (readers hold the lock)
+  freeSharedDumpPayload(Slot);
   Slot.nameLen = copyDumpBytes(Slot.name, kEJitSharedDumpNameBytes,
                                fnName.data(), fnName.size(), nameTrunc);
-  Slot.irSize = copyDumpBytes(Slot.ir, kEJitSharedDumpSlotTextBytes, IR.data(),
-                              IR.size(), irTrunc);
-  Slot.asmSize = copyDumpBytes(Slot.asmText, kEJitSharedDumpSlotTextBytes,
-                               ASM.data(), ASM.size(), asmTrunc);
+  Slot.irPtr = NewIR;
+  Slot.asmPtr = NewASM;
+  Slot.irSize = NewIRSize;
+  Slot.asmSize = NewASMSize;
   Slot.keyHi = (uint32_t)(cacheKey >> 32);
   Slot.keyLo = (uint32_t)(cacheKey & 0xffffffffu);
-  Slot.truncated.storeRelease((nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) |
-                              (asmTrunc ? 2u : 0u));
+  Slot.truncated.storeRelease(nameTrunc ? 4u : 0u);
   Slot.valid.storeRelease(1);
   sharedDumpUnlock(D);
   EJIT_DIAG_DEBUG("capture shared func=%s slot=%u ir=%u asm=%u trunc=0x%x &shared=%p",
             fnName.c_str(), target, (unsigned)IR.size(), (unsigned)ASM.size(),
-            (nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) | (asmTrunc ? 2u : 0u),
+            nameTrunc ? 4u : 0u,
             (void *)gDumpSharedState);
 }
 
@@ -378,12 +467,14 @@ static bool printSharedDumped(const char *name) {
     uint32_t trunc = Slot.truncated.loadAcquire();
     EJIT_DIAG("print_dumped shared hit requested=%s stored=%s slot=%u "
               "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u trunc=0x%x",
-              hasName ? name : "(all)", Slot.name, s, Slot.keyHi, Slot.keyLo,
+              hasName ? name : "(list)", Slot.name, s, Slot.keyHi, Slot.keyLo,
               Slot.irSize, Slot.asmSize, trunc);
-    if (Slot.irSize)
-      dumpBytesSafe("dump IR", Slot.ir, Slot.irSize);
-    if (Slot.asmSize)
-      dumpBytesSafe("dump ASM", Slot.asmText, Slot.asmSize);
+    if (hasName && Slot.irSize && Slot.irPtr)
+      dumpBytesSafe("dump IR", reinterpret_cast<const char *>(Slot.irPtr),
+                    Slot.irSize);
+    if (hasName && Slot.asmSize && Slot.asmPtr)
+      dumpBytesSafe("dump ASM", reinterpret_cast<const char *>(Slot.asmPtr),
+                    Slot.asmSize);
     any = true;
     if (hasName)
       break; // single-name query: done after the first match
@@ -391,7 +482,7 @@ static bool printSharedDumped(const char *name) {
   sharedDumpUnlock(D);
   if (!any)
     EJIT_DIAG_DEBUG("print_dumped shared miss name=%s &shared=%p",
-                    hasName ? name : "(all)", (void *)gDumpSharedState);
+                    hasName ? name : "(list)", (void *)gDumpSharedState);
   return any;
 }
 #endif
@@ -424,7 +515,7 @@ static void printOneDumpSafe(const char *requestedName,
   (void)keyLo;
   EJIT_DIAG("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
             "key_lo=0x%08x ir_size=%u asm_size=%u",
-            requestedName ? requestedName : "(all)", storedName.c_str(), keyHi,
+            requestedName ? requestedName : "(list)", storedName.c_str(), keyHi,
             keyLo, (unsigned)e.IR.size(), (unsigned)e.ASM.size());
   if (!e.IR.empty())
     dumpLinesSafe("dump IR", e.IR);
@@ -432,17 +523,16 @@ static void printOneDumpSafe(const char *requestedName,
     dumpLinesSafe("dump ASM", e.ASM);
 }
 
-/// Print the saved IR+ASM for \p name (or all saved entries when \p name is
-/// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no
-/// saved capture are reported as missing.
+/// Print the saved IR+ASM for \p name through EJIT_DIAG, one line per IR/ASM
+/// line. A null/empty name only lists saved entry names to avoid accidental
+/// large log storms.
 void printDumped(const char *name) {
   EJIT_DIAG_DEBUG("print_dumped enter name=%s &filter=%p &store=%p",
-            (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
+            (name && name[0]) ? name : "(list)", (void *)&gDumpFuncFilter,
             (void *)&gDumpStore);
   bool hasName = name && name[0];
-  // Try the local (owner-side, untruncated) store first — it has the full
-  // IR/ASM for every captured function. For a specific name this is a direct
-  // hit on the owner core; for "print all" it lists every capture in full.
+  // Try the local store first. A specific name prints the full local payload;
+  // an empty name only lists available entries.
   {
     std::lock_guard<DumpMutexType> lock(gDumpMutex);
     if (hasName) {
@@ -452,16 +542,23 @@ void printDumped(const char *name) {
         return;
       }
     } else if (!gDumpStore.empty()) {
-      for (auto &kv : gDumpStore)
-        printOneDumpSafe(nullptr, kv.first, kv.second);
+      EJIT_DIAG("print_dumped saved entries=%u", (unsigned)gDumpStore.size());
+      for (auto &kv : gDumpStore) {
+        (void)kv;
+        EJIT_DIAG("print_dumped saved name=%s key_hi=0x%08x key_lo=0x%08x "
+                  "ir_size=%u asm_size=%u",
+                  kv.first.c_str(), (uint32_t)(kv.second.cacheKey >> 32),
+                  (uint32_t)(kv.second.cacheKey & 0xffffffffu),
+                  (unsigned)kv.second.IR.size(), (unsigned)kv.second.ASM.size());
+      }
       return;
     }
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   // Local miss / empty (e.g. a non-owner core, whose per-core gDumpStore is
   // empty): serve from the cross-core shared per-name table. The table holds
-  // the last N captured functions (truncated to the slot text size); a specific
-  // name retrieves its slot, NULL lists all of them.
+  // the last N captured functions. A specific name retrieves its payload;
+  // NULL lists metadata only.
   if (printSharedDumped(name))
     return;
 #endif
@@ -644,22 +741,20 @@ EJitOrcEngine::Create(const Config &config,
           // ejit_print_dumped(). Bare-metal-safe (strings only, no
           // raw_fd_ostream). Captures the post-optimization IR and the emitted
           // assembly (from the same TargetMachine the JIT compiles with).
-          // The filter value "*" is a wildcard: every specialization is captured
-          // (ejit_dump_all(true) sets it). The local gDumpStore keeps one entry
-          // per function name (overwritten on re-compile), so dump-all is
-          // bounded by the number of distinct entry functions; the cross-core
-          // shared result keeps only the latest capture (see ejit_print_dumped).
+          // Capture is exact-name only. The local gDumpStore keeps one dynamic
+          // IR/ASM payload per captured function name (overwritten on
+          // re-compile); the shared dump table keeps cross-core visible dynamic
+          // payloads for recent captures.
           {
             std::string DumpFilter;
             bool hasFilter = getActiveDumpFilter(DumpFilter);
-            bool wildcard = hasFilter && DumpFilter == "*";
-            bool match = wildcard || (hasFilter && ctx->fnName == DumpFilter);
+            bool match = hasFilter && ctx->fnName == DumpFilter;
             EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
-                            "key_lo=0x%08x match=%d wildcard=%d &filter=%p",
+                            "key_lo=0x%08x match=%d &filter=%p",
                             hasFilter ? DumpFilter.c_str() : "(off)",
                             ctx->fnName.c_str(), (uint32_t)(ctx->cacheKey >> 32),
                             (uint32_t)(ctx->cacheKey & 0xffffffffu), match ? 1 : 0,
-                            wildcard ? 1 : 0, (void *)&gDumpFuncFilter);
+                            (void *)&gDumpFuncFilter);
             if (match) {
               // IR capture always runs first so it succeeds even if the ASM
               // diagnostic path is disabled or fails.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -905,7 +905,7 @@ void ejit_dump_func(const char *name) {
 
 void ejit_print_dumped(const char *name) {
   // gDumpSharedState is bound once in ejit_init; no per-call rebind needed.
-  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(all)");
+  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(list)");
   printDumped(name);
 }
 
@@ -929,19 +929,6 @@ uint32_t ejit_taskpool_get_worker_core() {
   // a private per-instance taskpool has no cross-core owner to report.
   return kEJitInvalidOwnerCore;
 #endif
-}
-
-//===----------------------------------------------------------------------===//
-// General diagnostics (available in every build, not only taskpool).
-//===----------------------------------------------------------------------===//
-
-void ejit_dump_all(bool enable) {
-  // gDumpSharedState is bound once in ejit_init; no per-call rebind needed.
-  // The "*" filter is a wildcard matched by every specialization in the IR
-  // transform layer (see getActiveDumpFilter / the capture condition). Capture
-  // is bounded by distinct function names; print with ejit_print_dumped(NULL).
-  EJIT_DIAG("dump_all enable=%u", enable ? 1u : 0u);
-  setDumpFuncFilter(enable ? std::string("*") : std::string());
 }
 
 void ejit_set_log_level(ejit_log_level_t level) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
+#include <cstdlib>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -926,6 +927,10 @@ namespace {
 // the non-shared EJitRuntimeState::isActive default (no entry => inactive).
 // setInstanceEnabled(true) flips 0->1 and bumps version on first activate.
 void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
+  bool canFreeDumpPayload =
+      st->magic == kEJitSharedAbiMagic &&
+      st->abiVersion == kEJitSharedAbiVersion &&
+      st->structSize == sizeof(EJitSharedTaskPoolState);
   for (uint32_t d = 0; d < kEJitSharedDimTypes; ++d)
     for (uint32_t i = 0; i < kEJitSharedInstances; ++i) {
       st->enabled[d][i].storeRelaxed(0);
@@ -988,12 +993,14 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
     Slot.keyHi = 0;
     Slot.keyLo = 0;
     Slot.reserved0 = 0;
+    if (canFreeDumpPayload && Slot.irPtr)
+      std::free(reinterpret_cast<void *>(Slot.irPtr));
+    if (canFreeDumpPayload && Slot.asmPtr)
+      std::free(reinterpret_cast<void *>(Slot.asmPtr));
+    Slot.irPtr = 0;
+    Slot.asmPtr = 0;
     for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
       Slot.name[i] = 0;
-    for (uint32_t i = 0; i < kEJitSharedDumpSlotTextBytes; ++i) {
-      Slot.ir[i] = 0;
-      Slot.asmText[i] = 0;
-    }
   }
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     st->buckets[b].writeFlag.storeRelaxed(0);

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -677,7 +677,6 @@ extern void ejit_register_static_var(const char *, void *);
 extern void ejit_register_lifecycle(const char *, uint32_t *);
 extern void ejit_set_log_level(int level);
 extern int ejit_get_log_level(void);
-extern void ejit_dump_all(bool enable);
 extern void ejit_print_registry(void);
 extern void ejit_print_func_meta(const char *funcName);
 // P0 diagnostics: code pool stats + active period map. Declared returning int
@@ -2793,7 +2792,7 @@ TEST(EJitPipelineIR, PeriodIndexReplacementAndFold) {
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
-// Log level + diagnostics C-API (ejit_set_log_level, ejit_dump_all,
+// Log level + diagnostics C-API (ejit_set_log_level,
 // ejit_print_registry, ejit_print_func_meta)
 //===----------------------------------------------------------------------===//
 
@@ -2817,12 +2816,6 @@ TEST(EJitDiagLogLevel, ClampsOutOfRange) {
   ejit_set_log_level(99);
   EXPECT_EQ(ejit_get_log_level(), 3);
   ejit_set_log_level(1); // restore
-}
-
-// ejit_dump_all must not crash whether or not the runtime is initialized.
-TEST(EJitDumpAll, ToggleWithoutCrash) {
-  ejit_dump_all(true);
-  ejit_dump_all(false);
 }
 
 // Registry / func-meta prints must not crash on an uninitialized runtime and on

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -16,6 +16,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "gtest/gtest.h"
+#include <cstdlib>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -1571,11 +1572,12 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
   EXPECT_TRUE(r.readyButNotShareable);
 }
 
-// 16/17 ABI v5 layout: the slot carries the executable range as fixed-width,
+// 16/17 ABI v6 layout: the slot carries the executable range as fixed-width,
 // naturally-aligned scalars (read back by value — endian-safe), and the
-// pool-split table is POD.
+// pool-split table is POD. v6 also changes dump slots from fixed text buffers
+// to dynamic payload pointers.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 5u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 6u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -1601,6 +1603,43 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   EXPECT_EQ(slot->poolSize, 0x200000ull);
   EXPECT_EQ(slot->poolId, 7u);
   EXPECT_EQ(slot->rangeReserved, 0u);
+}
+
+TEST_F(SharedTaskPoolTest, DumpDynamicPayloadsClearedOnInit) {
+  state_->magic = kEJitSharedAbiMagic;
+  state_->abiVersion = kEJitSharedAbiVersion;
+  state_->structSize = sizeof(EJitSharedTaskPoolState);
+
+  char *IR = static_cast<char *>(std::malloc(8));
+  char *ASM = static_cast<char *>(std::malloc(8));
+  ASSERT_NE(IR, nullptr);
+  ASSERT_NE(ASM, nullptr);
+  state_->dump.slots[0].valid.storeRelaxed(1);
+  state_->dump.slots[0].truncated.storeRelaxed(7);
+  state_->dump.slots[0].nameLen = 4;
+  state_->dump.slots[0].irPtr = reinterpret_cast<uintptr_t>(IR);
+  state_->dump.slots[0].asmPtr = reinterpret_cast<uintptr_t>(ASM);
+  state_->dump.slots[0].irSize = 7;
+  state_->dump.slots[0].asmSize = 7;
+  state_->dump.slots[0].keyHi = 0x12;
+  state_->dump.slots[0].keyLo = 0x34;
+  state_->dump.slots[0].name[0] = 'f';
+  state_->dump.nextSlot = 1;
+
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+
+  EXPECT_EQ(state_->dump.slots[0].valid.loadRelaxed(), 0u);
+  EXPECT_EQ(state_->dump.slots[0].truncated.loadRelaxed(), 0u);
+  EXPECT_EQ(state_->dump.slots[0].nameLen, 0u);
+  EXPECT_EQ(state_->dump.slots[0].irPtr, 0u);
+  EXPECT_EQ(state_->dump.slots[0].asmPtr, 0u);
+  EXPECT_EQ(state_->dump.slots[0].irSize, 0u);
+  EXPECT_EQ(state_->dump.slots[0].asmSize, 0u);
+  EXPECT_EQ(state_->dump.slots[0].keyHi, 0u);
+  EXPECT_EQ(state_->dump.slots[0].keyLo, 0u);
+  EXPECT_EQ(state_->dump.slots[0].name[0], 0);
+  EXPECT_EQ(state_->dump.nextSlot, 0u);
 }
 
 // 18/ Code-sharing OFF in 4K mode: a non-owner cleanly rejects and triggers NO


### PR DESCRIPTION
## Summary

This PR keeps the EJIT IR/ASM dump path cross-core visible, but removes the fixed-size shared text buffers and the dump-all workflow.

New behavior:

- `ejit_dump_func("func_name")` arms exact-name capture only.
- When that function is JIT-compiled, IR/ASM payloads are dynamically allocated to the actual generated text size.
- Shared dump slots store name + key + sizes + shared-visible IR/ASM payload pointers.
- `ejit_print_dumped("func_name")` can print from another core through the shared slot.
- `ejit_print_dumped(NULL)` / empty only lists saved names and sizes; it does not dump all payload text.
- `ejit_dump_all` and the `"*"` wildcard path are removed.

## Why

The previous fixed shared buffers were too small/rigid for real IR/ASM and could truncate useful output. The desired debug flow is still cross-core visible, but scoped to one function at a time. Dynamic allocation keeps shared-state size small while preserving full payloads for the selected function.

## Notes

- Shared ABI version is bumped from v5 to v6 because dump slots now store dynamic payload pointers instead of fixed text arrays.
- Slot overwrite frees the previous payloads. Shared-state reinit frees old payloads only when the blob is already known to be the same ABI, avoiding accidental free of stale/foreign layouts.
- This revision was rebuilt as a clean minimal diff to avoid unrelated clang-format indentation churn.

## Validation

- `rg` check: no `ejit_dump_all`, wildcard capture, fixed dump text buffer symbols, or old `asmText` slot buffers remain in EJIT runtime/orc/lipo code.
- `git diff --check`
- `python3 -m py_compile ejit_test/lipo/lipo.py`
- Single-TU compile checks using an existing AArch64 build command for:
  - `EJitOrcEngine.cpp`
  - `EJitSharedTaskPool.cpp`

No full LLVM rebuild was run in this fresh worktree.