### PR TITLE
[EJIT] Add wrapper timing diagnostics

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -365,7 +365,6 @@ def doit_gc_merge(args):
         # EJIT_SRE_TASKPOOL ifdef in EJitRuntime.cpp).
         "ejit_set_log_level", "ejit_get_log_level",
         "ejit_print_registry", "ejit_print_func_meta",
-        "ejit_dump_all",
         "ejit_get_code_pool_stats", "ejit_print_code_pool_stats",
         "ejit_print_active",
     ]

--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -376,7 +376,8 @@ def doit_gc_merge(args):
         "ejit_taskpool_compile_or_get_4d",
         "ejit_taskpool_set_instance_enabled", "ejit_taskpool_pending_count",
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
-        "ejit_taskpool_print_compiled", "ejit_dump_func", "ejit_print_dumped"
+        "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
+        "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped"
     ]
 
     defined = set()

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -581,7 +581,7 @@ if(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
 endif()
 
 # Re-enable textual assembly (.s) emission for the JIT IR/ASM diagnostic dump
-# (ejit_dump_func / ejit_dump_all) even in an EJIT_TRIM_LLVM_BACKEND build.
+# (ejit_dump_func / ejit_print_dumped) even in an EJIT_TRIM_LLVM_BACKEND build.
 # The trim normally #ifdef's out the AssemblyFile codegen path
 # (CodeGenTargetMachineImpl::createMCStreamer) to save image size; this option
 # overrides that so ejit_print_dumped can produce ASM on target. Cost: the

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -72,6 +72,9 @@ constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_3D =
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_4D =
     "ejit_taskpool_compile_or_get_4d";
 constexpr const char *FN_TASKPOOL_RELEASE_READ = "ejit_taskpool_release_read";
+constexpr const char *FN_TASKPOOL_TRACE_NOW = "ejit_taskpool_trace_now";
+constexpr const char *FN_TASKPOOL_TRACE_WRAPPER =
+    "ejit_taskpool_trace_wrapper";
 // Lifecycle activation is keyed by period/lifecycle name + instance index only.
 // PASS4 emits these name-level calls at ejit_period_lc entry/exit; there is no
 // array-pointer dimension in the active-state hot path.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -248,29 +248,14 @@ uint32_t ejit_taskpool_get_worker_core();
 /// non-empty, the next time a specialization whose entry name exactly matches
 /// \p name is JIT-compiled, the engine saves (in memory) its post-optimization
 /// IR and emitted assembly for later printing. Pass NULL or "" to disable
-/// further capture (already-saved entries are retained). The special name "*"
-/// is a wildcard that captures EVERY specialization (see ejit_dump_all). For
-/// performance analysis of individual functions.
+/// further capture (already-saved entries are retained). Capture is exact-name
+/// only, and shared IR/ASM payloads are allocated to the generated text size.
 void ejit_dump_func(const char *name);
 
-/// Print the saved IR+ASM for \p name (or all saved entries when \p name is
-/// NULL or "") through the platform log, one line per IR/ASM line, labeled
-/// "dump IR func=..." / "dump ASM func=...". Names with no saved capture are
-/// reported as missing. Paired with ejit_dump_func(): capture at compile
-/// time, print selectively later.
+/// Print the saved IR+ASM for \p name through the platform log, one line per
+/// IR/ASM line. Names with no saved capture are reported as missing. Passing
+/// NULL or "" only lists captured names; it does not dump all payloads.
 void ejit_print_dumped(const char *name);
-
-/// Convenience switch to capture IR+ASM for ALL JIT-compiled specializations
-/// (equivalent to ejit_dump_func("*")). When \p enable is true, every
-/// specialization's post-optimization IR and emitted assembly is saved (one
-/// entry per function name, overwritten on re-compile, so the store is bounded
-/// by the number of distinct entry functions); print later with
-/// ejit_print_dumped(NULL). When false, capture is disabled. NOTE: on a
-/// cross-core shared taskpool the captures live on the owner core (the one
-/// that runs the JIT worker); print from the owner core to see all entries,
-/// or use ejit_dump_func(name) for a single function whose capture is shared
-/// across cores.
-void ejit_dump_all(bool enable);
 
 /// Runtime diagnostic log level. Mirrors the EJIT_DIAG* macro thresholds.
 ///   EJIT_LOG_OFF    — no diagnostic output

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -211,6 +211,21 @@ void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
 void ejit_taskpool_release_read(uint32_t bucketIndex);
 unsigned ejit_taskpool_pending_count(void);
 
+// Diagnostic wrapper timing helpers. AOT wrappers only call these when built
+// with -ejit-wrapper-timing. Runtime aggregates repeated calls and prints one
+// summary per EJIT_WRAPPER_TIMING_REPORT_EVERY samples (default 1024; set to 0
+// to suppress periodic output) to avoid flooding board logs. The timestamp unit
+// is platform-defined: aarch64 uses CNTVCT_EL0 cycles/ticks, host fallback uses
+// nanoseconds.
+uint64_t ejit_taskpool_trace_now(void);
+void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
+                                 void *fnPtr, uint32_t bucketIndex,
+                                 uint64_t tBeforeLookup,
+                                 uint64_t tAfterLookup,
+                                 uint64_t tBeforeFn,
+                                 uint64_t tAfterFn,
+                                 uint64_t tAfterRelease);
+
 #ifdef EJIT_SRE_TASKPOOL_TESTING
 unsigned ejit_taskpool_poll_one(void);
 unsigned ejit_taskpool_poll_budget(unsigned maxItems);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -215,8 +215,8 @@ unsigned ejit_taskpool_pending_count(void);
 // with -ejit-wrapper-timing. Runtime aggregates repeated calls and prints one
 // summary per EJIT_WRAPPER_TIMING_REPORT_EVERY samples (default 1024; set to 0
 // to suppress periodic output) to avoid flooding board logs. The timestamp unit
-// is platform-defined: aarch64 uses CNTVCT_EL0 cycles/ticks, host fallback uses
-// nanoseconds.
+// is platform-defined: SRE/freestanding builds use SRE_CycleCountGet64(), host
+// fallback uses steady_clock nanoseconds.
 uint64_t ejit_taskpool_trace_now(void);
 void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
                                  void *fnPtr, uint32_t bucketIndex,

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -66,7 +66,9 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// (codeStart/codeSize/poolBase/poolSize/poolId) and the shared state gains a
 /// per-core, per-pool 4K split-readiness table, so a non-owner core in 4K-seal
 /// mode can split its pool once and seal exactly the pages the code covers.
-constexpr uint32_t kEJitSharedAbiVersion = 5u;
+/// v6: dump slots carry dynamic IR/ASM payload pointers instead of fixed text
+/// buffers.
+constexpr uint32_t kEJitSharedAbiVersion = 6u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -67,7 +67,10 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// per-core, per-pool 4K split-readiness table, so a non-owner core in 4K-seal
 /// mode can split its pool once and seal exactly the pages the code covers.
 /// v6: dump slots carry dynamic IR/ASM payload pointers instead of fixed text
-/// buffers.
+/// buffers, and each cache bucket carries a monotonic publishSeq word used by
+/// the optional EJIT_SRE_TASKPOOL_NO_RECLAIM seqlock reader (load-only hot-hit
+/// path with no per-hit read-token RMW). The field exists in every build for a
+/// stable layout; it is only written when NO_RECLAIM is enabled.
 constexpr uint32_t kEJitSharedAbiVersion = 6u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -391,6 +391,15 @@ private:
     uint32_t bucketIndex = 0;
     bool hasReadToken = false;
     bool readyButNotShareable = false;
+    /// EJIT_SRE_TASKPOOL_NO_RECLAIM only: a validated seqlock hit that holds NO
+    /// read token. classifyHit() treats it as a CacheHit; bucketIndex is the
+    /// out-of-range sentinel (kEJitSharedCacheBuckets) so the wrapper's
+    /// releaseRead() is a safe no-op (its range check rejects it).
+    bool noTokenHit = false;
+    /// Set by peerPrepareSlot() when the pointer came from the out-of-line cold
+    /// first-touch path (which self-revalidates), so the seqlock caller must not
+    /// second-guess it with the bucket publishSeq check.
+    bool coldPrepared = false;
   };
 
   // shared cache helpers (POD table in the shared blob)
@@ -398,6 +407,13 @@ private:
                         uint32_t numDims) const;
   SharedLookup cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
                            uint32_t numDims);
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  /// Load-only seqlock cache lookup (no per-hit read-token RMW). Returned hits
+  /// carry no read token (SharedLookup::noTokenHit). See the .cpp for the
+  /// never-free safety precondition.
+  SharedLookup cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
+                              uint32_t numDims);
+#endif
   /// Fixed-dimension specializations of cacheLookup() (0-4 dims). Identity
   /// hashing, slot identity comparison, and version comparison are all unrolled
   /// (no numDims loops, no dims[] indexing), so a cache hit reaches the shared

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -180,7 +180,16 @@ struct EJitSharedCacheSlot {
 //===----------------------------------------------------------------------===//
 struct alignas(kEJitSharedCacheLine) EJitSharedCacheBucket {
   EJitAtomicU32 writeFlag; ///< 0 = free, 1 = writer holds/pending
-  EJitAtomicU32 readers;   ///< active reader count
+  EJitAtomicU32 readers;   ///< active reader count (token model)
+  /// Monotonic publish sequence for the EJIT_SRE_TASKPOOL_NO_RECLAIM seqlock
+  /// reader: the publisher makes it ODD before writing a slot and EVEN after
+  /// (see bucketWrite/bucketWriteRelease). A load-only reader captures it before
+  /// its scan and re-checks it after loading fnPtr; an unequal/odd value means a
+  /// publish raced the read, so the reader discards and cleanly falls back. Zero
+  /// per-hit atomic RMW on this line (unlike the token's readers counter). Only
+  /// bumped in a NO_RECLAIM build; stays 0 otherwise, so the default token path
+  /// is byte-for-byte unchanged.
+  EJitAtomicU32 publishSeq;
   EJitSharedCacheSlot slots[kEJitSharedCacheSlots];
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -73,17 +73,11 @@
 #ifndef EJIT_SRE_SHARED_DUMP_NAME_BYTES
 #define EJIT_SRE_SHARED_DUMP_NAME_BYTES 128u
 #endif
-// Per-slot IR/ASM text capacity in the cross-core dump table (each slot holds
-// one captured function's name + IR + ASM, truncated to this size per text).
-#ifndef EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES
-#define EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES 8192u
-#endif
 // Number of per-name result slots in the cross-core dump table. Each captured
 // specialization occupies one slot keyed by entry name; when full, the oldest
 // slot is round-robin evicted. Covers this many distinct functions for
-// cross-core ejit_print_dumped(name) retrieval. NOTE: the table lives in the
-// fixed shared section, so sizeof(EJitSharedTaskPoolState) scales with
-// SLOT_COUNT * (2 * SLOT_TEXT_BYTES); resize the linker section accordingly.
+// cross-core ejit_print_dumped(name) retrieval. The table stores pointers to
+// dynamically allocated IR/ASM payloads, not fixed text buffers.
 #ifndef EJIT_SRE_SHARED_DUMP_SLOT_COUNT
 #define EJIT_SRE_SHARED_DUMP_SLOT_COUNT 50u
 #endif
@@ -103,8 +97,6 @@ constexpr uint32_t kEJitSharedQueueSlots = EJIT_SRE_TASKPOOL_QUEUE_CAPACITY;
 constexpr uint32_t kEJitSharedPoolSlots = EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS;
 constexpr uint32_t kEJitSharedDumpNameBytes =
     EJIT_SRE_SHARED_DUMP_NAME_BYTES;
-constexpr uint32_t kEJitSharedDumpSlotTextBytes =
-    EJIT_SRE_SHARED_DUMP_SLOT_TEXT_BYTES;
 constexpr uint32_t kEJitSharedDumpSlotCount =
     EJIT_SRE_SHARED_DUMP_SLOT_COUNT;
 constexpr uint32_t kEJitSharedCacheLine = 64u;
@@ -219,31 +211,28 @@ struct EJitSharedPoolSplit {
 };
 
 //===----------------------------------------------------------------------===//
-// EJitSharedDumpState: fixed-size cross-core diagnostic exchange.
+// EJitSharedDumpState: cross-core diagnostic exchange.
 //
 // The owner worker captures IR/ASM in its private ORC path, but shell/debug
 // requests can arrive on a different core. std::map/std::string cannot live in
 // shared memory, so the shared path uses one bounded filter plus a bounded
 // per-name result TABLE: each captured specialization occupies one slot keyed
 // by entry name; when the table is full the oldest slot is round-robin
-// evicted. This lets a non-owner core retrieve any recently-captured function
-// by name (not just the latest). It is diagnostic-only: long IR/ASM is
-// truncated (per-slot) instead of blocking normal JIT progress; the full,
-// untruncated IR/ASM remains available on the owner core via the per-core
-// gDumpStore + ejit_print_dumped(NULL).
+// evicted. IR/ASM payloads are allocated dynamically to their actual text size,
+// and the slot stores shared-visible pointers plus sizes.
 //===----------------------------------------------------------------------===//
 struct alignas(kEJitSharedCacheLine) EJitSharedDumpSlot {
   EJitAtomicU32 valid;       ///< 1 => name/ir/asm hold a capture
-  EJitAtomicU32 truncated;   ///< bit0 IR, bit1 ASM, bit2 name truncated
+  EJitAtomicU32 truncated;   ///< bit2 name truncated
   uint32_t nameLen;
   uint32_t irSize;
   uint32_t asmSize;
   uint32_t keyHi;
   uint32_t keyLo;
   uint32_t reserved0;
+  uintptr_t irPtr;
+  uintptr_t asmPtr;
   char name[kEJitSharedDumpNameBytes];
-  char ir[kEJitSharedDumpSlotTextBytes];
-  char asmText[kEJitSharedDumpSlotTextBytes];
 };
 
 struct alignas(kEJitSharedCacheLine) EJitSharedDumpState {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -23,9 +23,14 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <string>
+
+#ifdef EJIT_FREESTANDING
+extern "C" uint32_t SRE_TaskDelay(uint32_t tick);
+#endif
 
 #ifdef EJIT_FREESTANDING
 #include "llvm/ExecutionEngine/EJIT/EJitBareMetal.h"
@@ -141,17 +146,40 @@ using DumpMutexType = DumpSpinLock;
 using DumpMutexType = std::mutex;
 #endif
 
+#ifndef EJIT_DUMP_PRINT_THROTTLE_LINES
+#define EJIT_DUMP_PRINT_THROTTLE_LINES 16
+#endif
+
+#ifndef EJIT_DUMP_PRINT_THROTTLE_TICKS
+#define EJIT_DUMP_PRINT_THROTTLE_TICKS 1
+#endif
+
+static void throttleDumpPrint(unsigned printedLines) {
+#if defined(EJIT_FREESTANDING) && EJIT_DUMP_PRINT_THROTTLE_LINES > 0 &&        \
+    EJIT_DUMP_PRINT_THROTTLE_TICKS > 0
+  if (printedLines != 0 &&
+      (printedLines % EJIT_DUMP_PRINT_THROTTLE_LINES) == 0)
+    (void)SRE_TaskDelay(EJIT_DUMP_PRINT_THROTTLE_TICKS);
+#else
+  (void)printedLines;
+#endif
+}
+
 // Process-wide function-name filter for the IR+ASM diagnostic dump. Set via
 // ejit_dump_func() / setDumpFuncFilter(). Read in the IR transform layer.
 // A diagnostic: set before triggering the compile of interest; concurrent
 // set/read is benign (worst case a missed or extra dump).
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 EJitSharedTaskPoolState *gDumpSharedState = nullptr;
+static void clearSharedDumpSlots(EJitSharedDumpState &D);
 #endif
 static std::string gDumpFuncFilter;
+static void clearLocalDumpStore();
 
 void setDumpFuncFilter(const std::string &name) {
   gDumpFuncFilter = name;
+  if (name.empty())
+    clearLocalDumpStore();
   EJIT_DIAG_DEBUG("set_dump_filter value=%s &filter=%p",
             gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
             (void *)&gDumpFuncFilter);
@@ -171,14 +199,8 @@ void setDumpFuncFilter(const std::string &name) {
     D.filterName[len] = 0;
     D.filterLen = len;
     // A filter change invalidates all captured slots so stale results don't
-    // surface after re-arming.
-    for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-      D.slots[s].valid.storeRelease(0);
-      D.slots[s].nameLen = 0;
-      D.slots[s].irSize = 0;
-      D.slots[s].asmSize = 0;
-    }
-    D.nextSlot = 0;
+    // surface after re-arming. It also releases dynamic dump payloads.
+    clearSharedDumpSlots(D);
     D.filterEnabled.storeRelease(len ? 1u : 0u);
     D.lock.storeRelease(0);
     EJIT_DIAG_DEBUG("set_dump_filter shared enabled=%u len=%u &shared=%p",
@@ -191,8 +213,8 @@ void setDumpFuncFilter(const std::string &name) {
 void setDumpSharedState(EJitSharedTaskPoolState *state) {
   gDumpSharedState = state;
   EJIT_DIAG_DEBUG("set_dump_shared_state state=%p", (void *)state);
-  // If a filter was set before the shared state was bound — e.g. ejit_dump_all
-  // or ejit_dump_func called during the init_array phase, before ejit_init —
+  // If a filter was set before the shared state was bound — e.g. ejit_dump_func
+  // called during the init_array phase, before ejit_init —
   // propagate it into the now-bound shared state. Otherwise the owner worker
   // (possibly a different core) sees an empty shared filter and never captures,
   // even though the producer thinks dump is armed.
@@ -255,10 +277,16 @@ struct DumpEntry {
 static DumpMutexType gDumpMutex;
 static std::map<std::string, DumpEntry> gDumpStore;
 
+static void clearLocalDumpStore() {
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  gDumpStore.clear();
+}
+
 static void dumpBytesSafe(const char *label, const char *data, size_t n) {
   EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)n);
   size_t i = 0;
   unsigned lineNo = 0;
+  unsigned printedLines = 0;
   while (i < n) {
     size_t lineEnd = i;
     while (lineEnd < n && data[lineEnd] != '\n')
@@ -275,6 +303,7 @@ static void dumpBytesSafe(const char *label, const char *data, size_t n) {
         pos += chunk;
       }
     }
+    throttleDumpPrint(++printedLines);
     ++lineNo;
     i = lineEnd + 1;
   }
@@ -304,10 +333,70 @@ static uint32_t copyDumpBytes(char *dst, uint32_t cap, const char *src,
   return n;
 }
 
+static void freeSharedDumpPayload(EJitSharedDumpSlot &Slot) {
+  if (Slot.irPtr)
+    std::free(reinterpret_cast<void *>(Slot.irPtr));
+  if (Slot.asmPtr)
+    std::free(reinterpret_cast<void *>(Slot.asmPtr));
+  Slot.irPtr = 0;
+  Slot.asmPtr = 0;
+  Slot.irSize = 0;
+  Slot.asmSize = 0;
+}
+
+static void clearSharedDumpSlots(EJitSharedDumpState &D) {
+  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
+    EJitSharedDumpSlot &Slot = D.slots[s];
+    Slot.valid.storeRelease(0);
+    Slot.truncated.storeRelease(0);
+    Slot.nameLen = 0;
+    freeSharedDumpPayload(Slot);
+    Slot.keyHi = 0;
+    Slot.keyLo = 0;
+    Slot.reserved0 = 0;
+    for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
+      Slot.name[i] = 0;
+  }
+  D.nextSlot = 0;
+}
+
+static bool allocSharedDumpPayload(const std::string &Text, uintptr_t &Ptr,
+                                   uint32_t &Size) {
+  Ptr = 0;
+  Size = 0;
+  if (Text.empty())
+    return true;
+  if (Text.size() > 0xffffffffu)
+    return false;
+  char *Buf = static_cast<char *>(std::malloc(Text.size() + 1));
+  if (!Buf)
+    return false;
+  std::memcpy(Buf, Text.data(), Text.size());
+  Buf[Text.size()] = 0;
+  Ptr = reinterpret_cast<uintptr_t>(Buf);
+  Size = static_cast<uint32_t>(Text.size());
+  return true;
+}
+
 static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
                               const std::string &IR, const std::string &ASM) {
   if (!gDumpSharedState)
     return;
+  uintptr_t NewIR = 0;
+  uintptr_t NewASM = 0;
+  uint32_t NewIRSize = 0;
+  uint32_t NewASMSize = 0;
+  if (!allocSharedDumpPayload(IR, NewIR, NewIRSize) ||
+      !allocSharedDumpPayload(ASM, NewASM, NewASMSize)) {
+    if (NewIR)
+      std::free(reinterpret_cast<void *>(NewIR));
+    if (NewASM)
+      std::free(reinterpret_cast<void *>(NewASM));
+    EJIT_DIAG("capture shared failed func=%s ir=%u asm=%u: alloc failed",
+              fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size());
+    return;
+  }
+
   EJitSharedDumpState &D = gDumpSharedState->dump;
   sharedDumpLock(D);
   // Find an existing slot for fnName (overwrite it in place). Distinct names
@@ -335,23 +424,23 @@ static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
     D.nextSlot = (target + 1) % kEJitSharedDumpSlotCount;
   }
   EJitSharedDumpSlot &Slot = D.slots[target];
-  bool nameTrunc = false, irTrunc = false, asmTrunc = false;
+  bool nameTrunc = false;
   Slot.valid.storeRelease(0); // invalidate while writing (readers hold the lock)
+  freeSharedDumpPayload(Slot);
   Slot.nameLen = copyDumpBytes(Slot.name, kEJitSharedDumpNameBytes,
                                fnName.data(), fnName.size(), nameTrunc);
-  Slot.irSize = copyDumpBytes(Slot.ir, kEJitSharedDumpSlotTextBytes, IR.data(),
-                              IR.size(), irTrunc);
-  Slot.asmSize = copyDumpBytes(Slot.asmText, kEJitSharedDumpSlotTextBytes,
-                               ASM.data(), ASM.size(), asmTrunc);
+  Slot.irPtr = NewIR;
+  Slot.asmPtr = NewASM;
+  Slot.irSize = NewIRSize;
+  Slot.asmSize = NewASMSize;
   Slot.keyHi = (uint32_t)(cacheKey >> 32);
   Slot.keyLo = (uint32_t)(cacheKey & 0xffffffffu);
-  Slot.truncated.storeRelease((nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) |
-                              (asmTrunc ? 2u : 0u));
+  Slot.truncated.storeRelease(nameTrunc ? 4u : 0u);
   Slot.valid.storeRelease(1);
   sharedDumpUnlock(D);
   EJIT_DIAG_DEBUG("capture shared func=%s slot=%u ir=%u asm=%u trunc=0x%x &shared=%p",
             fnName.c_str(), target, (unsigned)IR.size(), (unsigned)ASM.size(),
-            (nameTrunc ? 4u : 0u) | (irTrunc ? 1u : 0u) | (asmTrunc ? 2u : 0u),
+            nameTrunc ? 4u : 0u,
             (void *)gDumpSharedState);
 }
 
@@ -378,12 +467,14 @@ static bool printSharedDumped(const char *name) {
     uint32_t trunc = Slot.truncated.loadAcquire();
     EJIT_DIAG("print_dumped shared hit requested=%s stored=%s slot=%u "
               "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u trunc=0x%x",
-              hasName ? name : "(all)", Slot.name, s, Slot.keyHi, Slot.keyLo,
+              hasName ? name : "(list)", Slot.name, s, Slot.keyHi, Slot.keyLo,
               Slot.irSize, Slot.asmSize, trunc);
-    if (Slot.irSize)
-      dumpBytesSafe("dump IR", Slot.ir, Slot.irSize);
-    if (Slot.asmSize)
-      dumpBytesSafe("dump ASM", Slot.asmText, Slot.asmSize);
+    if (hasName && Slot.irSize && Slot.irPtr)
+      dumpBytesSafe("dump IR", reinterpret_cast<const char *>(Slot.irPtr),
+                    Slot.irSize);
+    if (hasName && Slot.asmSize && Slot.asmPtr)
+      dumpBytesSafe("dump ASM", reinterpret_cast<const char *>(Slot.asmPtr),
+                    Slot.asmSize);
     any = true;
     if (hasName)
       break; // single-name query: done after the first match
@@ -391,7 +482,7 @@ static bool printSharedDumped(const char *name) {
   sharedDumpUnlock(D);
   if (!any)
     EJIT_DIAG_DEBUG("print_dumped shared miss name=%s &shared=%p",
-                    hasName ? name : "(all)", (void *)gDumpSharedState);
+                    hasName ? name : "(list)", (void *)gDumpSharedState);
   return any;
 }
 #endif
@@ -424,7 +515,7 @@ static void printOneDumpSafe(const char *requestedName,
   (void)keyLo;
   EJIT_DIAG("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
             "key_lo=0x%08x ir_size=%u asm_size=%u",
-            requestedName ? requestedName : "(all)", storedName.c_str(), keyHi,
+            requestedName ? requestedName : "(list)", storedName.c_str(), keyHi,
             keyLo, (unsigned)e.IR.size(), (unsigned)e.ASM.size());
   if (!e.IR.empty())
     dumpLinesSafe("dump IR", e.IR);
@@ -432,17 +523,16 @@ static void printOneDumpSafe(const char *requestedName,
     dumpLinesSafe("dump ASM", e.ASM);
 }
 
-/// Print the saved IR+ASM for \p name (or all saved entries when \p name is
-/// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no
-/// saved capture are reported as missing.
+/// Print the saved IR+ASM for \p name through EJIT_DIAG, one line per IR/ASM
+/// line. A null/empty name only lists saved entry names to avoid accidental
+/// large log storms.
 void printDumped(const char *name) {
   EJIT_DIAG_DEBUG("print_dumped enter name=%s &filter=%p &store=%p",
-            (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
+            (name && name[0]) ? name : "(list)", (void *)&gDumpFuncFilter,
             (void *)&gDumpStore);
   bool hasName = name && name[0];
-  // Try the local (owner-side, untruncated) store first — it has the full
-  // IR/ASM for every captured function. For a specific name this is a direct
-  // hit on the owner core; for "print all" it lists every capture in full.
+  // Try the local store first. A specific name prints the full local payload;
+  // an empty name only lists available entries.
   {
     std::lock_guard<DumpMutexType> lock(gDumpMutex);
     if (hasName) {
@@ -452,16 +542,23 @@ void printDumped(const char *name) {
         return;
       }
     } else if (!gDumpStore.empty()) {
-      for (auto &kv : gDumpStore)
-        printOneDumpSafe(nullptr, kv.first, kv.second);
+      EJIT_DIAG("print_dumped saved entries=%u", (unsigned)gDumpStore.size());
+      for (auto &kv : gDumpStore) {
+        (void)kv;
+        EJIT_DIAG("print_dumped saved name=%s key_hi=0x%08x key_lo=0x%08x "
+                  "ir_size=%u asm_size=%u",
+                  kv.first.c_str(), (uint32_t)(kv.second.cacheKey >> 32),
+                  (uint32_t)(kv.second.cacheKey & 0xffffffffu),
+                  (unsigned)kv.second.IR.size(), (unsigned)kv.second.ASM.size());
+      }
       return;
     }
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   // Local miss / empty (e.g. a non-owner core, whose per-core gDumpStore is
   // empty): serve from the cross-core shared per-name table. The table holds
-  // the last N captured functions (truncated to the slot text size); a specific
-  // name retrieves its slot, NULL lists all of them.
+  // the last N captured functions. A specific name retrieves its payload;
+  // NULL lists metadata only.
   if (printSharedDumped(name))
     return;
 #endif
@@ -644,22 +741,20 @@ EJitOrcEngine::Create(const Config &config,
           // ejit_print_dumped(). Bare-metal-safe (strings only, no
           // raw_fd_ostream). Captures the post-optimization IR and the emitted
           // assembly (from the same TargetMachine the JIT compiles with).
-          // The filter value "*" is a wildcard: every specialization is captured
-          // (ejit_dump_all(true) sets it). The local gDumpStore keeps one entry
-          // per function name (overwritten on re-compile), so dump-all is
-          // bounded by the number of distinct entry functions; the cross-core
-          // shared result keeps only the latest capture (see ejit_print_dumped).
+          // Capture is exact-name only. The local gDumpStore keeps one dynamic
+          // IR/ASM payload per captured function name (overwritten on
+          // re-compile); the shared dump table keeps cross-core visible dynamic
+          // payloads for recent captures.
           {
             std::string DumpFilter;
             bool hasFilter = getActiveDumpFilter(DumpFilter);
-            bool wildcard = hasFilter && DumpFilter == "*";
-            bool match = wildcard || (hasFilter && ctx->fnName == DumpFilter);
+            bool match = hasFilter && ctx->fnName == DumpFilter;
             EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
-                            "key_lo=0x%08x match=%d wildcard=%d &filter=%p",
+                            "key_lo=0x%08x match=%d &filter=%p",
                             hasFilter ? DumpFilter.c_str() : "(off)",
                             ctx->fnName.c_str(), (uint32_t)(ctx->cacheKey >> 32),
                             (uint32_t)(ctx->cacheKey & 0xffffffffu), match ? 1 : 0,
-                            wildcard ? 1 : 0, (void *)&gDumpFuncFilter);
+                            (void *)&gDumpFuncFilter);
             if (match) {
               // IR capture always runs first so it succeeds even if the ASM
               // diagnostic path is disabled or fails.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -3,6 +3,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/EJIT/EJit.h"
+#include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitFuncRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLifecycleRegistry.h"
@@ -16,11 +17,105 @@
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #endif
+#if !defined(EJIT_FREESTANDING) && !defined(__aarch64__)
+#include <chrono>
+#endif
 
 using namespace llvm;
 using namespace llvm::ejit;
 
 static EJit *gEJIT = nullptr;
+
+#ifndef EJIT_WRAPPER_TIMING_REPORT_EVERY
+#define EJIT_WRAPPER_TIMING_REPORT_EVERY 1024u
+#endif
+
+namespace {
+class TimingSpinLock {
+public:
+  void lock() {
+    uint32_t expected = 0;
+    while (!flag_.compareExchange(expected, 1u))
+      expected = 0;
+  }
+  void unlock() { flag_.storeRelease(0u); }
+
+private:
+  EJitAtomicU32 flag_;
+};
+
+struct WrapperTimingSlot {
+  bool Valid = false;
+  uint32_t FuncIndex = 0;
+  uint32_t Status = 0;
+  void *FnPtr = nullptr;
+  uint32_t BucketIndex = 0;
+  uint64_t Count = 0;
+  uint64_t GetFnSum = 0;
+  uint64_t GetFnMin = 0;
+  uint64_t GetFnMax = 0;
+  uint64_t FnCallSum = 0;
+  uint64_t FnCallMin = 0;
+  uint64_t FnCallMax = 0;
+  uint64_t ReleaseSum = 0;
+  uint64_t ReleaseMin = 0;
+  uint64_t ReleaseMax = 0;
+  uint64_t TotalSum = 0;
+  uint64_t TotalMin = 0;
+  uint64_t TotalMax = 0;
+};
+
+static TimingSpinLock gWrapperTimingLock;
+static WrapperTimingSlot gWrapperTimingSlots[32];
+
+static void updateTimingRange(uint64_t V, uint64_t &Sum, uint64_t &Min,
+                              uint64_t &Max, bool First) {
+  Sum += V;
+  if (First || V < Min)
+    Min = V;
+  if (First || V > Max)
+    Max = V;
+}
+
+static void resetTimingSlot(WrapperTimingSlot &S, uint32_t FuncIndex,
+                            uint32_t Status, void *FnPtr,
+                            uint32_t BucketIndex) {
+  S.Valid = true;
+  S.FuncIndex = FuncIndex;
+  S.Status = Status;
+  S.FnPtr = FnPtr;
+  S.BucketIndex = BucketIndex;
+  S.Count = 0;
+  S.GetFnSum = S.GetFnMin = S.GetFnMax = 0;
+  S.FnCallSum = S.FnCallMin = S.FnCallMax = 0;
+  S.ReleaseSum = S.ReleaseMin = S.ReleaseMax = 0;
+  S.TotalSum = S.TotalMin = S.TotalMax = 0;
+}
+
+static void reportTimingSlot(const WrapperTimingSlot &S) {
+  if (S.Count == 0)
+    return;
+  EJIT_DIAG("wrapper_timing_agg func=%u status=%u fn=%p bucket=%u count=%llu "
+            "get_fn_avg=%llu min=%llu max=%llu "
+            "fn_call_avg=%llu min=%llu max=%llu "
+            "release_avg=%llu min=%llu max=%llu "
+            "total_avg=%llu min=%llu max=%llu",
+            S.FuncIndex, S.Status, S.FnPtr, S.BucketIndex,
+            static_cast<unsigned long long>(S.Count),
+            static_cast<unsigned long long>(S.GetFnSum / S.Count),
+            static_cast<unsigned long long>(S.GetFnMin),
+            static_cast<unsigned long long>(S.GetFnMax),
+            static_cast<unsigned long long>(S.FnCallSum / S.Count),
+            static_cast<unsigned long long>(S.FnCallMin),
+            static_cast<unsigned long long>(S.FnCallMax),
+            static_cast<unsigned long long>(S.ReleaseSum / S.Count),
+            static_cast<unsigned long long>(S.ReleaseMin),
+            static_cast<unsigned long long>(S.ReleaseMax),
+            static_cast<unsigned long long>(S.TotalSum / S.Count),
+            static_cast<unsigned long long>(S.TotalMin),
+            static_cast<unsigned long long>(S.TotalMax));
+}
+} // namespace
 
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 static void bindDumpSharedStateFromRuntime() {
@@ -759,6 +854,64 @@ unsigned ejit_taskpool_pending_count(void) {
     return 0;
   }
   return tp->pendingCount();
+}
+
+uint64_t ejit_taskpool_trace_now(void) {
+#if defined(__aarch64__)
+  uint64_t v = 0;
+  asm volatile("mrs %0, cntvct_el0" : "=r"(v));
+  return v;
+#elif !defined(EJIT_FREESTANDING)
+  using clock = std::chrono::steady_clock;
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          clock::now().time_since_epoch())
+          .count());
+#else
+  return 0;
+#endif
+}
+
+void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
+                                 void *fnPtr, uint32_t bucketIndex,
+                                 uint64_t tBeforeLookup,
+                                 uint64_t tAfterLookup,
+                                 uint64_t tBeforeFn, uint64_t tAfterFn,
+                                 uint64_t tAfterRelease) {
+  uint64_t getFn = tAfterLookup - tBeforeLookup;
+  uint64_t fnCall = tAfterFn - tBeforeFn;
+  uint64_t release = tAfterRelease - tAfterFn;
+  uint64_t total = tAfterRelease - tBeforeLookup;
+  gWrapperTimingLock.lock();
+  unsigned SlotIdx = funcIndex % (sizeof(gWrapperTimingSlots) /
+                                  sizeof(gWrapperTimingSlots[0]));
+  WrapperTimingSlot &S = gWrapperTimingSlots[SlotIdx];
+  if (!S.Valid || S.FuncIndex != funcIndex || S.Status != status ||
+      S.FnPtr != fnPtr || S.BucketIndex != bucketIndex) {
+    reportTimingSlot(S);
+    resetTimingSlot(S, funcIndex, status, fnPtr, bucketIndex);
+  }
+
+  bool First = S.Count == 0;
+  ++S.Count;
+  updateTimingRange(getFn, S.GetFnSum, S.GetFnMin, S.GetFnMax, First);
+  updateTimingRange(fnCall, S.FnCallSum, S.FnCallMin, S.FnCallMax, First);
+  updateTimingRange(release, S.ReleaseSum, S.ReleaseMin, S.ReleaseMax, First);
+  updateTimingRange(total, S.TotalSum, S.TotalMin, S.TotalMax, First);
+
+#if EJIT_WRAPPER_TIMING_REPORT_EVERY > 0
+  if ((S.Count % EJIT_WRAPPER_TIMING_REPORT_EVERY) == 0) {
+    reportTimingSlot(S);
+    S.Count = 0;
+    S.GetFnSum = S.GetFnMin = S.GetFnMax = 0;
+    S.FnCallSum = S.FnCallMin = S.FnCallMax = 0;
+    S.ReleaseSum = S.ReleaseMin = S.ReleaseMax = 0;
+    S.TotalSum = S.TotalMin = S.TotalMax = 0;
+  }
+#else
+  (void)tAfterRelease;
+#endif
+  gWrapperTimingLock.unlock();
 }
 
 ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -905,7 +905,7 @@ void ejit_dump_func(const char *name) {
 
 void ejit_print_dumped(const char *name) {
   // gDumpSharedState is bound once in ejit_init; no per-call rebind needed.
-  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(all)");
+  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(list)");
   printDumped(name);
 }
 
@@ -929,19 +929,6 @@ uint32_t ejit_taskpool_get_worker_core() {
   // a private per-instance taskpool has no cross-core owner to report.
   return kEJitInvalidOwnerCore;
 #endif
-}
-
-//===----------------------------------------------------------------------===//
-// General diagnostics (available in every build, not only taskpool).
-//===----------------------------------------------------------------------===//
-
-void ejit_dump_all(bool enable) {
-  // gDumpSharedState is bound once in ejit_init; no per-call rebind needed.
-  // The "*" filter is a wildcard matched by every specialization in the IR
-  // transform layer (see getActiveDumpFilter / the capture condition). Capture
-  // is bounded by distinct function names; print with ejit_print_dumped(NULL).
-  EJIT_DIAG("dump_all enable=%u", enable ? 1u : 0u);
-  setDumpFuncFilter(enable ? std::string("*") : std::string());
 }
 
 void ejit_set_log_level(ejit_log_level_t level) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -17,7 +17,7 @@
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #endif
-#if !defined(EJIT_FREESTANDING) && !defined(__aarch64__)
+#ifndef EJIT_FREESTANDING
 #include <chrono>
 #endif
 
@@ -25,6 +25,10 @@ using namespace llvm;
 using namespace llvm::ejit;
 
 static EJit *gEJIT = nullptr;
+
+#ifdef EJIT_FREESTANDING
+extern "C" uint64_t SRE_CycleCountGet64(void);
+#endif
 
 #ifndef EJIT_WRAPPER_TIMING_REPORT_EVERY
 #define EJIT_WRAPPER_TIMING_REPORT_EVERY 1024u
@@ -857,18 +861,14 @@ unsigned ejit_taskpool_pending_count(void) {
 }
 
 uint64_t ejit_taskpool_trace_now(void) {
-#if defined(__aarch64__)
-  uint64_t v = 0;
-  asm volatile("mrs %0, cntvct_el0" : "=r"(v));
-  return v;
-#elif !defined(EJIT_FREESTANDING)
+#ifdef EJIT_FREESTANDING
+  return SRE_CycleCountGet64();
+#else
   using clock = std::chrono::steady_clock;
   return static_cast<uint64_t>(
       std::chrono::duration_cast<std::chrono::nanoseconds>(
           clock::now().time_since_epoch())
           .count());
-#else
-  return 0;
 #endif
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
+#include <cstdlib>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -926,6 +927,10 @@ namespace {
 // the non-shared EJitRuntimeState::isActive default (no entry => inactive).
 // setInstanceEnabled(true) flips 0->1 and bumps version on first activate.
 void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
+  bool canFreeDumpPayload =
+      st->magic == kEJitSharedAbiMagic &&
+      st->abiVersion == kEJitSharedAbiVersion &&
+      st->structSize == sizeof(EJitSharedTaskPoolState);
   for (uint32_t d = 0; d < kEJitSharedDimTypes; ++d)
     for (uint32_t i = 0; i < kEJitSharedInstances; ++i) {
       st->enabled[d][i].storeRelaxed(0);
@@ -988,12 +993,14 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
     Slot.keyHi = 0;
     Slot.keyLo = 0;
     Slot.reserved0 = 0;
+    if (canFreeDumpPayload && Slot.irPtr)
+      std::free(reinterpret_cast<void *>(Slot.irPtr));
+    if (canFreeDumpPayload && Slot.asmPtr)
+      std::free(reinterpret_cast<void *>(Slot.asmPtr));
+    Slot.irPtr = 0;
+    Slot.asmPtr = 0;
     for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
       Slot.name[i] = 0;
-    for (uint32_t i = 0; i < kEJitSharedDumpSlotTextBytes; ++i) {
-      Slot.ir[i] = 0;
-      Slot.asmText[i] = 0;
-    }
   }
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     st->buckets[b].writeFlag.storeRelaxed(0);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -33,8 +33,24 @@ inline void cpuRelax() { __asm__ __volatile__("" ::: "memory"); }
 //===----------------------------------------------------------------------===//
 // Inline per-bucket reader/writer lock over the two POD words (same protocol as
 // EJitRwLock §3.2, but operating on shared-blob fields directly).
+//
+// EJIT_SRE_TASKPOOL_NO_RECLAIM changes the READER discipline to a load-only
+// seqlock (no per-hit RMW on the shared readers line). This is memory-safe ONLY
+// because in that build a published fnPtr is never physically freed (the code
+// pool never reclaims; the taskpool releaser is never installed), so a hit that
+// hands back a pointer without a read token can never dangle. The writer still
+// takes writeFlag for writer/writer exclusion and additionally bumps a monotonic
+// per-bucket publishSeq (odd while writing, even when done) that the reader uses
+// to detect and discard a read that raced a publish. The default (token) build
+// is unchanged: publishSeq is never touched.
 //===----------------------------------------------------------------------===//
 bool bucketTryRead(EJitSharedCacheBucket &b) {
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  // Load-only: never touch the shared readers line. The seqlock validity check
+  // (bucketSeqBegin/bucketSeqStable) provides consistency; here we only refuse
+  // to start reading while a writer is mid-publish.
+  return b.writeFlag.loadAcquire() == 0;
+#else
   if (b.writeFlag.loadAcquire() != 0)
     return false;
   b.readers.fetchAdd(1);
@@ -43,16 +59,48 @@ bool bucketTryRead(EJitSharedCacheBucket &b) {
     return false;
   }
   return true;
+#endif
 }
-void bucketReadRelease(EJitSharedCacheBucket &b) { b.readers.fetchSub(1); }
+void bucketReadRelease(EJitSharedCacheBucket &b) {
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  (void)b; // no token was taken.
+#else
+  b.readers.fetchSub(1);
+#endif
+}
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+// Seqlock begin: snapshot the publish sequence. Returns false if a publish is in
+// progress (odd), so the caller cleanly falls back rather than reading a slot
+// mid-overwrite.
+static inline bool bucketSeqBegin(EJitSharedCacheBucket &b, uint32_t &seq) {
+  seq = b.publishSeq.loadAcquire();
+  return (seq & 1u) == 0;
+}
+// Seqlock end: the read is consistent iff the sequence is unchanged (no publish
+// to this bucket happened during the scan + fnPtr load). The compiler barrier
+// keeps the guarded field loads from being reordered across this check.
+static inline bool bucketSeqStable(EJitSharedCacheBucket &b, uint32_t seq0) {
+  asm volatile("" ::: "memory");
+  return b.publishSeq.loadAcquire() == seq0;
+}
+#endif
 void bucketWrite(EJitSharedCacheBucket &b) {
   uint32_t expected = 0;
   while (!b.writeFlag.compareExchange(expected, 1))
     expected = 0;
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  // Enter the odd (writing) phase before any slot field is written, so a
+  // concurrent seqlock reader that began even will observe the change.
+  b.publishSeq.fetchAdd(1);
+#endif
   while (b.readers.loadAcquire() != 0)
     cpuRelax();
 }
 void bucketWriteRelease(EJitSharedCacheBucket &b) {
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  // Leave the even (stable) phase after all slot fields are published.
+  b.publishSeq.fetchAdd(1);
+#endif
   b.writeFlag.storeRelease(0);
 }
 
@@ -292,6 +340,69 @@ EJitSharedTaskPool::cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
   return R;
 }
 
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+//===----------------------------------------------------------------------===//
+// Load-only seqlock cache lookup (NO_RECLAIM build only). Same result as
+// cacheLookup() but with ZERO per-hit RMW on the shared bucket line: the reader
+// never touches bucket.readers. Consistency is a seqlock over bucket.publishSeq
+// (snapshot before the scan, re-check after resolving). If a publish raced the
+// read, retry a bounded number of times, then clean-miss and let the caller
+// fall back. Memory-safe ONLY because a published fnPtr is never freed in this
+// build, so a returned pointer that holds no read token can never dangle.
+//===----------------------------------------------------------------------===//
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
+                                   uint32_t numDims) {
+  SharedLookup R;
+  if (numDims > 4)
+    return R;
+  uint64_t key = hashIdentity(funcIndex, dims, numDims);
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) { // publish in progress -> retry
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.identityHash != key)
+        continue;
+      if (!slotIdentityMatches(Slot, funcIndex, dims, numDims))
+        continue;
+      bool versionsOk = true;
+      for (uint32_t i = 0; i < numDims; ++i)
+        if (Slot.versions[i] !=
+            instanceVersion(dims[i].dimType, dims[i].instanceId)) {
+          versionsOk = false;
+          break;
+        }
+      if (!versionsOk)
+        break; // identity matched but stale -> clean miss
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    // Validate that the scan + resolve observed a single stable publish epoch.
+    // A cold peer preparation (coldPrepared) re-validates itself and may legally
+    // span a publish, so it is exempt from the outer seq re-check.
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue; // publish raced the read -> retry
+    }
+    return hit; // validated hit (noTokenHit) or clean miss
+  }
+  return R; // repeated contention -> clean fallback to the slow path
+}
+#endif // EJIT_SRE_TASKPOOL_NO_RECLAIM
+
 //===----------------------------------------------------------------------===//
 // Shared slot resolution: applied once a slot's identity + versions have
 // matched (bucket read lock held). Dimension-independent, so cacheLookup() and
@@ -329,8 +440,13 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   // publishing). Return directly while holding the read token.
   if (self == owner) {
     R.fnPtr = fn;
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+    R.noTokenHit = true;
+    R.bucketIndex = kEJitSharedCacheBuckets; // sentinel -> releaseRead no-op
+#else
     R.bucketIndex = bucket;
     R.hasReadToken = true;
+#endif
     return R;
   }
 
@@ -341,8 +457,13 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : uint64_t{0};
   if (CanMemoize && (Slot.executableCoreMask.loadAcquire() & CoreBit) != 0) {
     R.fnPtr = fn;
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+    R.noTokenHit = true;
+    R.bucketIndex = kEJitSharedCacheBuckets; // sentinel -> releaseRead no-op
+#else
     R.bucketIndex = bucket;
     R.hasReadToken = true;
+#endif
     return R;
   }
 
@@ -425,8 +546,19 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
   if (CanMemoize)
     S2.executableCoreMask.fetchOr(CoreBit);
   R.fnPtr = Snap.fn;
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  // NO_RECLAIM: this cold path already fully re-validated identity/versions/fnPtr
+  // above under a load-only re-read, so it hands back a validated pointer with no
+  // read token. coldPrepared tells the seqlock caller not to re-check publishSeq
+  // (this out-of-line path legally spanned platform calls and possible publishes,
+  // but the re-validation guarantees the returned pointer is current).
+  R.noTokenHit = true;
+  R.coldPrepared = true;
+  R.bucketIndex = kEJitSharedCacheBuckets; // sentinel -> releaseRead no-op
+#else
   R.bucketIndex = Snap.bucket;
   R.hasReadToken = true;
+#endif
   return R; // token held (re-acquired); caller releases after using fnPtr.
 }
 
@@ -1005,6 +1137,7 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     st->buckets[b].writeFlag.storeRelaxed(0);
     st->buckets[b].readers.storeRelaxed(0);
+    st->buckets[b].publishSeq.storeRelaxed(0); // even => no publish in flight
     for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
       EJitSharedCacheSlot &Slot = st->buckets[b].slots[s];
       Slot.state.storeRelaxed(
@@ -1178,6 +1311,20 @@ EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
     R.fastPathTerminal = true;
     return R;
   }
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  // Seqlock hit: same terminal CacheHit, but no read token was taken and the
+  // bucketIndex is the out-of-range sentinel, so the wrapper's releaseRead()
+  // cleanly no-ops. Safe because published code is never freed in this build.
+  if (Hit.noTokenHit && Hit.fnPtr) {
+    EJIT_STAT_INC(state_->counters.cacheHits);
+    R.status = EJitCompileOrGetStatus::CacheHit;
+    R.fnPtr = Hit.fnPtr;
+    R.bucketIndex = Hit.bucketIndex; // == kEJitSharedCacheBuckets (sentinel)
+    R.hasReadToken = false;
+    R.fastPathTerminal = true;
+    return R;
+  }
+#endif
   if (Hit.readyButNotShareable) {
     // The work is already done but this core may not read the cross-core
     // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
@@ -1224,7 +1371,11 @@ EJitSharedTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
 
   // Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
   // compiled entry is still served even when the pool is globally Off.
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  return classifyHit(cacheLookupSeq(funcIndex, dims, numDims));
+#else
   return classifyHit(cacheLookup(funcIndex, dims, numDims));
+#endif
 }
 
 //===----------------------------------------------------------------------===//
@@ -1243,7 +1394,11 @@ EJitSharedTaskPool::tryCacheHit0D(uint32_t funcIndex) {
     R.fastPathTerminal = true;
     return R;
   }
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  return classifyHit(cacheLookupSeq(funcIndex, nullptr, 0));
+#else
   return classifyHit(cacheLookup0D(funcIndex));
+#endif
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -1263,7 +1418,12 @@ EJitSharedTaskPool::tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  const EJitDimPair d1[1] = {{dim0, inst0}};
+  return classifyHit(cacheLookupSeq(funcIndex, d1, 1));
+#else
   return classifyHit(cacheLookup1D(funcIndex, dim0, inst0));
+#endif
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -1284,7 +1444,12 @@ EJitSharedTaskPool::tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  const EJitDimPair d2[2] = {{dim0, inst0}, {dim1, inst1}};
+  return classifyHit(cacheLookupSeq(funcIndex, d2, 2));
+#else
   return classifyHit(cacheLookup2D(funcIndex, dim0, inst0, dim1, inst1));
+#endif
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -1306,8 +1471,13 @@ EJitSharedTaskPool::tryCacheHit3D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  const EJitDimPair d3[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
+  return classifyHit(cacheLookupSeq(funcIndex, d3, 3));
+#else
   return classifyHit(
       cacheLookup3D(funcIndex, dim0, inst0, dim1, inst1, dim2, inst2));
+#endif
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -1330,8 +1500,14 @@ EJitSharedTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
     R.fastPathTerminal = true;
     return R;
   }
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  const EJitDimPair d4[4] = {
+      {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
+  return classifyHit(cacheLookupSeq(funcIndex, d4, 4));
+#else
   return classifyHit(cacheLookup4D(funcIndex, dim0, inst0, dim1, inst1, dim2,
                                    inst2, dim3, inst3));
+#endif
 }
 
 EJitSharedTaskPool::CompileOrGetResult
@@ -1404,6 +1580,18 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     if (PS == EJitPublishStatus::Published) {
       state_->counters.asyncCompiles.fetchAdd(1);
       publishCodePoolStats();
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+      SharedLookup Hit2 = cacheLookupSeq(funcIndex, dims, numDims);
+      if ((Hit2.hasReadToken || Hit2.noTokenHit) && Hit2.fnPtr) {
+        R.status = EJitCompileOrGetStatus::CacheHit;
+        R.fnPtr = Hit2.fnPtr;
+        R.bucketIndex = Hit2.bucketIndex; // sentinel -> releaseRead no-op
+        R.hasReadToken = Hit2.hasReadToken;
+        EJIT_DIAG_VERBOSE("shared taskpool sync compiled func=%u fn=%p", funcIndex,
+                          Hit2.fnPtr);
+        return R;
+      }
+#else
       SharedLookup Hit2 = cacheLookup(funcIndex, dims, numDims);
       if (Hit2.hasReadToken && Hit2.fnPtr) {
         R.status = EJitCompileOrGetStatus::CacheHit;
@@ -1414,6 +1602,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                           Hit2.fnPtr);
         return R;
       }
+#endif
     } else {
       if (releaseFn_) releaseFn_(releaseCtx_, fn);
     }

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -53,6 +53,11 @@ static cl::opt<bool> EJitWrapperFixedDimEntry(
              "(ejit_taskpool_compile_or_get_Nd) for ejit_entry functions with "
              "<= 4 dims instead of the generic ejit_taskpool_compile_or_get"));
 
+static cl::opt<bool> EJitWrapperTiming(
+    "ejit-wrapper-timing", cl::init(false), cl::Hidden,
+    cl::desc("Emit diagnostic timing probes around taskpool lookup, indirect "
+             "JIT call, and read-token release in ejit_entry wrappers"));
+
 // Wrapper generation now unconditionally uses the unified taskpool API
 // (ejit_taskpool_compile_or_get + ejit_taskpool_release_read). Both Sync
 // and Async modes are runtime-configurable — the AOT wrapper code is
@@ -492,6 +497,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // callers; the wrapper just does not select them.
     bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
+    auto *I64Ty = Type::getInt64Ty(Ctx);
     Value *DimsAlloca = UseFixed
                             ? nullptr
                             : Builder.CreateAlloca(ArrayType::get(DimPairTy, 4),
@@ -529,6 +535,21 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     Value *OutFnArg = Builder.CreatePointerCast(OutFnAlloca, PtrTy);
     Value *OutBucketArg = Builder.CreatePointerCast(OutBucketAlloca, PtrTy);
     Value *Status = nullptr;
+    FunctionCallee TraceNow{};
+    FunctionCallee TraceWrapper{};
+    Value *TBeforeLookup = nullptr;
+    Value *TAfterLookup = nullptr;
+    if (EJitWrapperTiming) {
+      TraceNow = M.getOrInsertFunction(FN_TASKPOOL_TRACE_NOW,
+                                       FunctionType::get(I64Ty, false));
+      SmallVector<Type *, 9> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty,
+                                         I64Ty, I64Ty, I64Ty, I64Ty, I64Ty};
+      TraceWrapper = M.getOrInsertFunction(
+          FN_TASKPOOL_TRACE_WRAPPER,
+          FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
+      TBeforeLookup =
+          Builder.CreateCall(TraceNow, {}, "ejit_t_before_lookup");
+    }
     if (UseFixed) {
       // ejit_taskpool_compile_or_get_Nd(i32 funcIndex,
       //     [i32 dimType, i32 instanceId] * N, ptr outFn, ptr outBucket)
@@ -576,6 +597,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
                                    ConstantInt::get(I32Ty, DimCount), OutFnArg,
                                    OutBucketArg});
     }
+    if (EJitWrapperTiming)
+      TAfterLookup = Builder.CreateCall(TraceNow, {}, "ejit_t_after_lookup");
     Value *OutFn = Builder.CreateLoad(PtrTy, OutFnAlloca, "ejit_fn");
     Value *HitStatus =
         Builder.CreateICmpEQ(Status, ConstantInt::get(I32Ty, 0));
@@ -592,16 +615,42 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       Args.push_back(&Arg);
 
     if (F->getReturnType()->isVoidTy()) {
+      Value *TBeforeFn = nullptr;
+      if (EJitWrapperTiming)
+        TBeforeFn = Builder.CreateCall(TraceNow, {}, "ejit_t_before_fn");
       Builder.CreateCall(F->getFunctionType(), OutFn, Args);
+      Value *TAfterFn = nullptr;
+      if (EJitWrapperTiming)
+        TAfterFn = Builder.CreateCall(TraceNow, {}, "ejit_t_after_fn");
       // Always release the taskpool read token after the JIT call finishes.
       Value *Bucket = Builder.CreateLoad(I32Ty, OutBucketAlloca);
       Builder.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
+      if (EJitWrapperTiming) {
+        Value *TAfterRelease =
+            Builder.CreateCall(TraceNow, {}, "ejit_t_after_release");
+        Builder.CreateCall(TraceWrapper,
+                           {FuncIdx, Status, OutFn, Bucket, TBeforeLookup,
+                            TAfterLookup, TBeforeFn, TAfterFn, TAfterRelease});
+      }
       Builder.CreateRetVoid();
     } else {
+      Value *TBeforeFn = nullptr;
+      if (EJitWrapperTiming)
+        TBeforeFn = Builder.CreateCall(TraceNow, {}, "ejit_t_before_fn");
       Value *RetVal = Builder.CreateCall(F->getFunctionType(), OutFn, Args);
+      Value *TAfterFn = nullptr;
+      if (EJitWrapperTiming)
+        TAfterFn = Builder.CreateCall(TraceNow, {}, "ejit_t_after_fn");
       // Always release the taskpool read token after the JIT call finishes.
       Value *Bucket = Builder.CreateLoad(I32Ty, OutBucketAlloca);
       Builder.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
+      if (EJitWrapperTiming) {
+        Value *TAfterRelease =
+            Builder.CreateCall(TraceNow, {}, "ejit_t_after_release");
+        Builder.CreateCall(TraceWrapper,
+                           {FuncIdx, Status, OutFn, Bucket, TBeforeLookup,
+                            TAfterLookup, TBeforeFn, TAfterFn, TAfterRelease});
+      }
       Builder.CreateRet(RetVal);
     }
 

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-timing.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-timing.ll
@@ -1,0 +1,27 @@
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s --check-prefix=OFF
+; RUN: opt -passes=ejit-wrapper-gen -ejit-wrapper-timing -S %s | FileCheck %s --check-prefix=ON
+
+; OFF-NOT: @ejit_taskpool_trace_now
+; OFF-NOT: @ejit_taskpool_trace_wrapper
+
+; ON-LABEL: define i32 @timed_entry(
+; ON: call i64 @ejit_taskpool_trace_now()
+; ON: call i32 @ejit_taskpool_compile_or_get_1d
+; ON: call i64 @ejit_taskpool_trace_now()
+; ON: call i64 @ejit_taskpool_trace_now()
+; ON: call i32 %ejit_fn
+; ON: call i64 @ejit_taskpool_trace_now()
+; ON: call void @ejit_taskpool_release_read
+; ON: call i64 @ejit_taskpool_trace_now()
+; ON: call void @ejit_taskpool_trace_wrapper
+
+define i32 @timed_entry(i32 %cell) !ejit.metadata !0 {
+entry:
+  %v = load i32, ptr @data
+  ret i32 %v
+}
+
+@data = global i32 7, !ejit.metadata !10
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -88,10 +88,24 @@ target_compile_definitions(EJITSharedTaskPoolTests PRIVATE
   EJIT_SRE_TASKPOOL
   EJIT_SRE_SHARED_TASKPOOL
   EJIT_SRE_TASKPOOL_TESTING
+  EJIT_STATS_ENABLE
   EJIT_SRE_TASKPOOL_BUCKETS=32
   EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
   EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=1048576
   )
+
+# Opt-in: build the shared taskpool tests with the load-only NO_RECLAIM seqlock
+# hit path (and cross-core code sharing, so the peer path is exercised too), to
+# validate the optimization. Configure a separate build dir with
+# -DEJIT_TEST_NO_RECLAIM=ON. Off by default so the normal build tests the token
+# path.
+option(EJIT_TEST_NO_RECLAIM
+  "Build EJITSharedTaskPoolTests with EJIT_SRE_TASKPOOL_NO_RECLAIM" OFF)
+if(EJIT_TEST_NO_RECLAIM)
+  target_compile_definitions(EJITSharedTaskPoolTests PRIVATE
+    EJIT_SRE_TASKPOOL_NO_RECLAIM
+    EJIT_SRE_SHARED_CODE_POINTERS)
+endif()
 
 # Convenience target: build + run only the cross-core shared taskpool tests.
 add_custom_target(check-ejit-shared-taskpool

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -677,7 +677,6 @@ extern void ejit_register_static_var(const char *, void *);
 extern void ejit_register_lifecycle(const char *, uint32_t *);
 extern void ejit_set_log_level(int level);
 extern int ejit_get_log_level(void);
-extern void ejit_dump_all(bool enable);
 extern void ejit_print_registry(void);
 extern void ejit_print_func_meta(const char *funcName);
 // P0 diagnostics: code pool stats + active period map. Declared returning int
@@ -2793,7 +2792,7 @@ TEST(EJitPipelineIR, PeriodIndexReplacementAndFold) {
 //===----------------------------------------------------------------------===//
 
 //===----------------------------------------------------------------------===//
-// Log level + diagnostics C-API (ejit_set_log_level, ejit_dump_all,
+// Log level + diagnostics C-API (ejit_set_log_level,
 // ejit_print_registry, ejit_print_func_meta)
 //===----------------------------------------------------------------------===//
 
@@ -2817,12 +2816,6 @@ TEST(EJitDiagLogLevel, ClampsOutOfRange) {
   ejit_set_log_level(99);
   EXPECT_EQ(ejit_get_log_level(), 3);
   ejit_set_log_level(1); // restore
-}
-
-// ejit_dump_all must not crash whether or not the runtime is initialized.
-TEST(EJitDumpAll, ToggleWithoutCrash) {
-  ejit_dump_all(true);
-  ejit_dump_all(false);
 }
 
 // Registry / func-meta prints must not crash on an uninitialized runtime and on

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -16,6 +16,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "gtest/gtest.h"
+#include <cstdlib>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -1571,11 +1572,12 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
   EXPECT_TRUE(r.readyButNotShareable);
 }
 
-// 16/17 ABI v5 layout: the slot carries the executable range as fixed-width,
+// 16/17 ABI v6 layout: the slot carries the executable range as fixed-width,
 // naturally-aligned scalars (read back by value — endian-safe), and the
-// pool-split table is POD.
+// pool-split table is POD. v6 also changes dump slots from fixed text buffers
+// to dynamic payload pointers.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 5u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 6u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -1601,6 +1603,43 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   EXPECT_EQ(slot->poolSize, 0x200000ull);
   EXPECT_EQ(slot->poolId, 7u);
   EXPECT_EQ(slot->rangeReserved, 0u);
+}
+
+TEST_F(SharedTaskPoolTest, DumpDynamicPayloadsClearedOnInit) {
+  state_->magic = kEJitSharedAbiMagic;
+  state_->abiVersion = kEJitSharedAbiVersion;
+  state_->structSize = sizeof(EJitSharedTaskPoolState);
+
+  char *IR = static_cast<char *>(std::malloc(8));
+  char *ASM = static_cast<char *>(std::malloc(8));
+  ASSERT_NE(IR, nullptr);
+  ASSERT_NE(ASM, nullptr);
+  state_->dump.slots[0].valid.storeRelaxed(1);
+  state_->dump.slots[0].truncated.storeRelaxed(7);
+  state_->dump.slots[0].nameLen = 4;
+  state_->dump.slots[0].irPtr = reinterpret_cast<uintptr_t>(IR);
+  state_->dump.slots[0].asmPtr = reinterpret_cast<uintptr_t>(ASM);
+  state_->dump.slots[0].irSize = 7;
+  state_->dump.slots[0].asmSize = 7;
+  state_->dump.slots[0].keyHi = 0x12;
+  state_->dump.slots[0].keyLo = 0x34;
+  state_->dump.slots[0].name[0] = 'f';
+  state_->dump.nextSlot = 1;
+
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+
+  EXPECT_EQ(state_->dump.slots[0].valid.loadRelaxed(), 0u);
+  EXPECT_EQ(state_->dump.slots[0].truncated.loadRelaxed(), 0u);
+  EXPECT_EQ(state_->dump.slots[0].nameLen, 0u);
+  EXPECT_EQ(state_->dump.slots[0].irPtr, 0u);
+  EXPECT_EQ(state_->dump.slots[0].asmPtr, 0u);
+  EXPECT_EQ(state_->dump.slots[0].irSize, 0u);
+  EXPECT_EQ(state_->dump.slots[0].asmSize, 0u);
+  EXPECT_EQ(state_->dump.slots[0].keyHi, 0u);
+  EXPECT_EQ(state_->dump.slots[0].keyLo, 0u);
+  EXPECT_EQ(state_->dump.slots[0].name[0], 0);
+  EXPECT_EQ(state_->dump.nextSlot, 0u);
 }
 
 // 18/ Code-sharing OFF in 4K mode: a non-owner cleanly rejects and triggers NO

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -16,8 +16,11 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "gtest/gtest.h"
+#include <algorithm>
+#include <cstdio>
 #include <cstdlib>
 #include <memory>
+#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -1573,9 +1576,9 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
 }
 
 // 16/17 ABI v6 layout: the slot carries the executable range as fixed-width,
-// naturally-aligned scalars (read back by value — endian-safe), and the
-// pool-split table is POD. v6 also changes dump slots from fixed text buffers
-// to dynamic payload pointers.
+// naturally-aligned scalars (read back by value — endian-safe), the pool-split
+// table is POD, dump slots use dynamic payload pointers, and each bucket
+// carries the NO_RECLAIM seqlock publishSeq word.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   EXPECT_EQ(kEJitSharedAbiVersion, 6u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
@@ -2180,5 +2183,261 @@ TEST_F(SharedTaskPoolTest, FixedDimVersionMismatchMisses) {
   EXPECT_FALSE(fixedMiss2.fastPathTerminal);
   EXPECT_FALSE(fixedMiss2.hasReadToken);
 }
+
+//===----------------------------------------------------------------------===//
+// Read-token discipline + invalidation, valid in BOTH builds:
+//  * default (token) build: a hit holds a read token, keeps readers > 0, and
+//    hands back a real bucketIndex the caller releases.
+//  * EJIT_SRE_TASKPOOL_NO_RECLAIM (seqlock) build: a hit holds NO token, never
+//    touches readers, and returns the out-of-range sentinel bucketIndex so the
+//    wrapper's releaseRead() cleanly no-ops. The safety of skipping the token
+//    rests on published code never being freed in that build.
+// In EITHER build, activate/deactivate (a version bump) must still invalidate:
+// a hit for a re-disabled instance is never served stale code.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, HitTokenDisciplineAndVersionInvalidation) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitDimPair d0[1] = {dim(1u, 2u)};
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(1, 2, true); // enable the instance (bumps version)
+  ASSERT_EQ(owner.compileOrGet(9, d0, 1, codeFor(9)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  auto hit = owner.tryCacheHit1D(9, 1, 2);
+  ASSERT_TRUE(hit.fastPathTerminal);
+  EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(hit.fnPtr, codeFor(9)); // correct specialization pointer
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  EXPECT_FALSE(hit.hasReadToken);
+  EXPECT_EQ(hit.bucketIndex, kEJitSharedCacheBuckets); // sentinel
+  // No token was taken: readers stay 0 across the whole hit.
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
+    EXPECT_EQ(state_->buckets[b].readers.loadAcquire(), 0u);
+  owner.releaseRead(hit.bucketIndex); // sentinel -> safe no-op
+#else
+  EXPECT_TRUE(hit.hasReadToken);
+  EXPECT_LT(hit.bucketIndex, kEJitSharedCacheBuckets);
+  EXPECT_GT(state_->buckets[hit.bucketIndex].readers.loadAcquire(), 0u);
+  owner.releaseRead(hit.bucketIndex);
+  EXPECT_EQ(state_->buckets[hit.bucketIndex].readers.loadAcquire(), 0u);
+#endif
+
+  // Deactivate → re-activate bumps the instance version: the stale-version slot
+  // must NOT be served; the fast path cleanly reports it (disabled or miss) so
+  // the caller recompiles. This holds identically in the seqlock build.
+  owner.setInstanceEnabled(1, 2, false);
+  auto disabled = owner.tryCacheHit1D(9, 1, 2);
+  EXPECT_NE(disabled.status, EJitCompileOrGetStatus::CacheHit);
+  owner.setInstanceEnabled(1, 2, true);
+  auto stale = owner.tryCacheHit1D(9, 1, 2);
+  // Re-enabled but version moved on: identity matches, version does not → not a
+  // hit (a fresh compile must republish under the new version).
+  EXPECT_NE(stale.status, EJitCompileOrGetStatus::CacheHit);
+  if (stale.hasReadToken)
+    owner.releaseRead(stale.bucketIndex);
+}
+
+//===----------------------------------------------------------------------===//
+// Phase-1 hot-hit micro-benchmark (DISABLED by default; run explicitly with
+//   --gtest_also_run_disabled_tests --gtest_filter='*HotHitMicroBench*'
+// on an aarch64 host). Measures the per-hit cost of the shared taskpool hit
+// path components to drive the read-token optimization. Not a correctness test.
+//===----------------------------------------------------------------------===//
+#if defined(__aarch64__)
+namespace {
+static inline uint64_t benchNow() {
+  uint64_t v;
+  asm volatile("isb; mrs %0, cntvct_el0" : "=r"(v)::"memory");
+  return v;
+}
+static inline uint64_t benchFreq() {
+  uint64_t v;
+  asm volatile("mrs %0, cntfrq_el0" : "=r"(v));
+  return v;
+}
+struct BatchStats {
+  double avgNs, p50, p90, p99, maxNs;
+  size_t samples;
+};
+static BatchStats summarize(std::vector<double> &perIterNs) {
+  std::sort(perIterNs.begin(), perIterNs.end());
+  BatchStats s;
+  s.samples = perIterNs.size();
+  double sum = 0;
+  for (double v : perIterNs)
+    sum += v;
+  s.avgNs = sum / perIterNs.size();
+  auto pct = [&](double p) {
+    size_t idx = static_cast<size_t>(p * (perIterNs.size() - 1));
+    return perIterNs[idx];
+  };
+  s.p50 = pct(0.50);
+  s.p90 = pct(0.90);
+  s.p99 = pct(0.99);
+  s.maxNs = perIterNs.back();
+  return s;
+}
+static void report(const char *name, const BatchStats &s) {
+  printf("  %-28s avg=%.1fns p50=%.1f p90=%.1f p99=%.1f max=%.1f (n=%zu batches)\n",
+         name, s.avgNs, s.p50, s.p90, s.p99, s.maxNs, s.samples);
+}
+} // namespace
+
+TEST_F(SharedTaskPoolTest, DISABLED_HotHitMicroBench) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 42);
+  EJitCoreId::setCurrentForTest(0); // owner-core hit path
+  const uint64_t freq = benchFreq();
+  const double tickNs = 1e9 / static_cast<double>(freq);
+  const uint32_t kIters = 2000;    // per batch
+  const uint32_t kBatches = 2000;  // distribution samples
+  printf("HotHit micro-bench: cntfrq=%llu Hz (%.3f ns/tick), %u iters x %u batches\n",
+         (unsigned long long)freq, tickNs, kIters, kBatches);
+
+  // Warm up + correctness sanity.
+  {
+    auto r = owner.tryCacheHit0D(42);
+    ASSERT_TRUE(r.fastPathTerminal);
+    ASSERT_NE(r.fnPtr, nullptr);
+    if (r.hasReadToken)
+      owner.releaseRead(r.bucketIndex);
+  }
+
+  auto runBatches = [&](auto &&body) {
+    std::vector<double> perIterNs;
+    perIterNs.reserve(kBatches);
+    for (uint32_t b = 0; b < kBatches; ++b) {
+      uint64_t t0 = benchNow();
+      for (uint32_t i = 0; i < kIters; ++i)
+        body();
+      uint64_t t1 = benchNow();
+      perIterNs.push_back((double)(t1 - t0) * tickNs / kIters);
+    }
+    return summarize(perIterNs);
+  };
+
+  volatile void *sink = nullptr;
+
+  // (A) Full current hit path: lookup (read-token acquire) + releaseRead.
+  auto full = runBatches([&] {
+    auto r = owner.tryCacheHit0D(42);
+    sink = r.fnPtr;
+    owner.releaseRead(r.bucketIndex);
+  });
+
+  // (B) Lookup only (read-token acquired but released untimed): isolates get_fn.
+  auto lookup = runBatches([&] {
+    auto r = owner.tryCacheHit0D(42);
+    sink = r.fnPtr;
+    owner.releaseRead(r.bucketIndex); // released, but the timed body is above
+  });
+  // Re-time (B) with release truly outside the measured region is not possible
+  // per-iter; instead measure release in isolation as (C).
+
+  // (C) releaseRead in isolation (lookup done untimed just before).
+  auto release = runBatches([&] {
+    auto r = owner.tryCacheHit0D(42); // untimed-ish, but included; see note
+    owner.releaseRead(r.bucketIndex);
+    sink = r.fnPtr;
+  });
+
+  // (D) Load-only seqlock-style read of the SAME slot: no RMW atomics, no
+  // release. This is the target design's per-hit cost.
+  EJitSharedCacheSlot *slot = findReadySlot(42);
+  ASSERT_NE(slot, nullptr);
+  auto seqlike = runBatches([&] {
+    // state(acquire) -> identity loads -> fnPtr(acquire) -> re-check state.
+    uint32_t s0 = slot->state.loadAcquire();
+    uint32_t fi = slot->funcIndex;
+    uint64_t h = slot->identityHash;
+    void *fn = reinterpret_cast<void *>(slot->fnPtr.loadAcquire());
+    uint32_t s1 = slot->state.loadAcquire();
+    if (s0 == s1 && fi == 42 && h)
+      sink = fn;
+  });
+  (void)sink;
+
+  printf("Shared taskpool owner-core 0D hot hit component costs:\n");
+  report("A full (lookup+release)", full);
+  report("B lookup+release (dup)", lookup);
+  report("C lookup+release iso", release);
+  report("D seqlock load-only", seqlike);
+  printf("Delta A-D (RMW+release removed) approx avg = %.1f ns/hit\n",
+         full.avgNs - seqlike.avgNs);
+}
+
+// Multi-core contention model of the real board: N cores hammering the SAME hot
+// function share one bucket cache line. The read-token RMW (fetchAdd/fetchSub on
+// bucket.readers) then bounces that line between cores; a load-only seqlock read
+// does not. This is the scenario the 6us regression comes from.
+TEST_F(SharedTaskPoolTest, DISABLED_HotHitContendedBench) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 42);
+  EJitSharedCacheSlot *slot = findReadySlot(42);
+  ASSERT_NE(slot, nullptr);
+  EJitSharedCacheBucket *bucket = nullptr;
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets && !bucket; ++b)
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s)
+      if (&state_->buckets[b].slots[s] == slot) {
+        bucket = &state_->buckets[b];
+        break;
+      }
+  ASSERT_NE(bucket, nullptr);
+  const double tickNs = 1e9 / static_cast<double>(benchFreq());
+  const uint32_t kIters = 200000;
+
+  for (unsigned T : {1u, 2u, 4u, 8u}) {
+    std::vector<double> tokDur(T), seqDur(T);
+    auto tokenBody = [&](unsigned idx) {
+      uint64_t t0 = benchNow();
+      volatile uint64_t acc = 0;
+      for (uint32_t i = 0; i < kIters; ++i) {
+        bucket->readers.fetchAdd(1);
+        acc += slot->fnPtr.loadAcquire();
+        bucket->readers.fetchSub(1);
+      }
+      uint64_t t1 = benchNow();
+      (void)acc;
+      tokDur[idx] = (double)(t1 - t0) * tickNs / kIters;
+    };
+    auto seqBody = [&](unsigned idx) {
+      uint64_t t0 = benchNow();
+      volatile uint64_t acc = 0;
+      for (uint32_t i = 0; i < kIters; ++i) {
+        uint32_t s0 = slot->state.loadAcquire();
+        acc += slot->fnPtr.loadAcquire();
+        uint32_t s1 = slot->state.loadAcquire();
+        acc += (s0 == s1);
+      }
+      uint64_t t1 = benchNow();
+      (void)acc;
+      seqDur[idx] = (double)(t1 - t0) * tickNs / kIters;
+    };
+    auto runContended = [&](auto body, std::vector<double> &dur) {
+      std::vector<std::thread> ths;
+      for (unsigned t = 0; t < T; ++t)
+        ths.emplace_back([&, t] { body(t); });
+      for (auto &th : ths)
+        th.join();
+      double sum = 0, mx = 0;
+      for (double d : dur) {
+        sum += d;
+        mx = std::max(mx, d);
+      }
+      return std::pair<double, double>(sum / T, mx);
+    };
+    auto tok = runContended(tokenBody, tokDur);
+    auto seq = runContended(seqBody, seqDur);
+    printf("T=%u cores same bucket: token(RMW) avg=%.1fns max=%.1f | "
+           "seqlock(load) avg=%.1fns max=%.1f | token/seqlock=%.1fx\n",
+           T, tok.first, tok.second, seq.first, seq.second,
+           seq.first > 0 ? tok.first / seq.first : 0.0);
+  }
+}
+#endif // __aarch64__
 
 } // namespace


### PR DESCRIPTION
## Dependency / Merge Order

This PR is now based on `[EJIT] Use dynamic shared IR ASM dump payloads` (`91e6b7fd1cac`), which already updates the shared-taskpool ABI to v6.

The intended merge order is:

1. dynamic shared IR/ASM dump payloads, introducing ABI v6;
2. this PR, which keeps ABI v6 and adds wrapper timing plus the optional hot-hit optimization fields on top of that same v6 layout.

In other words, this PR should not be reviewed as an independent ABI bump competing with the dump-payload PR.

## Summary

Add two default-off tools for investigating and reducing EJIT shared-taskpool hot-hit overhead:

- wrapper timing probes, enabled by `-mllvm -ejit-wrapper-timing`;
- optional `EJIT_SRE_TASKPOOL_NO_RECLAIM` shared-taskpool hot-hit path, based on the current no-physical-code-reclaim assumption.

The wrapper timing mode instruments generated `ejit_entry` wrappers around:

- taskpool `compile_or_get` / fnPtr lookup;
- indirect JIT function call;
- `ejit_taskpool_release_read`.

The runtime reports aggregated timing instead of printing every call. `EJIT_WRAPPER_TIMING_REPORT_EVERY` controls the reporting interval; `0` disables periodic output.

## Hot-Hit Optimization

The optional `EJIT_SRE_TASKPOOL_NO_RECLAIM` path adds a `publishSeq` seqlock-style word to each shared cache bucket. When physical code is never reclaimed or overwritten unsafely, cache-hit readers can use a load-only fast path and avoid per-hit read-token RMW traffic.

This is intentionally guarded by a compile-time option because it depends on the no-reclaim model. If future code-pool reclamation is added, this path must either stay disabled or be paired with a safe reclamation protocol.

## Files

- `EJitWrapperGen.cpp`: hidden `-ejit-wrapper-timing` option and wrapper probes.
- `EJitRuntime.{h,cpp}`: timestamp, trace-print, and timing aggregation C ABI.
- `EJitSharedTaskPool.{h,cpp}` / `EJitSharedTaskPoolState.h`: optional no-reclaim hot-hit path and `publishSeq` field.
- `EJitSharedPlatform.h`: ABI v6 comment updated to include both dynamic dump payloads and the no-reclaim `publishSeq` field.
- `EJitCommon.h` / `lipo.py`: symbol retention for the new optional C APIs.
- `EJitSharedTaskPoolTest.cpp`: coverage for timing aggregation and no-reclaim behavior.
- `ejit-wrapper-timing.ll`: lit coverage for default-off and enabled wrapper IR shape.

## Validation

- Rebased/cherry-picked onto `91e6b7fd1cac` (`[EJIT] Use dynamic shared IR ASM dump payloads`).
- Resolved the shared ABI v6 conflict by keeping a single v6 layout description that covers both dynamic dump payloads and `publishSeq`.
- `git diff --check` passes.

Full rebuild was not rerun after the final rebase in this worktree; this PR remains default-off and is intended for board-side performance validation.