### PR TITLE
[EJIT] Add target-aware loop vectorization to JIT pipeline

### DIFF
--- a/ejit_test/ejit_ir_pipeline_loop_bench.c
+++ b/ejit_test/ejit_ir_pipeline_loop_bench.c
@@ -1,0 +1,65 @@
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+
+enum { ElementCount = 4096 };
+
+uint32_t ejit_probe_scalar(const uint16_t *, const uint16_t *, size_t);
+uint32_t ejit_probe_vector(const uint16_t *, const uint16_t *, size_t);
+
+static uint16_t lhs[ElementCount];
+static uint16_t rhs[ElementCount];
+static volatile uint32_t sink;
+
+static inline uint64_t readCycles(void) {
+#if defined(__aarch64__)
+  uint64_t value;
+  __asm__ volatile("isb\n\tmrs %0, cntvct_el0" : "=r"(value) :: "memory");
+  return value;
+#else
+#error This benchmark requires native AArch64
+#endif
+}
+
+static uint64_t measure(uint32_t (*fn)(const uint16_t *, const uint16_t *,
+                                      size_t),
+                        size_t count, unsigned rounds) {
+  for (unsigned i = 0; i != 100; ++i)
+    sink ^= fn(lhs, rhs, count);
+
+  uint64_t begin = readCycles();
+  for (unsigned i = 0; i != rounds; ++i)
+    sink ^= fn(lhs, rhs, count);
+  uint64_t end = readCycles();
+  return end - begin;
+}
+
+int main(void) {
+  for (unsigned i = 0; i != ElementCount; ++i) {
+    lhs[i] = (uint16_t)((i * 17u + 3u) & 1023u);
+    rhs[i] = (uint16_t)((i * 29u + 7u) & 1023u);
+  }
+
+  uint32_t scalarResult = ejit_probe_scalar(lhs, rhs, ElementCount);
+  uint32_t vectorResult = ejit_probe_vector(lhs, rhs, ElementCount);
+  if (scalarResult != vectorResult) {
+    fprintf(stderr, "result mismatch: scalar=%u vector=%u\n", scalarResult,
+            vectorResult);
+    return 1;
+  }
+
+  const size_t counts[] = {4, 8, 16, 32, 64, 256, 1024, 4096};
+  for (unsigned i = 0; i != sizeof(counts) / sizeof(counts[0]); ++i) {
+    size_t count = counts[i];
+    unsigned rounds = count <= 64 ? 1000000u : 200000u;
+    if (count >= 1024)
+      rounds = 20000u;
+    uint64_t scalar = measure(ejit_probe_scalar, count, rounds);
+    uint64_t vector = measure(ejit_probe_vector, count, rounds);
+    printf("count=%4zu scalar=%8.3f vector=%8.3f ticks/call speedup=%5.2fx\n",
+           count, (double)scalar / rounds, (double)vector / rounds,
+           (double)scalar / vector);
+  }
+  printf("sink=%u\n", sink);
+  return 0;
+}

--- a/ejit_test/ejit_ir_pipeline_loop_probe.c
+++ b/ejit_test/ejit_ir_pipeline_loop_probe.c
@@ -1,0 +1,18 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef EJIT_PROBE_NAME
+#define EJIT_PROBE_NAME ejit_ir_pipeline_loop_probe
+#endif
+
+// Models a medium-size business loop that survives specialization: the period
+// and may_const decisions are already resolved, but the data processed by each
+// iteration remains dynamic.
+__attribute__((noinline)) uint32_t
+EJIT_PROBE_NAME(const uint16_t *__restrict lhs,
+                const uint16_t *__restrict rhs, size_t count) {
+  uint32_t sum = 0;
+  for (size_t i = 0; i < count; ++i)
+    sum += (uint32_t)lhs[i] * 3u + (uint32_t)rhs[i] * 5u;
+  return sum;
+}

--- a/jit_design_doc/EJIT_IR_PIPELINE_PERF_AUDIT.md
+++ b/jit_design_doc/EJIT_IR_PIPELINE_PERF_AUDIT.md
@@ -1,0 +1,159 @@
+# EJIT IR Pipeline Runtime-Performance Audit
+
+## Scope
+
+This audit prioritizes steady-state execution time. JIT compilation is
+asynchronous, so compile latency and moderate code-size growth are not used as
+rejection criteria. The accompanying change implements the two pass additions
+that survived this audit: final `InstSimplify` and target-aware loop
+vectorization. Broader O2/SLP/GVN additions remain excluded.
+
+Baseline: `dong/ejit_dev_spec4` at `d60b61f8da65`.
+
+## Current pipeline
+
+After period indices and `may_const` loads are specialized, the current fixed
+pipeline is:
+
+```text
+LowerExpectIntrinsic
+InstCombine, SCCP, SimplifyCFG, InstCombine, SimplifyCFG, ADCE
+LoopSimplify
+LoopFullUnroll, IndVarSimplify, LoopDeletion
+Promote
+StructFieldPass
+InstCombine, SCCP, SimplifyCFG, ADCE
+```
+
+The requested optimization level is ignored. In particular, the post-JIT
+pipeline has no target-aware loop vectorization and ends with ADCE, which can
+expose simplifications after the last InstCombine/InstSimplify opportunity.
+
+`EJitPassBuilder` also registers the generic `TargetIRAnalysis()` rather than
+the active `TargetMachine::getTargetIRAnalysis()`. This is sufficient for the
+current scalar pipeline, but not a sound profitability model for target-aware
+vectorization.
+
+## Evidence from captured EJIT IR
+
+Three complete `IR after runOptimizationPipeline` modules from the complex
+board test were extracted and compiled for `aarch64_be-target-linux-gnu`.
+The current source pipeline has the same ordering as the captured build; the
+newer `may_const` work changes which loads can be specialized, not the cleanup
+ordering examined here.
+
+Running a complete `default<O2>` pipeline after the EJIT pipeline produced no
+uniform benefit: one module was unchanged, one shrank by 8 bytes, and one grew
+by 4 bytes. Therefore, appending full O2 is not recommended.
+
+### Residual scalar simplification
+
+One real post-pipeline function retained this sequence:
+
+```llvm
+%sum = add i32 %a, %b
+%iszero = icmp eq i32 %sum, 0
+%copy = add i32 0, %sum
+%result = select i1 %iszero, i32 0, i32 %copy
+ret i32 %result
+```
+
+The result is always `%sum`. A final `InstSimplify` removes the conditional
+selection without perturbing another captured module. For the affected
+AArch64 function it removes one instruction and the flag-dependent `csel`
+(84 to 80 bytes). A final `InstCombine` removes two instructions (84 to 76
+bytes), but also grew another captured function by one instruction due to a
+different select/add canonicalization. The conservative recommendation is:
+
+```text
+... cleanup SCCP, SimplifyCFG, ADCE, InstSimplify
+```
+
+This is a small but directly demonstrated runtime cleanup. If `InstCombine`
+is preferred, it needs a broader machine-code benchmark before adoption.
+
+## Targeted loop-vectorization experiment
+
+The probe in `ejit_test/ejit_ir_pipeline_loop_probe.c` models a runtime-sized
+loop over two arrays after lifecycle and `may_const` branches have already
+been specialized:
+
+```c
+sum += lhs[i] * 3u + rhs[i] * 5u;
+```
+
+After the existing AOT-preoptimization approximation and the exact current
+runtime pass sequence, the loop remains scalar. The scalar AArch64 function is
+48 bytes. The smallest tested profitable extension is:
+
+```text
+LoopSimplify
+LoopRotate
+LoopVectorize
+InstCombine
+SimplifyCFG
+```
+
+It produces a NEON loop using `ld1`, `umull`/`umlal`, vector additions, and
+`addv`, with a scalar remainder. The function grows to 352 bytes. Adding
+`SLPVectorizer` does not change this probe's code or performance; SLP alone is
+effectively identical to the scalar baseline, so it should not be added based
+on this evidence.
+
+Removing both `restrict` qualifiers produced the same vector code and speedup
+for this read-only reduction. The result therefore does not depend on an
+idealized no-alias annotation. Loops that also write through potentially
+aliasing pointers may require runtime alias checks and need separate business
+benchmarks.
+
+Native AArch64 measurements were pinned to one Neoverse-N2 CPU and used
+`cntvct_el0`. Absolute counter ticks are not CPU cycles, but the relative
+results were stable across repeated runs:
+
+| elements | scalar ticks/call | vector ticks/call | speedup |
+|---------:|------------------:|------------------:|--------:|
+| 4        | 0.168             | 0.136             | 1.23x   |
+| 8        | 0.321             | 0.161             | 1.99x   |
+| 16       | 0.645             | 0.224             | 2.87x   |
+| 32       | 1.301             | 0.369             | 3.52x   |
+| 64       | 2.607             | 0.652             | 4.00x   |
+| 256      | 10.464            | 2.263             | 4.62x   |
+| 1024     | 42.185            | 8.696             | 4.85x   |
+| 4096     | 168.016           | 34.508             | 4.87x   |
+
+The three captured complex-test specializations contain no remaining
+vectorizable loops, so this pass does not improve that particular demo. Its
+value is for real JIT functions that retain medium or large data loops after
+specialization.
+
+## Required production wiring
+
+Do not add `LoopVectorizePass` to the current manager with generic TTI.
+`EJitOrcEngine` already owns `dumpTM`, built from the same
+`JITTargetMachineBuilder` as LLJIT. Pass that target machine (or its TTI
+callback) into `EJitOptimizer`, then register:
+
+```cpp
+FAM.registerPass([&] { return TM->getTargetIRAnalysis(); });
+FAM.registerPass([&] { return LoopAccessAnalysis(); });
+```
+
+The implementation also needs the Vectorize component in the trimmed link.
+That increases the runtime image, but does not change shared-taskpool or code
+pool ABI. Validate both little-endian AArch64 and `aarch64_be` output, and
+compare final machine code for representative business functions before
+enabling it unconditionally.
+
+## Implemented scope
+
+1. Add final `InstSimplify` after cleanup ADCE. This is low risk and is backed
+   by a real EJIT post-pipeline dump.
+2. Add target-aware `LoopRotate + LoopVectorize`, reusing the TargetMachine
+   already created by `EJitOrcEngine`; no second TargetMachine is created.
+3. Do not append full O2, SLP, GVN, or EarlyCSE merely because they are absent.
+   Full O2 was inconsistent on captured modules, SLP did not help the loop
+   probe, and duplicate-load experiments were already folded by AArch64
+   CodeGen without GVN/EarlyCSE.
+4. The remaining board acceptance item is to dump and diff one real loop-heavy
+   business function and measure its final AArch64 code. Synthetic/native
+   measurements prove the mechanism and potential, not every workload.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -19,6 +19,8 @@
 #include "llvm/ExecutionEngine/EJIT/EJitPassBuilder.h"
 
 namespace llvm {
+class TargetMachine;
+
 namespace ejit {
 
 /// JIT optimization pipeline. Runs on the extracted bitcode module during
@@ -27,14 +29,14 @@ namespace ejit {
 /// every compilation.
 class EJitOptimizer {
 public:
-  EJitOptimizer(PeriodArrayRegistry &reg);
+  EJitOptimizer(PeriodArrayRegistry &reg, const TargetMachine *TM = nullptr);
 
   /// Run the full JIT specialization pipeline:
   ///   1. Parameter substitution (ejit_period_arr_ind → constants)
   ///   2. InstCombine (fold GEP chains from substituted params)
-  ///   3. Inline (L2+: expand callee bodies so may_const GEPs are traceable)
-  ///   4. StructFieldPass (may_const loads → runtime constants)
-  ///   5. Core optimization pipeline (L1/L2/L3)
+  ///   3. StructFieldPass (may_const loads → runtime constants)
+  ///   4. Scalar and loop specialization cleanup
+  ///   5. Target-aware vectorization of remaining runtime-sized loops
   void runPipeline(Module &M, const SpecializationContext &ctx);
 
   /// Clear all cached analysis results. Must be called between compilations

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitPassBuilder.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitPassBuilder.h
@@ -19,18 +19,21 @@
 #include "llvm/Analysis/LoopAnalysisManager.h"
 
 namespace llvm {
+class TargetMachine;
+
 namespace ejit {
 
 /// Registers only the analyses required by EJIT's optimization pipeline.
 ///
-/// EJIT uses 8 passes: InstCombine, SCCP, ADCE, SimplifyCFG,
-/// LoopFullUnroll, LoopSimplify, AlwaysInliner, Promote (Mem2Reg).
+/// EJIT uses a compact specialization pipeline plus target-aware loop
+/// vectorization. This helper registers only the analyses that pipeline needs.
 ///
 /// PassBuilder::registerFunctionAnalyses registers ~40 analyses; we register
-/// only the ~13 that these 8 passes actually need.
+/// a smaller explicit subset to keep the embedded link surface controlled.
 namespace EJitPassBuilder {
 
-void registerFunctionAnalyses(FunctionAnalysisManager &FAM);
+void registerFunctionAnalyses(FunctionAnalysisManager &FAM,
+                              const TargetMachine *TM = nullptr);
 void registerLoopAnalyses(LoopAnalysisManager &LAM);
 void registerCGSCCAnalyses(CGSCCAnalysisManager &CGAM);
 void registerModuleAnalyses(ModuleAnalysisManager &MAM);

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -31,6 +31,7 @@ if(EJIT_FREESTANDING_MUTEX)
   # Targets are created before this CMakeLists.txt runs, so they exist.
   foreach(_tgt LLVMOrcJIT LLVMJITLink LLVMSupport LLVMCodeGen LLVMCore
               LLVMAnalysis LLVMTransformUtils LLVMInstCombine LLVMScalarOpts
+              LLVMVectorize LLVMSandboxIR
               LLVMipo LLVMObject LLVMMC LLVMMCParser LLVMTarget
               LLVMSelectionDAG LLVMGlobalISel LLVMAsmPrinter LLVMPasses
               LLVMExecutionEngine LLVMOrcShared LLVMRuntimeDyld LLVMOrcTargetProcess
@@ -120,6 +121,7 @@ add_llvm_component_library(LLVMEJIT
   InstCombine
   TransformUtils
   Analysis
+  Vectorize
   ${EJIT_TARGET_COMPONENTS}
   # IPO and Scalar are not listed here — their LINK_COMPONENTS would
   # recursively pull in BitWriter, Instrumentation, Linker, AsmParser,
@@ -162,7 +164,7 @@ endif()
 # Resolve LLVM component names → library names (e.g. "Core" → "LLVMCore")
 llvm_map_components_to_libnames(EJIT_LLVM_LIBS
   BitReader Core OrcJIT JITLink Support
-  InstCombine TransformUtils Analysis
+  InstCombine TransformUtils Analysis Vectorize SandboxIR
   ${EJIT_TARGET_COMPONENTS}
   )
 # IPO and Scalar are added manually to avoid their LINK_COMPONENTS

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -13,24 +13,27 @@
 // #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar/ADCE.h"
+#include "llvm/Transforms/Scalar/IndVarSimplify.h"
+#include "llvm/Transforms/Scalar/InstSimplifyPass.h"
+#include "llvm/Transforms/Scalar/LoopDeletion.h"
+#include "llvm/Transforms/Scalar/LoopPassManager.h"
+#include "llvm/Transforms/Scalar/LoopRotation.h"
+#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
 #include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
-#include "llvm/Transforms/Scalar/IndVarSimplify.h"
-#include "llvm/Transforms/Scalar/LoopDeletion.h"
-#include "llvm/Transforms/Scalar/LoopPassManager.h"
-#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
 #include "llvm/Transforms/Utils/LoopSimplify.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
+#include "llvm/Transforms/Vectorize/LoopVectorize.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
 
 #define DEBUG_TYPE "ejit-optimizer"
 
-EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
+EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg, const TargetMachine *TM)
     : registry_(reg) {
-  EJitPassBuilder::registerFunctionAnalyses(FAM_);
+  EJitPassBuilder::registerFunctionAnalyses(FAM_, TM);
   EJitPassBuilder::registerLoopAnalyses(LAM_);
   EJitPassBuilder::registerCGSCCAnalyses(CGAM_);
   EJitPassBuilder::registerModuleAnalyses(MAM_);
@@ -91,6 +94,24 @@ EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
   cleanupFPM_.addPass(SCCPPass());
   cleanupFPM_.addPass(SimplifyCFGPass());
   cleanupFPM_.addPass(ADCEPass());
+
+  // ADCE can expose identities after the preceding InstCombine opportunity.
+  // InstSimplify catches those without InstCombine's broader canonicalization,
+  // which can occasionally grow otherwise-good target code.
+  cleanupFPM_.addPass(InstSimplifyPass());
+
+  // Specialization can leave runtime-sized data loops after all may_const
+  // branches have folded. Canonicalize and rotate them before target-aware
+  // vectorization, then clean up the generated vector and remainder loops.
+  cleanupFPM_.addPass(LoopSimplifyPass());
+  {
+    LoopPassManager LPM;
+    LPM.addPass(LoopRotatePass());
+    cleanupFPM_.addPass(createFunctionToLoopPassAdaptor(std::move(LPM)));
+  }
+  cleanupFPM_.addPass(LoopVectorizePass());
+  cleanupFPM_.addPass(InstCombinePass());
+  cleanupFPM_.addPass(SimplifyCFGPass());
 }
 
 void EJitOptimizer::clearAnalyses() {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -107,12 +107,14 @@ struct EJitOrcEngine::Impl {
   std::map<std::string, void *> userSymbols;
   /// If non-empty, dump JIT-optimized IR to this directory.
   std::string dumpJITDir;
-  /// Persistent optimizer — analysis managers are registered once and reused.
-  std::unique_ptr<EJitOptimizer> optimizer;
-  /// TargetMachine used for the name-filtered ASM diagnostic dump (created
-  /// once from the same JITTargetMachineBuilder the JIT compiles with, so the
-  /// emitted assembly matches the real JIT output). Null if creation failed.
+  /// TargetMachine shared by target-aware optimizer analyses and the
+  /// name-filtered ASM diagnostic dump. It is created from the same
+  /// JITTargetMachineBuilder used by the JIT. Null if creation failed.
   std::unique_ptr<TargetMachine> dumpTM;
+  /// Persistent optimizer — analysis managers are registered once and reused.
+  /// Declared after dumpTM so it is destroyed before the TargetMachine whose
+  /// target-aware TTI callback it holds.
+  std::unique_ptr<EJitOptimizer> optimizer;
 };
 
 namespace llvm {
@@ -669,7 +671,8 @@ EJitOrcEngine::Create(const Config &config,
 
   // Create persistent optimizer — analysis managers are registered once here
   // and reused across compilations (cleared between runs).
-  engine->P->optimizer = std::make_unique<EJitOptimizer>(periodReg);
+  engine->P->optimizer =
+      std::make_unique<EJitOptimizer>(periodReg, engine->P->dumpTM.get());
 
   // Register all known global variable addresses from the PeriodArrayRegistry
   // so that external global references in any loaded bitcode module resolve

--- a/llvm/lib/ExecutionEngine/EJIT/EJitPassBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitPassBuilder.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Analysis/DemandedBits.h"
 #include "llvm/Analysis/LastRunTrackingAnalysis.h"
 #include "llvm/Analysis/LazyValueInfo.h"
+#include "llvm/Analysis/LoopAccessAnalysis.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/MemoryDependenceAnalysis.h"
 #include "llvm/Analysis/MemorySSA.h"
@@ -28,12 +29,14 @@
 #include "llvm/Analysis/TypeBasedAliasAnalysis.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/PassInstrumentation.h"
+#include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/Scalar/SimpleLoopUnswitch.h"
+#include "llvm/Transforms/Vectorize/LoopVectorize.h"
 
 using namespace llvm;
 
 void ejit::EJitPassBuilder::registerFunctionAnalyses(
-    FunctionAnalysisManager &FAM) {
+    FunctionAnalysisManager &FAM, const TargetMachine *TM) {
   // AAManager and its sub-analyses.  AAManager() runs its internal
   // sub-analyses (BasicAA etc.) via FAM.  Register them all in FAM
   // so the AAManager Result can access them during run().
@@ -52,6 +55,7 @@ void ejit::EJitPassBuilder::registerFunctionAnalyses(
   FAM.registerPass([&] { return DemandedBitsAnalysis(); });
   FAM.registerPass([&] { return DominatorTreeAnalysis(); });
   FAM.registerPass([&] { return LazyValueAnalysis(); });
+  FAM.registerPass([&] { return LoopAccessAnalysis(); });
   FAM.registerPass([&] { return LoopAnalysis(); });
   // LastRunTrackingAnalysis needed by SimplifyCFG pass infrastructure.
   FAM.registerPass([&] { return LastRunTrackingAnalysis(); });
@@ -63,7 +67,9 @@ void ejit::EJitPassBuilder::registerFunctionAnalyses(
   FAM.registerPass([&] { return PassInstrumentationAnalysis(); });
   FAM.registerPass([&] { return PostDominatorTreeAnalysis(); });
   FAM.registerPass([&] { return ScalarEvolutionAnalysis(); });
-  FAM.registerPass([&] { return TargetIRAnalysis(); });
+  FAM.registerPass([&] { return ShouldRunExtraVectorPasses(); });
+  FAM.registerPass(
+      [TM] { return TM ? TM->getTargetIRAnalysis() : TargetIRAnalysis(); });
   FAM.registerPass([&] { return TargetLibraryAnalysis(); });
 }
 

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -25,15 +25,18 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #endif
 #include "llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h"
+#include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #ifdef EJIT_SRE_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h"
 #endif
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 #ifndef EJIT_FREESTANDING
@@ -1247,6 +1250,101 @@ TEST(EJitOptimizer, FoldsExpectGuardedConstantBranch) {
   auto *RetVal = dyn_cast<ConstantInt>(Ret->getReturnValue());
   ASSERT_NE(RetVal, nullptr);
   EXPECT_EQ(RetVal->getZExtValue(), 0u);
+}
+
+TEST(EJitOptimizer, RemovesIdentitySelectAfterCleanup) {
+  LLVMContext Ctx;
+  auto M = createTestModule(Ctx, "identity_select");
+  IRBuilder<> B(Ctx);
+  Type *I32Ty = B.getInt32Ty();
+  FunctionType *FT = FunctionType::get(I32Ty, {I32Ty, I32Ty}, false);
+  Function *F =
+      Function::Create(FT, GlobalValue::ExternalLinkage, "identity", M.get());
+  auto AI = F->arg_begin();
+  Value *A = &*AI++;
+  Value *BArg = &*AI;
+  BasicBlock *Entry = BasicBlock::Create(Ctx, "entry", F);
+  B.SetInsertPoint(Entry);
+  Value *Sum = B.CreateAdd(A, BArg, "sum");
+  Value *IsZero = B.CreateICmpEQ(Sum, B.getInt32(0), "iszero");
+  // Construct the redundant add explicitly so IRBuilder does not fold it.
+  Value *Copy = BinaryOperator::CreateAdd(B.getInt32(0), Sum, "copy", Entry);
+  B.CreateRet(B.CreateSelect(IsZero, B.getInt32(0), Copy, "result"));
+
+  PeriodArrayRegistry Reg;
+  EJitOptimizerTestAccess Opt(Reg);
+  Opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
+
+  EXPECT_FALSE(any_of(instructions(F),
+                      [](Instruction &I) { return isa<SelectInst>(I); }));
+}
+
+TEST(EJitOptimizer, VectorizesRuntimeSizedDataLoopWithTargetTTI) {
+  ASSERT_FALSE(InitializeNativeTarget());
+  auto JTMB = orc::JITTargetMachineBuilder::detectHost();
+  ASSERT_TRUE(!!JTMB) << toString(JTMB.takeError());
+  auto TM = JTMB->createTargetMachine();
+  ASSERT_TRUE(!!TM) << toString(TM.takeError());
+
+  LLVMContext Ctx;
+  auto M = std::make_unique<Module>("vector_loop", Ctx);
+  M->setTargetTriple((*TM)->getTargetTriple());
+  M->setDataLayout((*TM)->createDataLayout());
+  IRBuilder<> B(Ctx);
+  Type *I16Ty = B.getInt16Ty();
+  Type *I32Ty = B.getInt32Ty();
+  Type *I64Ty = B.getInt64Ty();
+  FunctionType *FT = FunctionType::get(
+      I32Ty, {PointerType::getUnqual(Ctx), PointerType::getUnqual(Ctx), I64Ty},
+      false);
+  Function *F = Function::Create(FT, GlobalValue::ExternalLinkage,
+                                 "runtime_data_loop", M.get());
+  auto AI = F->arg_begin();
+  Value *LHS = &*AI++;
+  Value *RHS = &*AI++;
+  Value *Count = &*AI;
+
+  BasicBlock *Entry = BasicBlock::Create(Ctx, "entry", F);
+  BasicBlock *Loop = BasicBlock::Create(Ctx, "loop", F);
+  BasicBlock *Exit = BasicBlock::Create(Ctx, "exit", F);
+  B.SetInsertPoint(Entry);
+  Value *IsEmpty = B.CreateICmpEQ(Count, B.getInt64(0));
+  B.CreateCondBr(IsEmpty, Exit, Loop);
+
+  B.SetInsertPoint(Loop);
+  PHINode *Index = B.CreatePHI(I64Ty, 2, "index");
+  PHINode *Sum = B.CreatePHI(I32Ty, 2, "sum");
+  Index->addIncoming(B.getInt64(0), Entry);
+  Sum->addIncoming(B.getInt32(0), Entry);
+  Value *L =
+      B.CreateZExt(B.CreateLoad(I16Ty, B.CreateGEP(I16Ty, LHS, Index)), I32Ty);
+  Value *R =
+      B.CreateZExt(B.CreateLoad(I16Ty, B.CreateGEP(I16Ty, RHS, Index)), I32Ty);
+  Value *NextSum = B.CreateAdd(Sum, B.CreateAdd(B.CreateMul(L, B.getInt32(3)),
+                                                B.CreateMul(R, B.getInt32(5))));
+  Value *NextIndex = B.CreateAdd(Index, B.getInt64(1));
+  Value *Done = B.CreateICmpEQ(NextIndex, Count);
+  B.CreateCondBr(Done, Exit, Loop);
+  Index->addIncoming(NextIndex, Loop);
+  Sum->addIncoming(NextSum, Loop);
+
+  B.SetInsertPoint(Exit);
+  PHINode *Result = B.CreatePHI(I32Ty, 2);
+  Result->addIncoming(B.getInt32(0), Entry);
+  Result->addIncoming(NextSum, Loop);
+  B.CreateRet(Result);
+
+  PeriodArrayRegistry Reg;
+  EJitOptimizerTestAccess Opt(Reg, TM->get());
+  Opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
+
+  bool HasVectorInstruction = false;
+  for (Instruction &I : instructions(F)) {
+    HasVectorInstruction |= I.getType()->isVectorTy();
+    for (Value *Op : I.operands())
+      HasVectorInstruction |= Op->getType()->isVectorTy();
+  }
+  EXPECT_TRUE(HasVectorInstruction);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## 中文说明

### 改动内容

- 在 EJIT 最终清理阶段增加保守的 `InstSimplify`，消除 ADCE 后暴露的恒等式。
- 复用 ORC 已创建的 `TargetMachine` 注册真实目标 TTI，并加入最小循环优化链：
  `LoopSimplify -> LoopRotate -> LoopVectorize -> InstCombine -> SimplifyCFG`。
- 为裁剪构建补入 `LLVMVectorize` / `LLVMSandboxIR` 组件。
- 新增两个聚焦单测、AArch64 可复现 probe/benchmark，以及完整审计文档。
- 不引入完整 O2、SLP、GVN 或 EarlyCSE。

### 为什么这样做

异步编译场景更关注生成代码的稳态执行性能。现有 EJIT pipeline 在特化后仍可能留下运行时长度的数据循环，但此前使用通用 TTI 且没有 LoopVectorize，无法按 AArch64 目标做可靠的向量化收益判断。

对三份真实 EJIT post-pipeline IR 追加完整 O2 的结果并不稳定，因此本 PR 只加入有明确证据的最终恒等式清理和目标感知循环向量化。

### 测量结果

Neoverse-N2 原生 AArch64 probe（`cntvct_el0`，固定 CPU）：

| elements | speedup |
|---:|---:|
| 4 | 1.23x |
| 8 | 1.99x |
| 16 | 2.87x |
| 64 | 4.00x |
| 256 | 4.62x |
| 4096 | 4.87x |

真实 post-pipeline 残留恒等式经 `InstSimplify` 后去掉一个 AArch64 指令及条件 `csel`（84B -> 80B）。

### 验证

- native AArch64 shared-taskpool：`LLVMEJIT` / `EJITTests` 构建成功。
- `EJitOptimizer.*`：13/13 passed。
- 完整 `EJITTests`：103/105；两个失败为主线现有的 `EJitStructFieldPass` 测试，单独运行同样失败，与本改动无关。
- `aarch64_be + freestanding + taskpool + code pool`：`LLVMEJIT` 与 minimal archive 构建成功。
- `git diff --check` clean；所有构建均为 `-j8`。

### 风险与待验证项

- probe 中函数体从 48B 增长到 352B，这是向量主循环、运行时检查和标量尾循环的代价。
- 裁剪链接新增 Vectorize/SandboxIR；本地未剥离 combined archive 约 85MB，最终 lipo/GC 后的产品镜像增量仍需测量。
- 三份 complex-test 特化 IR 本身没有剩余可向量化循环，因此不会从该 pass 获益。
- 合入前建议在板上 dump/diff 一份真实 loop-heavy 业务函数并测稳态性能。

完整证据见 `jit_design_doc/EJIT_IR_PIPELINE_PERF_AUDIT.md`。

---

## English Summary

This PR adds two evidence-backed post-specialization optimizations:

1. A conservative final `InstSimplify` after ADCE.
2. Target-aware `LoopRotate + LoopVectorize`, using the existing ORC `TargetMachine` TTI, followed by minimal cleanup.

It intentionally does **not** append full O2, SLP, GVN, or EarlyCSE. Full O2 was inconsistent on captured EJIT modules, while SLP added no benefit to the measured loop probe.

On a pinned Neoverse-N2, the runtime-sized AArch64 loop probe improved from 1.23x at 4 elements to 4.87x at 4096 elements. The tradeoff is code size: the probe grows from 48B to 352B, and the trimmed runtime now links Vectorize/SandboxIR. Final board image size and a real loop-heavy business function still require on-target validation.

No taskpool, code-pool, shared ABI, or public C ABI semantics are changed.