### PR TITLE
[EJIT] Add post-compile hot-path benchmark and performance audit

### DIFF
--- a/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
+++ b/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
@@ -1,0 +1,257 @@
+# EJIT Shared Taskpool — Cache-Query Performance Audit & Model
+
+Scope: the cross-core shared taskpool cache-hit **query** path (spec §5.2 steps
+0–1), from the AOT wrapper's C ABI call through the read-token / seqlock release.
+This document is the performance model behind the Commit 2 optimization; it does
+**not** describe the compile/enqueue slow path.
+
+All static instruction counts are AArch64, `clang -Os`, default capacities
+(`EJIT_SRE_TASKPOOL_BUCKETS=32`, `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS=16`).
+All per-hit measurements are on an aarch64 host via `perf stat`, stats OFF
+(`EJIT_STATS_ENABLE` undefined — the production default), 100M iterations. Host
+nanoseconds are for **relative comparison only**; they are not board cycles.
+
+Reproduce with the benchmark added in Commit 1:
+
+```
+clang++ -std=c++17 -O2 -Illvm/include \
+  -DEJIT_SRE_TASKPOOL -DEJIT_SRE_SHARED_TASKPOOL -DEJIT_SRE_TASKPOOL_TESTING \
+  -DEJIT_SRE_TASKPOOL_BUCKETS=32 -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024 \
+  [-DEJIT_SRE_SHARED_CODE_POINTERS] [-DEJIT_SRE_TASKPOOL_NO_RECLAIM] \
+  llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp -o bench
+perf stat -e instructions,cycles ./bench single0d 15 100000000
+```
+
+Or via CMake: configure with `-DEJIT_BUILD_CACHE_QUERY_BENCH=ON` (and
+`-DEJIT_TEST_NO_RECLAIM=ON` for the seqlock + code-sharing variant), build
+`EJITSharedCacheQueryBench`.
+
+---
+
+## 1. Baseline call chain (per layer)
+
+```
+wrapper IR / AOT entry
+ └─ ejit_taskpool_compile_or_get[_0d/_1d/_2d]     (C ABI shell, EJitRuntime.cpp)
+     └─ EJitSharedTaskPool::tryCacheHit[0D/1D/2D]  (Ready gate + instance-enabled)
+         └─ cacheLookup[0D/1D/2D] | cacheLookupSeq[0D/1D/2D]
+             ├─ hashIdentity (inlined / unrolled)  key
+             ├─ bucket = key % 32
+             ├─ bucketTryRead  (token: 1 acquire load + 1 RMW; seqlock: 1 load)
+             ├─ slot scan 0..15  (per slot: identityHash reject → state acquire →
+             │                    generation → identity → version)
+             └─ resolveMatchedSlot
+                 ├─ owner core / memoized peer → return fnPtr (+ read token)
+                 └─ cold peer first touch → peerPrepareSlot (noinline)
+         └─ classifyHit  (CacheHit / InstanceDisabled / OffMode / notShareable)
+ └─ JIT function indirect call
+ └─ releaseRead  (token: 1 RMW; seqlock: no-op sentinel)
+```
+
+### Static per-layer instruction counts (AArch64, -Os)
+
+| Layer (function)                 | token | NO_RECLAIM |
+|----------------------------------|------:|-----------:|
+| `ejit_taskpool_compile_or_get_0d` (C shell) | ~20 | ~20 |
+| `tryCacheHit0D`                  | 36 | 43 |
+| `tryCacheHit1D`                  | 48 | 54 |
+| `tryCacheHit2D`                  | 55 | 61 |
+| `tryCacheHit` (generic)          | 55 | 61 |
+| `cacheLookup0D` / `cacheLookupSeq0D` | 69 | 68 |
+| `cacheLookup1D` / `cacheLookupSeq1D` | 104 | 109 |
+| `cacheLookup2D` / `cacheLookupSeq2D` | 140 | 144 |
+| `cacheLookup` (generic)          | 136 | 138 |
+| `resolveMatchedSlot`             | 36 | 42 |
+| `peerPrepareSlot` (cold, noinline) | 150 | ~150 |
+| `classifyHit`                    | 22 | 32 |
+| `hashIdentity` (generic)         | 16 | 16 |
+| `releaseRead`                    | 14 | 1 (no-op) |
+
+Static counts are whole-function sizes (they include the miss/error tails and
+the 16-iteration loop body once). The **executed** hit path touches only a
+subset — see §3.
+
+### Per-basic-block path classification
+
+For the fixed-dim lookups the blocks partition as:
+- **cache-hit blocks**: hash build → `bucketTryRead` success → the *matching*
+  slot iteration → `resolveMatchedSlot` owner/memoized return.
+- **miss-only blocks**: the loop `continue` edges (rejected slots) and the
+  fall-through `bucketReadRelease; return R`.
+- **owner-only blocks**: `resolveMatchedSlot` `self == owner` early return.
+- **peer-only blocks**: `resolveMatchedSlot` memoized-mask branch + the call to
+  `peerPrepareSlot`.
+- **error-only blocks**: `numDims > 4` guard (generic only), `!bucketTryRead`
+  contended fallback, `fnPtr == 0` racing-publish fallback.
+
+---
+
+## 2. Actual cache-hit executed path (measured, stats OFF)
+
+`insns/hit` and `ns/hit` are the perf-measured loop totals; the benchmark loop
+harness is **~14 instructions** (measured from the disassembled loop:
+call-arg setup, `gSink` volatile add, status/hasReadToken test, loop counter),
+so the executed query path is `insns/hit − 14`.
+
+| Config (owner core, stats off) | slot | insns/hit | ns/hit | exec path insns |
+|--------------------------------|-----:|----------:|-------:|----------------:|
+| token 0D                       | 0    | 124 | 20.2 | ~110 |
+| token 0D                       | 15   | 214 | 22.7 | ~200 |
+| token 1D                       | 0    | 184 | 24.1 | ~170 |
+| token 2D                       | 0    | 221 | 25.3 | ~207 |
+| NO_RECLAIM 0D                  | 0    | 119 | 9.0  | **~105** |
+| NO_RECLAIM 0D                  | 15   | 224 | 15.1 | ~210 |
+| NO_RECLAIM 1D                  | 0    | 163 | 11.5 | ~149 |
+| NO_RECLAIM 2D                  | 0    | 220 | 15.6 | ~206 |
+| NO_RECLAIM 0D peer (memoized)  | 0    | 125 | 9.5  | ~111 |
+
+Dominant costs, in order:
+1. **Token read/release RMW** (`bucket.readers` fetchAdd + fetchSub, two
+   `ldaddal`): ~11 ns of the 20 ns token 0D hit. The seqlock (NO_RECLAIM) build
+   removes both → **2.0–2.3× faster** at slot 0.
+2. **Linear 16-slot scan**: ~0.8 ns and (post-opt) ~6 instructions per scanned
+   non-matching slot. Only material for busy buckets / deep slots.
+3. **`resolveMatchedSlot` owner gate**: `EJitCoreId::current()` + `ownerCoreId`
+   load + branch.
+4. Per-slot `state` **acquire load** (`ldar`) — one per scanned slot in the old
+   order; skipped for rejected slots after the reorder (§4).
+
+---
+
+## 3. Slot-depth distribution
+
+`cachePublish` fills the first empty slot, so entries in one bucket stack at
+slots 0,1,2,… in publish order; a bucket evicts its slot-0 occupant when full.
+With 32 buckets and a good hash, the expected occupancy per bucket for N live
+specializations is N/32; the hit slot depth is therefore **0 for the vast
+majority** of realistic workloads and only grows for hash-colliding identities
+or > 32 hot specializations.
+
+The Commit 1 benchmark (`bench0D`) and the `SlotDepthHitsAtEveryDepth` test
+place a target at each depth 0/1/5/15 deterministically (0D funcIndex multiples
+of 32 collide into bucket 0). Measured slope: token **+0.83 ns/slot** before,
+**+0.16 ns/slot** after the reorder; NO_RECLAIM **+0.92 ns/slot** before,
+**+0.41 ns/slot** after.
+
+---
+
+## 4. Candidate directions — benefit / risk
+
+| Dir | Idea | Benefit | Mem cost | Concurrency / version risk | Verdict |
+|-----|------|---------|----------|----------------------------|---------|
+| A | slot-depth stat | diagnostic only | 0 | none | shipped as bench + test |
+| B | per-funcIndex slot **hint** | cuts deep-slot scan | +4–8 B/func shared | must re-validate gen+identity+version; stale slot must not alias | **not shipped** — real depth ≈0; complexity/risk > benefit |
+| C | direct-mapped primary slot | O(1) common hit | +shared index | different specialization must not alias same funcIndex | **not shipped** — aliasing risk, marginal at depth 0 |
+| D | version digest word | 1 u32 compare vs per-dim loop | +4 B/slot | digest collision must never authorize stale code (hint only) | **report only** — needs ABI bump; per-dim loop already cheap (≤4) |
+| E | packed epoch/state word | 1 read vs several | +8 B | epoch may only *reject* / gate slow check | **report only** — needs strict equivalence proof + ABI bump |
+| F | owner-only hot/cold split | smaller I-cache footprint | 0 | must not bypass read token | partially present (`peerPrepareSlot` already noinline); owner path already tight |
+| G | move `identityHash` into slot line 0 | 1 cache line/scan vs 2 | 0 (reorder) | big-endian safe (by-value); **changes shared layout → ABI bump** | **report only** — see §5 |
+| H | hash algo | — | — | — | **not changed**: 0D≈funcIndex, 1D/2D few XOR+mul, `%32`→`&31` already; objdump shows hash is not the bottleneck |
+| **I** | **fixed-dim seqlock `cacheLookupSeqNd`** | −20 insns vs generic in NO_RECLAIM | 0 | never-free precondition (already the NO_RECLAIM invariant) | **SHIPPED** (Commit 2) |
+| — | **identityHash-first scan reorder** | −32/−36 % ns at depth 15 | 0 | identical semantics (final gate unchanged) | **SHIPPED** (Commit 2) |
+| J | wrapper call-site local cache | skips ABI shell | +8 B/site | cross-core/deactivate/version correctness unproven | **not shipped** — see the separate `ejit-callsite-local-cache` experiment; needs strict proof |
+
+---
+
+## 5. What shipped (Commit 2)
+
+1. **Fixed-dimension seqlock specializations** `cacheLookupSeq0D/1D/2D`
+   (Direction I / priority #1). In NO_RECLAIM builds `tryCacheHit0D/1D/2D`
+   previously fell back to the *generic* `cacheLookupSeq` (generic hash loop +
+   `slotIdentityMatches`). They now use unrolled specializations mirroring
+   `cacheLookup0D/1D/2D`. Isolated entirely behind `EJIT_SRE_TASKPOOL_NO_RECLAIM`
+   (the "code never freed" build), satisfying the never-free precondition
+   constraint. No new shared state, no layout/ABI change.
+2. **identityHash-first scan reorder** across `cacheLookup`,
+   `cacheLookup0D..4D`, `cacheLookupSeq`, and the new `cacheLookupSeq0D/1D/2D`.
+   The per-slot loop now rejects on the plain `identityHash` compare **before**
+   the acquiring `state` load. Correctness is unchanged: a match still requires
+   the acquire `state==Ready` load **plus** the full `funcIndex/numDims/dims`
+   identity **plus** the per-dim version check before any pointer is returned;
+   `identityHash` is only a fast-reject hint (a 64-bit hash collision falls
+   through to the authoritative identity compare, and a stale/false-negative
+   read is a benign clean miss under both the bucket read token and the seqlock
+   `publishSeq` re-check). No layout/ABI change; big-endian safe (by-value
+   scalar compares).
+
+**Before → after** (owner, stats off):
+- token 0D slot 15: 304 → 214 insns, 33.2 → 22.7 ns (**−32 %**)
+- NO_RECLAIM 0D slot 0: 139 → 119 insns, 9.6 → 9.0 ns
+- NO_RECLAIM 0D slot 15: 364 → 224 insns, 23.4 → 15.1 ns (**−36 %**)
+- token 0D slot 0 unchanged (single slot, nothing to skip)
+
+Shared-state memory change: **0 bytes** (`sizeof(EJitSharedTaskPoolState)` and
+every slot/bucket offset identical; verified by static_assert + offsetof probe).
+New shared reads/writes per hit: **0** (both changes are pure code).
+
+---
+
+## 6. Not shipped — reasons
+
+- **B/C slot hint / primary slot**: realistic hit depth is ≈0 (N/32 occupancy),
+  so the win is confined to pathological buckets while the correctness surface
+  (stale-slot aliasing, generation/version re-validation) grows. Kept as a
+  measured direction only.
+- **D/E/G packed digest / epoch / hot-field layout**: each requires changing the
+  shared `EJitSharedCacheSlot` layout (or adding a word), i.e. an
+  `abiVersion` bump and cross-core coordinated redeploy. The audit's hard
+  constraint is to not change default ABI / cache identity, and the measured
+  benefit (per-dim version loop is ≤4 iterations; `identityHash` already
+  fast-rejects) does not justify the ABI churn. Direction G (move `identityHash`
+  to the first cache line so a scan touches one line instead of two) is the most
+  promising future ABI-bump candidate and is documented here for that purpose.
+- **H hash**: objdump confirms the hash is a handful of instructions and not the
+  bottleneck; `% 32` already lowers to `& 31`. Changing it risks collisions for
+  no measured gain.
+- **J wrapper call-site cache**: not correctness-provable against deactivate /
+  version-bump / cross-core code sharing without a generation+version guard that
+  costs about as much as the lookup it replaces.
+
+---
+
+## 7. The "< 100 instructions" target
+
+The common **NO_RECLAIM owner-core 0D** hit executes **~105** instructions
+(stats off, slot 0), just above the 100 target; token 0D is ~110. The residual,
+from the disassembly, is:
+- the cross-TU `bl` chain (C ABI shell → `tryCacheHit0D` → `cacheLookupSeq0D` →
+  `resolveMatchedSlot`) with its arg setup / return-struct spill (~30 insns of
+  call glue that a full-image **LTO** build collapses),
+- `EJitCoreId::current()` (a real call for the core id) + the owner gate,
+- the seqlock `bucketSeqBegin`/`bucketSeqStable` pair (~6 insns),
+- `classifyHit`'s outcome classification + `CompileOrGetResult` construction.
+
+With whole-image LTO (the production firmware link, where these functions inline
+into the wrapper), the call glue disappears and the path is expected to fall
+below 100. On the token path the two `readers` RMWs make the instruction count
+secondary to the atomic latency; the seqlock build is the one that both hits
+~105 instructions and is 2× faster in cycles.
+
+---
+
+## 8. Correctness invariants preserved
+
+Deactivated instance never served (instance-enabled gate unchanged); version
+bump invalidates old slots (per-dim version check still after identity);
+generation reset drops old slots (`generation` compare unchanged); identity-hash
+collision cannot alias (authoritative identity compare after the hash reject);
+peer without execute permission never gets a pointer (`resolveMatchedSlot` /
+`peerPrepareSlot` untouched); read token pairing intact (token path unchanged;
+seqlock takes no token by construction); publish/overwrite races handled (bucket
+write lock / `publishSeq` seqlock unchanged); POD / standard-layout / trivially
+destructible shared state unchanged; no dynamic init; stats OFF keeps the hot
+path free of counter RMW. Verified by the existing suite plus the new
+`SlotDepthHitsAtEveryDepth`, `SlotDepthNoIdentityAliasAcrossBucket`,
+`SeqFixedDimMatchesGeneric0D1D2D`, and `SeqFixedDimVersionBumpMisses` tests.
+
+---
+
+## 9. Still to validate on-board
+
+Host cannot model real cross-core cache coherence or SRE `enable_ex`/split
+latency; the state machine and return semantics are deterministically tested on
+host, but the actual peer first-touch seal cost, the cross-core `ldar`/RMW
+latency, and the board cycle counts must be measured on hardware. Host
+nanoseconds here are for relative comparison only.

--- a/jit_design_doc/EJIT_HOTPATH_PERF_AUDIT.md
+++ b/jit_design_doc/EJIT_HOTPATH_PERF_AUDIT.md
@@ -1,0 +1,391 @@
+# EmbeddedJIT Post-Compile Hot-Path Performance Audit
+
+Branch: `codex/ejit-baseline-perf-audit`
+Baseline: `dong/ejit_dev_spec4` @ `68ed1d88d8be`
+Measurement host: **native aarch64** (`aarch64-unknown-linux-gnu`, clang 23),
+production optimization level `-Os`, `perf` PMU available.
+
+> Scope: this audit studies **only** the EmbeddedJIT hot path taken *after* a
+> function is already JIT-compiled — the "wrapper cache hit" the business sees
+> as *AOT ~9 µs vs JIT wrapper ~15 µs*. It deliberately does **not** touch the
+> AsmLexer, the `-O2` crash, the 4K/2M permission model, IR/ASM dump, the
+> AArch64 AsmParser, backend trimming, the SRE platform API, `may_const`
+> correctness, online PGO, the light backend, or the global log framework.
+
+---
+
+## 0. TL;DR
+
+* The complete **wrapper cache-hit path is ~216 aarch64 instructions / ~45
+  cycles** in the production (`NO_RECLAIM` + shared-code-pointers) build — it is
+  **not** under 100 instructions. Section 5 breaks down where every instruction
+  goes.
+* The single biggest lever, the cache-query cost, is **already addressed by
+  PR #82** (unrolled fixed-dimension seqlock lookups). This audit confirms that
+  finding independently and does **not** re-implement it.
+* The remaining, PR #82-independent overhead is **plumbing**: the C-ABI shell
+  (~47 ins) and the wrapper glue (~23 ins). A **trusted-wrapper fast C-ABI**
+  removes ~24 instructions / ~5 cycles (~11 % of the wrapper-hit path),
+  measured in both the token and the seqlock builds. It is presented as a
+  **measured prototype**, not merged, because the change spans the C ABI and
+  `EJitWrapperGen` which cannot be end-to-end correctness-tested in this
+  environment (no board, no full clang build).
+* Two design decisions are quantitatively **validated**: keeping statistics
+  opt-in (`EJIT_STATS_ENABLE` off) saves ~13 cycles/hit, and the `NO_RECLAIM`
+  seqlock read path costs ~2.2× fewer cycles than the token path even on a
+  single core (and avoids cross-core cache-line bouncing).
+
+---
+
+## 1. Deliverables
+
+| Item | File |
+|---|---|
+| Three-tier benchmark (its own `main`) | `llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBench.cpp` |
+| Faithful same-ABI C-shell + wrapper TU | `llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBenchAbi.{h,cpp}` |
+| CMake target `EJITHotPathBench` (+ `EJIT_TEST_STATS` opt-in) | `llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt` |
+| This report | `jit_design_doc/EJIT_HOTPATH_PERF_AUDIT.md` |
+
+Build (standalone, no full LLVM build required):
+
+```
+# production premise: seqlock + cross-core sharing
+cmake -B build -DEJIT_TEST_NO_RECLAIM=ON …
+ninja -C build EJITHotPathBench
+# or directly, at -Os:
+clang++ -std=c++17 -Os -I llvm/include -Illvm/unittests/ExecutionEngine/EJIT \
+  -DEJIT_SRE_TASKPOOL -DEJIT_SRE_SHARED_TASKPOOL -DEJIT_SRE_TASKPOOL_TESTING \
+  -DEJIT_SRE_TASKPOOL_BUCKETS=32 -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024 \
+  -DEJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=1048576 \
+  -DEJIT_SRE_TASKPOOL_NO_RECLAIM -DEJIT_SRE_SHARED_CODE_POINTERS \
+  llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBench.cpp \
+  llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBenchAbi.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp -lpthread -o hotbench
+```
+
+Run: `./hotbench [iters]` for the full distribution table, or
+`perf stat -e instructions,cycles ./hotbench single <workload> <iters>` for
+per-workload instruction/cycle attribution (`single empty` is the calibration
+floor to subtract).
+
+---
+
+## 2. The real wrapper cache-hit call chain
+
+Verified against the source (file:line):
+
+```
+business call
+  └─ AOT wrapper (EJitWrapperGen.cpp: jit_entry)
+       ├─ load __ejit_funcidx_<name> global
+       ├─ jit_call: load dimType globals, extract instanceId from args
+       │    └─ ejit_taskpool_compile_or_get_0d/1d/2d          (EJitRuntime.cpp:586/614/646)
+       │         ├─ null-init *outFn,*outBucket
+       │         ├─ gEJIT ? gEJIT->sharedTaskPool() : nullptr  (two dependent loads)
+       │         ├─ dim-range check (fixed-dim entries)
+       │         └─ tp->tryCacheHit0D/1D/2D                    (EJitSharedTaskPool.cpp:1415/1430/1453)
+       │              ├─ state_ && initState==Ready            (acquire load)
+       │              ├─ instance-enabled check (1D/2D)
+       │              ├─ cacheLookup0D / cacheLookupSeq        (:604 / :363)   ← dominant cost
+       │              │    ├─ key = hash(funcIndex,dims)
+       │              │    ├─ bucket = key % 32
+       │              │    ├─ bucketTryRead / bucketSeqBegin   (:57 / :74)
+       │              │    ├─ generation.loadAcquire
+       │              │    ├─ slot scan (≤16): state, generation, identityHash,
+       │              │    │    funcIndex/numDims, dims, versions
+       │              │    └─ resolveMatchedSlot               (:417)
+       │              │         ├─ self = EJitCoreId::current()  (external bl on real platform)
+       │              │         ├─ owner = ownerCoreId.loadRelaxed
+       │              │         ├─ fn = Slot.fnPtr.loadAcquire
+       │              │         ├─ owner  → return {fn, noTokenHit|token}
+       │              │         └─ peer   → executableCoreMask bit → return / peerPrepareSlot
+       │              └─ classifyHit                           (:1341, always_inline)
+       │         └─ write *outFn,*outBucket, taskpoolStatus()
+       ├─ jit_dispatch: status==OK && fn ? indirect-call fn(args)
+       │    └─ ejit_taskpool_release_read(bucket)              (releaseRead: token=RMW, NO_RECLAIM=no-op)
+       └─ jit_fallback: original AOT body
+```
+
+---
+
+## 3. Method
+
+* Native aarch64, `-Os`, pinned with `taskset -c 3`.
+* **ns distribution**: warm up, then time `B` batches of `K=4000` iterations
+  each (`B·K ≥ 4,000,000`), report mean / min / p50 / p95 / p99 of the per-batch
+  ns/iter — a stable distribution without per-call timer cost in the loop.
+* **instructions / cycles**: `perf stat` around a tight single-workload loop
+  (`single` mode), 50,000,000 iterations, minus the `empty` loop (0.10 ins /
+  0.11 cyc — effectively the floor).
+* A `volatile` sink consumes every looked-up pointer and every return value so
+  the optimizer cannot elide the call; disassembly (§5) confirms the path is
+  actually executed. No `volatile` global is *written* inside the timed region,
+  so the measured cost is the hot path, not synthetic store traffic.
+* The three tiers are kept strictly separate. The C-ABI tier calls a **faithful
+  reproduction** of the production `ejit_taskpool_compile_or_get*` shell (same
+  validation, same `tryCacheHit` dispatch, same status mapping, same double
+  out-param write-back); the only difference is the pool is resolved from a stub
+  instead of the full `gEJIT` object graph, which is irrelevant to the hot path.
+  The wrapper tier is a real cross-TU function doing a real indirect call. This
+  is the "same-ABI host wrapper" the brief permits when the true target binary
+  cannot run here. **No internal `tryCacheHit` number is ever presented as a
+  C-ABI or wrapper number.**
+
+Limitation, stated honestly: the host is aarch64 (so the architecture, `-Os`,
+instruction counts and cycle counts are directly representative), but it is not
+the customer board, the indirect call is a plain `blr` to a small local
+function (no BTI/PAC, perfectly predicted), and `EJitCoreId::current()` is a
+thread-local rather than the platform `mrs`. The board-specific `blr`/`current()`
+costs are analyzed in §7 and flagged for on-board confirmation.
+
+---
+
+## 4. Measured results (production `NO_RECLAIM` + shared build, `-Os`)
+
+### 4.1 Per-op instructions & cycles (perf, 50 M iters, net of empty loop)
+
+| tier | workload | ins/op | cyc/op |
+|---|---|--:|--:|
+| baseline | empty loop | 0.10 | 0.11 |
+| baseline | direct AOT body | ~2 | ~2 |
+| baseline | direct JIT fnPtr (indirect call) | 9.1 | 2.4 |
+| internal | tryCacheHit0D + release | 146.2 | 30.6 |
+| cabi | `bench_cabi_0d` (full shell) | 193.3 | 40.1 |
+| cabi | `bench_cabi_1d` | ~ | ~ |
+| cabi | `bench_cabi_generic` 3D | — | — |
+| wrapper | **wrapper_hit (end-to-end)** | **216.3** | **45.3** |
+| wrapper | wrapper_hit **trusted fast-ABI** | **192.3** | **40.4** |
+| wrapper | wrapper_fallback (miss → AOT) | 554.5 | 108.4 |
+
+### 4.2 ns distribution (p50, batched, `-Os`)
+
+| tier | workload | p50 ns | p95 ns | p99 ns |
+|---|---|--:|--:|--:|
+| internal | owner 0D slot0 | 10.55 | 11.60 | 13.24 |
+| internal | owner 0D slot1 | 11.28 | 12.37 | 12.99 |
+| internal | owner 0D slot5 | 14.79 | 16.07 | 17.67 |
+| internal | owner 0D slot15 | 24.47 | 25.89 | 27.43 |
+| internal | peer 0D slot0 | 11.25 | 12.35 | 13.03 |
+| internal | peer 0D slot15 | 25.09 | 26.49 | 27.95 |
+| internal | owner 1D | 14.21 | 15.49 | 16.78 |
+| internal | owner 2D | 17.24 | 18.62 | 20.12 |
+| cabi | cabi_0d | 13.40 | 14.63 | 15.31 |
+| cabi | cabi_1d | 17.65 | 18.99 | 20.69 |
+| cabi | cabi_2d | 21.78 | 23.18 | 24.55 |
+| cabi | cabi_generic 3D | 26.28 | 27.82 | 29.55 |
+| wrapper | wrapper_hit | 14.98 | 16.27 | 17.49 |
+| wrapper | wrapper_hit trusted | 13.56 | 14.71 | 15.24 |
+| wrapper | wrapper_fallback | 38.67 | 40.21 | 41.81 |
+| baseline | direct AOT / fnPtr / empty | ~2.0 | | |
+
+Observations:
+
+* **Slot depth** (0/1/5/15): each extra occupied slot in a bucket adds ~1 ns;
+  slot 15 is 2.3× slot 0. The common case is slot 0/1 (see §6); the deep-slot
+  tail is real but not the steady state.
+* **owner vs peer**: the peer memoized path adds only ~0.7 ns (one extra
+  `executableCoreMask` acquire load + bit test).
+* **0D → 1D → 2D → 3D**: each dimension adds ~3–4 ns (one more hash multiply,
+  one more identity compare, one more version compare).
+* **AOT vs JIT-direct vs wrapper-hit**: the AOT body and a direct call of the
+  same compiled function are ~2 ns; the *entire* extra cost of going through the
+  wrapper (cache query + C ABI + indirect dispatch + release) is the ~13 ns net
+  the business observes as the AOT/JIT gap — and §5 shows it is dominated by the
+  cache query, not the indirect branch.
+
+---
+
+## 5. Where the ~216 instructions go (answer to "is it < 100?")
+
+**No — the full wrapper hit is ~216 instructions / ~45 cycles.** Layered
+attribution (net of the empty loop):
+
+| layer | ins | cyc | notes |
+|---|--:|--:|---|
+| indirect JIT call itself | ~9 | ~2 | the `blr` is cheap and well-predicted |
+| cache query (tryCacheHit0D → lookup → resolveMatchedSlot) | ~137 | ~28 | **dominant**; the baseline `NO_RECLAIM` 0D path runs the *generic* `cacheLookupSeq`, **PR #82** unrolls it |
+| C-ABI shell | ~47 | ~9.5 | out-param null-init + double write-back, `gEJIT→sharedTaskPool()` double load, status switch |
+| wrapper glue | ~23 | ~5 | funcIndex load, status decode, branch layout, release call |
+
+The critical structural finding: in the **baseline** the `NO_RECLAIM` 0D hit
+uses the *generic* `cacheLookupSeq` (≈146 dynamic ins) even though a token build
+uses the unrolled `cacheLookup0D` (≈126 ins). PR #82 closes exactly this gap by
+adding `cacheLookupSeq0D/1D/2D`; this audit reproduces the gap but does not
+re-implement the fix (see §9).
+
+---
+
+## 6. Directional audit findings
+
+Each direction from the brief, with the current state, the measured cost, and
+the disposition.
+
+### 6.1 Wrapper (EJitWrapperGen)
+* The fixed-dimension entries (`_0d/_1d/_2d`, scalar args, no `dims[]` alloca)
+  are already emitted for `DimCount ≤ 2` and are the common path — confirmed.
+* The wrapper does **not** rebuild a `dims[]` array or reload funcIndex/dimType
+  redundantly on the fixed-dim path.
+* The one clear residual is that the wrapper pays the **full public C-ABI
+  contract** (out-param null-init, double write-back, status decode) on every
+  hit even though it always passes valid pointers and only needs the fnPtr. See
+  §8 (trusted fast-ABI).
+* Hot/cold split: the AOT fallback body is already a separate block; a miss
+  costs ~554 ins / ~108 cyc (§4.1) — 2.4× a hit — because it re-enters
+  `compileOrGet` (enqueue/dedup) every call. For an *already-compiled* steady
+  state this is off the hot path, but a workload with frequent misses/disabled
+  instances/version bumps pays it repeatedly. **Recommendation (not
+  implemented): a wrapper that, after the first fallback, remembers "not ready"
+  cheaply would help miss-heavy phases** — needs careful invalidation and is out
+  of this round's testable scope.
+
+### 6.2 C-ABI shell (EJitRuntime.cpp)
+* `if (outFn) *outFn = nullptr; … if (outFn) *outFn = fnPtr;` is a redundant
+  double store + redundant null guard for the trusted wrapper caller.
+* `gEJIT` → `gEJIT->sharedTaskPool()` is two dependent loads + two null checks
+  per call; the pool pointer is stable after init.
+* Disposition: addressed by the **additive** trusted fast-ABI (§8); the public
+  ABI is left byte-for-byte unchanged.
+
+### 6.3 Shared taskpool state checks
+* `initState==Ready` (acquire) is read once per hit; `ownerCoreId` is a relaxed
+  load (already relaxed by commit `ffb907e`); `codeSharingEnabled` is a
+  compile-time constant in the production build (also `ffb907e`) — no per-hit
+  runtime load. **No redundant Ready/mode/version re-reads found on the hit
+  path.**
+* `resolveMatchedSlot` is tight (~40 ins) and returns `SharedLookup`
+  **register-packed** (`x0`=fnPtr, `x1`=flags+bucket) — no struct spill. The
+  stack frame it does build is forced solely by the `EJitCoreId::current()`
+  call. No cheap win found here without changing semantics.
+* Bucket layout is `alignas(64)` (one bucket per cache line); no false sharing
+  between buckets was observed.
+
+### 6.4 Cache query
+* Bucket index is `key % 32`; with 32 buckets the compiler lowers it to a mask
+  — confirmed in disassembly. Hash is the golden-ratio multiply.
+* Slot-depth distribution: the common hit is slot 0/1; deep slots (5, 15) are
+  measured for worst-case but must not drive the design. Confirmed the linear
+  16-slot scan cost is ~1 ns/slot.
+* The fixed-dim direct paths for 0D/1D/2D exist. **The unrolled seqlock variants
+  are PR #82's contribution** and are the right fix for the `NO_RECLAIM` gap in
+  §5.
+
+### 6.5 Read token / releaseRead  (key)
+* Token build: `bucketTryRead` does `readers.fetchAdd`, re-checks `writeFlag`;
+  `releaseRead` does `readers.fetchSub` — **two atomic RMWs per hit on the
+  shared `readers` line** (`__aarch64_ldadd` outlined helpers here).
+* `NO_RECLAIM` build: read is **load-only** (`writeFlag` acquire load +
+  seqlock); `releaseRead` compiles to **1 instruction (ret)**.
+* Measured (single core): token internal0d **67.3 cyc** vs `NO_RECLAIM`
+  **30.6 cyc** — the token path is **~2.2× the cycles despite fewer
+  instructions** because the atomic RMWs serialize. Under 30+ cores hitting one
+  bucket the token `readers` line also bounces; the seqlock path never writes
+  it. **This is the quantitative justification that the `NO_RECLAIM` premise
+  (code pool never physically reclaims) is worth it, and that no per-hit read
+  token is needed when publications are never freed.** The code already enforces
+  "no physical release" structurally in that build (the releaser is never
+  installed); the seqlock only refuses to *start* a read during a publish and
+  re-checks `publishSeq` after, so a slot overwrite/version bump/deactivate can
+  never hand back stale code.
+
+### 6.6 Indirect function call
+* A direct call of the compiled function through an opaque pointer is
+  **9.1 ins / 2.4 cyc** — the indirect `blr` is essentially free here. The
+  business "~200-cycle fn_call" is therefore **not** the indirect branch; it is
+  the surrounding cache query + C-ABI + the callee body, or a
+  BTI/PAC/mispredict effect specific to the board (§7).
+
+### 6.7 JIT machine-code quality
+* Not re-measured end-to-end here (needs the full compile pipeline + board). The
+  benchmark isolates the *dispatch* cost from the *callee body* cost by
+  providing a tiny leaf and a larger loop callee, so a future board run can
+  attribute the callee-body delta separately. No `may_const` semantics were
+  touched.
+
+### 6.8 Statistics / diagnostics overhead
+* Disassembly: with `EJIT_STATS_ENABLE` **off**, `classifyHit` is 33
+  instructions with **zero** atomic/counter code. With it **on**, it is 46
+  instructions with **two `bl __aarch64_ldadd8_acq_rel`** counter increments.
+* Measured cost of stats **on**: +13.7 cyc on the bare 0D query
+  (30.6 → 44.3 cyc, **+45 %**) and +9.4 cyc on the wrapper hit (45.2 → 54.6).
+* `EJIT_DIAG_*` verbose calls are guarded by a level check and disappear at the
+  default level. **Conclusion: statistics being opt-in (default off) is correct
+  and materially important; no counter code remains in the disassembly when
+  off.**
+
+---
+
+## 7. The board-specific unknowns (must be confirmed on hardware)
+
+* `EJitCoreId::current()` is an **external `bl`** on the real platform
+  (`ejit_sre_current_core_id()`), called once per hit inside
+  `resolveMatchedSlot`. Its cost (a function call, possibly an `mrs MPIDR_EL1`)
+  is not visible on the host (thread-local). If it is expensive it is a real
+  per-hit tax; it cannot be inlined cross-TU without LTO.
+* BTI/PAC on the customer build add landing pads / pointer-auth to the indirect
+  `blr` that the host does not model.
+* Branch prediction of a *single* stable fnPtr (as here) is best-case; a site
+  that alternates between fnPtrs would mispredict more.
+
+---
+
+## 8. Optimization candidate: trusted-wrapper fast C-ABI (measured, not merged)
+
+An **additive** internal entry (`bench_cabi_hit_0d` in the benchmark) returns
+the fnPtr directly (nullptr on any non-hit), skipping the out-param null-init +
+double write-back and the status switch; the wrapper then just tests
+`fn != null`. The public `ejit_taskpool_compile_or_get*` ABI is untouched.
+
+Measured (perf, 50 M iters):
+
+| build | wrapper_hit | wrapper_hit trusted | Δ |
+|---|--:|--:|--:|
+| `NO_RECLAIM` | 216.3 ins / 45.3 cyc | 192.3 ins / 40.4 cyc | **−24 ins / −4.9 cyc (~11 %)** |
+| token | 192.4 ins / 74.3 cyc | 168.4 ins / 72.2 cyc | −24 ins / −2.1 cyc |
+
+Risk / why it is **not** in a production commit this round:
+* It requires a new additive C-ABI symbol in `EJitRuntime.cpp` **and** a change
+  to `EJitWrapperGen.cpp` to emit it for fixed-dim hits.
+* Neither the C ABI nor the wrapper generator is covered by the unit tests that
+  are buildable here (they need `gEJIT` / a full clang build), and this
+  environment cannot run the customer target. Per the brief's rule that only
+  reliably **validated** changes enter production code, it is delivered as a
+  **measured prototype + recommendation**, pending an on-board + full-clang
+  correctness run.
+
+---
+
+## 9. Relationship to PR #78 / PR #82
+
+* **PR #82** (`codex/ejit-cache-query-audit`): adds unrolled fixed-dimension
+  **seqlock** lookups (`cacheLookupSeq0D/1D/2D`), identityHash-first slot scan,
+  slot-depth diagnostics, and a cache-query microbenchmark. This audit
+  **independently confirms** that the generic `cacheLookupSeq` is the dominant
+  cost in the baseline `NO_RECLAIM` 0D path (§5) and therefore that PR #82's fix
+  is the right lever — but **does not re-implement it**. This audit's
+  contribution is complementary: the *full three-tier* benchmark (internal +
+  real C-ABI + wrapper end-to-end), the token-vs-seqlock and stats-on/off
+  quantification, and the C-ABI/wrapper-plumbing analysis PR #82 does not cover.
+* **PR #78** (`may_const` test): no overlap; `may_const` semantics were not
+  touched.
+
+---
+
+## 10. Test & build validation
+
+* `EJITTaskPoolTests`: **82 / 82 pass** (real CMake build).
+* `EJITSharedTaskPoolTests` (default token config): **55 / 69 pass**; the 14
+  failures are **pre-existing on the baseline** — they are cross-core
+  code-sharing / FourK / PeerPrepare tests that require
+  `EJIT_SRE_SHARED_CODE_POINTERS`, which commit `ffb907e` made a **compile-time**
+  gate and the default test target does not define. They are mutually exclusive
+  with the "sharing off" tests across configs and are **not** caused by this
+  audit (which changes **no** runtime library code). This is documented here per
+  the "no unexplained pre-existing failures" requirement.
+* This audit adds **only** benchmark/diagnostic files and a report; the shared
+  taskpool library is unchanged, so the test result is identical to baseline by
+  construction.
+
+## 11. Push status
+
+Not pushed. No PR opened. Local commits only, working tree clean.

--- a/jit_design_doc/EJIT_HOTPATH_PERF_AUDIT.md
+++ b/jit_design_doc/EJIT_HOTPATH_PERF_AUDIT.md
@@ -194,6 +194,24 @@ Observations:
   the business observes as the AOT/JIT gap — and §5 shows it is dominated by the
   cache query, not the indirect branch.
 
+### 4.3 16-thread same-wrapper contention
+
+After stacking this audit on PR #82, the benchmark was extended with 16 real
+Linux threads. `same` runs the exact 0D wrapper on every thread; `spread` runs
+the same C-ABI -> indirect call -> release sequence with one funcIndex/bucket
+per thread. Each thread executes 1,000,000 calls and all calls hit.
+
+| protocol | same wrapper/slot | separate funcIndex buckets |
+|---|---:|---:|
+| read-token | 1.05-1.10 us/call median | 27.2-27.3 ns/call median |
+| NO_RECLAIM seqlock | 15.09-15.14 ns/call median | 14.66-14.70 ns/call median |
+
+Same-slot scaling makes the mechanism explicit: read-token grows from about
+28 ns at one thread to 1.30 us at 16 threads, while NO_RECLAIM remains about
+15 ns from one through 16 threads. The token's two shared atomic RMW operations
+cause cache-line bouncing; PR #82's load-only path removes that contention
+under the never-physically-reclaim premise.
+
 ---
 
 ## 5. Where the ~216 instructions go (answer to "is it < 100?")
@@ -357,12 +375,13 @@ Risk / why it is **not** in a production commit this round:
 
 ## 9. Relationship to PR #78 / PR #82
 
-* **PR #82** (`codex/ejit-cache-query-audit`): adds unrolled fixed-dimension
+* This branch is now **stacked directly on PR #82**
+  (`codex/ejit-cache-query-audit`), which adds unrolled fixed-dimension
   **seqlock** lookups (`cacheLookupSeq0D/1D/2D`), identityHash-first slot scan,
   slot-depth diagnostics, and a cache-query microbenchmark. This audit
-  **independently confirms** that the generic `cacheLookupSeq` is the dominant
-  cost in the baseline `NO_RECLAIM` 0D path (§5) and therefore that PR #82's fix
-  is the right lever — but **does not re-implement it**. This audit's
+  confirms that the cache lookup remains the dominant fixed cost and validates
+  PR #82 through the complete C-ABI/wrapper path. This audit does not
+  re-implement the production optimization. Its
   contribution is complementary: the *full three-tier* benchmark (internal +
   real C-ABI + wrapper end-to-end), the token-vs-seqlock and stats-on/off
   quantification, and the C-ABI/wrapper-plumbing analysis PR #82 does not cover.
@@ -388,4 +407,5 @@ Risk / why it is **not** in a production commit this round:
 
 ## 11. Push status
 
-Not pushed. No PR opened. Local commits only, working tree clean.
+PR #83 is open as a draft. The stacked rebase and 16-thread benchmark extension
+are local and have not been force-pushed.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -413,6 +413,19 @@ private:
   /// never-free safety precondition.
   SharedLookup cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
                               uint32_t numDims);
+  /// Fixed-dimension load-only seqlock specializations (0-2 dims). Same
+  /// never-free seqlock discipline as cacheLookupSeq() but with the identity
+  /// hashing, slot identity comparison, and version comparison unrolled exactly
+  /// like cacheLookup0D/1D/2D — so a NO_RECLAIM fixed-dimension caller reaches
+  /// the shared slot resolution without the generic numDims loop, the
+  /// slotIdentityMatches() call, or variable-length dims[] handling. Behavior
+  /// is identical to cacheLookupSeq() with the matching numDims. 3D/4D keep
+  /// using the generic cacheLookupSeq() (rare on the hot path).
+  SharedLookup cacheLookupSeq0D(uint32_t funcIndex);
+  SharedLookup cacheLookupSeq1D(uint32_t funcIndex, uint32_t dim0,
+                                uint32_t inst0);
+  SharedLookup cacheLookupSeq2D(uint32_t funcIndex, uint32_t dim0,
+                                uint32_t inst0, uint32_t dim1, uint32_t inst1);
 #endif
   /// Fixed-dimension specializations of cacheLookup() (0-4 dims). Identity
   /// hashing, slot identity comparison, and version comparison are all unrolled

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -115,6 +115,12 @@ void bucketWriteRelease(EJitSharedCacheBucket &b) {
 
 constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 
+/// Mixing constant shared by hashIdentity() and every unrolled fixed-dimension
+/// lookup (cacheLookupNd / cacheLookupSeqNd). Kept here so the NO_RECLAIM
+/// fixed-dimension seqlock specializations defined above the generic
+/// cacheLookupNd block can also reference it.
+constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -321,12 +327,12 @@ EJitSharedTaskPool::cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen) // stale across an owner re-init: ignore.
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (!slotIdentityMatches(Slot, funcIndex, dims, numDims))
       continue;
@@ -378,12 +384,12 @@ EJitSharedTaskPool::cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
     SharedLookup hit;
     for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
       EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue; // plain-load fast reject before the acquiring state load.
       if (Slot.state.loadAcquire() !=
           static_cast<uint32_t>(EJitSharedSlotState::Ready))
         continue;
       if (Slot.generation != curGen)
-        continue;
-      if (Slot.identityHash != key)
         continue;
       if (!slotIdentityMatches(Slot, funcIndex, dims, numDims))
         continue;
@@ -409,6 +415,149 @@ EJitSharedTaskPool::cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
     return hit; // validated hit (noTokenHit) or clean miss
   }
   return R; // repeated contention -> clean fallback to the slow path
+}
+
+//===----------------------------------------------------------------------===//
+// Fixed-dimension load-only seqlock specializations (0-2 dims, NO_RECLAIM
+// build only). Each mirrors the matching cacheLookup0D/1D/2D scan (unrolled
+// identity hash, unrolled identity + version comparison, plain-identityHash
+// fast reject before the acquiring state load) wrapped in the same bounded
+// seqlock retry as cacheLookupSeq(). A NO_RECLAIM fixed-dimension caller thus
+// avoids the generic numDims loop / slotIdentityMatches() call entirely.
+// Behavior is identical to cacheLookupSeq() with the matching numDims; the
+// cross-core fnPtr gate and cold peer preparation stay shared via
+// resolveMatchedSlot().
+//===----------------------------------------------------------------------===//
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq0D(uint32_t funcIndex) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex); // hashIdentity(fi, _, 0)
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue; // plain-load fast reject before the acquiring state load.
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 0)
+        continue;
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq1D(uint32_t funcIndex, uint32_t dim0,
+                                     uint32_t inst0) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue;
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 1)
+        continue;
+      if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+        continue;
+      if (Slot.versions[0] != instanceVersion(dim0, inst0))
+        break; // identity matched but stale -> clean miss.
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq2D(uint32_t funcIndex, uint32_t dim0,
+                                     uint32_t inst0, uint32_t dim1,
+                                     uint32_t inst1) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue;
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 2)
+        continue;
+      if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+        continue;
+      if (Slot.dims[1].dimType != dim1 || Slot.dims[1].instanceId != inst1)
+        continue;
+      if (Slot.versions[0] != instanceVersion(dim0, inst0))
+        break;
+      if (Slot.versions[1] != instanceVersion(dim1, inst1))
+        break;
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
 }
 #endif // EJIT_SRE_TASKPOOL_NO_RECLAIM
 
@@ -598,7 +747,6 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
 // each specialization stays small. Results are identical to cacheLookup() with
 // the matching numDims. kHashMul mirrors the mixing constant in hashIdentity().
 //===----------------------------------------------------------------------===//
-static constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
 EJitSharedTaskPool::SharedLookup
 EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
@@ -611,12 +759,12 @@ EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 0)
       continue;
@@ -641,12 +789,12 @@ EJitSharedTaskPool::cacheLookup1D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 1)
       continue;
@@ -677,12 +825,12 @@ EJitSharedTaskPool::cacheLookup2D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 2)
       continue;
@@ -719,12 +867,12 @@ EJitSharedTaskPool::cacheLookup3D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 3)
       continue;
@@ -768,12 +916,12 @@ EJitSharedTaskPool::cacheLookup4D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 4)
       continue;
@@ -1420,7 +1568,7 @@ EJitSharedTaskPool::tryCacheHit0D(uint32_t funcIndex) {
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  return classifyHit(cacheLookupSeq(funcIndex, nullptr, 0));
+  return classifyHit(cacheLookupSeq0D(funcIndex));
 #else
   return classifyHit(cacheLookup0D(funcIndex));
 #endif
@@ -1442,8 +1590,7 @@ EJitSharedTaskPool::tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  const EJitDimPair d1[1] = {{dim0, inst0}};
-  return classifyHit(cacheLookupSeq(funcIndex, d1, 1));
+  return classifyHit(cacheLookupSeq1D(funcIndex, dim0, inst0));
 #else
   return classifyHit(cacheLookup1D(funcIndex, dim0, inst0));
 #endif
@@ -1466,8 +1613,7 @@ EJitSharedTaskPool::tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  const EJitDimPair d2[2] = {{dim0, inst0}, {dim1, inst1}};
-  return classifyHit(cacheLookupSeq(funcIndex, d2, 2));
+  return classifyHit(cacheLookupSeq2D(funcIndex, dim0, inst0, dim1, inst1));
 #else
   return classifyHit(cacheLookup2D(funcIndex, dim0, inst0, dim1, inst1));
 #endif

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -148,3 +148,52 @@ if(EJIT_BUILD_CACHE_QUERY_BENCH)
       EJIT_SRE_SHARED_CODE_POINTERS)
   endif()
 endif()
+
+# EJIT post-compile hot-path benchmark: measures the full "wrapper cache hit"
+# path the business sees (AOT ~9us vs JIT wrapper ~15us) across three strictly
+# separated tiers — internal cache-query, the real same-ABI C shell, and the
+# wrapper end-to-end with a real indirect call. It has its own main() (NOT a
+# gtest), links only the shared-taskpool sources + platform + the faithful
+# C-ABI/wrapper TU, and prints a machine-readable table so `perf stat` can
+# attribute instructions/cycles per hit. Only LLVMSupport is linked (unused by
+# the bench itself; kept for symmetry with the sibling benches).
+option(EJIT_TEST_STATS
+  "Build EJITHotPathBench with EJIT_STATS_ENABLE (measure counter cost)" OFF)
+if(NOT WIN32)
+  # Link only LLVMSupport (the sibling taskpool tests do the same): the bench
+  # compiles the shared-taskpool sources directly and must NOT pull in
+  # OrcJIT/EJIT/the full LLVM.
+  set(EJIT_HOTPATH_LINK_COMPONENTS_SAVED "${LLVM_LINK_COMPONENTS}")
+  set(LLVM_LINK_COMPONENTS Support)
+  add_llvm_executable(EJITHotPathBench
+    EJitHotPathBench.cpp
+    EJitHotPathBenchAbi.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp
+
+    PARTIAL_SOURCES_INTENDED
+    )
+  set(LLVM_LINK_COMPONENTS "${EJIT_HOTPATH_LINK_COMPONENTS_SAVED}")
+  target_compile_definitions(EJITHotPathBench PRIVATE
+    EJIT_SRE_TASKPOOL
+    EJIT_SRE_SHARED_TASKPOOL
+    EJIT_SRE_TASKPOOL_TESTING
+    EJIT_SRE_TASKPOOL_BUCKETS=32
+    EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
+    EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=1048576
+    )
+  # Match the embedded production optimization level so the measured
+  # instruction/cycle counts reflect the shipped build.
+  target_compile_options(EJITHotPathBench PRIVATE -Os)
+  # Opt-in: mirror EJIT_TEST_NO_RECLAIM so the benchmark exercises the load-only
+  # seqlock hit path + cross-core code sharing (the production premise).
+  if(EJIT_TEST_NO_RECLAIM)
+    target_compile_definitions(EJITHotPathBench PRIVATE
+      EJIT_SRE_TASKPOOL_NO_RECLAIM
+      EJIT_SRE_SHARED_CODE_POINTERS)
+  endif()
+  # Opt-in: embed the statistics counters to measure their per-hit cost.
+  if(EJIT_TEST_STATS)
+    target_compile_definitions(EJITHotPathBench PRIVATE EJIT_STATS_ENABLE)
+  endif()
+endif()

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -115,3 +115,36 @@ add_custom_target(check-ejit-shared-taskpool
   COMMENT "Running EmbeddedJIT cross-core shared taskpool unit tests"
   USES_TERMINAL
   )
+
+# Optional cache-query microbenchmark (NOT a gtest binary: standalone main()).
+# Off by default so it never bloats normal test builds. Enable with
+# -DEJIT_BUILD_CACHE_QUERY_BENCH=ON to build a host-runnable binary that prints a
+# machine-readable table of the 0D/1D/2D owner/peer cache-hit query cost by slot
+# depth (drive it under `perf stat -e instructions` for per-hit attribution).
+# Links only the shared-taskpool sources + platform, like the tests above.
+option(EJIT_BUILD_CACHE_QUERY_BENCH
+  "Build the EJIT shared taskpool cache-query microbenchmark" OFF)
+if(EJIT_BUILD_CACHE_QUERY_BENCH)
+  add_llvm_executable(EJITSharedCacheQueryBench
+    EJitSharedCacheQueryBench.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp
+
+    PARTIAL_SOURCES_INTENDED
+    )
+  target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
+    EJIT_SRE_TASKPOOL
+    EJIT_SRE_SHARED_TASKPOOL
+    EJIT_SRE_TASKPOOL_TESTING
+    EJIT_SRE_TASKPOOL_BUCKETS=32
+    EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
+    )
+  # Opt-in: build the benchmark with the load-only NO_RECLAIM seqlock hit path
+  # + cross-core code sharing (so peer hits and the fixed-dim seqlock lookups
+  # are exercised), mirroring EJIT_TEST_NO_RECLAIM above.
+  if(EJIT_TEST_NO_RECLAIM)
+    target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
+      EJIT_SRE_TASKPOOL_NO_RECLAIM
+      EJIT_SRE_SHARED_CODE_POINTERS)
+  endif()
+endif()

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -177,6 +177,7 @@ if(NOT WIN32)
   target_compile_definitions(EJITHotPathBench PRIVATE
     EJIT_SRE_TASKPOOL
     EJIT_SRE_SHARED_TASKPOOL
+    EJIT_SRE_SHARED_CODE_POINTERS
     EJIT_SRE_TASKPOOL_TESTING
     EJIT_SRE_TASKPOOL_BUCKETS=32
     EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
@@ -189,11 +190,11 @@ if(NOT WIN32)
   # seqlock hit path + cross-core code sharing (the production premise).
   if(EJIT_TEST_NO_RECLAIM)
     target_compile_definitions(EJITHotPathBench PRIVATE
-      EJIT_SRE_TASKPOOL_NO_RECLAIM
-      EJIT_SRE_SHARED_CODE_POINTERS)
+      EJIT_SRE_TASKPOOL_NO_RECLAIM)
   endif()
   # Opt-in: embed the statistics counters to measure their per-hit cost.
   if(EJIT_TEST_STATS)
     target_compile_definitions(EJITHotPathBench PRIVATE EJIT_STATS_ENABLE)
   endif()
+  target_link_libraries(EJITHotPathBench PRIVATE ${LLVM_PTHREAD_LIB})
 endif()

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBench.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBench.cpp
@@ -1,0 +1,486 @@
+//===-- EJitHotPathBench.cpp - EJIT post-compile hot-path benchmark -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  End-to-end microbenchmark for the EmbeddedJIT post-compile hot path (the
+//  "wrapper cache hit" the business sees as AOT ~9us vs JIT wrapper ~15us). It
+//  has its own main() and links only the shared-taskpool sources + platform +
+//  the faithful C-ABI/wrapper TU (EJitHotPathBenchAbi.cpp), so it builds and
+//  runs on the host without the full LLVM/ORC graph.
+//
+//  Three measurement tiers, kept strictly separate (the audit brief forbids
+//  passing an internal tryCacheHit measurement off as a C-ABI or wrapper
+//  number):
+//
+//    [internal]  tryCacheHit0D/1D/2D/3D/4D + releaseRead, owner & peer, slot
+//                depth 0/1/5/15 — the cache-query cost in isolation.
+//    [cabi]      the real same-ABI C shell bench_cabi_0d/1d/2d/generic — the
+//                cost the wrapper pays to cross into the runtime.
+//    [wrapper]   bench_wrapper_0d_* — full jit_entry -> C ABI -> indirect call
+//                -> release -> return, plus AOT/direct baselines.
+//
+//  Method: warm up, then time B batches of K iterations each (B*K >= the
+//  requested total, default 4,000,000). Report mean, min, p50, p95, p99 of the
+//  per-batch ns/iter AND cycles/iter (rdtsc on x86), so a stable distribution
+//  is shown without per-call timer cost inside the loop. Two calibration rows
+//  (empty loop, timer/rdtsc self-cost) are printed so every number can be read
+//  net of measurement overhead. A volatile sink defeats dead-code elimination.
+//
+//===----------------------------------------------------------------------===//
+
+#include "EJitHotPathBenchAbi.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <memory>
+#include <vector>
+
+using namespace llvm::ejit;
+using namespace ejitbench;
+
+namespace {
+
+volatile uint64_t gSink = 0;
+
+uint64_t nowNs() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ull +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+
+// Free-running counter for a secondary per-op tick figure. On x86 this is the
+// TSC; on aarch64 it is the fixed-frequency virtual counter CNTVCT_EL0 (the
+// same source the VDSO clock_gettime uses), reported as "ticks" — authoritative
+// instructions/cycles come from `perf stat` around the `single` mode below.
+#if defined(__x86_64__)
+static inline uint64_t rdcycle() {
+  uint32_t lo, hi, aux;
+  __asm__ __volatile__("rdtscp" : "=a"(lo), "=d"(hi), "=c"(aux));
+  return (static_cast<uint64_t>(hi) << 32) | lo;
+}
+#define HAVE_CYCLES 1
+#elif defined(__aarch64__)
+static inline uint64_t rdcycle() {
+  uint64_t v;
+  __asm__ __volatile__("mrs %0, cntvct_el0" : "=r"(v));
+  return v;
+}
+#define HAVE_CYCLES 1
+#else
+static inline uint64_t rdcycle() { return 0; }
+#define HAVE_CYCLES 0
+#endif
+
+struct Stat {
+  double meanNs = 0, mnNs = 0, p50Ns = 0, p95Ns = 0, p99Ns = 0;
+  double meanCyc = 0, p50Cyc = 0, p99Cyc = 0;
+};
+
+double pct(std::vector<double> &v, double p) {
+  if (v.empty())
+    return 0;
+  size_t i = static_cast<size_t>(p * (v.size() - 1));
+  return v[i];
+}
+
+// Time `body(i)` over B batches of K iters. body must fold something into
+// gSink.
+template <class F> Stat measure(uint64_t totalIters, F &&body) {
+  const uint64_t K = 4000;
+  uint64_t B = totalIters / K;
+  if (B < 250)
+    B = 250;
+  // Warmup.
+  for (uint64_t i = 0; i < K; ++i)
+    body(i);
+  std::vector<double> ns(B), cyc(B);
+  for (uint64_t b = 0; b < B; ++b) {
+    uint64_t c0 = rdcycle();
+    uint64_t t0 = nowNs();
+    for (uint64_t i = 0; i < K; ++i)
+      body(b * K + i);
+    uint64_t t1 = nowNs();
+    uint64_t c1 = rdcycle();
+    ns[b] = double(t1 - t0) / double(K);
+    cyc[b] = double(c1 - c0) / double(K);
+  }
+  std::sort(ns.begin(), ns.end());
+  std::sort(cyc.begin(), cyc.end());
+  Stat s;
+  double sum = 0, sumc = 0;
+  for (double x : ns)
+    sum += x;
+  for (double x : cyc)
+    sumc += x;
+  s.meanNs = sum / B;
+  s.mnNs = ns.front();
+  s.p50Ns = pct(ns, 0.50);
+  s.p95Ns = pct(ns, 0.95);
+  s.p99Ns = pct(ns, 0.99);
+  s.meanCyc = sumc / B;
+  s.p50Cyc = pct(cyc, 0.50);
+  s.p99Cyc = pct(cyc, 0.99);
+  return s;
+}
+
+void row(const char *tier, const char *name, const Stat &s) {
+  std::printf("%-9s %-26s mean=%7.2fns p50=%7.2f p95=%7.2f p99=%7.2f min=%7.2f "
+              "| cyc mean=%7.1f p50=%7.1f p99=%7.1f\n",
+              tier, name, s.meanNs, s.p50Ns, s.p95Ns, s.p99Ns, s.mnNs,
+              s.meanCyc, s.p50Cyc, s.p99Cyc);
+}
+
+//===-- Pool bring-up -----------------------------------------------------===//
+struct RangeCtx {
+  uintptr_t poolBase = 0x40000000ull;
+  uint64_t poolSize = 0x200000ull;
+  uintptr_t codeStart = 0x40000000ull;
+  uint64_t codeSize = 64;
+  uint32_t poolId = 0;
+};
+
+// The compiler callback publishes the REAL executable JIT function address, so
+// the wrapper's indirect call actually runs it.
+bool benchCompile(void * /*ctx*/, const EJitCompileRequest & /*req*/,
+                  void **outFn) {
+  *outFn = benchJitFn0D();
+  return true;
+}
+bool benchCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
+  auto *r = static_cast<RangeCtx *>(ctx);
+  out->fnPtr = const_cast<void *>(fnPtr);
+  out->codeStart = r->codeStart;
+  out->codeSize = r->codeSize;
+  out->poolBase = r->poolBase;
+  out->poolSize = r->poolSize;
+  out->poolId = r->poolId;
+  return true;
+}
+bool benchPrepareCode(void * /*ctx*/, const void * /*fnPtr*/) { return true; }
+
+struct Bench {
+  std::unique_ptr<EJitSharedTaskPoolState> state;
+  EJitSharedTaskPool pool;
+  RangeCtx range;
+  EJitStub stub;
+
+  void bringUpOwner(bool codeSharing) {
+    EJitCoreId::resetForTest();
+    EJitCoreId::setCurrentForTest(0);
+    state.reset(new EJitSharedTaskPoolState());
+    pool.bind(state.get());
+    pool.setCompiler(&benchCompile, nullptr);
+    pool.setMode(EJitCompileMode::Async);
+    pool.setCodeSharingEnabled(codeSharing);
+    pool.setCodeRangeProvider(&benchCodeRange, &range);
+    pool.setPrepareCodeCallback(&benchPrepareCode, nullptr);
+    if (pool.init() != EJitSharedTaskPool::InitResult::BecameOwner) {
+      std::fprintf(stderr, "owner election failed\n");
+      std::exit(1);
+    }
+    stub.sharedPool = &pool;
+    gEJITStub = &stub;
+  }
+  void publish0D(uint32_t fi) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.compileOrGet(fi, nullptr, 0, benchJitFn0D());
+    pool.pollOne();
+  }
+  void publish1D(uint32_t fi, uint32_t d0, uint32_t i0) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    EJitDimPair dims[1] = {{d0, i0}};
+    pool.compileOrGet(fi, dims, 1, benchJitFn0D());
+    pool.pollOne();
+  }
+  void publish2D(uint32_t fi, uint32_t d0, uint32_t i0, uint32_t d1,
+                 uint32_t i1) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    pool.setInstanceEnabled(d1, i1, true);
+    EJitDimPair dims[2] = {{d0, i0}, {d1, i1}};
+    pool.compileOrGet(fi, dims, 2, benchJitFn0D());
+    pool.pollOne();
+  }
+};
+
+const uint32_t kB = kEJitSharedCacheBuckets;
+
+//===-- Tier 1: internal cache-query --------------------------------------===//
+// 0D depth sweep: publish depth+1 colliders into bucket 0, hammer the deepest.
+void internal0D(uint64_t iters, uint32_t depth, bool peer) {
+  Bench B;
+  B.bringUpOwner(peer);
+  uint32_t target = 0;
+  for (uint32_t d = 0; d <= depth; ++d) {
+    B.publish0D(d * kB);
+    target = d * kB;
+  }
+  uint32_t core = 0;
+  if (peer) {
+    core = 1;
+    EJitCoreId::setCurrentForTest(core);
+    auto w = B.pool.tryCacheHit0D(target);
+    if (w.hasReadToken)
+      B.pool.releaseRead(w.bucketIndex);
+  }
+  EJitCoreId::setCurrentForTest(core);
+  Stat s = measure(iters, [&](uint64_t) {
+    auto r = B.pool.tryCacheHit0D(target);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  });
+  char nm[64];
+  std::snprintf(nm, sizeof nm, "%s0D slot%u", peer ? "peer" : "owner", depth);
+  row("internal", nm, s);
+}
+
+void internal1D(uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  B.publish1D(7, 0, 3);
+  EJitCoreId::setCurrentForTest(0);
+  Stat s = measure(iters, [&](uint64_t) {
+    auto r = B.pool.tryCacheHit1D(7, 0, 3);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  });
+  row("internal", "owner1D", s);
+}
+
+void internal2D(uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  B.publish2D(9, 0, 1, 1, 2);
+  EJitCoreId::setCurrentForTest(0);
+  Stat s = measure(iters, [&](uint64_t) {
+    auto r = B.pool.tryCacheHit2D(9, 0, 1, 1, 2);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  });
+  row("internal", "owner2D", s);
+}
+
+//===-- Tier 2: C ABI -----------------------------------------------------===//
+void cabi0D(uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  B.publish0D(0);
+  EJitCoreId::setCurrentForTest(0);
+  Stat s = measure(iters, [&](uint64_t) {
+    void *fn;
+    uint32_t bk;
+    uint32_t st = bench_cabi_0d(0, &fn, &bk);
+    gSink += reinterpret_cast<uintptr_t>(fn) + st;
+    if (st == BENCH_OK && bk < kB)
+      bench_cabi_release_read(bk);
+  });
+  row("cabi", "cabi_0d", s);
+}
+void cabi1D(uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  B.publish1D(7, 0, 3);
+  EJitCoreId::setCurrentForTest(0);
+  Stat s = measure(iters, [&](uint64_t) {
+    void *fn;
+    uint32_t bk;
+    uint32_t st = bench_cabi_1d(7, 0, 3, &fn, &bk);
+    gSink += reinterpret_cast<uintptr_t>(fn) + st;
+    if (st == BENCH_OK && bk < kB)
+      bench_cabi_release_read(bk);
+  });
+  row("cabi", "cabi_1d", s);
+}
+void cabi2D(uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  B.publish2D(9, 0, 1, 1, 2);
+  EJitCoreId::setCurrentForTest(0);
+  Stat s = measure(iters, [&](uint64_t) {
+    void *fn;
+    uint32_t bk;
+    uint32_t st = bench_cabi_2d(9, 0, 1, 1, 2, &fn, &bk);
+    gSink += reinterpret_cast<uintptr_t>(fn) + st;
+    if (st == BENCH_OK && bk < kB)
+      bench_cabi_release_read(bk);
+  });
+  row("cabi", "cabi_2d", s);
+}
+void cabiGeneric3D(uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  EJitCoreId::setCurrentForTest(0);
+  B.pool.setInstanceEnabled(0, 1, true);
+  B.pool.setInstanceEnabled(1, 2, true);
+  B.pool.setInstanceEnabled(2, 3, true);
+  EJitDimPair d3[3] = {{0, 1}, {1, 2}, {2, 3}};
+  B.pool.compileOrGet(11, d3, 3, benchJitFn0D());
+  B.pool.pollOne();
+  Stat s = measure(iters, [&](uint64_t) {
+    void *fn;
+    uint32_t bk;
+    uint32_t st = bench_cabi_generic(11, d3, 3, &fn, &bk);
+    gSink += reinterpret_cast<uintptr_t>(fn) + st;
+    if (st == BENCH_OK && bk < kB)
+      bench_cabi_release_read(bk);
+  });
+  row("cabi", "cabi_generic3d", s);
+}
+
+//===-- Tier 3: wrapper end-to-end + baselines ----------------------------===//
+void wrapperE2E(uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  B.publish0D(0); // funcIndex 0 == kWrapperFuncIndex0D
+  EJitCoreId::setCurrentForTest(0);
+
+  // Calibration: empty loop and timer self-cost.
+  Stat emptyS = measure(iters, [&](uint64_t i) { gSink += i; });
+  row("baseline", "empty_loop", emptyS);
+
+  // Direct AOT body (the "AOT ~9us" analogue: no wrapper, no cache).
+  Stat aotS =
+      measure(iters, [&](uint64_t i) { gSink += bench_aot_0d((long)i); });
+  row("baseline", "direct_aot", aotS);
+
+  // Direct call of the same JIT function through an opaque pointer (isolates
+  // the indirect-call cost the wrapper's jit_dispatch pays).
+  volatile auto fp = reinterpret_cast<long (*)(long)>(benchJitFn0D());
+  Stat fpS = measure(iters, [&](uint64_t i) {
+    auto f = fp;
+    gSink += f((long)i);
+  });
+  row("baseline", "direct_jit_fnptr", fpS);
+
+  // Wrapper: cache hit -> indirect JIT call -> release -> return.
+  Stat whS = measure(
+      iters, [&](uint64_t i) { gSink += bench_wrapper_0d_hit((long)i); });
+  row("wrapper", "wrapper_hit", whS);
+
+  // Wrapper: forced AOT fallback (miss -> AOT body).
+  Stat wfS = measure(
+      iters, [&](uint64_t i) { gSink += bench_wrapper_0d_fallback((long)i); });
+  row("wrapper", "wrapper_fallback", wfS);
+
+  // Wrapper via the trusted fast ABI (optimization candidate).
+  Stat wtS = measure(
+      iters, [&](uint64_t i) { gSink += bench_wrapper_0d_trusted((long)i); });
+  row("wrapper", "wrapper_hit_trusted", wtS);
+}
+
+// Tight single-workload loops for `perf stat` attribution. No timing calls, no
+// other tiers — run `perf stat -e instructions,cycles ./bench single <name> N`
+// and subtract the `empty` run to get net instructions/cycles per op.
+int runSingle(const char *name, uint64_t iters) {
+  Bench B;
+  B.bringUpOwner(false);
+  B.publish0D(0);
+  B.publish1D(7, 0, 3);
+  B.publish2D(9, 0, 1, 1, 2);
+  EJitCoreId::setCurrentForTest(0);
+  uint64_t acc = 0;
+  if (!std::strcmp(name, "empty")) {
+    for (uint64_t i = 0; i < iters; ++i)
+      acc += i;
+  } else if (!std::strcmp(name, "internal0d")) {
+    for (uint64_t i = 0; i < iters; ++i) {
+      auto r = B.pool.tryCacheHit0D(0);
+      acc += reinterpret_cast<uintptr_t>(r.fnPtr);
+      if (r.hasReadToken)
+        B.pool.releaseRead(r.bucketIndex);
+    }
+  } else if (!std::strcmp(name, "cabi0d")) {
+    for (uint64_t i = 0; i < iters; ++i) {
+      void *fn;
+      uint32_t bk;
+      uint32_t st = bench_cabi_0d(0, &fn, &bk);
+      acc += reinterpret_cast<uintptr_t>(fn) + st;
+      if (st == BENCH_OK && bk < kB)
+        bench_cabi_release_read(bk);
+    }
+  } else if (!std::strcmp(name, "direct_fnptr")) {
+    volatile auto fp = reinterpret_cast<long (*)(long)>(benchJitFn0D());
+    for (uint64_t i = 0; i < iters; ++i) {
+      auto f = fp;
+      acc += f((long)i);
+    }
+  } else if (!std::strcmp(name, "wrapper_hit")) {
+    for (uint64_t i = 0; i < iters; ++i)
+      acc += bench_wrapper_0d_hit((long)i);
+  } else if (!std::strcmp(name, "wrapper_trusted")) {
+    for (uint64_t i = 0; i < iters; ++i)
+      acc += bench_wrapper_0d_trusted((long)i);
+  } else if (!std::strcmp(name, "wrapper_fallback")) {
+    for (uint64_t i = 0; i < iters; ++i)
+      acc += bench_wrapper_0d_fallback((long)i);
+  } else {
+    std::fprintf(stderr, "unknown single workload '%s'\n", name);
+    return 2;
+  }
+  gSink += acc;
+  std::fprintf(stderr, "single %s iters=%llu sink=%llu\n", name,
+               (unsigned long long)iters, (unsigned long long)gSink);
+  return 0;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc >= 2 && !std::strcmp(argv[1], "single")) {
+    const char *name = argc >= 3 ? argv[2] : "empty";
+    uint64_t n = argc >= 4 ? strtoull(argv[3], nullptr, 10) : 50000000ull;
+    return runSingle(name, n);
+  }
+  uint64_t iters = 4000000ull;
+  if (argc >= 2)
+    iters = strtoull(argv[1], nullptr, 10);
+
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  const char *cfg = "NO_RECLAIM+SHARED_CODE_POINTERS (seqlock, no token)";
+#else
+  const char *cfg = "token (per-hit RMW read lock)";
+#endif
+#ifdef EJIT_STATS_ENABLE
+  const char *stats = "STATS=ON";
+#else
+  const char *stats = "STATS=OFF";
+#endif
+  std::printf("# EJIT hot-path bench  config=%s  %s  iters=%llu  buckets=%u  "
+              "cycles=%d\n",
+              cfg, stats, (unsigned long long)iters, kB, HAVE_CYCLES);
+  std::printf("# tier      name                       ns distribution "
+              "                       | cycles\n");
+
+  // Tier 1: internal cache-query, owner slot depth sweep + peer + 1D/2D.
+  for (uint32_t d : {0u, 1u, 5u, 15u})
+    internal0D(iters, d, /*peer=*/false);
+  for (uint32_t d : {0u, 15u})
+    internal0D(iters, d, /*peer=*/true);
+  internal1D(iters);
+  internal2D(iters);
+
+  // Tier 2: C ABI.
+  cabi0D(iters);
+  cabi1D(iters);
+  cabi2D(iters);
+  cabiGeneric3D(iters);
+
+  // Tier 3: wrapper e2e + baselines.
+  wrapperE2E(iters);
+
+  std::printf("# sink=%llu\n", (unsigned long long)gSink);
+  return 0;
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBench.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBench.cpp
@@ -35,12 +35,14 @@
 #include "EJitHotPathBenchAbi.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <memory>
+#include <thread>
 #include <vector>
 
 using namespace llvm::ejit;
@@ -381,6 +383,123 @@ void wrapperE2E(uint64_t iters) {
   row("wrapper", "wrapper_hit_trusted", wtS);
 }
 
+struct alignas(64) ThreadResult {
+  uint64_t elapsedNs = 0;
+  uint64_t hits = 0;
+  uint64_t sink = 0;
+};
+
+struct alignas(64) StartGate {
+  std::atomic<uint32_t> ready{0};
+  std::atomic<bool> go{false};
+};
+
+// Model multiple target cores calling either one hot wrapper/slot or separate
+// funcIndex buckets. The same mode executes the exact wrapper function. The
+// spread mode spells out the wrapper's C-ABI/indirect-call/release sequence so
+// each thread can use a different funcIndex without generating 16 wrappers.
+void wrapperMultiThread(uint64_t iters, uint32_t threadCount, bool sameSlot) {
+  if (threadCount == 0 || threadCount >= kEJitSharedCacheBuckets) {
+    std::fprintf(stderr, "mt threads must be in [1,%u)\n",
+                 kEJitSharedCacheBuckets);
+    std::exit(2);
+  }
+
+  Bench B;
+  B.bringUpOwner(/*codeSharing=*/true);
+  if (sameSlot) {
+    B.publish0D(0);
+  } else {
+    for (uint32_t t = 0; t < threadCount; ++t)
+      B.publish0D(t + 1u); // 0D identities map to distinct buckets 1..N.
+  }
+
+  StartGate gate;
+  std::unique_ptr<ThreadResult[]> results(new ThreadResult[threadCount]);
+  std::vector<std::thread> threads;
+  threads.reserve(threadCount);
+  for (uint32_t t = 0; t < threadCount; ++t) {
+    threads.emplace_back([&, t] {
+      EJitCoreId::setCurrentForTest(t + 1u);
+      uint32_t target = sameSlot ? 0u : t + 1u;
+
+      // Complete peer execute-permission preparation before timing.
+      void *warmFn = nullptr;
+      uint32_t warmBucket = 0;
+      uint32_t warmStatus = bench_cabi_0d(target, &warmFn, &warmBucket);
+      bool warmOk = warmStatus == BENCH_OK && warmFn;
+      if (warmOk && warmBucket < kB)
+        bench_cabi_release_read(warmBucket);
+
+      gate.ready.fetch_add(1, std::memory_order_release);
+      while (!gate.go.load(std::memory_order_acquire))
+        std::this_thread::yield();
+      if (!warmOk)
+        return;
+
+      uint64_t acc = 0;
+      uint64_t hits = 0;
+      uint64_t begin = nowNs();
+      if (sameSlot) {
+        for (uint64_t i = 0; i < iters; ++i) {
+          acc += static_cast<uint64_t>(bench_wrapper_0d_hit((long)i));
+          ++hits;
+        }
+      } else {
+        for (uint64_t i = 0; i < iters; ++i) {
+          void *fn = nullptr;
+          uint32_t bucket = 0;
+          uint32_t status = bench_cabi_0d(target, &fn, &bucket);
+          if (status == BENCH_OK && fn) {
+            acc += static_cast<uint64_t>(
+                reinterpret_cast<long (*)(long)>(fn)((long)i));
+            bench_cabi_release_read(bucket);
+            ++hits;
+          }
+        }
+      }
+      results[t].elapsedNs = nowNs() - begin;
+      results[t].hits = hits;
+      results[t].sink = acc;
+    });
+  }
+
+  while (gate.ready.load(std::memory_order_acquire) != threadCount)
+    std::this_thread::yield();
+  uint64_t wallBegin = nowNs();
+  gate.go.store(true, std::memory_order_release);
+  for (std::thread &T : threads)
+    T.join();
+  uint64_t wallNs = nowNs() - wallBegin;
+
+  uint64_t totalHits = 0;
+  uint64_t sink = 0;
+  std::vector<double> nsPerCall;
+  nsPerCall.reserve(threadCount);
+  for (uint32_t t = 0; t < threadCount; ++t) {
+    totalHits += results[t].hits;
+    sink ^= results[t].sink;
+    nsPerCall.push_back(double(results[t].elapsedNs) / double(iters));
+  }
+  std::sort(nsPerCall.begin(), nsPerCall.end());
+  gSink += sink;
+
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  const char *discipline = "noreclaim-seqlock";
+#else
+  const char *discipline = "read-token";
+#endif
+  double throughput = double(totalHits) * 1000.0 / double(wallNs);
+  std::printf(
+      "mt-wrapper mode=%s discipline=%s threads=%u iters/thread=%llu "
+      "min=%.3f median=%.3f max=%.3f ns/call "
+      "throughput=%.3f Mcall/s hits=%llu/%llu sink=%llu\n",
+      sameSlot ? "same" : "spread", discipline, threadCount,
+      (unsigned long long)iters, nsPerCall.front(), nsPerCall[threadCount / 2u],
+      nsPerCall.back(), throughput, (unsigned long long)totalHits,
+      (unsigned long long)(iters * threadCount), (unsigned long long)sink);
+}
+
 // Tight single-workload loops for `perf stat` attribution. No timing calls, no
 // other tiers — run `perf stat -e instructions,cycles ./bench single <name> N`
 // and subtract the `empty` run to get net instructions/cycles per op.
@@ -439,6 +558,18 @@ int runSingle(const char *name, uint64_t iters) {
 } // namespace
 
 int main(int argc, char **argv) {
+  if (argc >= 2 && !std::strcmp(argv[1], "mt-wrapper")) {
+    const char *mode = argc >= 3 ? argv[2] : "same";
+    uint64_t n = argc >= 4 ? strtoull(argv[3], nullptr, 10) : 1000000ull;
+    uint32_t threads =
+        argc >= 5 ? (uint32_t)strtoul(argv[4], nullptr, 10) : 16u;
+    if (std::strcmp(mode, "same") != 0 && std::strcmp(mode, "spread") != 0) {
+      std::fprintf(stderr, "mt-wrapper mode must be same or spread\n");
+      return 2;
+    }
+    wrapperMultiThread(n, threads, std::strcmp(mode, "same") == 0);
+    return 0;
+  }
   if (argc >= 2 && !std::strcmp(argv[1], "single")) {
     const char *name = argc >= 3 ? argv[2] : "empty";
     uint64_t n = argc >= 4 ? strtoull(argv[3], nullptr, 10) : 50000000ull;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBenchAbi.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBenchAbi.cpp
@@ -1,0 +1,288 @@
+//===-- EJitHotPathBenchAbi.cpp - faithful C ABI + wrapper mirror ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This translation unit reproduces, byte-for-byte where it matters, the two
+//  production layers that sit between a business call and the compiled JIT
+//  code:
+//
+//    1. The C ABI shell (EJitRuntime.cpp: ejit_taskpool_compile_or_get{,_0d,
+//       _1d,_2d} + ejit_taskpool_release_read). The ONLY change is that the
+//       pool is resolved from a local EJitStub instead of the full gEJIT
+//       runtime object — the two dependent loads + null checks are preserved so
+//       the shim's instruction cost matches production. Every validation, the
+//       tryCacheHit dispatch, the status mapping, and the outFn/outBucket
+//       write-back are identical.
+//
+//    2. The AOT wrapper (EJitWrapperGen.cpp output): jit_entry -> jit_call (the
+//       C ABI) -> jit_dispatch (indirect call through fnPtr + release_read) ->
+//       return, with a jit_fallback AOT body.
+//
+//  It is a SEPARATE TU so the C ABI is a real cross-TU call (not inlined) and
+//  the indirect JIT call is a real `call *reg` the compiler cannot devirtualize
+//  — exactly the code shape the real wrapper executes. Compiled at -Os to match
+//  the embedded production build.
+//
+//  LIMITATION (documented honestly): the measurement host is native AArch64,
+//  but it is not the customer board. The indirect call is a plain `blr` to a
+//  stable local target (no BTI/PAC), EJitCoreId::current() uses the host test
+//  implementation, and the pool is resolved from a stub rather than the full
+//  gEJIT graph. This TU is the faithful same-ABI host wrapper the audit brief
+//  permits when the true target binary cannot be executed here.
+//
+//===----------------------------------------------------------------------===//
+
+#include "EJitHotPathBenchAbi.h"
+
+using namespace llvm::ejit;
+
+namespace ejitbench {
+
+EJitStub *gEJITStub = nullptr;
+
+// funcIndex the wrapper "loads from its per-function global". Constant here so
+// the wrapper mirrors the AOT-baked immediate.
+static constexpr uint32_t kWrapperFuncIndex0D = 0;
+
+//===-- Status mapping (mirrors EJitRuntime.cpp taskpoolStatus) -----------===//
+static uint32_t benchStatus(EJitCompileOrGetStatus s) {
+  switch (s) {
+  case EJitCompileOrGetStatus::CacheHit:
+    return BENCH_OK;
+  case EJitCompileOrGetStatus::EnqueuedPending:
+  case EJitCompileOrGetStatus::AlreadyPending:
+    return BENCH_PENDING;
+  case EJitCompileOrGetStatus::QueueFullFallback:
+    return BENCH_ERR_QUEUE_FULL;
+  case EJitCompileOrGetStatus::OffMode:
+    return BENCH_ERR_DISABLED;
+  case EJitCompileOrGetStatus::InstanceDisabled:
+    return BENCH_ERR_INSTANCE_DISABLED;
+  case EJitCompileOrGetStatus::InvalidParam:
+    return BENCH_ERR_INVALID_PARAM;
+  case EJitCompileOrGetStatus::CompileFailed:
+  default:
+    return BENCH_ERR_COMPILE_FAILED;
+  }
+}
+
+static inline EJitSharedTaskPool *activePool() {
+  return gEJITStub ? gEJITStub->sharedPool : nullptr;
+}
+
+static inline bool dimInRange(uint32_t dimType, uint32_t instanceId) {
+  return dimType < EJitSwitchController::MAX_DIM_TYPES &&
+         instanceId < EJitSwitchController::MAX_INSTANCES;
+}
+
+extern "C" {
+
+uint32_t bench_cabi_0d(uint32_t funcIndex, void **outFn, uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  EJitSharedTaskPool *tp = activePool();
+  if (!tp)
+    return BENCH_ERR_NOT_ACTIVE;
+  auto fast = tp->tryCacheHit0D(funcIndex);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return benchStatus(fast.status);
+  }
+  auto r = tp->compileOrGet(funcIndex, nullptr, 0, nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return benchStatus(r.status);
+}
+
+uint32_t bench_cabi_1d(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                       void **outFn, uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  EJitSharedTaskPool *tp = activePool();
+  if (!tp)
+    return BENCH_ERR_NOT_ACTIVE;
+  if (!dimInRange(dim0, inst0))
+    return BENCH_ERR_INVALID_PARAM;
+  auto fast = tp->tryCacheHit1D(funcIndex, dim0, inst0);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return benchStatus(fast.status);
+  }
+  const EJitDimPair dims[1] = {{dim0, inst0}};
+  auto r = tp->compileOrGet(funcIndex, dims, 1, nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return benchStatus(r.status);
+}
+
+uint32_t bench_cabi_2d(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                       uint32_t dim1, uint32_t inst1, void **outFn,
+                       uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  EJitSharedTaskPool *tp = activePool();
+  if (!tp)
+    return BENCH_ERR_NOT_ACTIVE;
+  if (!dimInRange(dim0, inst0) || !dimInRange(dim1, inst1))
+    return BENCH_ERR_INVALID_PARAM;
+  auto fast = tp->tryCacheHit2D(funcIndex, dim0, inst0, dim1, inst1);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return benchStatus(fast.status);
+  }
+  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
+  auto r = tp->compileOrGet(funcIndex, dims, 2, nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return benchStatus(r.status);
+}
+
+uint32_t bench_cabi_generic(uint32_t funcIndex, const EJitDimPair *dims,
+                            uint32_t numDims, void **outFn,
+                            uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  EJitSharedTaskPool *tp = activePool();
+  if (!tp)
+    return BENCH_ERR_NOT_ACTIVE;
+  if (numDims > 4)
+    return BENCH_ERR_INVALID_PARAM;
+  if (numDims > 0 && !dims)
+    return BENCH_ERR_INVALID_PARAM;
+  for (uint32_t i = 0; i < numDims; ++i)
+    if (!dimInRange(dims[i].dimType, dims[i].instanceId))
+      return BENCH_ERR_INVALID_PARAM;
+  auto fast = tp->tryCacheHit(funcIndex, dims, numDims);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return benchStatus(fast.status);
+  }
+  auto r = tp->compileOrGet(funcIndex, dims, numDims, nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return benchStatus(r.status);
+}
+
+void bench_cabi_release_read(uint32_t bucketIndex) {
+  EJitSharedTaskPool *tp = activePool();
+  if (tp)
+    tp->releaseRead(bucketIndex);
+}
+
+// Optimization candidate: additive trusted-wrapper fast entry. Returns the
+// fnPtr directly (nullptr unless a real CacheHit), skips the outFn NULL guard
+// + double write. bucketIndex is still handed back for the token build's
+// release; a NO_RECLAIM build hands back the sentinel so release no-ops.
+void *bench_cabi_hit_0d(uint32_t funcIndex, uint32_t *outBucket) {
+  EJitSharedTaskPool *tp = activePool();
+  if (!tp)
+    return nullptr;
+  auto fast = tp->tryCacheHit0D(funcIndex);
+  if (fast.status == EJitCompileOrGetStatus::CacheHit) {
+    *outBucket = fast.bucketIndex;
+    return fast.fnPtr;
+  }
+  // Miss / disabled / not-shareable: let the caller run its AOT body. (A true
+  // miss still needs enqueuing; the wrapper's fallback path calls the generic
+  // ABI once to kick compilation — mirrored in the driver, not timed here.)
+  *outBucket = 0;
+  return nullptr;
+}
+
+//===-- Real "JIT" bodies + AOT bodies for the indirect-call e2e ----------===//
+// Tiny leaf JIT function: magnifies the fixed wrapper/dispatch overhead.
+__attribute__((noinline)) long benchJitRaw0D(long arg) { return arg + 1; }
+
+// Larger JIT function: a short data-dependent loop so the callee body dominates
+// and the fixed overhead becomes a small fraction (for the "big function"
+// comparison the brief asks for).
+__attribute__((noinline)) long benchJitRawBigImpl(long arg) {
+  long acc = arg;
+  for (int i = 0; i < 24; ++i)
+    acc = acc * 1103515245 + 12345 + (acc >> 7);
+  return acc;
+}
+
+long bench_aot_0d(long arg) { return benchJitRaw0D(arg); }
+long bench_call_jit_direct(long arg) { return benchJitRaw0D(arg); }
+
+// The wrapper: mirrors EJitWrapperGen. jit_entry loads funcIndex (immediate),
+// jit_call runs the C ABI, jit_dispatch does the indirect call + release, and
+// jit_fallback runs the AOT body.
+long bench_wrapper_0d_hit(long arg) {
+  void *fn;
+  uint32_t bucket;
+  uint32_t st = bench_cabi_0d(kWrapperFuncIndex0D, &fn, &bucket);
+  if (st == BENCH_OK && fn) {
+    long r = reinterpret_cast<long (*)(long)>(fn)(arg);
+    bench_cabi_release_read(bucket);
+    return r;
+  }
+  return benchJitRaw0D(arg); // jit_fallback AOT body
+}
+
+long bench_wrapper_0d_fallback(long arg) {
+  // Same wrapper prologue, but funcIndex is one that never hits, so the C ABI
+  // returns non-OK and we always take the AOT fallback. Measures the wrapper
+  // overhead paid on a fallback.
+  void *fn;
+  uint32_t bucket;
+  uint32_t st = bench_cabi_0d(0xFFFFFFu, &fn, &bucket);
+  if (st == BENCH_OK && fn) {
+    long r = reinterpret_cast<long (*)(long)>(fn)(arg);
+    bench_cabi_release_read(bucket);
+    return r;
+  }
+  return benchJitRaw0D(arg);
+}
+
+long bench_wrapper_0d_trusted(long arg) {
+  uint32_t bucket;
+  void *fn = bench_cabi_hit_0d(kWrapperFuncIndex0D, &bucket);
+  if (fn) {
+    long r = reinterpret_cast<long (*)(long)>(fn)(arg);
+    bench_cabi_release_read(bucket);
+    return r;
+  }
+  return benchJitRaw0D(arg);
+}
+
+} // extern "C"
+
+void *benchJitFn0D() { return reinterpret_cast<void *>(&benchJitRaw0D); }
+void *benchJitFnBig() { return reinterpret_cast<void *>(&benchJitRawBigImpl); }
+long benchJitRawBig(long arg) { return benchJitRawBigImpl(arg); }
+
+} // namespace ejitbench

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBenchAbi.h
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitHotPathBenchAbi.h
@@ -1,0 +1,91 @@
+//===-- EJitHotPathBenchAbi.h - shared decls for the hot-path bench -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Declarations shared between the benchmark driver (EJitHotPathBench.cpp) and
+//  the ABI/wrapper translation unit (EJitHotPathBenchAbi.cpp). The two live in
+//  SEPARATE translation units on purpose so the optimizer cannot inline the
+//  C-ABI shim into the measurement loop or fold away the indirect call — the
+//  compiled code path mirrors what a cross-TU AOT wrapper actually executes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EJIT_HOTPATH_BENCH_ABI_H
+#define LLVM_EJIT_HOTPATH_BENCH_ABI_H
+
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+#include <cstdint>
+
+namespace ejitbench {
+
+// Faithful mirror of the runtime's EJit black-box object indirection: the
+// production C ABI resolves the pool via `gEJIT ? gEJIT->sharedTaskPool() :
+// nullptr`, i.e. TWO dependent loads + two null checks. We reproduce that exact
+// shape so the shim's measured cost matches production (the only thing we drop
+// is the real gEJIT object graph, which is irrelevant to the hot path).
+struct EJitStub {
+  llvm::ejit::EJitSharedTaskPool *sharedPool = nullptr;
+};
+
+// Installed once by the driver before measuring; read by the shim TU.
+extern EJitStub *gEJITStub;
+
+// Status codes mirroring EJitError.h's ejit_status_t hot-path subset.
+enum BenchStatus : uint32_t {
+  BENCH_OK = 0,
+  BENCH_PENDING = 1,
+  BENCH_ERR_DISABLED = 2,
+  BENCH_ERR_INSTANCE_DISABLED = 3,
+  BENCH_ERR_QUEUE_FULL = 4,
+  BENCH_ERR_INVALID_PARAM = 5,
+  BENCH_ERR_COMPILE_FAILED = 6,
+  BENCH_ERR_NOT_ACTIVE = 7,
+};
+
+//===-- Faithful same-ABI C shim (mirrors EJitRuntime.cpp) ----------------===//
+// Byte-for-byte the same body as ejit_taskpool_compile_or_get{,_0d,_1d,_2d},
+// except the pool is resolved from gEJITStub instead of gEJIT. Kept in a
+// separate TU and NOT inlined, exactly like the real C ABI relative to the
+// wrapper.
+extern "C" {
+uint32_t bench_cabi_0d(uint32_t funcIndex, void **outFn, uint32_t *outBucket);
+uint32_t bench_cabi_1d(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                       void **outFn, uint32_t *outBucket);
+uint32_t bench_cabi_2d(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
+                       uint32_t dim1, uint32_t inst1, void **outFn,
+                       uint32_t *outBucket);
+uint32_t bench_cabi_generic(uint32_t funcIndex,
+                            const llvm::ejit::EJitDimPair *dims,
+                            uint32_t numDims, void **outFn,
+                            uint32_t *outBucket);
+void bench_cabi_release_read(uint32_t bucketIndex);
+
+// Experimental additive "trusted-wrapper" fast entry (optimization candidate):
+// returns the fnPtr directly (nullptr on any non-hit) and, in a NO_RECLAIM
+// build, needs no out-bucket / release at all. Never replaces the public ABI.
+void *bench_cabi_hit_0d(uint32_t funcIndex, uint32_t *outBucket);
+}
+
+//===-- Wrapper end-to-end (mirrors EJitWrapperGen output) ----------------===//
+// jit_entry -> jit_call (C ABI) -> jit_dispatch (indirect call + release) ->
+// return, with a jit_fallback AOT body. Real indirect call through fnPtr.
+extern "C" {
+long bench_wrapper_0d_hit(long arg);      // resolves to a real JIT fn, calls it
+long bench_wrapper_0d_fallback(long arg); // forced AOT fallback body
+long bench_wrapper_0d_trusted(long arg);  // uses bench_cabi_hit_0d fast entry
+long bench_aot_0d(long arg);              // the AOT body alone (direct)
+long bench_call_jit_direct(long arg);     // direct call of the same JIT fn
+}
+
+// Addresses published into the cache as "compiled code" (real, executable).
+void *benchJitFn0D();  // tiny leaf, magnifies fixed overhead
+void *benchJitFnBig(); // larger body, dilutes fixed overhead
+long benchJitRawBig(long arg);
+
+} // namespace ejitbench
+
+#endif

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
@@ -1,0 +1,288 @@
+//===-- EJitSharedCacheQueryBench.cpp - cache-hit query microbenchmark ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Deterministic, single-thread microbenchmark + slot-depth diagnostics for the
+//  cross-core SHARED taskpool cache-hit query path (spec §5.2 steps 0-1). It is
+//  NOT a gtest binary: it has its own main(), links only the shared-taskpool
+//  sources + EJitSharedPlatform, and prints a machine-readable table so an
+//  external harness (perf stat, this file's own cycle counter) can attribute
+//  instructions/cycles per hit.
+//
+//  What it measures, per the audit requirements:
+//    * 0D / 1D / 2D owner-core cache hit
+//    * hit slot depth 0, 1, 5, 15 (the linear 16-slot bucket scan)
+//    * peer-core hit (code sharing on, execute-permission already memoized)
+//    * a slot-depth histogram for a synthetic mixed workload
+//
+//  Slot depth is controlled deterministically: 0D identities whose funcIndex is
+//  a multiple of kEJitSharedCacheBuckets (32) all hash to bucket 0 and fill its
+//  slots 0,1,2,... in publish order (cachePublish uses first-empty), so the Nth
+//  published collider lands at slot N.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <memory>
+#include <vector>
+
+using namespace llvm::ejit;
+
+namespace {
+
+// Deterministic, non-null "compiled code" pointer derived from funcIndex. Never
+// executed — only cached/compared/returned.
+void *codeFor(uint32_t funcIndex) {
+  return reinterpret_cast<void *>(0x100000ull +
+                                  static_cast<uintptr_t>(funcIndex) * 64u);
+}
+
+bool benchCompile(void * /*ctx*/, const EJitCompileRequest &req, void **outFn) {
+  *outFn = codeFor(req.funcIndex);
+  return true;
+}
+
+// Owner-side resolver: hand back a fixed 2MiB pool range so peer preparation
+// (4K/2M) and codeStart/codeSize metadata are exercised.
+struct RangeCtx {
+  uintptr_t poolBase = 0x40000000ull;
+  uint64_t poolSize = 0x200000ull;
+  uintptr_t codeStart = 0x40000000ull;
+  uint64_t codeSize = 64;
+  uint32_t poolId = 0;
+};
+bool benchCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
+  auto *r = static_cast<RangeCtx *>(ctx);
+  out->fnPtr = const_cast<void *>(fnPtr);
+  out->codeStart = r->codeStart;
+  out->codeSize = r->codeSize;
+  out->poolBase = r->poolBase;
+  out->poolSize = r->poolSize;
+  out->poolId = r->poolId;
+  return true;
+}
+
+// Peer execute-permission preparation always succeeds in this host harness.
+bool benchPrepareCode(void * /*ctx*/, const void * /*fnPtr*/) { return true; }
+
+uint64_t nowNs() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ull +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+
+// Global sink so the compiler cannot elide the looked-up pointer.
+volatile uintptr_t gSink = 0;
+
+struct Bench {
+  std::unique_ptr<EJitSharedTaskPoolState> state;
+  EJitSharedTaskPool pool;
+  RangeCtx range;
+
+  void bringUpOwner(bool codeSharing) {
+    EJitCoreId::resetForTest();
+    EJitCoreId::setCurrentForTest(0);
+    state.reset(new EJitSharedTaskPoolState());
+    pool.bind(state.get());
+    pool.setCompiler(&benchCompile, nullptr);
+    pool.setMode(EJitCompileMode::Async);
+    pool.setCodeSharingEnabled(codeSharing);
+    pool.setCodeRangeProvider(&benchCodeRange, &range);
+    pool.setPrepareCodeCallback(&benchPrepareCode, nullptr);
+    if (pool.init() != EJitSharedTaskPool::InitResult::BecameOwner) {
+      std::fprintf(stderr, "owner election failed\n");
+      std::exit(1);
+    }
+  }
+
+  // Publish one 0D identity on the owner core (compile inline via Async enqueue
+  // + pollOne).
+  void publish0D(uint32_t funcIndex) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.compileOrGet(funcIndex, nullptr, 0, codeFor(funcIndex));
+    pool.pollOne();
+  }
+  void publish1D(uint32_t funcIndex, uint32_t d0, uint32_t i0) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    EJitDimPair dims[1] = {{d0, i0}};
+    pool.compileOrGet(funcIndex, dims, 1, codeFor(funcIndex));
+    pool.pollOne();
+  }
+  void publish2D(uint32_t funcIndex, uint32_t d0, uint32_t i0, uint32_t d1,
+                 uint32_t i1) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    pool.setInstanceEnabled(d1, i1, true);
+    EJitDimPair dims[2] = {{d0, i0}, {d1, i1}};
+    pool.compileOrGet(funcIndex, dims, 2, codeFor(funcIndex));
+    pool.pollOne();
+  }
+};
+
+// --- 0D slot-depth sweep -----------------------------------------------------
+// Publish (depth+1) 0D colliders into bucket 0, then hammer the deepest one.
+uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(/*codeSharing=*/peer);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  uint32_t targetFunc = 0;
+  for (uint32_t d = 0; d <= depth; ++d) {
+    uint32_t fi = d * kB; // all hash to bucket 0
+    B.publish0D(fi);
+    targetFunc = fi; // deepest published so far
+  }
+  uint32_t core = 0;
+  if (peer) {
+    core = 1;
+    EJitCoreId::setCurrentForTest(core);
+    // Warm the memoized execute-permission bit for this peer core.
+    auto w = B.pool.tryCacheHit0D(targetFunc);
+    if (w.hasReadToken)
+      B.pool.releaseRead(w.bucketIndex);
+  }
+  EJitCoreId::setCurrentForTest(core);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit0D(targetFunc);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+uint64_t bench1D(uint32_t depth, uint64_t iters, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(false);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  // 1D identities colliding into one bucket: vary funcIndex by multiples that
+  // keep the same hash bucket is nontrivial, so instead vary instanceId and
+  // accept the natural bucket; publish depth+1 entries and hammer the last.
+  uint32_t targetFunc = 7;
+  for (uint32_t d = 0; d <= depth; ++d) {
+    B.publish1D(targetFunc, 0, d); // same funcIndex, distinct instanceId
+  }
+  // The deepest is instanceId=depth; ensure it is enabled and query it.
+  EJitCoreId::setCurrentForTest(0);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit1D(targetFunc, 0, depth);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+uint64_t bench2D(uint64_t iters, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(false);
+  uint32_t targetFunc = 9;
+  B.publish2D(targetFunc, 0, 1, 1, 2);
+  EJitCoreId::setCurrentForTest(0);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit2D(targetFunc, 0, 1, 1, 2);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+void runTable(uint64_t iters) {
+  std::printf("# config,dim,slotDepth,core,nsPerHit,hits/iters\n");
+  double ns;
+  uint64_t h;
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench0D(depth, iters, /*peer=*/false, &ns);
+    std::printf("owner0D,0,%u,0,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench0D(depth, iters, /*peer=*/true, &ns);
+    std::printf("peer0D,0,%u,1,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench1D(depth, iters, &ns);
+    std::printf("owner1D,1,%u,0,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  h = bench2D(iters, &ns);
+  std::printf("owner2D,2,0,0,%.3f,%llu/%llu\n", ns, (unsigned long long)h,
+              (unsigned long long)iters);
+}
+
+} // namespace
+
+// Usage:
+//   bench                 -> full table, 20M iters each
+//   bench <iters>         -> full table with given iters
+//   bench single0d <d> <iters>   -> ONE tight loop (for perf stat attribution)
+//   bench single0dpeer <d> <iters>
+//   bench single1d <d> <iters>
+//   bench single2d <iters>
+int main(int argc, char **argv) {
+  uint64_t iters = 20000000ull;
+  if (argc >= 2 && std::strncmp(argv[1], "single", 6) == 0) {
+    double ns;
+    uint64_t h = 0;
+    const char *what = argv[1];
+    if (std::strcmp(what, "single0d") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, false, &ns);
+    } else if (std::strcmp(what, "single0dpeer") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, true, &ns);
+    } else if (std::strcmp(what, "single1d") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench1D(d, iters, &ns);
+    } else if (std::strcmp(what, "single2d") == 0) {
+      iters = argc >= 3 ? strtoull(argv[2], nullptr, 10) : iters;
+      h = bench2D(iters, &ns);
+    } else {
+      std::fprintf(stderr, "unknown single mode %s\n", what);
+      return 2;
+    }
+    std::printf("%s ns/hit=%.3f hits=%llu/%llu sink=%llu\n", what, ns,
+                (unsigned long long)h, (unsigned long long)iters,
+                (unsigned long long)gSink);
+    return 0;
+  }
+  if (argc >= 2)
+    iters = strtoull(argv[1], nullptr, 10);
+  runTable(iters);
+  std::printf("# sink=%llu\n", (unsigned long long)gSink);
+  return 0;
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2259,6 +2259,167 @@ TEST_F(SharedTaskPoolTest, HitTokenDisciplineAndVersionInvalidation) {
 }
 
 //===----------------------------------------------------------------------===//
+// Slot-depth diagnostics: 0D identities whose funcIndex is a multiple of
+// kEJitSharedCacheBuckets all hash to bucket 0 and fill its slots 0,1,2,... in
+// publish order (cachePublish uses first-empty). This deterministically places
+// a target at a chosen linear-scan depth, exercising the per-slot scan (and the
+// identityHash-first fast-reject reorder) and proving the deepest slot is still
+// found and correctly identified.
+//===----------------------------------------------------------------------===//
+namespace {
+// Return the linear slot index at which \p funcIndex is Ready in its bucket, or
+// -1 if not found. Pure diagnostic scan (no lock needed in the single-thread
+// test).
+int slotDepthOf(EJitSharedTaskPoolState *st, uint32_t funcIndex,
+                uint32_t numDims) {
+  uint32_t bucket = funcIndex % kEJitSharedCacheBuckets; // 0D key == funcIndex
+  auto &B = st->buckets[bucket];
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    auto &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() ==
+            static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
+        Slot.funcIndex == funcIndex && Slot.numDims == numDims)
+      return static_cast<int>(s);
+  }
+  return -1;
+}
+} // namespace
+
+TEST_F(SharedTaskPoolTest, SlotDepthHitsAtEveryDepth) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+
+  // Fill bucket 0 slots 0..15 with distinct 0D colliders.
+  for (uint32_t d = 0; d < kEJitSharedCacheSlots; ++d) {
+    uint32_t fi = d * kB;
+    ASSERT_EQ(owner.compileOrGet(fi, nullptr, 0, codeFor(fi)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(owner.pollOne());
+    EXPECT_EQ(slotDepthOf(state_.get(), fi, 0), static_cast<int>(d));
+  }
+
+  // Every colliding identity — including the deepest slot 15 — must still be a
+  // correct cache hit with its own specialization pointer.
+  for (uint32_t d = 0; d < kEJitSharedCacheSlots; ++d) {
+    uint32_t fi = d * kB;
+    auto hit = owner.tryCacheHit0D(fi);
+    ASSERT_TRUE(hit.fastPathTerminal) << "depth " << d;
+    EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit) << "depth " << d;
+    EXPECT_EQ(hit.fnPtr, codeFor(fi)) << "depth " << d;
+    if (hit.hasReadToken)
+      owner.releaseRead(hit.bucketIndex);
+  }
+
+  // An unpublished colliding key in the same (now full) bucket is a clean miss.
+  auto miss = owner.tryCacheHit0D(kEJitSharedCacheSlots * kB);
+  EXPECT_NE(miss.status, EJitCompileOrGetStatus::CacheHit);
+  if (miss.hasReadToken)
+    owner.releaseRead(miss.bucketIndex);
+}
+
+// The identityHash-first reorder must never alias two identities that share a
+// bucket: a wrong-funcIndex query with the same bucket must miss even when a
+// different identity is Ready there.
+TEST_F(SharedTaskPoolTest, SlotDepthNoIdentityAliasAcrossBucket) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  // Publish only funcIndex 5*kB at slot 0 of bucket 0.
+  uint32_t present = 5 * kB;
+  ASSERT_EQ(owner.compileOrGet(present, nullptr, 0, codeFor(present)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  // A different colliding funcIndex (same bucket, different identity) misses.
+  auto miss = owner.tryCacheHit0D(9 * kB);
+  EXPECT_NE(miss.status, EJitCompileOrGetStatus::CacheHit);
+  if (miss.hasReadToken)
+    owner.releaseRead(miss.bucketIndex);
+  // The present one still hits with the right pointer.
+  auto hit = owner.tryCacheHit0D(present);
+  EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(hit.fnPtr, codeFor(present));
+  if (hit.hasReadToken)
+    owner.releaseRead(hit.bucketIndex);
+}
+
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+//===----------------------------------------------------------------------===//
+// NO_RECLAIM fixed-dimension seqlock specializations (cacheLookupSeq0D/1D/2D):
+// the unrolled seqlock lookups reached by tryCacheHit0D/1D/2D must return the
+// SAME result as the generic seqlock path (cacheLookupSeq via tryCacheHit), for
+// hits, deep-slot hits, misses, disabled instances, and version invalidation.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, SeqFixedDimMatchesGeneric0D1D2D) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(1, 2, true);
+  owner.setInstanceEnabled(3, 4, true);
+
+  // Publish a 0D, a 1D and a 2D specialization.
+  ASSERT_EQ(owner.compileOrGet(21, nullptr, 0, codeFor(21)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EJitDimPair d1[1] = {dim(1, 2)};
+  ASSERT_EQ(owner.compileOrGet(22, d1, 1, codeFor(22)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EJitDimPair d2[2] = {dim(1, 2), dim(3, 4)};
+  ASSERT_EQ(owner.compileOrGet(23, d2, 2, codeFor(23)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  // Fixed-dim seqlock entry vs generic seqlock entry: identical outcomes.
+  auto fixed0 = owner.tryCacheHit0D(21);
+  auto gen0 = owner.tryCacheHit(21, nullptr, 0);
+  EXPECT_EQ(fixed0.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed0.status, gen0.status);
+  EXPECT_EQ(fixed0.fnPtr, gen0.fnPtr);
+  EXPECT_EQ(fixed0.fnPtr, codeFor(21));
+
+  auto fixed1 = owner.tryCacheHit1D(22, 1, 2);
+  auto gen1 = owner.tryCacheHit(22, d1, 1);
+  EXPECT_EQ(fixed1.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed1.status, gen1.status);
+  EXPECT_EQ(fixed1.fnPtr, gen1.fnPtr);
+  EXPECT_EQ(fixed1.fnPtr, codeFor(22));
+
+  auto fixed2 = owner.tryCacheHit2D(23, 1, 2, 3, 4);
+  auto gen2 = owner.tryCacheHit(23, d2, 2);
+  EXPECT_EQ(fixed2.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed2.status, gen2.status);
+  EXPECT_EQ(fixed2.fnPtr, gen2.fnPtr);
+  EXPECT_EQ(fixed2.fnPtr, codeFor(23));
+
+  // A miss and a wrong-dim query must also agree (both miss).
+  EXPECT_NE(owner.tryCacheHit0D(99).status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_NE(owner.tryCacheHit1D(22, 1, 3).status,
+            EJitCompileOrGetStatus::CacheHit); // wrong instanceId
+}
+
+// Version bump after a seqlock fixed-dim publish must invalidate the old slot.
+TEST_F(SharedTaskPoolTest, SeqFixedDimVersionBumpMisses) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(2, 7, true);
+  EJitDimPair d1[1] = {dim(2, 7)};
+  ASSERT_EQ(owner.compileOrGet(31, d1, 1, codeFor(31)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EXPECT_EQ(owner.tryCacheHit1D(31, 2, 7).status,
+            EJitCompileOrGetStatus::CacheHit);
+  // Deactivate (bumps version): stale slot must not be served.
+  owner.setInstanceEnabled(2, 7, false);
+  EXPECT_NE(owner.tryCacheHit1D(31, 2, 7).status,
+            EJitCompileOrGetStatus::CacheHit);
+}
+#endif // EJIT_SRE_TASKPOOL_NO_RECLAIM
+
+//===----------------------------------------------------------------------===//
 // Phase-1 hot-hit micro-benchmark (DISABLED by default; run explicitly with
 //   --gtest_also_run_disabled_tests --gtest_filter='*HotHitMicroBench*'
 // on an aarch64 host). Measures the per-hit cost of the shared taskpool hit


### PR DESCRIPTION
## 定位

PR #83 是一个 **EmbeddedJIT 编译完成后热路径的性能测量与归因工具**，不修改生产运行逻辑，也不改变 shared ABI。

主线已经有面向真实板上业务的 wrapper timing 探针，可输出：

- `get_fn_avg`
- `fn_call_avg`
- `release_avg`
- `total_avg`

但板上探针容易受到调度、日志和业务负载扰动，也不方便稳定构造同 slot 与分散 bucket 的对照实验。本 PR 增加独立的 native AArch64 benchmark，用于在受控环境中拆分每一层固定开销并做可重复回归。

两者关系：

- 主线 wrapper timing：测真实业务，真实性高。
- PR #83 benchmark：做受控归因，可重复性高。

## 与 PR #82 的关系

本分支现已直接基于 PR #82。

- PR #82：真正优化 Shared Taskpool cache lookup，包括 fixed-dimension seqlock 路径和 slot 扫描顺序。
- PR #83：通过完整 wrapper 调用链验证 PR #82 的收益，并提供后续性能回归工具。

当前提交结构：

```text
PR #82
  47e9938b  cache-query benchmark
  ab6dfc16  fixed-dimension seqlock optimization
  8f0b78a9  performance model

PR #83
  5335f934  post-compile hot-path benchmark
  3171b1d5  16-thread wrapper benchmark
```

PR #82 合入后，本 PR 可再 rebase 到最新 `ejit_dev_spec4`，最终只保留后两个 benchmark 提交。

## 测量链路

benchmark 分层测量：

```text
业务 wrapper
→ C ABI
→ cache lookup
→ 获取 fnPtr
→ 间接 blr
→ JIT 函数体
→ release_read
→ 返回
```

覆盖：

- internal cache query
- 完整 C ABI shell
- wrapper cache hit
- wrapper fallback
- direct AOT
- direct fnPtr
- trusted fast-ABI 实验原型
- owner 与 prepared peer
- 0D/1D/2D/3D
- slot depth
- stats ON/OFF
- read-token 与 NO_RECLAIM
- 1/2/4/8/16 线程扩展
- 16 线程同一热函数与分散 funcIndex/bucket

benchmark 使用真实间接函数调用；`std::thread` 只存在于独立 host benchmark target，不进入 LLVMEJIT 生产库或 freestanding 路径。

## 单线程结果

native Little-Endian AArch64、`-Os`、NO_RECLAIM、stats OFF：

- internal owner 0D slot-0：约 `9.3 ns`
- C ABI 0D：约 `13.2 ns`
- 完整 wrapper hit：约 `15.0 ns`
- direct AOT / direct fnPtr：约 `2.0 ns`
- wrapper fallback：约 `36.9 ns`

此前静态/PMU 审计得到的代表值：

- 完整 wrapper hit：约 `216 instructions / 45 cycles`
- 单独间接 `blr`：约 `9 instructions / 2 cycles`

说明主要固定成本来自 cache query，而不是间接跳转本身。

## 16 线程完整 Wrapper 验证

每线程调用 1,000,000 次，全部命中：

| 查询协议 | 同一函数/slot | 分散 funcIndex/bucket |
|---|---:|---:|
| read-token | 约 1.05–1.10 us/call | 约 27.2–27.3 ns/call |
| NO_RECLAIM seqlock | 约 15.09–15.14 ns/call | 约 14.66–14.70 ns/call |

同一热函数随线程数扩展：

| 线程数 | read-token | NO_RECLAIM |
|---:|---:|---:|
| 1 | 约 28 ns | 约 15.0 ns |
| 2 | 约 134 ns | 约 15.3 ns |
| 4 | 约 276 ns | 约 15.1 ns |
| 8 | 约 608 ns | 约 15.1 ns |
| 16 | 约 1.30 us | 约 15.2 ns |

结论：read-token 每次 hit 的共享原子 RMW 会在多核调用同一热函数时造成严重 cache-line bouncing。PR #82 的 NO_RECLAIM 只读 seqlock 路径穿过完整 C ABI、`blr` 和 release 后依然稳定，1 到 16 线程基本不退化。

该结果依赖产品前提：生成代码不会被物理释放或覆盖。

## 构建注意事项

`EJIT_SRE_TASKPOOL_NO_RECLAIM` 是编译期选项。切换到 PR #82/#83 后必须重新运行 CMake configure，并重新编译 `EJitSharedTaskPool.cpp.o`。

不能只看旧构建目录中的 Cache 值，必须确认实际编译命令含有：

```text
-DEJIT_SRE_TASKPOOL_NO_RECLAIM
```

例如：

```bash
grep 'EJIT_SRE_TASKPOOL_NO_RECLAIM' build/CMakeCache.txt

grep -R -- '-DEJIT_SRE_TASKPOOL_NO_RECLAIM' \
  build/build.ninja build/compile_commands.json
```

## 验证

- `EJITTaskPoolTests`：82/82 通过
- native AArch64 token benchmark：通过
- native AArch64 NO_RECLAIM benchmark：通过
- 16-thread same/spread：全部命中
- 完整三层 hot-path benchmark：通过
- `clang-format --dry-run --Werror`：通过
- `git diff --check`：通过
- 所有构建最多使用 `-j8`

## 风险与边界

- 本 PR 是 benchmark/DFX 工具，不是新的生产调度路径。
- Host 测试可以复现共享缓存线争用，但不能替代板上的 CoreId、barrier、I-cache/TLB 和调度验证。
- NO_RECLAIM 只适用于生成代码不物理回收的模型。
- trusted fast-ABI 仍是 benchmark 内实验原型，未进入生产 C ABI。
