### PR TITLE
[EJIT] Fix miscompilation for i128 type

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -180,15 +180,16 @@ static Constant *createConstantFromMemory(const void *addr, Type *Ty,
   unsigned byteSize = DL.getTypeStoreSize(Ty);
 
   if (Ty->isIntegerTy()) {
-    APInt val(byteSize * 8, 0);
-    if (byteSize <= 8) {
-      uint64_t raw = 0;
-      std::memcpy(&raw, addr, byteSize);
-      if (!DL.isLittleEndian())
-        raw >>= (8 - byteSize) * 8;
-      val = APInt(byteSize * 8, raw);
-    }
-    return ConstantInt::get(Ty, val);
+    // Only integers that fit in a single 64-bit word are materialized here.
+    // Wider integers (e.g. __int128, or _BitInt(N) with N > 64) are left
+    // un-substituted.
+    if (byteSize > 8)
+      return nullptr;
+    uint64_t raw = 0;
+    std::memcpy(&raw, addr, byteSize);
+    if (!DL.isLittleEndian())
+      raw >>= (8 - byteSize) * 8;
+    return ConstantInt::get(Ty, APInt(byteSize * 8, raw));
   }
   if (Ty->isFloatTy()) {
     float v;


### PR DESCRIPTION
Although we probably are not going to have any i128 constants, if we have the following code snippet:
```
struct BigCfg {
    attribute((ejit_may_const)) unsigned __int128 big;
};

#define N 8
attribute((ejit_period_arr("bigcfg"))) struct BigCfg g_big[N];
```
where we have an `__int128` with the `ejit_may_const` attribute, and then we initialize it with some huge value like:
```
unsigned __int128 val = ((unsigned __int128)0xA1A2A3A4B1B2B3B4ULL << 64) | 0xC1C2C3C4D1D2D3D4ULL;
g_big[0].big = val;
```
then `ejit_activate`, this i128 value gets substituted with a zero value, which is completely wrong!

In the struct field pass, our create-constant-from-memory helper does something like this for integer types:
```
if (Ty->isIntegerTy()) {
    APInt val(byteSize * 8, 0);           <-- val is set to 0 here
    if (byteSize <= 8) {
        uint64_t raw = 0;
        std::memcpy(&raw, addr, byteSize);
        if (!DL.isLittleEndian())
        raw >>= (8 - byteSize) * 8;
        val = APInt(byteSize * 8, raw);
    }
    return ConstantInt::get(Ty, val);     <-- this returns val=0 because byteSize>8, since this is an int128
}
```

We should return `nullptr` (or otherwise bail) in cases like this, so we leave the load untouched instead of substituting a wrong constant and silently miscompiling. It is easy to imagine someone annotating and `__int128` field this way without realizing it is unsupported. This patch fixes that.
