### PR TITLE
[EJIT] Trim FastISel symbols in ejit.o with EJIT_TRIM_LLVM_BACKEND

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2777,7 +2777,15 @@ bool AArch64TargetLowering::allowsMisalignedMemoryAccesses(
 FastISel *
 AArch64TargetLowering::createFastISel(FunctionLoweringInfo &funcInfo,
                                       const TargetLibraryInfo *libInfo) const {
+#ifndef EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL
   return AArch64::createFastISel(funcInfo, libInfo);
+#else
+  // FastISel is trimmed (AArch64FastISel.cpp is not built). A null FastISel is
+  // a supported SelectionDAGISel fallback, so codegen uses SelectionDAG.
+  (void)funcInfo;
+  (void)libInfo;
+  return nullptr;
+#endif
 }
 
 MachineBasicBlock *

--- a/llvm/lib/Target/AArch64/CMakeLists.txt
+++ b/llvm/lib/Target/AArch64/CMakeLists.txt
@@ -8,8 +8,8 @@ tablegen(LLVM AArch64GenAsmWriter1.inc -gen-asm-writer -asmwriternum=1)
 tablegen(LLVM AArch64GenCallingConv.inc -gen-callingconv)
 tablegen(LLVM AArch64GenDAGISel.inc -gen-dag-isel)
 tablegen(LLVM AArch64GenDisassemblerTables.inc -gen-disassembler)
-tablegen(LLVM AArch64GenFastISel.inc -gen-fast-isel)
 if(NOT EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL AND NOT EJIT_TRIM_LLVM_BACKEND)
+tablegen(LLVM AArch64GenFastISel.inc -gen-fast-isel)
 tablegen(LLVM AArch64GenGlobalISel.inc -gen-global-isel)
 tablegen(LLVM AArch64GenO0PreLegalizeGICombiner.inc -gen-global-isel-combiner
               -combiners="AArch64O0PreLegalizerCombiner")
@@ -45,7 +45,6 @@ set(AARCH64_CODEGEN_SOURCES
   AArch64ExpandImm.cpp
   AArch64ExpandPseudoInsts.cpp
   AArch64FalkorHWPFFix.cpp
-  AArch64FastISel.cpp
   AArch64A53Fix835769.cpp
   AArch64FrameLowering.cpp
   AArch64CompressJumpTables.cpp
@@ -79,6 +78,10 @@ set(AARCH64_CODEGEN_SOURCES
   )
 
 if(NOT EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL AND NOT EJIT_TRIM_LLVM_BACKEND)
+  list(APPEND AARCH64_CODEGEN_SOURCES
+    AArch64FastISel.cpp
+    )
+
   list(APPEND AARCH64_CODEGEN_SOURCES
     SMEABIPass.cpp
     SMEPeepholeOpt.cpp


### PR DESCRIPTION
Our default instruction selection method is SelectionDAG with O2 enabled, so we don't need these FastISel symbols and they can be trimmed under `EJIT_TRIM_LLVM_BACKEND`.

Reduces the size of ejit.o by ~123 KB.