### PR TITLE
[EJIT] Audit and optimize shared taskpool cache-query hot path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,7 @@
 #   --sre-taskpool-buckets=<n>  taskpool dedup/cache bucket count (default: 32)
 #   --sre-taskpool-queue-capacity=<n>  taskpool async queue capacity, pow2 (default: 1024)
 #   --sre-shared-taskpool / --no-sre-shared-taskpool  cross-core shared taskpool, single shared worker (default OFF; needs --sre-taskpool)
+#   --sre-taskpool-no-reclaim / --no-sre-taskpool-no-reclaim  load-only cache-hit path (default OFF; requires shared taskpool and no physical code reclamation)
 #   --sre-taskpool-worker-stack-size=<bytes>  shared worker task stack size (default: 1048576)
 #   --sre-shared-code-pointers / --no-sre-shared-code-pointers  allow non-owner cores to read shared cache fnPtrs (default OFF; needs platform same-VA + cache coherence)
 #   --stats / --no-stats  embed EJIT taskpool statistics counters (default OFF; per-call atomic cost on the hot path)
@@ -110,6 +111,7 @@ do_configure() {
         -DEJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS} \
         -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY} \
         -DEJIT_SRE_SHARED_TASKPOOL=${EJIT_SRE_SHARED_TASKPOOL} \
+        -DEJIT_SRE_TASKPOOL_NO_RECLAIM=${EJIT_SRE_TASKPOOL_NO_RECLAIM} \
         -DEJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE} \
         -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS} \
         -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS} \
@@ -136,6 +138,7 @@ do_configure() {
         -DEJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS} \
         -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY} \
         -DEJIT_SRE_SHARED_TASKPOOL=${EJIT_SRE_SHARED_TASKPOOL} \
+        -DEJIT_SRE_TASKPOOL_NO_RECLAIM=${EJIT_SRE_TASKPOOL_NO_RECLAIM} \
         -DEJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE} \
         -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS} \
         -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS} \
@@ -177,6 +180,7 @@ do_configure() {
       -DEJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS}
       -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}
       -DEJIT_SRE_SHARED_TASKPOOL=${EJIT_SRE_SHARED_TASKPOOL}
+      -DEJIT_SRE_TASKPOOL_NO_RECLAIM=${EJIT_SRE_TASKPOOL_NO_RECLAIM}
       -DEJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE}
       -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS}
       -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS}
@@ -219,6 +223,7 @@ do_configure() {
       -DEJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS}
       -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}
       -DEJIT_SRE_SHARED_TASKPOOL=${EJIT_SRE_SHARED_TASKPOOL}
+      -DEJIT_SRE_TASKPOOL_NO_RECLAIM=${EJIT_SRE_TASKPOOL_NO_RECLAIM}
       -DEJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE}
       -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS}
       -DEJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS}
@@ -293,6 +298,7 @@ EJIT_SRE_TASKPOOL=OFF
 EJIT_SRE_TASKPOOL_BUCKETS=32
 EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
 EJIT_SRE_SHARED_TASKPOOL=OFF
+EJIT_SRE_TASKPOOL_NO_RECLAIM=OFF
 EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=1048576
 EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS=1
 EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS=100
@@ -324,6 +330,8 @@ while [[ $# -gt 0 ]]; do
     --sre-taskpool-queue-capacity=*) EJIT_SRE_TASKPOOL_QUEUE_CAPACITY="${1#--sre-taskpool-queue-capacity=}" ;;
     --sre-shared-taskpool) EJIT_SRE_SHARED_TASKPOOL=ON ;;
     --no-sre-shared-taskpool) EJIT_SRE_SHARED_TASKPOOL=OFF ;;
+    --sre-taskpool-no-reclaim) EJIT_SRE_TASKPOOL_NO_RECLAIM=ON ;;
+    --no-sre-taskpool-no-reclaim) EJIT_SRE_TASKPOOL_NO_RECLAIM=OFF ;;
     --sre-taskpool-worker-stack-size=*) EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE="${1#--sre-taskpool-worker-stack-size=}" ;;
     --sre-taskpool-worker-throttle-items=*) EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS="${1#--sre-taskpool-worker-throttle-items=}" ;;
     --sre-taskpool-worker-throttle-delay-ticks=*) EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS="${1#--sre-taskpool-worker-throttle-delay-ticks=}" ;;
@@ -364,7 +372,7 @@ BUILD_DIR=$(build_dir "$TYPE" "$ARCH" "$VARIANT")
 log "Type=${TYPE}  Arch=${ARCH}  Variant=${VARIANT}  ccache=$($USE_CCACHE && echo on || echo off)"
 log "EJIT: triple=${EJIT_TARGET_TRIPLE:-$(target_triple "$ARCH")}  sre-code-pool=${EJIT_SRE_CODE_POOL}  ptno=${EJIT_SRE_CODE_POOL_PTNO}"
 log "EJIT: sre-taskpool=${EJIT_SRE_TASKPOOL} buckets=${EJIT_SRE_TASKPOOL_BUCKETS} queue=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}"
-log "EJIT: sre-shared-taskpool=${EJIT_SRE_SHARED_TASKPOOL} worker-stack=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE} throttle-items=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS} throttle-delay-ticks=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS} shared-code-pointers=${EJIT_SRE_SHARED_CODE_POINTERS}"
+log "EJIT: sre-shared-taskpool=${EJIT_SRE_SHARED_TASKPOOL} no-reclaim=${EJIT_SRE_TASKPOOL_NO_RECLAIM} worker-stack=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE} throttle-items=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_ITEMS} throttle-delay-ticks=${EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS} shared-code-pointers=${EJIT_SRE_SHARED_CODE_POINTERS}"
 log "Build dir: ${BUILD_DIR}"
 
 if $DO_CONFIGURE; then

--- a/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
+++ b/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
@@ -1,0 +1,257 @@
+# EJIT Shared Taskpool — Cache-Query Performance Audit & Model
+
+Scope: the cross-core shared taskpool cache-hit **query** path (spec §5.2 steps
+0–1), from the AOT wrapper's C ABI call through the read-token / seqlock release.
+This document is the performance model behind the Commit 2 optimization; it does
+**not** describe the compile/enqueue slow path.
+
+All static instruction counts are AArch64, `clang -Os`, default capacities
+(`EJIT_SRE_TASKPOOL_BUCKETS=32`, `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS=16`).
+All per-hit measurements are on an aarch64 host via `perf stat`, stats OFF
+(`EJIT_STATS_ENABLE` undefined — the production default), 100M iterations. Host
+nanoseconds are for **relative comparison only**; they are not board cycles.
+
+Reproduce with the benchmark added in Commit 1:
+
+```
+clang++ -std=c++17 -O2 -Illvm/include \
+  -DEJIT_SRE_TASKPOOL -DEJIT_SRE_SHARED_TASKPOOL -DEJIT_SRE_TASKPOOL_TESTING \
+  -DEJIT_SRE_TASKPOOL_BUCKETS=32 -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024 \
+  [-DEJIT_SRE_SHARED_CODE_POINTERS] [-DEJIT_SRE_TASKPOOL_NO_RECLAIM] \
+  llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp -o bench
+perf stat -e instructions,cycles ./bench single0d 15 100000000
+```
+
+Or via CMake: configure with `-DEJIT_BUILD_CACHE_QUERY_BENCH=ON` (and
+`-DEJIT_TEST_NO_RECLAIM=ON` for the seqlock + code-sharing variant), build
+`EJITSharedCacheQueryBench`.
+
+---
+
+## 1. Baseline call chain (per layer)
+
+```
+wrapper IR / AOT entry
+ └─ ejit_taskpool_compile_or_get[_0d/_1d/_2d]     (C ABI shell, EJitRuntime.cpp)
+     └─ EJitSharedTaskPool::tryCacheHit[0D/1D/2D]  (Ready gate + instance-enabled)
+         └─ cacheLookup[0D/1D/2D] | cacheLookupSeq[0D/1D/2D]
+             ├─ hashIdentity (inlined / unrolled)  key
+             ├─ bucket = key % 32
+             ├─ bucketTryRead  (token: 1 acquire load + 1 RMW; seqlock: 1 load)
+             ├─ slot scan 0..15  (per slot: identityHash reject → state acquire →
+             │                    generation → identity → version)
+             └─ resolveMatchedSlot
+                 ├─ owner core / memoized peer → return fnPtr (+ read token)
+                 └─ cold peer first touch → peerPrepareSlot (noinline)
+         └─ classifyHit  (CacheHit / InstanceDisabled / OffMode / notShareable)
+ └─ JIT function indirect call
+ └─ releaseRead  (token: 1 RMW; seqlock: no-op sentinel)
+```
+
+### Static per-layer instruction counts (AArch64, -Os)
+
+| Layer (function)                 | token | NO_RECLAIM |
+|----------------------------------|------:|-----------:|
+| `ejit_taskpool_compile_or_get_0d` (C shell) | ~20 | ~20 |
+| `tryCacheHit0D`                  | 36 | 43 |
+| `tryCacheHit1D`                  | 48 | 54 |
+| `tryCacheHit2D`                  | 55 | 61 |
+| `tryCacheHit` (generic)          | 55 | 61 |
+| `cacheLookup0D` / `cacheLookupSeq0D` | 69 | 68 |
+| `cacheLookup1D` / `cacheLookupSeq1D` | 104 | 109 |
+| `cacheLookup2D` / `cacheLookupSeq2D` | 140 | 144 |
+| `cacheLookup` (generic)          | 136 | 138 |
+| `resolveMatchedSlot`             | 36 | 42 |
+| `peerPrepareSlot` (cold, noinline) | 150 | ~150 |
+| `classifyHit`                    | 22 | 32 |
+| `hashIdentity` (generic)         | 16 | 16 |
+| `releaseRead`                    | 14 | 1 (no-op) |
+
+Static counts are whole-function sizes (they include the miss/error tails and
+the 16-iteration loop body once). The **executed** hit path touches only a
+subset — see §3.
+
+### Per-basic-block path classification
+
+For the fixed-dim lookups the blocks partition as:
+- **cache-hit blocks**: hash build → `bucketTryRead` success → the *matching*
+  slot iteration → `resolveMatchedSlot` owner/memoized return.
+- **miss-only blocks**: the loop `continue` edges (rejected slots) and the
+  fall-through `bucketReadRelease; return R`.
+- **owner-only blocks**: `resolveMatchedSlot` `self == owner` early return.
+- **peer-only blocks**: `resolveMatchedSlot` memoized-mask branch + the call to
+  `peerPrepareSlot`.
+- **error-only blocks**: `numDims > 4` guard (generic only), `!bucketTryRead`
+  contended fallback, `fnPtr == 0` racing-publish fallback.
+
+---
+
+## 2. Actual cache-hit executed path (measured, stats OFF)
+
+`insns/hit` and `ns/hit` are the perf-measured loop totals; the benchmark loop
+harness is **~14 instructions** (measured from the disassembled loop:
+call-arg setup, `gSink` volatile add, status/hasReadToken test, loop counter),
+so the executed query path is `insns/hit − 14`.
+
+| Config (owner core, stats off) | slot | insns/hit | ns/hit | exec path insns |
+|--------------------------------|-----:|----------:|-------:|----------------:|
+| token 0D                       | 0    | 124 | 20.2 | ~110 |
+| token 0D                       | 15   | 214 | 22.7 | ~200 |
+| token 1D                       | 0    | 184 | 24.1 | ~170 |
+| token 2D                       | 0    | 221 | 25.3 | ~207 |
+| NO_RECLAIM 0D                  | 0    | 119 | 9.0  | **~105** |
+| NO_RECLAIM 0D                  | 15   | 224 | 15.1 | ~210 |
+| NO_RECLAIM 1D                  | 0    | 163 | 11.5 | ~149 |
+| NO_RECLAIM 2D                  | 0    | 220 | 15.6 | ~206 |
+| NO_RECLAIM 0D peer (memoized)  | 0    | 125 | 9.5  | ~111 |
+
+Dominant costs, in order:
+1. **Token read/release RMW** (`bucket.readers` fetchAdd + fetchSub, two
+   `ldaddal`): ~11 ns of the 20 ns token 0D hit. The seqlock (NO_RECLAIM) build
+   removes both → **2.0–2.3× faster** at slot 0.
+2. **Linear 16-slot scan**: ~0.8 ns and (post-opt) ~6 instructions per scanned
+   non-matching slot. Only material for busy buckets / deep slots.
+3. **`resolveMatchedSlot` owner gate**: `EJitCoreId::current()` + `ownerCoreId`
+   load + branch.
+4. Per-slot `state` **acquire load** (`ldar`) — one per scanned slot in the old
+   order; skipped for rejected slots after the reorder (§4).
+
+---
+
+## 3. Slot-depth distribution
+
+`cachePublish` fills the first empty slot, so entries in one bucket stack at
+slots 0,1,2,… in publish order; a bucket evicts its slot-0 occupant when full.
+With 32 buckets and a good hash, the expected occupancy per bucket for N live
+specializations is N/32; the hit slot depth is therefore **0 for the vast
+majority** of realistic workloads and only grows for hash-colliding identities
+or > 32 hot specializations.
+
+The Commit 1 benchmark (`bench0D`) and the `SlotDepthHitsAtEveryDepth` test
+place a target at each depth 0/1/5/15 deterministically (0D funcIndex multiples
+of 32 collide into bucket 0). Measured slope: token **+0.83 ns/slot** before,
+**+0.16 ns/slot** after the reorder; NO_RECLAIM **+0.92 ns/slot** before,
+**+0.41 ns/slot** after.
+
+---
+
+## 4. Candidate directions — benefit / risk
+
+| Dir | Idea | Benefit | Mem cost | Concurrency / version risk | Verdict |
+|-----|------|---------|----------|----------------------------|---------|
+| A | slot-depth stat | diagnostic only | 0 | none | shipped as bench + test |
+| B | per-funcIndex slot **hint** | cuts deep-slot scan | +4–8 B/func shared | must re-validate gen+identity+version; stale slot must not alias | **not shipped** — real depth ≈0; complexity/risk > benefit |
+| C | direct-mapped primary slot | O(1) common hit | +shared index | different specialization must not alias same funcIndex | **not shipped** — aliasing risk, marginal at depth 0 |
+| D | version digest word | 1 u32 compare vs per-dim loop | +4 B/slot | digest collision must never authorize stale code (hint only) | **report only** — needs ABI bump; per-dim loop already cheap (≤4) |
+| E | packed epoch/state word | 1 read vs several | +8 B | epoch may only *reject* / gate slow check | **report only** — needs strict equivalence proof + ABI bump |
+| F | owner-only hot/cold split | smaller I-cache footprint | 0 | must not bypass read token | partially present (`peerPrepareSlot` already noinline); owner path already tight |
+| G | move `identityHash` into slot line 0 | 1 cache line/scan vs 2 | 0 (reorder) | big-endian safe (by-value); **changes shared layout → ABI bump** | **report only** — see §5 |
+| H | hash algo | — | — | — | **not changed**: 0D≈funcIndex, 1D/2D few XOR+mul, `%32`→`&31` already; objdump shows hash is not the bottleneck |
+| **I** | **fixed-dim seqlock `cacheLookupSeqNd`** | −20 insns vs generic in NO_RECLAIM | 0 | never-free precondition (already the NO_RECLAIM invariant) | **SHIPPED** (Commit 2) |
+| — | **identityHash-first scan reorder** | −32/−36 % ns at depth 15 | 0 | identical semantics (final gate unchanged) | **SHIPPED** (Commit 2) |
+| J | wrapper call-site local cache | skips ABI shell | +8 B/site | cross-core/deactivate/version correctness unproven | **not shipped** — see the separate `ejit-callsite-local-cache` experiment; needs strict proof |
+
+---
+
+## 5. What shipped (Commit 2)
+
+1. **Fixed-dimension seqlock specializations** `cacheLookupSeq0D/1D/2D`
+   (Direction I / priority #1). In NO_RECLAIM builds `tryCacheHit0D/1D/2D`
+   previously fell back to the *generic* `cacheLookupSeq` (generic hash loop +
+   `slotIdentityMatches`). They now use unrolled specializations mirroring
+   `cacheLookup0D/1D/2D`. Isolated entirely behind `EJIT_SRE_TASKPOOL_NO_RECLAIM`
+   (the "code never freed" build), satisfying the never-free precondition
+   constraint. No new shared state, no layout/ABI change.
+2. **identityHash-first scan reorder** across `cacheLookup`,
+   `cacheLookup0D..4D`, `cacheLookupSeq`, and the new `cacheLookupSeq0D/1D/2D`.
+   The per-slot loop now rejects on the plain `identityHash` compare **before**
+   the acquiring `state` load. Correctness is unchanged: a match still requires
+   the acquire `state==Ready` load **plus** the full `funcIndex/numDims/dims`
+   identity **plus** the per-dim version check before any pointer is returned;
+   `identityHash` is only a fast-reject hint (a 64-bit hash collision falls
+   through to the authoritative identity compare, and a stale/false-negative
+   read is a benign clean miss under both the bucket read token and the seqlock
+   `publishSeq` re-check). No layout/ABI change; big-endian safe (by-value
+   scalar compares).
+
+**Before → after** (owner, stats off):
+- token 0D slot 15: 304 → 214 insns, 33.2 → 22.7 ns (**−32 %**)
+- NO_RECLAIM 0D slot 0: 139 → 119 insns, 9.6 → 9.0 ns
+- NO_RECLAIM 0D slot 15: 364 → 224 insns, 23.4 → 15.1 ns (**−36 %**)
+- token 0D slot 0 unchanged (single slot, nothing to skip)
+
+Shared-state memory change: **0 bytes** (`sizeof(EJitSharedTaskPoolState)` and
+every slot/bucket offset identical; verified by static_assert + offsetof probe).
+New shared reads/writes per hit: **0** (both changes are pure code).
+
+---
+
+## 6. Not shipped — reasons
+
+- **B/C slot hint / primary slot**: realistic hit depth is ≈0 (N/32 occupancy),
+  so the win is confined to pathological buckets while the correctness surface
+  (stale-slot aliasing, generation/version re-validation) grows. Kept as a
+  measured direction only.
+- **D/E/G packed digest / epoch / hot-field layout**: each requires changing the
+  shared `EJitSharedCacheSlot` layout (or adding a word), i.e. an
+  `abiVersion` bump and cross-core coordinated redeploy. The audit's hard
+  constraint is to not change default ABI / cache identity, and the measured
+  benefit (per-dim version loop is ≤4 iterations; `identityHash` already
+  fast-rejects) does not justify the ABI churn. Direction G (move `identityHash`
+  to the first cache line so a scan touches one line instead of two) is the most
+  promising future ABI-bump candidate and is documented here for that purpose.
+- **H hash**: objdump confirms the hash is a handful of instructions and not the
+  bottleneck; `% 32` already lowers to `& 31`. Changing it risks collisions for
+  no measured gain.
+- **J wrapper call-site cache**: not correctness-provable against deactivate /
+  version-bump / cross-core code sharing without a generation+version guard that
+  costs about as much as the lookup it replaces.
+
+---
+
+## 7. The "< 100 instructions" target
+
+The common **NO_RECLAIM owner-core 0D** hit executes **~105** instructions
+(stats off, slot 0), just above the 100 target; token 0D is ~110. The residual,
+from the disassembly, is:
+- the cross-TU `bl` chain (C ABI shell → `tryCacheHit0D` → `cacheLookupSeq0D` →
+  `resolveMatchedSlot`) with its arg setup / return-struct spill (~30 insns of
+  call glue that a full-image **LTO** build collapses),
+- `EJitCoreId::current()` (a real call for the core id) + the owner gate,
+- the seqlock `bucketSeqBegin`/`bucketSeqStable` pair (~6 insns),
+- `classifyHit`'s outcome classification + `CompileOrGetResult` construction.
+
+With whole-image LTO (the production firmware link, where these functions inline
+into the wrapper), the call glue disappears and the path is expected to fall
+below 100. On the token path the two `readers` RMWs make the instruction count
+secondary to the atomic latency; the seqlock build is the one that both hits
+~105 instructions and is 2× faster in cycles.
+
+---
+
+## 8. Correctness invariants preserved
+
+Deactivated instance never served (instance-enabled gate unchanged); version
+bump invalidates old slots (per-dim version check still after identity);
+generation reset drops old slots (`generation` compare unchanged); identity-hash
+collision cannot alias (authoritative identity compare after the hash reject);
+peer without execute permission never gets a pointer (`resolveMatchedSlot` /
+`peerPrepareSlot` untouched); read token pairing intact (token path unchanged;
+seqlock takes no token by construction); publish/overwrite races handled (bucket
+write lock / `publishSeq` seqlock unchanged); POD / standard-layout / trivially
+destructible shared state unchanged; no dynamic init; stats OFF keeps the hot
+path free of counter RMW. Verified by the existing suite plus the new
+`SlotDepthHitsAtEveryDepth`, `SlotDepthNoIdentityAliasAcrossBucket`,
+`SeqFixedDimMatchesGeneric0D1D2D`, and `SeqFixedDimVersionBumpMisses` tests.
+
+---
+
+## 9. Still to validate on-board
+
+Host cannot model real cross-core cache coherence or SRE `enable_ex`/split
+latency; the state machine and return semantics are deterministically tested on
+host, but the actual peer first-touch seal cost, the cross-core `ldar`/RMW
+latency, and the board cycle counts must be measured on hardware. Host
+nanoseconds here are for relative comparison only.

--- a/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
+++ b/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
@@ -25,8 +25,11 @@ perf stat -e instructions,cycles ./bench single0d 15 100000000
 ```
 
 Or via CMake: configure with `-DEJIT_BUILD_CACHE_QUERY_BENCH=ON` (and
-`-DEJIT_TEST_NO_RECLAIM=ON` for the seqlock + code-sharing variant), build
-`EJITSharedCacheQueryBench`.
+`-DEJIT_TEST_NO_RECLAIM=ON` for a benchmark-only seqlock + code-sharing
+variant), then build `EJITSharedCacheQueryBench`. Production builds enable the
+same implementation with `-DEJIT_SRE_TASKPOOL_NO_RECLAIM=ON`; this requires
+`EJIT_SRE_SHARED_TASKPOOL=ON` and is safe only while published JIT code is never
+physically reclaimed. The `ejit-minimal-aarch64_be` preset enables it.
 
 ---
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -718,6 +718,8 @@ endif()
 # requires EJIT_SRE_TASKPOOL (it reuses the request/identity model and macros).
 option(EJIT_SRE_SHARED_TASKPOOL
   "Enable the EmbeddedJIT cross-core shared taskpool (single shared worker owner)" ON)
+option(EJIT_SRE_TASKPOOL_NO_RECLAIM
+  "Use load-only shared-cache reads when published JIT code is never reclaimed" OFF)
 # Fixed cache slots per bucket in the shared POD cache (no std::unordered_map can
 # live in shared memory, so each bucket is a fixed slot array).
 set(EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS "16" CACHE STRING
@@ -775,6 +777,11 @@ if(EJIT_SRE_SHARED_TASKPOOL)
                  "platformCoreId=${EJIT_FREESTANDING}, "
                  "codePointers=${EJIT_SRE_SHARED_CODE_POINTERS}, "
                  "sharedSection=${_ejit_shared_section})")
+endif()
+
+if(EJIT_SRE_TASKPOOL_NO_RECLAIM AND NOT EJIT_SRE_SHARED_TASKPOOL)
+  message(FATAL_ERROR
+    "EJIT_SRE_TASKPOOL_NO_RECLAIM requires EJIT_SRE_SHARED_TASKPOOL=ON")
 endif()
 
 set(LLVM_TARGETS_TO_BUILD "all"

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -80,6 +80,7 @@
         "EJIT_SRE_CODE_POOL_PTNO": "8",
         "EJIT_SRE_TASKPOOL": "ON",
         "EJIT_SRE_SHARED_TASKPOOL": "ON",
+        "EJIT_SRE_TASKPOOL_NO_RECLAIM": "ON",
         "EJIT_SRE_SHARED_CODE_POINTERS": "ON",
         "EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE": "262144",
         "EJIT_SHARED_SECTION_ATTR": "__attribute__((section(\".mc_shared\")))",

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -413,6 +413,19 @@ private:
   /// never-free safety precondition.
   SharedLookup cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
                               uint32_t numDims);
+  /// Fixed-dimension load-only seqlock specializations (0-2 dims). Same
+  /// never-free seqlock discipline as cacheLookupSeq() but with the identity
+  /// hashing, slot identity comparison, and version comparison unrolled exactly
+  /// like cacheLookup0D/1D/2D — so a NO_RECLAIM fixed-dimension caller reaches
+  /// the shared slot resolution without the generic numDims loop, the
+  /// slotIdentityMatches() call, or variable-length dims[] handling. Behavior
+  /// is identical to cacheLookupSeq() with the matching numDims. 3D/4D keep
+  /// using the generic cacheLookupSeq() (rare on the hot path).
+  SharedLookup cacheLookupSeq0D(uint32_t funcIndex);
+  SharedLookup cacheLookupSeq1D(uint32_t funcIndex, uint32_t dim0,
+                                uint32_t inst0);
+  SharedLookup cacheLookupSeq2D(uint32_t funcIndex, uint32_t dim0,
+                                uint32_t inst0, uint32_t dim1, uint32_t inst1);
 #endif
   /// Fixed-dimension specializations of cacheLookup() (0-4 dims). Identity
   /// hashing, slot identity comparison, and version comparison are all unrolled

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -126,7 +126,14 @@ add_llvm_component_library(LLVMEJIT
   # and AggressiveInstCombine.  Instead, they are added manually to the
   # ejit_minimal target below (see §6.5 of EJIT_LIBRARY_TRIMMING.md).
   # ExecutionEngine is not listed — it's already pulled by OrcJIT.
-  )
+)
+
+if(EJIT_SRE_TASKPOOL_NO_RECLAIM)
+  target_compile_definitions(LLVMEJIT PRIVATE
+    EJIT_SRE_TASKPOOL_NO_RECLAIM)
+  message(STATUS
+    "EmbeddedJIT: NO_RECLAIM shared-cache hot path enabled (JIT code must never be physically reclaimed)")
+endif()
 
 # Propagate the target triple setting to the C++ code
 if(EJIT_DEFAULT_TARGET_TRIPLE)

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -1215,6 +1215,13 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
 }
 
 void EJitSharedTaskPool::releaseRead(uint32_t bucketIndex) {
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  // A load-only seqlock hit takes no read token and deliberately returns the
+  // one-past-the-end bucket as a sentinel. Wrappers still call releaseRead()
+  // uniformly, so this is an expected no-op rather than a rejected release.
+  if (bucketIndex == kEJitSharedCacheBuckets)
+    return;
+#endif
   if (!state_ || bucketIndex >= kEJitSharedCacheBuckets) {
     EJIT_DIAG("shared releaseRead reject: state=%p bucket=%u (max=%u)",
               (void *)state_, bucketIndex, kEJitSharedCacheBuckets);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -115,6 +115,12 @@ void bucketWriteRelease(EJitSharedCacheBucket &b) {
 
 constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 
+/// Mixing constant shared by hashIdentity() and every unrolled fixed-dimension
+/// lookup (cacheLookupNd / cacheLookupSeqNd). Kept here so the NO_RECLAIM
+/// fixed-dimension seqlock specializations defined above the generic
+/// cacheLookupNd block can also reference it.
+constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -321,12 +327,12 @@ EJitSharedTaskPool::cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen) // stale across an owner re-init: ignore.
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (!slotIdentityMatches(Slot, funcIndex, dims, numDims))
       continue;
@@ -378,12 +384,12 @@ EJitSharedTaskPool::cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
     SharedLookup hit;
     for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
       EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue; // plain-load fast reject before the acquiring state load.
       if (Slot.state.loadAcquire() !=
           static_cast<uint32_t>(EJitSharedSlotState::Ready))
         continue;
       if (Slot.generation != curGen)
-        continue;
-      if (Slot.identityHash != key)
         continue;
       if (!slotIdentityMatches(Slot, funcIndex, dims, numDims))
         continue;
@@ -409,6 +415,149 @@ EJitSharedTaskPool::cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
     return hit; // validated hit (noTokenHit) or clean miss
   }
   return R; // repeated contention -> clean fallback to the slow path
+}
+
+//===----------------------------------------------------------------------===//
+// Fixed-dimension load-only seqlock specializations (0-2 dims, NO_RECLAIM
+// build only). Each mirrors the matching cacheLookup0D/1D/2D scan (unrolled
+// identity hash, unrolled identity + version comparison, plain-identityHash
+// fast reject before the acquiring state load) wrapped in the same bounded
+// seqlock retry as cacheLookupSeq(). A NO_RECLAIM fixed-dimension caller thus
+// avoids the generic numDims loop / slotIdentityMatches() call entirely.
+// Behavior is identical to cacheLookupSeq() with the matching numDims; the
+// cross-core fnPtr gate and cold peer preparation stay shared via
+// resolveMatchedSlot().
+//===----------------------------------------------------------------------===//
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq0D(uint32_t funcIndex) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex); // hashIdentity(fi, _, 0)
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue; // plain-load fast reject before the acquiring state load.
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 0)
+        continue;
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq1D(uint32_t funcIndex, uint32_t dim0,
+                                     uint32_t inst0) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue;
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 1)
+        continue;
+      if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+        continue;
+      if (Slot.versions[0] != instanceVersion(dim0, inst0))
+        break; // identity matched but stale -> clean miss.
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq2D(uint32_t funcIndex, uint32_t dim0,
+                                     uint32_t inst0, uint32_t dim1,
+                                     uint32_t inst1) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue;
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 2)
+        continue;
+      if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+        continue;
+      if (Slot.dims[1].dimType != dim1 || Slot.dims[1].instanceId != inst1)
+        continue;
+      if (Slot.versions[0] != instanceVersion(dim0, inst0))
+        break;
+      if (Slot.versions[1] != instanceVersion(dim1, inst1))
+        break;
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
 }
 #endif // EJIT_SRE_TASKPOOL_NO_RECLAIM
 
@@ -598,7 +747,6 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
 // each specialization stays small. Results are identical to cacheLookup() with
 // the matching numDims. kHashMul mirrors the mixing constant in hashIdentity().
 //===----------------------------------------------------------------------===//
-static constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
 EJitSharedTaskPool::SharedLookup
 EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
@@ -611,12 +759,12 @@ EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 0)
       continue;
@@ -641,12 +789,12 @@ EJitSharedTaskPool::cacheLookup1D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 1)
       continue;
@@ -677,12 +825,12 @@ EJitSharedTaskPool::cacheLookup2D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 2)
       continue;
@@ -719,12 +867,12 @@ EJitSharedTaskPool::cacheLookup3D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 3)
       continue;
@@ -768,12 +916,12 @@ EJitSharedTaskPool::cacheLookup4D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 4)
       continue;
@@ -1420,7 +1568,7 @@ EJitSharedTaskPool::tryCacheHit0D(uint32_t funcIndex) {
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  return classifyHit(cacheLookupSeq(funcIndex, nullptr, 0));
+  return classifyHit(cacheLookupSeq0D(funcIndex));
 #else
   return classifyHit(cacheLookup0D(funcIndex));
 #endif
@@ -1442,8 +1590,7 @@ EJitSharedTaskPool::tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  const EJitDimPair d1[1] = {{dim0, inst0}};
-  return classifyHit(cacheLookupSeq(funcIndex, d1, 1));
+  return classifyHit(cacheLookupSeq1D(funcIndex, dim0, inst0));
 #else
   return classifyHit(cacheLookup1D(funcIndex, dim0, inst0));
 #endif
@@ -1466,8 +1613,7 @@ EJitSharedTaskPool::tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  const EJitDimPair d2[2] = {{dim0, inst0}, {dim1, inst1}};
-  return classifyHit(cacheLookupSeq(funcIndex, d2, 2));
+  return classifyHit(cacheLookupSeq2D(funcIndex, dim0, inst0, dim1, inst1));
 #else
   return classifyHit(cacheLookup2D(funcIndex, dim0, inst0, dim1, inst1));
 #endif

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -115,3 +115,36 @@ add_custom_target(check-ejit-shared-taskpool
   COMMENT "Running EmbeddedJIT cross-core shared taskpool unit tests"
   USES_TERMINAL
   )
+
+# Optional cache-query microbenchmark (NOT a gtest binary: standalone main()).
+# Off by default so it never bloats normal test builds. Enable with
+# -DEJIT_BUILD_CACHE_QUERY_BENCH=ON to build a host-runnable binary that prints a
+# machine-readable table of the 0D/1D/2D owner/peer cache-hit query cost by slot
+# depth (drive it under `perf stat -e instructions` for per-hit attribution).
+# Links only the shared-taskpool sources + platform, like the tests above.
+option(EJIT_BUILD_CACHE_QUERY_BENCH
+  "Build the EJIT shared taskpool cache-query microbenchmark" OFF)
+if(EJIT_BUILD_CACHE_QUERY_BENCH)
+  add_llvm_executable(EJITSharedCacheQueryBench
+    EJitSharedCacheQueryBench.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp
+
+    PARTIAL_SOURCES_INTENDED
+    )
+  target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
+    EJIT_SRE_TASKPOOL
+    EJIT_SRE_SHARED_TASKPOOL
+    EJIT_SRE_TASKPOOL_TESTING
+    EJIT_SRE_TASKPOOL_BUCKETS=32
+    EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
+    )
+  # Opt-in: build the benchmark with the load-only NO_RECLAIM seqlock hit path
+  # + cross-core code sharing (so peer hits and the fixed-dim seqlock lookups
+  # are exercised), mirroring EJIT_TEST_NO_RECLAIM above.
+  if(EJIT_TEST_NO_RECLAIM)
+    target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
+      EJIT_SRE_TASKPOOL_NO_RECLAIM
+      EJIT_SRE_SHARED_CODE_POINTERS)
+  endif()
+endif()

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
@@ -1,0 +1,288 @@
+//===-- EJitSharedCacheQueryBench.cpp - cache-hit query microbenchmark ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Deterministic, single-thread microbenchmark + slot-depth diagnostics for the
+//  cross-core SHARED taskpool cache-hit query path (spec §5.2 steps 0-1). It is
+//  NOT a gtest binary: it has its own main(), links only the shared-taskpool
+//  sources + EJitSharedPlatform, and prints a machine-readable table so an
+//  external harness (perf stat, this file's own cycle counter) can attribute
+//  instructions/cycles per hit.
+//
+//  What it measures, per the audit requirements:
+//    * 0D / 1D / 2D owner-core cache hit
+//    * hit slot depth 0, 1, 5, 15 (the linear 16-slot bucket scan)
+//    * peer-core hit (code sharing on, execute-permission already memoized)
+//    * a slot-depth histogram for a synthetic mixed workload
+//
+//  Slot depth is controlled deterministically: 0D identities whose funcIndex is
+//  a multiple of kEJitSharedCacheBuckets (32) all hash to bucket 0 and fill its
+//  slots 0,1,2,... in publish order (cachePublish uses first-empty), so the Nth
+//  published collider lands at slot N.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <memory>
+#include <vector>
+
+using namespace llvm::ejit;
+
+namespace {
+
+// Deterministic, non-null "compiled code" pointer derived from funcIndex. Never
+// executed — only cached/compared/returned.
+void *codeFor(uint32_t funcIndex) {
+  return reinterpret_cast<void *>(0x100000ull +
+                                  static_cast<uintptr_t>(funcIndex) * 64u);
+}
+
+bool benchCompile(void * /*ctx*/, const EJitCompileRequest &req, void **outFn) {
+  *outFn = codeFor(req.funcIndex);
+  return true;
+}
+
+// Owner-side resolver: hand back a fixed 2MiB pool range so peer preparation
+// (4K/2M) and codeStart/codeSize metadata are exercised.
+struct RangeCtx {
+  uintptr_t poolBase = 0x40000000ull;
+  uint64_t poolSize = 0x200000ull;
+  uintptr_t codeStart = 0x40000000ull;
+  uint64_t codeSize = 64;
+  uint32_t poolId = 0;
+};
+bool benchCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
+  auto *r = static_cast<RangeCtx *>(ctx);
+  out->fnPtr = const_cast<void *>(fnPtr);
+  out->codeStart = r->codeStart;
+  out->codeSize = r->codeSize;
+  out->poolBase = r->poolBase;
+  out->poolSize = r->poolSize;
+  out->poolId = r->poolId;
+  return true;
+}
+
+// Peer execute-permission preparation always succeeds in this host harness.
+bool benchPrepareCode(void * /*ctx*/, const void * /*fnPtr*/) { return true; }
+
+uint64_t nowNs() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ull +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+
+// Global sink so the compiler cannot elide the looked-up pointer.
+volatile uintptr_t gSink = 0;
+
+struct Bench {
+  std::unique_ptr<EJitSharedTaskPoolState> state;
+  EJitSharedTaskPool pool;
+  RangeCtx range;
+
+  void bringUpOwner(bool codeSharing) {
+    EJitCoreId::resetForTest();
+    EJitCoreId::setCurrentForTest(0);
+    state.reset(new EJitSharedTaskPoolState());
+    pool.bind(state.get());
+    pool.setCompiler(&benchCompile, nullptr);
+    pool.setMode(EJitCompileMode::Async);
+    pool.setCodeSharingEnabled(codeSharing);
+    pool.setCodeRangeProvider(&benchCodeRange, &range);
+    pool.setPrepareCodeCallback(&benchPrepareCode, nullptr);
+    if (pool.init() != EJitSharedTaskPool::InitResult::BecameOwner) {
+      std::fprintf(stderr, "owner election failed\n");
+      std::exit(1);
+    }
+  }
+
+  // Publish one 0D identity on the owner core (compile inline via Async enqueue
+  // + pollOne).
+  void publish0D(uint32_t funcIndex) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.compileOrGet(funcIndex, nullptr, 0, codeFor(funcIndex));
+    pool.pollOne();
+  }
+  void publish1D(uint32_t funcIndex, uint32_t d0, uint32_t i0) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    EJitDimPair dims[1] = {{d0, i0}};
+    pool.compileOrGet(funcIndex, dims, 1, codeFor(funcIndex));
+    pool.pollOne();
+  }
+  void publish2D(uint32_t funcIndex, uint32_t d0, uint32_t i0, uint32_t d1,
+                 uint32_t i1) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    pool.setInstanceEnabled(d1, i1, true);
+    EJitDimPair dims[2] = {{d0, i0}, {d1, i1}};
+    pool.compileOrGet(funcIndex, dims, 2, codeFor(funcIndex));
+    pool.pollOne();
+  }
+};
+
+// --- 0D slot-depth sweep -----------------------------------------------------
+// Publish (depth+1) 0D colliders into bucket 0, then hammer the deepest one.
+uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(/*codeSharing=*/peer);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  uint32_t targetFunc = 0;
+  for (uint32_t d = 0; d <= depth; ++d) {
+    uint32_t fi = d * kB; // all hash to bucket 0
+    B.publish0D(fi);
+    targetFunc = fi; // deepest published so far
+  }
+  uint32_t core = 0;
+  if (peer) {
+    core = 1;
+    EJitCoreId::setCurrentForTest(core);
+    // Warm the memoized execute-permission bit for this peer core.
+    auto w = B.pool.tryCacheHit0D(targetFunc);
+    if (w.hasReadToken)
+      B.pool.releaseRead(w.bucketIndex);
+  }
+  EJitCoreId::setCurrentForTest(core);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit0D(targetFunc);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+uint64_t bench1D(uint32_t depth, uint64_t iters, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(false);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  // 1D identities colliding into one bucket: vary funcIndex by multiples that
+  // keep the same hash bucket is nontrivial, so instead vary instanceId and
+  // accept the natural bucket; publish depth+1 entries and hammer the last.
+  uint32_t targetFunc = 7;
+  for (uint32_t d = 0; d <= depth; ++d) {
+    B.publish1D(targetFunc, 0, d); // same funcIndex, distinct instanceId
+  }
+  // The deepest is instanceId=depth; ensure it is enabled and query it.
+  EJitCoreId::setCurrentForTest(0);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit1D(targetFunc, 0, depth);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+uint64_t bench2D(uint64_t iters, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(false);
+  uint32_t targetFunc = 9;
+  B.publish2D(targetFunc, 0, 1, 1, 2);
+  EJitCoreId::setCurrentForTest(0);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit2D(targetFunc, 0, 1, 1, 2);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+void runTable(uint64_t iters) {
+  std::printf("# config,dim,slotDepth,core,nsPerHit,hits/iters\n");
+  double ns;
+  uint64_t h;
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench0D(depth, iters, /*peer=*/false, &ns);
+    std::printf("owner0D,0,%u,0,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench0D(depth, iters, /*peer=*/true, &ns);
+    std::printf("peer0D,0,%u,1,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench1D(depth, iters, &ns);
+    std::printf("owner1D,1,%u,0,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  h = bench2D(iters, &ns);
+  std::printf("owner2D,2,0,0,%.3f,%llu/%llu\n", ns, (unsigned long long)h,
+              (unsigned long long)iters);
+}
+
+} // namespace
+
+// Usage:
+//   bench                 -> full table, 20M iters each
+//   bench <iters>         -> full table with given iters
+//   bench single0d <d> <iters>   -> ONE tight loop (for perf stat attribution)
+//   bench single0dpeer <d> <iters>
+//   bench single1d <d> <iters>
+//   bench single2d <iters>
+int main(int argc, char **argv) {
+  uint64_t iters = 20000000ull;
+  if (argc >= 2 && std::strncmp(argv[1], "single", 6) == 0) {
+    double ns;
+    uint64_t h = 0;
+    const char *what = argv[1];
+    if (std::strcmp(what, "single0d") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, false, &ns);
+    } else if (std::strcmp(what, "single0dpeer") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, true, &ns);
+    } else if (std::strcmp(what, "single1d") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench1D(d, iters, &ns);
+    } else if (std::strcmp(what, "single2d") == 0) {
+      iters = argc >= 3 ? strtoull(argv[2], nullptr, 10) : iters;
+      h = bench2D(iters, &ns);
+    } else {
+      std::fprintf(stderr, "unknown single mode %s\n", what);
+      return 2;
+    }
+    std::printf("%s ns/hit=%.3f hits=%llu/%llu sink=%llu\n", what, ns,
+                (unsigned long long)h, (unsigned long long)iters,
+                (unsigned long long)gSink);
+    return 0;
+  }
+  if (argc >= 2)
+    iters = strtoull(argv[1], nullptr, 10);
+  runTable(iters);
+  std::printf("# sink=%llu\n", (unsigned long long)gSink);
+  return 0;
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2259,6 +2259,167 @@ TEST_F(SharedTaskPoolTest, HitTokenDisciplineAndVersionInvalidation) {
 }
 
 //===----------------------------------------------------------------------===//
+// Slot-depth diagnostics: 0D identities whose funcIndex is a multiple of
+// kEJitSharedCacheBuckets all hash to bucket 0 and fill its slots 0,1,2,... in
+// publish order (cachePublish uses first-empty). This deterministically places
+// a target at a chosen linear-scan depth, exercising the per-slot scan (and the
+// identityHash-first fast-reject reorder) and proving the deepest slot is still
+// found and correctly identified.
+//===----------------------------------------------------------------------===//
+namespace {
+// Return the linear slot index at which \p funcIndex is Ready in its bucket, or
+// -1 if not found. Pure diagnostic scan (no lock needed in the single-thread
+// test).
+int slotDepthOf(EJitSharedTaskPoolState *st, uint32_t funcIndex,
+                uint32_t numDims) {
+  uint32_t bucket = funcIndex % kEJitSharedCacheBuckets; // 0D key == funcIndex
+  auto &B = st->buckets[bucket];
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    auto &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() ==
+            static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
+        Slot.funcIndex == funcIndex && Slot.numDims == numDims)
+      return static_cast<int>(s);
+  }
+  return -1;
+}
+} // namespace
+
+TEST_F(SharedTaskPoolTest, SlotDepthHitsAtEveryDepth) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+
+  // Fill bucket 0 slots 0..15 with distinct 0D colliders.
+  for (uint32_t d = 0; d < kEJitSharedCacheSlots; ++d) {
+    uint32_t fi = d * kB;
+    ASSERT_EQ(owner.compileOrGet(fi, nullptr, 0, codeFor(fi)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(owner.pollOne());
+    EXPECT_EQ(slotDepthOf(state_.get(), fi, 0), static_cast<int>(d));
+  }
+
+  // Every colliding identity — including the deepest slot 15 — must still be a
+  // correct cache hit with its own specialization pointer.
+  for (uint32_t d = 0; d < kEJitSharedCacheSlots; ++d) {
+    uint32_t fi = d * kB;
+    auto hit = owner.tryCacheHit0D(fi);
+    ASSERT_TRUE(hit.fastPathTerminal) << "depth " << d;
+    EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit) << "depth " << d;
+    EXPECT_EQ(hit.fnPtr, codeFor(fi)) << "depth " << d;
+    if (hit.hasReadToken)
+      owner.releaseRead(hit.bucketIndex);
+  }
+
+  // An unpublished colliding key in the same (now full) bucket is a clean miss.
+  auto miss = owner.tryCacheHit0D(kEJitSharedCacheSlots * kB);
+  EXPECT_NE(miss.status, EJitCompileOrGetStatus::CacheHit);
+  if (miss.hasReadToken)
+    owner.releaseRead(miss.bucketIndex);
+}
+
+// The identityHash-first reorder must never alias two identities that share a
+// bucket: a wrong-funcIndex query with the same bucket must miss even when a
+// different identity is Ready there.
+TEST_F(SharedTaskPoolTest, SlotDepthNoIdentityAliasAcrossBucket) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  // Publish only funcIndex 5*kB at slot 0 of bucket 0.
+  uint32_t present = 5 * kB;
+  ASSERT_EQ(owner.compileOrGet(present, nullptr, 0, codeFor(present)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  // A different colliding funcIndex (same bucket, different identity) misses.
+  auto miss = owner.tryCacheHit0D(9 * kB);
+  EXPECT_NE(miss.status, EJitCompileOrGetStatus::CacheHit);
+  if (miss.hasReadToken)
+    owner.releaseRead(miss.bucketIndex);
+  // The present one still hits with the right pointer.
+  auto hit = owner.tryCacheHit0D(present);
+  EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(hit.fnPtr, codeFor(present));
+  if (hit.hasReadToken)
+    owner.releaseRead(hit.bucketIndex);
+}
+
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+//===----------------------------------------------------------------------===//
+// NO_RECLAIM fixed-dimension seqlock specializations (cacheLookupSeq0D/1D/2D):
+// the unrolled seqlock lookups reached by tryCacheHit0D/1D/2D must return the
+// SAME result as the generic seqlock path (cacheLookupSeq via tryCacheHit), for
+// hits, deep-slot hits, misses, disabled instances, and version invalidation.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, SeqFixedDimMatchesGeneric0D1D2D) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(1, 2, true);
+  owner.setInstanceEnabled(3, 4, true);
+
+  // Publish a 0D, a 1D and a 2D specialization.
+  ASSERT_EQ(owner.compileOrGet(21, nullptr, 0, codeFor(21)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EJitDimPair d1[1] = {dim(1, 2)};
+  ASSERT_EQ(owner.compileOrGet(22, d1, 1, codeFor(22)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EJitDimPair d2[2] = {dim(1, 2), dim(3, 4)};
+  ASSERT_EQ(owner.compileOrGet(23, d2, 2, codeFor(23)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  // Fixed-dim seqlock entry vs generic seqlock entry: identical outcomes.
+  auto fixed0 = owner.tryCacheHit0D(21);
+  auto gen0 = owner.tryCacheHit(21, nullptr, 0);
+  EXPECT_EQ(fixed0.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed0.status, gen0.status);
+  EXPECT_EQ(fixed0.fnPtr, gen0.fnPtr);
+  EXPECT_EQ(fixed0.fnPtr, codeFor(21));
+
+  auto fixed1 = owner.tryCacheHit1D(22, 1, 2);
+  auto gen1 = owner.tryCacheHit(22, d1, 1);
+  EXPECT_EQ(fixed1.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed1.status, gen1.status);
+  EXPECT_EQ(fixed1.fnPtr, gen1.fnPtr);
+  EXPECT_EQ(fixed1.fnPtr, codeFor(22));
+
+  auto fixed2 = owner.tryCacheHit2D(23, 1, 2, 3, 4);
+  auto gen2 = owner.tryCacheHit(23, d2, 2);
+  EXPECT_EQ(fixed2.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed2.status, gen2.status);
+  EXPECT_EQ(fixed2.fnPtr, gen2.fnPtr);
+  EXPECT_EQ(fixed2.fnPtr, codeFor(23));
+
+  // A miss and a wrong-dim query must also agree (both miss).
+  EXPECT_NE(owner.tryCacheHit0D(99).status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_NE(owner.tryCacheHit1D(22, 1, 3).status,
+            EJitCompileOrGetStatus::CacheHit); // wrong instanceId
+}
+
+// Version bump after a seqlock fixed-dim publish must invalidate the old slot.
+TEST_F(SharedTaskPoolTest, SeqFixedDimVersionBumpMisses) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(2, 7, true);
+  EJitDimPair d1[1] = {dim(2, 7)};
+  ASSERT_EQ(owner.compileOrGet(31, d1, 1, codeFor(31)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EXPECT_EQ(owner.tryCacheHit1D(31, 2, 7).status,
+            EJitCompileOrGetStatus::CacheHit);
+  // Deactivate (bumps version): stale slot must not be served.
+  owner.setInstanceEnabled(2, 7, false);
+  EXPECT_NE(owner.tryCacheHit1D(31, 2, 7).status,
+            EJitCompileOrGetStatus::CacheHit);
+}
+#endif // EJIT_SRE_TASKPOOL_NO_RECLAIM
+
+//===----------------------------------------------------------------------===//
 // Phase-1 hot-hit micro-benchmark (DISABLED by default; run explicitly with
 //   --gtest_also_run_disabled_tests --gtest_filter='*HotHitMicroBench*'
 // on an aarch64 host). Measures the per-hit cost of the shared taskpool hit


### PR DESCRIPTION
## 中文

### 改动目标

本 PR 审计并优化 Shared Taskpool 的 cache-hit 查询热路径，重点减少固定维度查询和深 slot 扫描中的指令及共享内存访问开销。

### 具体改动

- 新增可复现的 cache-query benchmark 与 slot-depth 诊断。
- 在 `EJIT_SRE_TASKPOOL_NO_RECLAIM` 模式下，为 0D/1D/2D 增加固定维度 seqlock 查询路径，避免通用维度循环和通用 identity 比较。
- 调整 slot 扫描顺序：先用 `identityHash` 快速排除，再执行 acquire state、完整 identity、generation 和 version 校验。
- 保持 shared-state 大小、字段布局和 ABI 不变；不增加每次命中的共享读写。
- 补充性能模型、候选优化方向及硬件验证边界文档。

### 单线程收益（PR 本身的前后对比）

Host AArch64、Little Endian、`-Os`、stats OFF：

- 常见 NO_RECLAIM owner 0D slot-0：`139 -> 119` 条内部查询指令，`9.6ns -> 9.0ns`。
- token 0D slot-15：`304 -> 214`，`33.2ns -> 22.7ns`。
- NO_RECLAIM 0D slot-15：`364 -> 224`，`23.4ns -> 15.1ns`。

浅 slot 是小幅正收益，深 slot 收益更明显。文档中的约 105 条仅是 `tryCacheHit0D` 内部查询执行路径估算，不包含完整 C ABI shell、wrapper 和最终间接函数调用。

### 16 线程竞争验证

在 32-core Neoverse-N2 Little-Endian AArch64 主机上，使用真实 16 个 Linux 线程模拟多个核反复查询同一个 0D specialization；每线程 1,000,000 次，全部 `16,000,000/16,000,000` 命中：

| 查询协议 | 16 线程同一 slot | 16 线程分散 bucket |
|---|---:|---:|
| read-token | 约 1.44–1.58 us/hit | 约 26–45 ns/hit |
| NO_RECLAIM seqlock | 约 12.35–12.42 ns/hit | 约 12.34–12.40 ns/hit |

同一 slot 的线程扩展：

| 线程数 | read-token | NO_RECLAIM seqlock |
|---:|---:|---:|
| 1 | 26 ns | 12.4 ns |
| 2 | 119 ns | 12.3 ns |
| 4 | 294 ns | 12.4 ns |
| 8 | 710 ns | 12.3 ns |
| 16 | 1,560 ns | 12.4 ns |

该结果说明 read-token 的共享原子 RMW 在多核同一热函数场景下会产生严重 cache-line bouncing；NO_RECLAIM 的只读 seqlock 路径在“生成代码永不物理回收”的产品前提下消除了该争用。

注意：这是**协议/部署配置对比**，不能把 read-token 到 NO_RECLAIM 的全部倍率都解释为本 PR 的局部指令重排收益。本 PR 自身的前后收益以“单线程收益”一节为准。

### 构建与部署注意事项

`EJIT_SRE_TASKPOOL_NO_RECLAIM` 是编译期配置。切换到包含本 PR 的分支后，必须重新运行 CMake configure 并重新编译相关 TU。仅在旧版本的 `CMakeCache.txt` 中看到 `ON`，不能证明新路径已经编入。

建议确认实际编译命令中存在：

```text
-DEJIT_SRE_TASKPOOL_NO_RECLAIM
```

例如：

```bash
grep 'EJIT_SRE_TASKPOOL_NO_RECLAIM' build/CMakeCache.txt
grep -R -- '-DEJIT_SRE_TASKPOOL_NO_RECLAIM' \
  build/build.ninja build/compile_commands.json
```

重新 configure 后应能看到 `EJitSharedTaskPool.cpp.o` 被重新编译。

### 风险与边界

- NO_RECLAIM 路径严格依赖“生成代码不物理释放、不覆盖仍可能被调用的代码”的产品不变量。
- activate/deactivate、generation、Ready、identity 和 version 校验仍保留；本 PR 不以跳过正确性校验换取速度。
- Host 结果能复现共享缓存线争用，但不能替代真实平台上的 CoreId、内存屏障、I-cache/TLB 和调度验证。
- 1D 深 slot benchmark 仍应改成确定性 hash 冲突后再作为权威 slot-depth 数据。
- 16-thread benchmark 扩展目前作为额外验证，未包含在本 PR 的三个提交中。

### 验证

- `EJITTaskPoolTests`: 82/82
- `EJITTests`: 82/82
- 新增 slot-depth / fixed-dimension tests 通过
- `LLVMEJIT` 链接成功
- `clang-format` 与 `git diff --check` 干净
- 构建均限制为 `-j8`

---

## English

### Goal

This PR audits and optimizes the Shared Taskpool cache-hit query path, with emphasis on fixed-dimension lookups and reducing linear-scan cost for deeper cache slots.

### Changes

- Adds a reproducible cache-query benchmark and slot-depth diagnostics.
- Adds fixed-dimension 0D/1D/2D seqlock lookup paths under `EJIT_SRE_TASKPOOL_NO_RECLAIM`, avoiding generic dimension loops and identity matching.
- Checks `identityHash` before the acquiring state load while retaining authoritative state, identity, generation, and version validation.
- Keeps shared-state size, layout, and ABI unchanged, with no additional per-hit shared reads or writes.
- Documents the performance model, alternatives, and hardware-validation boundaries.

### Single-thread benefit attributable to this PR

Host AArch64 Little Endian, `-Os`, stats disabled:

- Common NO_RECLAIM owner 0D slot-0: `139 -> 119` internal-query instructions, `9.6ns -> 9.0ns`.
- Token 0D slot-15: `304 -> 214`, `33.2ns -> 22.7ns`.
- NO_RECLAIM 0D slot-15: `364 -> 224`, `23.4ns -> 15.1ns`.

Shallow slots receive a modest positive improvement, while deeper slots benefit more. The documented ~105 instructions cover only the internal `tryCacheHit0D` path, not the complete C ABI shell, wrapper, or final indirect call.

### 16-thread contention validation

On a 32-core Neoverse-N2 Little-Endian AArch64 host, 16 real Linux threads repeatedly queried the same 0D specialization, one million iterations per thread. All `16,000,000/16,000,000` queries hit:

| Protocol | Same slot | Separate buckets |
|---|---:|---:|
| read-token | about 1.44–1.58 us/hit | about 26–45 ns/hit |
| NO_RECLAIM seqlock | about 12.35–12.42 ns/hit | about 12.34–12.40 ns/hit |

Same-slot scaling:

| Threads | read-token | NO_RECLAIM seqlock |
|---:|---:|---:|
| 1 | 26 ns | 12.4 ns |
| 2 | 119 ns | 12.3 ns |
| 4 | 294 ns | 12.4 ns |
| 8 | 710 ns | 12.3 ns |
| 16 | 1,560 ns | 12.4 ns |

The read-token atomic RMWs cause severe cache-line bouncing when many cores call one hot function. Under the product invariant that generated code is never physically reclaimed, the read-only NO_RECLAIM seqlock path removes this contention.

This is a **protocol/deployment comparison**. The full read-token-to-NO_RECLAIM ratio must not be presented as the benefit of this PR's local instruction reordering; the directly attributable before/after numbers are listed in the single-thread section.

### Build and deployment requirement

`EJIT_SRE_TASKPOOL_NO_RECLAIM` is a compile-time configuration. After switching to this PR, rerun CMake configure and rebuild the affected translation units. Seeing `ON` in an old `CMakeCache.txt` alone does not prove that the path was compiled.

Verify that the actual compile command contains:

```text
-DEJIT_SRE_TASKPOOL_NO_RECLAIM
```

After reconfiguration, `EJitSharedTaskPool.cpp.o` should be rebuilt.

### Risks and boundaries

- NO_RECLAIM requires that generated code is not physically reclaimed or overwritten while it may still be called.
- Activate/deactivate, generation, Ready, identity, and version validation remain intact.
- Host results reproduce shared-cache-line contention but do not replace target validation of CoreId, barriers, I-cache/TLB behavior, and scheduling.
- The 1D deep-slot benchmark still needs deterministic hash-colliding inputs before those depth numbers are authoritative.
- The 16-thread benchmark extension is additional validation and is not part of this PR's current three commits.

### Validation

- `EJITTaskPoolTests`: 82/82
- `EJITTests`: 82/82
- New slot-depth and fixed-dimension tests pass
- `LLVMEJIT` links successfully
- `clang-format` and `git diff --check` are clean
- All builds were limited to `-j8`
