### PR TITLE
[EJIT] Improve hash function to decrease collisions

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -191,6 +191,7 @@ ALL_TESTS=(
   ejit_ptr_period_test
   ejit_trace_test
   ejit_volatile_test
+  ejit_chain_bench
 )
 
 # Per-test compile flags (e.g. for disabling global constructors)
@@ -247,6 +248,7 @@ TEST_ARGS[ejit_baremetal_link_test]="0 3"
 TEST_ARGS[ejit_sync_mode_test]="0"
 TEST_ARGS[ejit_new_attr_test]="0"
 TEST_ARGS[ejit_fixed_dim_test]="0 1"
+TEST_ARGS[ejit_chain_bench]=""
 
 if [[ ${#SELECTED[@]} -eq 0 ]]; then
   SELECTED=("${ALL_TESTS[@]}")

--- a/ejit_test/ejit_chain_bench.c
+++ b/ejit_test/ejit_chain_bench.c
@@ -1,0 +1,109 @@
+/**
+ * EJIT cache-chain lookup benchmark.
+ *
+ * Engineered worst case for a weak identity hash: many entry functions with
+ * small consecutive funcIndexes, all on ONE period type, each with many
+ * instances. A hash that folds funcIndex in raw collapses funcIndex ^ instanceId
+ * onto a handful of keys, so every specialization of this family lands in a few
+ * buckets -- filling each 16-slot bucket into a 16-deep chain whose slots all
+ * share one identityHash. The lookup prefilter (identityHash != key) then
+ * rejects nothing and every lookup runs the full funcIndex/dims/versions
+ * compare against all 16 slots. A hash that diffuses funcIndex spreads the same
+ * specializations across all buckets with distinct keys: short chains, one full
+ * compare per lookup.
+ *
+ * NFUNC*NINST is sized to fill the cache exactly (no eviction) so this measures
+ * pure chain-scan cost, not recompile churn. Warm up compiles every
+ * specialization; the timed loop is pure cache hits. Uses only public API
+ * (ejit_taskpool_get_stats), so the same binary runs against either runtime.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "ejit_test_helpers.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
+
+#define NINST 16
+#define NFUNC 16
+#define NSPEC (NFUNC * NINST)
+
+struct Cfg {
+  ejit_may_const uint32_t v;
+};
+ejit_period_arr(p) struct Cfg g[NINST];
+
+/* 16 entry functions, all indexed by period `p`, trivial bodies so the per-call
+   cost is dominated by the wrapper's cache lookup rather than the JIT'd body. */
+#define DEF_F(n)                                                               \
+  ejit_entry uint32_t f##n(ejit_period_arr_ind(p) uint8_t i) {                 \
+    return g[i].v + (n);                                                       \
+  }
+DEF_F(0) DEF_F(1) DEF_F(2) DEF_F(3) DEF_F(4) DEF_F(5) DEF_F(6) DEF_F(7)
+DEF_F(8) DEF_F(9) DEF_F(10) DEF_F(11) DEF_F(12) DEF_F(13) DEF_F(14) DEF_F(15)
+
+typedef uint32_t (*fn_t)(uint8_t);
+static fn_t funcs[NFUNC] = {f0,  f1,  f2,  f3,  f4,  f5,  f6,  f7,
+                            f8,  f9,  f10, f11, f12, f13, f14, f15};
+
+static double now_ms(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000.0 + ts.tv_nsec / 1e6;
+}
+
+int main(void) {
+  for (int i = 0; i < NINST; i++)
+    g[i].v = 100u + (uint32_t)i;
+
+  ejit_config_t cfg;
+  ejit_default_config(&cfg);
+  ejit_init(&cfg);
+  for (int i = 0; i < NINST; i++)
+    ejit_activate("p", (uint8_t)i);
+
+  /* Warm up: compile+publish every (func, instance). Drain per call because the
+     in-flight dedup is keyed on funcIndex alone. */
+  volatile uint32_t sink = 0;
+  for (int i = 0; i < NINST; i++)
+    for (int f = 0; f < NFUNC; f++) {
+      sink += funcs[f]((uint8_t)i);
+      ejit_drain_taskpool();
+    }
+
+  ejit_taskpool_stats_t s0;
+  memset(&s0, 0, sizeof s0);
+  ejit_taskpool_get_stats(&s0);
+  printf("warmup: expected=%d ready=%u compiles=%llu\n", NSPEC, s0.readyEntries,
+         (unsigned long long)s0.asyncCompiles);
+  if (s0.readyEntries < (uint32_t)NSPEC)
+    printf("  note: %u of %d specializations live (%u evicted during warmup)\n",
+           s0.readyEntries, NSPEC, (uint32_t)NSPEC - s0.readyEntries);
+
+  /* Timed loop: pure cache-hit lookups over every specialization. */
+  const long REP = 40000;
+  double t0 = now_ms();
+  for (long r = 0; r < REP; r++)
+    for (int i = 0; i < NINST; i++)
+      for (int f = 0; f < NFUNC; f++)
+        sink += funcs[f]((uint8_t)i);
+  double t1 = now_ms();
+  (void)sink;
+
+  ejit_taskpool_stats_t s1;
+  memset(&s1, 0, sizeof s1);
+  ejit_taskpool_get_stats(&s1);
+
+  long lookups = REP * (long)NINST * NFUNC;
+  double ms = t1 - t0;
+  printf("lookups=%ld  time=%.1f ms  ns/lookup=%.2f\n", lookups, ms,
+         ms * 1e6 / (double)lookups);
+  printf("loop delta: cacheHits=%llu compiles=%llu (compiles>0 => eviction "
+         "churn)\n",
+         (unsigned long long)(s1.cacheHits - s0.cacheHits),
+         (unsigned long long)(s1.asyncCompiles - s0.asyncCompiles));
+
+  ejit_shutdown();
+  return 0;
+}

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
@@ -76,17 +76,6 @@ inline uint64_t ejitHashDim(uint64_t key, uint32_t dimType,
   return key * kEJitHashMul;
 }
 
-/// fmix64 avalanche. Multiplication only carries bits upward, so without this
-/// dimType (high half) and numDims (top byte) never reach the bucket index.
-inline uint64_t ejitFinalize64(uint64_t k) {
-  k ^= k >> 33;
-  k *= 0xff51afd7ed558ccdULL;
-  k ^= k >> 33;
-  k *= 0xc4ceb9fe1a85ec53ULL;
-  k ^= k >> 33;
-  return k;
-}
-
 struct EJitCompileRequest {
   uint32_t funcIndex;
   uint32_t numDims;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
@@ -52,6 +52,41 @@ struct EJitDimPair {
   uint32_t instanceId;
 };
 
+//===----------------------------------------------------------------------===//
+// Compile-identity hash for (funcIndex, numDims, dims[]). Callers take the low
+// bits as a cache bucket index. Every hash site composes these helpers: a
+// lookup that hashes differently from the publish that stored the slot probes a
+// different bucket and never matches.
+//===----------------------------------------------------------------------===//
+constexpr uint64_t kEJitHashMul = 0x9e3779b97f4a7c15ULL;
+
+/// Seed from the scalar part. funcIndex is diffused before any dim is folded in:
+/// used raw it shares the low bits of instanceId and XOR-cancels against it.
+inline uint64_t ejitHashSeed(uint32_t funcIndex, uint32_t numDims) {
+  return (static_cast<uint64_t>(funcIndex) * kEJitHashMul) ^
+         (static_cast<uint64_t>(numDims) << 56);
+}
+
+/// Fold one (dimType, instanceId) pair in. The multiply keeps the fold
+/// order-sensitive, so f(a, b) and f(b, a) stay distinct.
+inline uint64_t ejitHashDim(uint64_t key, uint32_t dimType,
+                            uint32_t instanceId) {
+  key ^= (static_cast<uint64_t>(dimType) << 32) |
+         static_cast<uint64_t>(instanceId);
+  return key * kEJitHashMul;
+}
+
+/// fmix64 avalanche. Multiplication only carries bits upward, so without this
+/// dimType (high half) and numDims (top byte) never reach the bucket index.
+inline uint64_t ejitFinalize64(uint64_t k) {
+  k ^= k >> 33;
+  k *= 0xff51afd7ed558ccdULL;
+  k ^= k >> 33;
+  k *= 0xc4ceb9fe1a85ec53ULL;
+  k ^= k >> 33;
+  return k;
+}
+
 struct EJitCompileRequest {
   uint32_t funcIndex;
   uint32_t numDims;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -285,13 +285,10 @@ bool EJitSharedTaskPool::queuePop(EJitCompileRequest &out) {
 uint64_t EJitSharedTaskPool::hashIdentity(uint32_t funcIndex,
                                           const EJitDimPair *dims,
                                           uint32_t numDims) const {
-  uint64_t key = static_cast<uint64_t>(funcIndex);
-  for (uint32_t i = 0; i < numDims; ++i) {
-    key ^= (static_cast<uint64_t>(dims[i].dimType) << 32) |
-           static_cast<uint64_t>(dims[i].instanceId);
-    key *= 0x9e3779b97f4a7c15ULL;
-  }
-  return key;
+  uint64_t key = ejitHashSeed(funcIndex, numDims);
+  for (uint32_t i = 0; i < numDims; ++i)
+    key = ejitHashDim(key, dims[i].dimType, dims[i].instanceId);
+  return ejitFinalize64(key);
 }
 
 static bool slotIdentityMatches(const EJitSharedCacheSlot &s,
@@ -596,14 +593,14 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
 // loop, no dims[] indirection, no generic numDims>4 guard. The matched-slot
 // fnPtr gate and cold peer preparation are shared via resolveMatchedSlot(), so
 // each specialization stays small. Results are identical to cacheLookup() with
-// the matching numDims. kHashMul mirrors the mixing constant in hashIdentity().
+// the matching numDims. The key composes the ejitHash* helpers so it cannot
+// drift from hashIdentity().
 //===----------------------------------------------------------------------===//
-static constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
 EJitSharedTaskPool::SharedLookup
 EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
   SharedLookup R;
-  uint64_t key = static_cast<uint64_t>(funcIndex); // hashIdentity(fi, _, 0)
+  uint64_t key = ejitFinalize64(ejitHashSeed(funcIndex, 0));
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -631,9 +628,9 @@ EJitSharedTaskPool::SharedLookup
 EJitSharedTaskPool::cacheLookup1D(uint32_t funcIndex, uint32_t dim0,
                                   uint32_t inst0) {
   SharedLookup R;
-  uint64_t key = static_cast<uint64_t>(funcIndex);
-  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
-  key *= kHashMul;
+  uint64_t key = ejitHashSeed(funcIndex, 1);
+  key = ejitHashDim(key, dim0, inst0);
+  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -665,11 +662,10 @@ EJitSharedTaskPool::cacheLookup2D(uint32_t funcIndex, uint32_t dim0,
                                   uint32_t inst0, uint32_t dim1,
                                   uint32_t inst1) {
   SharedLookup R;
-  uint64_t key = static_cast<uint64_t>(funcIndex);
-  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
-  key *= kHashMul;
-  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
-  key *= kHashMul;
+  uint64_t key = ejitHashSeed(funcIndex, 2);
+  key = ejitHashDim(key, dim0, inst0);
+  key = ejitHashDim(key, dim1, inst1);
+  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -705,13 +701,11 @@ EJitSharedTaskPool::cacheLookup3D(uint32_t funcIndex, uint32_t dim0,
                                   uint32_t inst0, uint32_t dim1, uint32_t inst1,
                                   uint32_t dim2, uint32_t inst2) {
   SharedLookup R;
-  uint64_t key = static_cast<uint64_t>(funcIndex);
-  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
-  key *= kHashMul;
-  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
-  key *= kHashMul;
-  key ^= (static_cast<uint64_t>(dim2) << 32) | static_cast<uint64_t>(inst2);
-  key *= kHashMul;
+  uint64_t key = ejitHashSeed(funcIndex, 3);
+  key = ejitHashDim(key, dim0, inst0);
+  key = ejitHashDim(key, dim1, inst1);
+  key = ejitHashDim(key, dim2, inst2);
+  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -752,15 +746,12 @@ EJitSharedTaskPool::cacheLookup4D(uint32_t funcIndex, uint32_t dim0,
                                   uint32_t dim2, uint32_t inst2, uint32_t dim3,
                                   uint32_t inst3) {
   SharedLookup R;
-  uint64_t key = static_cast<uint64_t>(funcIndex);
-  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
-  key *= kHashMul;
-  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
-  key *= kHashMul;
-  key ^= (static_cast<uint64_t>(dim2) << 32) | static_cast<uint64_t>(inst2);
-  key *= kHashMul;
-  key ^= (static_cast<uint64_t>(dim3) << 32) | static_cast<uint64_t>(inst3);
-  key *= kHashMul;
+  uint64_t key = ejitHashSeed(funcIndex, 4);
+  key = ejitHashDim(key, dim0, inst0);
+  key = ejitHashDim(key, dim1, inst1);
+  key = ejitHashDim(key, dim2, inst2);
+  key = ejitHashDim(key, dim3, inst3);
+  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -288,7 +288,7 @@ uint64_t EJitSharedTaskPool::hashIdentity(uint32_t funcIndex,
   uint64_t key = ejitHashSeed(funcIndex, numDims);
   for (uint32_t i = 0; i < numDims; ++i)
     key = ejitHashDim(key, dims[i].dimType, dims[i].instanceId);
-  return ejitFinalize64(key);
+  return key;
 }
 
 static bool slotIdentityMatches(const EJitSharedCacheSlot &s,
@@ -600,7 +600,7 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
 EJitSharedTaskPool::SharedLookup
 EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
   SharedLookup R;
-  uint64_t key = ejitFinalize64(ejitHashSeed(funcIndex, 0));
+  uint64_t key = ejitHashSeed(funcIndex, 0);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -630,7 +630,6 @@ EJitSharedTaskPool::cacheLookup1D(uint32_t funcIndex, uint32_t dim0,
   SharedLookup R;
   uint64_t key = ejitHashSeed(funcIndex, 1);
   key = ejitHashDim(key, dim0, inst0);
-  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -665,7 +664,6 @@ EJitSharedTaskPool::cacheLookup2D(uint32_t funcIndex, uint32_t dim0,
   uint64_t key = ejitHashSeed(funcIndex, 2);
   key = ejitHashDim(key, dim0, inst0);
   key = ejitHashDim(key, dim1, inst1);
-  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -705,7 +703,6 @@ EJitSharedTaskPool::cacheLookup3D(uint32_t funcIndex, uint32_t dim0,
   key = ejitHashDim(key, dim0, inst0);
   key = ejitHashDim(key, dim1, inst1);
   key = ejitHashDim(key, dim2, inst2);
-  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))
@@ -751,7 +748,6 @@ EJitSharedTaskPool::cacheLookup4D(uint32_t funcIndex, uint32_t dim0,
   key = ejitHashDim(key, dim1, inst1);
   key = ejitHashDim(key, dim2, inst2);
   key = ejitHashDim(key, dim3, inst3);
-  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   EJitSharedCacheBucket &B = state_->buckets[bucket];
   if (!bucketTryRead(B))

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -104,7 +104,7 @@ uint64_t EJitTaskPoolCache::hashKey(uint32_t funcIndex, const EJitDimPair *dims,
   uint64_t key = ejitHashSeed(funcIndex, numDims);
   for (uint32_t i = 0; i < numDims; ++i)
     key = ejitHashDim(key, dims[i].dimType, dims[i].instanceId);
-  return ejitFinalize64(key);
+  return key;
 }
 
 bool EJitTaskPoolCache::identityMatches(const EJitCacheEntry &e,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -101,13 +101,10 @@ EJitTaskQueue::tryEnqueue(const EJitCompileRequest &req) {
 
 uint64_t EJitTaskPoolCache::hashKey(uint32_t funcIndex, const EJitDimPair *dims,
                                     uint32_t numDims) const {
-  uint64_t key = static_cast<uint64_t>(funcIndex);
-  for (uint32_t i = 0; i < numDims; ++i) {
-    key ^= (static_cast<uint64_t>(dims[i].dimType) << 32) |
-           static_cast<uint64_t>(dims[i].instanceId);
-    key *= 0x9e3779b97f4a7c15ULL;
-  }
-  return key;
+  uint64_t key = ejitHashSeed(funcIndex, numDims);
+  for (uint32_t i = 0; i < numDims; ++i)
+    key = ejitHashDim(key, dims[i].dimType, dims[i].instanceId);
+  return ejitFinalize64(key);
 }
 
 bool EJitTaskPoolCache::identityMatches(const EJitCacheEntry &e,

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -44,6 +44,7 @@ set(EJIT_TASKPOOL_LINK_COMPONENTS_SAVED "${LLVM_LINK_COMPONENTS}")
 set(LLVM_LINK_COMPONENTS Support)
 add_llvm_unittest(EJITTaskPoolTests
   EJitTaskPoolTest.cpp
+  EJitIdentityHashTest.cpp
   ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
   ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSreQueue.cpp
   ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitWorker.cpp

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitIdentityHashTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitIdentityHashTest.cpp
@@ -1,0 +1,90 @@
+//===-- EJitIdentityHashTest.cpp - Unit tests for the identity hash ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Tests the compile-identity hash (EJitSreQueue.h). An identity is
+//  (funcIndex, numDims, dims[]) and callers take the low bits of the hash as a
+//  cache bucket index, so every field must reach those low bits.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h"
+#include "gtest/gtest.h"
+#include <set>
+
+using namespace llvm::ejit;
+
+namespace {
+
+constexpr uint32_t kBuckets = 32;
+
+uint64_t hash(uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims) {
+  uint64_t key = ejitHashSeed(funcIndex, numDims);
+  for (uint32_t i = 0; i < numDims; ++i)
+    key = ejitHashDim(key, dims[i].dimType, dims[i].instanceId);
+  return ejitFinalize64(key);
+}
+
+uint64_t hash1D(uint32_t funcIndex, uint32_t dimType, uint32_t instanceId) {
+  const EJitDimPair d[1] = {{dimType, instanceId}};
+  return hash(funcIndex, d, 1);
+}
+
+// Every identity here has funcIndex ^ instanceId == 3, which collapsed onto one
+// key when funcIndex was folded in raw.
+TEST(EJitIdentityHash, FuncIndexDoesNotCancelAgainstInstanceId) {
+  std::set<uint64_t> keys = {hash1D(1, 0, 2), hash1D(2, 0, 1), hash1D(3, 0, 0),
+                             hash1D(4, 0, 7)};
+  EXPECT_EQ(keys.size(), 4u);
+}
+
+// dimType is folded into the high half, so without the avalanche it never
+// reaches the low bits used as the bucket index.
+TEST(EJitIdentityHash, DimTypeReachesTheBucketIndex) {
+  std::set<uint32_t> buckets;
+  for (uint32_t dt = 0; dt < 8; ++dt)
+    buckets.insert(static_cast<uint32_t>(hash1D(1, dt, 2) % kBuckets));
+  EXPECT_GT(buckets.size(), 1u);
+}
+
+TEST(EJitIdentityHash, NumDimsIsPartOfTheIdentity) {
+  const EJitDimPair d1[1] = {{0, 5}};
+  const EJitDimPair d2[2] = {{0, 5}, {1, 6}};
+  EXPECT_NE(hash(7, nullptr, 0), hash(7, d1, 1));
+  EXPECT_NE(hash(7, d1, 1), hash(7, d2, 2));
+}
+
+TEST(EJitIdentityHash, DimOrderMatters) {
+  const EJitDimPair ab[2] = {{0, 1}, {1, 2}};
+  const EJitDimPair ba[2] = {{1, 2}, {0, 1}};
+  EXPECT_NE(hash(3, ab, 2), hash(3, ba, 2));
+}
+
+// Several entry functions over a couple of period types, many instances each:
+// the shape the old hash collapsed. Every identity gets its own key.
+TEST(EJitIdentityHash, DistinctKeysAndFullBucketCoverage) {
+  std::set<uint64_t> keys;
+  std::set<uint32_t> buckets;
+  unsigned identities = 0;
+
+  for (uint32_t funcIndex = 1; funcIndex <= 8; ++funcIndex) {
+    for (uint32_t dimType = 0; dimType < 2; ++dimType) {
+      for (uint32_t inst = 0; inst < 16; ++inst) {
+        uint64_t k = hash1D(funcIndex, dimType, inst);
+        keys.insert(k);
+        buckets.insert(static_cast<uint32_t>(k % kBuckets));
+        ++identities;
+      }
+    }
+  }
+
+  EXPECT_EQ(identities, 256u);
+  EXPECT_EQ(keys.size(), identities);
+  EXPECT_EQ(buckets.size(), kBuckets);
+}
+
+} // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitIdentityHashTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitIdentityHashTest.cpp
@@ -26,7 +26,7 @@ uint64_t hash(uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims) {
   uint64_t key = ejitHashSeed(funcIndex, numDims);
   for (uint32_t i = 0; i < numDims; ++i)
     key = ejitHashDim(key, dims[i].dimType, dims[i].instanceId);
-  return ejitFinalize64(key);
+  return key;
 }
 
 uint64_t hash1D(uint32_t funcIndex, uint32_t dimType, uint32_t instanceId) {
@@ -42,13 +42,13 @@ TEST(EJitIdentityHash, FuncIndexDoesNotCancelAgainstInstanceId) {
   EXPECT_EQ(keys.size(), 4u);
 }
 
-// dimType is folded into the high half, so without the avalanche it never
-// reaches the low bits used as the bucket index.
-TEST(EJitIdentityHash, DimTypeReachesTheBucketIndex) {
-  std::set<uint32_t> buckets;
+// dimType must distinguish the identity key so the bucket scan's prefilter can
+// tell two same-func, same-instance identities on different period types apart.
+TEST(EJitIdentityHash, DimTypeDistinguishesTheKey) {
+  std::set<uint64_t> keys;
   for (uint32_t dt = 0; dt < 8; ++dt)
-    buckets.insert(static_cast<uint32_t>(hash1D(1, dt, 2) % kBuckets));
-  EXPECT_GT(buckets.size(), 1u);
+    keys.insert(hash1D(1, dt, 2));
+  EXPECT_EQ(keys.size(), 8u);
 }
 
 TEST(EJitIdentityHash, NumDimsIsPartOfTheIdentity) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -762,7 +762,6 @@ TEST_F(SharedTaskPoolTest, BigEndianFieldSemantics) {
   uint64_t key = ejitHashSeed(func, 2);
   for (uint32_t i = 0; i < 2; ++i)
     key = ejitHashDim(key, d0[i].dimType, d0[i].instanceId);
-  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   const EJitSharedCacheBucket &B = state_->buckets[bucket];
   bool found = false;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -758,13 +758,11 @@ TEST_F(SharedTaskPoolTest, BigEndianFieldSemantics) {
 
   // Inspect the published slot directly: each field equals exactly what we put
   // in (correct on aarch64_be precisely because access is by-field, by-value).
-  uint64_t key = 0; // recompute the same identity hash the pool uses
-  key = static_cast<uint64_t>(func);
-  for (uint32_t i = 0; i < 2; ++i) {
-    key ^= (static_cast<uint64_t>(d0[i].dimType) << 32) |
-           static_cast<uint64_t>(d0[i].instanceId);
-    key *= 0x9e3779b97f4a7c15ULL;
-  }
+  // Recompute the same identity hash the pool uses.
+  uint64_t key = ejitHashSeed(func, 2);
+  for (uint32_t i = 0; i < 2; ++i)
+    key = ejitHashDim(key, d0[i].dimType, d0[i].instanceId);
+  key = ejitFinalize64(key);
   uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
   const EJitSharedCacheBucket &B = state_->buckets[bucket];
   bool found = false;


### PR DESCRIPTION
The current `hashIdentity` function used in `EJitSharedTaskPool` allows a lot of collisions which can lead to forming long chains in the buckets we have. This patch introduces a modified and better hash function that decreases the amount of collisions, keeping the length of the chains small. Should improve the performance of cache lookup and cache eviction.
