### PR TITLE
[EJIT] Benchmark funcIndex-only shared-cache hit path

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -374,6 +374,11 @@ def doit_gc_merge(args):
         "ejit_taskpool_compile_or_get_0d", "ejit_taskpool_compile_or_get_1d",
         "ejit_taskpool_compile_or_get_2d", "ejit_taskpool_compile_or_get_3d",
         "ejit_taskpool_compile_or_get_4d",
+        # BENCHMARK ONLY / UNSAFE FOR GENERAL USE: optional root, retained only
+        # when the runtime was built with EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP.
+        "ejit_taskpool_compile_or_get_func_only",
+        "ejit_taskpool_compile_or_get_func_only_1d",
+        "ejit_taskpool_compile_or_get_func_only_2d",
         "ejit_taskpool_set_instance_enabled", "ejit_taskpool_pending_count",
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",

--- a/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
+++ b/jit_design_doc/EJIT_CACHE_QUERY_PERF.md
@@ -1,0 +1,257 @@
+# EJIT Shared Taskpool — Cache-Query Performance Audit & Model
+
+Scope: the cross-core shared taskpool cache-hit **query** path (spec §5.2 steps
+0–1), from the AOT wrapper's C ABI call through the read-token / seqlock release.
+This document is the performance model behind the Commit 2 optimization; it does
+**not** describe the compile/enqueue slow path.
+
+All static instruction counts are AArch64, `clang -Os`, default capacities
+(`EJIT_SRE_TASKPOOL_BUCKETS=32`, `EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS=16`).
+All per-hit measurements are on an aarch64 host via `perf stat`, stats OFF
+(`EJIT_STATS_ENABLE` undefined — the production default), 100M iterations. Host
+nanoseconds are for **relative comparison only**; they are not board cycles.
+
+Reproduce with the benchmark added in Commit 1:
+
+```
+clang++ -std=c++17 -O2 -Illvm/include \
+  -DEJIT_SRE_TASKPOOL -DEJIT_SRE_SHARED_TASKPOOL -DEJIT_SRE_TASKPOOL_TESTING \
+  -DEJIT_SRE_TASKPOOL_BUCKETS=32 -DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024 \
+  [-DEJIT_SRE_SHARED_CODE_POINTERS] [-DEJIT_SRE_TASKPOOL_NO_RECLAIM] \
+  llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp \
+  llvm/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp -o bench
+perf stat -e instructions,cycles ./bench single0d 15 100000000
+```
+
+Or via CMake: configure with `-DEJIT_BUILD_CACHE_QUERY_BENCH=ON` (and
+`-DEJIT_TEST_NO_RECLAIM=ON` for the seqlock + code-sharing variant), build
+`EJITSharedCacheQueryBench`.
+
+---
+
+## 1. Baseline call chain (per layer)
+
+```
+wrapper IR / AOT entry
+ └─ ejit_taskpool_compile_or_get[_0d/_1d/_2d]     (C ABI shell, EJitRuntime.cpp)
+     └─ EJitSharedTaskPool::tryCacheHit[0D/1D/2D]  (Ready gate + instance-enabled)
+         └─ cacheLookup[0D/1D/2D] | cacheLookupSeq[0D/1D/2D]
+             ├─ hashIdentity (inlined / unrolled)  key
+             ├─ bucket = key % 32
+             ├─ bucketTryRead  (token: 1 acquire load + 1 RMW; seqlock: 1 load)
+             ├─ slot scan 0..15  (per slot: identityHash reject → state acquire →
+             │                    generation → identity → version)
+             └─ resolveMatchedSlot
+                 ├─ owner core / memoized peer → return fnPtr (+ read token)
+                 └─ cold peer first touch → peerPrepareSlot (noinline)
+         └─ classifyHit  (CacheHit / InstanceDisabled / OffMode / notShareable)
+ └─ JIT function indirect call
+ └─ releaseRead  (token: 1 RMW; seqlock: no-op sentinel)
+```
+
+### Static per-layer instruction counts (AArch64, -Os)
+
+| Layer (function)                 | token | NO_RECLAIM |
+|----------------------------------|------:|-----------:|
+| `ejit_taskpool_compile_or_get_0d` (C shell) | ~20 | ~20 |
+| `tryCacheHit0D`                  | 36 | 43 |
+| `tryCacheHit1D`                  | 48 | 54 |
+| `tryCacheHit2D`                  | 55 | 61 |
+| `tryCacheHit` (generic)          | 55 | 61 |
+| `cacheLookup0D` / `cacheLookupSeq0D` | 69 | 68 |
+| `cacheLookup1D` / `cacheLookupSeq1D` | 104 | 109 |
+| `cacheLookup2D` / `cacheLookupSeq2D` | 140 | 144 |
+| `cacheLookup` (generic)          | 136 | 138 |
+| `resolveMatchedSlot`             | 36 | 42 |
+| `peerPrepareSlot` (cold, noinline) | 150 | ~150 |
+| `classifyHit`                    | 22 | 32 |
+| `hashIdentity` (generic)         | 16 | 16 |
+| `releaseRead`                    | 14 | 1 (no-op) |
+
+Static counts are whole-function sizes (they include the miss/error tails and
+the 16-iteration loop body once). The **executed** hit path touches only a
+subset — see §3.
+
+### Per-basic-block path classification
+
+For the fixed-dim lookups the blocks partition as:
+- **cache-hit blocks**: hash build → `bucketTryRead` success → the *matching*
+  slot iteration → `resolveMatchedSlot` owner/memoized return.
+- **miss-only blocks**: the loop `continue` edges (rejected slots) and the
+  fall-through `bucketReadRelease; return R`.
+- **owner-only blocks**: `resolveMatchedSlot` `self == owner` early return.
+- **peer-only blocks**: `resolveMatchedSlot` memoized-mask branch + the call to
+  `peerPrepareSlot`.
+- **error-only blocks**: `numDims > 4` guard (generic only), `!bucketTryRead`
+  contended fallback, `fnPtr == 0` racing-publish fallback.
+
+---
+
+## 2. Actual cache-hit executed path (measured, stats OFF)
+
+`insns/hit` and `ns/hit` are the perf-measured loop totals; the benchmark loop
+harness is **~14 instructions** (measured from the disassembled loop:
+call-arg setup, `gSink` volatile add, status/hasReadToken test, loop counter),
+so the executed query path is `insns/hit − 14`.
+
+| Config (owner core, stats off) | slot | insns/hit | ns/hit | exec path insns |
+|--------------------------------|-----:|----------:|-------:|----------------:|
+| token 0D                       | 0    | 124 | 20.2 | ~110 |
+| token 0D                       | 15   | 214 | 22.7 | ~200 |
+| token 1D                       | 0    | 184 | 24.1 | ~170 |
+| token 2D                       | 0    | 221 | 25.3 | ~207 |
+| NO_RECLAIM 0D                  | 0    | 119 | 9.0  | **~105** |
+| NO_RECLAIM 0D                  | 15   | 224 | 15.1 | ~210 |
+| NO_RECLAIM 1D                  | 0    | 163 | 11.5 | ~149 |
+| NO_RECLAIM 2D                  | 0    | 220 | 15.6 | ~206 |
+| NO_RECLAIM 0D peer (memoized)  | 0    | 125 | 9.5  | ~111 |
+
+Dominant costs, in order:
+1. **Token read/release RMW** (`bucket.readers` fetchAdd + fetchSub, two
+   `ldaddal`): ~11 ns of the 20 ns token 0D hit. The seqlock (NO_RECLAIM) build
+   removes both → **2.0–2.3× faster** at slot 0.
+2. **Linear 16-slot scan**: ~0.8 ns and (post-opt) ~6 instructions per scanned
+   non-matching slot. Only material for busy buckets / deep slots.
+3. **`resolveMatchedSlot` owner gate**: `EJitCoreId::current()` + `ownerCoreId`
+   load + branch.
+4. Per-slot `state` **acquire load** (`ldar`) — one per scanned slot in the old
+   order; skipped for rejected slots after the reorder (§4).
+
+---
+
+## 3. Slot-depth distribution
+
+`cachePublish` fills the first empty slot, so entries in one bucket stack at
+slots 0,1,2,… in publish order; a bucket evicts its slot-0 occupant when full.
+With 32 buckets and a good hash, the expected occupancy per bucket for N live
+specializations is N/32; the hit slot depth is therefore **0 for the vast
+majority** of realistic workloads and only grows for hash-colliding identities
+or > 32 hot specializations.
+
+The Commit 1 benchmark (`bench0D`) and the `SlotDepthHitsAtEveryDepth` test
+place a target at each depth 0/1/5/15 deterministically (0D funcIndex multiples
+of 32 collide into bucket 0). Measured slope: token **+0.83 ns/slot** before,
+**+0.16 ns/slot** after the reorder; NO_RECLAIM **+0.92 ns/slot** before,
+**+0.41 ns/slot** after.
+
+---
+
+## 4. Candidate directions — benefit / risk
+
+| Dir | Idea | Benefit | Mem cost | Concurrency / version risk | Verdict |
+|-----|------|---------|----------|----------------------------|---------|
+| A | slot-depth stat | diagnostic only | 0 | none | shipped as bench + test |
+| B | per-funcIndex slot **hint** | cuts deep-slot scan | +4–8 B/func shared | must re-validate gen+identity+version; stale slot must not alias | **not shipped** — real depth ≈0; complexity/risk > benefit |
+| C | direct-mapped primary slot | O(1) common hit | +shared index | different specialization must not alias same funcIndex | **not shipped** — aliasing risk, marginal at depth 0 |
+| D | version digest word | 1 u32 compare vs per-dim loop | +4 B/slot | digest collision must never authorize stale code (hint only) | **report only** — needs ABI bump; per-dim loop already cheap (≤4) |
+| E | packed epoch/state word | 1 read vs several | +8 B | epoch may only *reject* / gate slow check | **report only** — needs strict equivalence proof + ABI bump |
+| F | owner-only hot/cold split | smaller I-cache footprint | 0 | must not bypass read token | partially present (`peerPrepareSlot` already noinline); owner path already tight |
+| G | move `identityHash` into slot line 0 | 1 cache line/scan vs 2 | 0 (reorder) | big-endian safe (by-value); **changes shared layout → ABI bump** | **report only** — see §5 |
+| H | hash algo | — | — | — | **not changed**: 0D≈funcIndex, 1D/2D few XOR+mul, `%32`→`&31` already; objdump shows hash is not the bottleneck |
+| **I** | **fixed-dim seqlock `cacheLookupSeqNd`** | −20 insns vs generic in NO_RECLAIM | 0 | never-free precondition (already the NO_RECLAIM invariant) | **SHIPPED** (Commit 2) |
+| — | **identityHash-first scan reorder** | −32/−36 % ns at depth 15 | 0 | identical semantics (final gate unchanged) | **SHIPPED** (Commit 2) |
+| J | wrapper call-site local cache | skips ABI shell | +8 B/site | cross-core/deactivate/version correctness unproven | **not shipped** — see the separate `ejit-callsite-local-cache` experiment; needs strict proof |
+
+---
+
+## 5. What shipped (Commit 2)
+
+1. **Fixed-dimension seqlock specializations** `cacheLookupSeq0D/1D/2D`
+   (Direction I / priority #1). In NO_RECLAIM builds `tryCacheHit0D/1D/2D`
+   previously fell back to the *generic* `cacheLookupSeq` (generic hash loop +
+   `slotIdentityMatches`). They now use unrolled specializations mirroring
+   `cacheLookup0D/1D/2D`. Isolated entirely behind `EJIT_SRE_TASKPOOL_NO_RECLAIM`
+   (the "code never freed" build), satisfying the never-free precondition
+   constraint. No new shared state, no layout/ABI change.
+2. **identityHash-first scan reorder** across `cacheLookup`,
+   `cacheLookup0D..4D`, `cacheLookupSeq`, and the new `cacheLookupSeq0D/1D/2D`.
+   The per-slot loop now rejects on the plain `identityHash` compare **before**
+   the acquiring `state` load. Correctness is unchanged: a match still requires
+   the acquire `state==Ready` load **plus** the full `funcIndex/numDims/dims`
+   identity **plus** the per-dim version check before any pointer is returned;
+   `identityHash` is only a fast-reject hint (a 64-bit hash collision falls
+   through to the authoritative identity compare, and a stale/false-negative
+   read is a benign clean miss under both the bucket read token and the seqlock
+   `publishSeq` re-check). No layout/ABI change; big-endian safe (by-value
+   scalar compares).
+
+**Before → after** (owner, stats off):
+- token 0D slot 15: 304 → 214 insns, 33.2 → 22.7 ns (**−32 %**)
+- NO_RECLAIM 0D slot 0: 139 → 119 insns, 9.6 → 9.0 ns
+- NO_RECLAIM 0D slot 15: 364 → 224 insns, 23.4 → 15.1 ns (**−36 %**)
+- token 0D slot 0 unchanged (single slot, nothing to skip)
+
+Shared-state memory change: **0 bytes** (`sizeof(EJitSharedTaskPoolState)` and
+every slot/bucket offset identical; verified by static_assert + offsetof probe).
+New shared reads/writes per hit: **0** (both changes are pure code).
+
+---
+
+## 6. Not shipped — reasons
+
+- **B/C slot hint / primary slot**: realistic hit depth is ≈0 (N/32 occupancy),
+  so the win is confined to pathological buckets while the correctness surface
+  (stale-slot aliasing, generation/version re-validation) grows. Kept as a
+  measured direction only.
+- **D/E/G packed digest / epoch / hot-field layout**: each requires changing the
+  shared `EJitSharedCacheSlot` layout (or adding a word), i.e. an
+  `abiVersion` bump and cross-core coordinated redeploy. The audit's hard
+  constraint is to not change default ABI / cache identity, and the measured
+  benefit (per-dim version loop is ≤4 iterations; `identityHash` already
+  fast-rejects) does not justify the ABI churn. Direction G (move `identityHash`
+  to the first cache line so a scan touches one line instead of two) is the most
+  promising future ABI-bump candidate and is documented here for that purpose.
+- **H hash**: objdump confirms the hash is a handful of instructions and not the
+  bottleneck; `% 32` already lowers to `& 31`. Changing it risks collisions for
+  no measured gain.
+- **J wrapper call-site cache**: not correctness-provable against deactivate /
+  version-bump / cross-core code sharing without a generation+version guard that
+  costs about as much as the lookup it replaces.
+
+---
+
+## 7. The "< 100 instructions" target
+
+The common **NO_RECLAIM owner-core 0D** hit executes **~105** instructions
+(stats off, slot 0), just above the 100 target; token 0D is ~110. The residual,
+from the disassembly, is:
+- the cross-TU `bl` chain (C ABI shell → `tryCacheHit0D` → `cacheLookupSeq0D` →
+  `resolveMatchedSlot`) with its arg setup / return-struct spill (~30 insns of
+  call glue that a full-image **LTO** build collapses),
+- `EJitCoreId::current()` (a real call for the core id) + the owner gate,
+- the seqlock `bucketSeqBegin`/`bucketSeqStable` pair (~6 insns),
+- `classifyHit`'s outcome classification + `CompileOrGetResult` construction.
+
+With whole-image LTO (the production firmware link, where these functions inline
+into the wrapper), the call glue disappears and the path is expected to fall
+below 100. On the token path the two `readers` RMWs make the instruction count
+secondary to the atomic latency; the seqlock build is the one that both hits
+~105 instructions and is 2× faster in cycles.
+
+---
+
+## 8. Correctness invariants preserved
+
+Deactivated instance never served (instance-enabled gate unchanged); version
+bump invalidates old slots (per-dim version check still after identity);
+generation reset drops old slots (`generation` compare unchanged); identity-hash
+collision cannot alias (authoritative identity compare after the hash reject);
+peer without execute permission never gets a pointer (`resolveMatchedSlot` /
+`peerPrepareSlot` untouched); read token pairing intact (token path unchanged;
+seqlock takes no token by construction); publish/overwrite races handled (bucket
+write lock / `publishSeq` seqlock unchanged); POD / standard-layout / trivially
+destructible shared state unchanged; no dynamic init; stats OFF keeps the hot
+path free of counter RMW. Verified by the existing suite plus the new
+`SlotDepthHitsAtEveryDepth`, `SlotDepthNoIdentityAliasAcrossBucket`,
+`SeqFixedDimMatchesGeneric0D1D2D`, and `SeqFixedDimVersionBumpMisses` tests.
+
+---
+
+## 9. Still to validate on-board
+
+Host cannot model real cross-core cache coherence or SRE `enable_ex`/split
+latency; the state machine and return semantics are deterministically tested on
+host, but the actual peer first-touch seal cost, the cross-core `ldar`/RMW
+latency, and the board cycle counts must be measured on hardware. Host
+nanoseconds here are for relative comparison only.

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -777,6 +777,32 @@ if(EJIT_SRE_SHARED_TASKPOOL)
                  "sharedSection=${_ejit_shared_section})")
 endif()
 
+# Never reclaim or overwrite published taskpool code. This enables the
+# load-only seqlock cache-hit reader and removes the read-token RMW/release
+# pair. It is an explicit whole-runtime lifetime contract, not a debug switch.
+option(EJIT_SRE_TASKPOOL_NO_RECLAIM
+  "Never reclaim published EmbeddedJIT taskpool code (enables load-only cache hits)" OFF)
+if(EJIT_SRE_TASKPOOL_NO_RECLAIM AND NOT EJIT_SRE_SHARED_TASKPOOL)
+  message(FATAL_ERROR
+    "EJIT_SRE_TASKPOOL_NO_RECLAIM requires EJIT_SRE_SHARED_TASKPOOL=ON")
+endif()
+
+# Deliberately unsafe benchmark experiment: cache hits are selected only by
+# funcIndex. The wrapper still carries 1D/2D scalar dimensions for a true miss,
+# but the hit path skips identity, active-state and version validation.
+option(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+  "BENCHMARK ONLY: use funcIndex-only shared-taskpool cache hits" OFF)
+if(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+  if(NOT EJIT_SRE_TASKPOOL_NO_RECLAIM)
+    message(FATAL_ERROR
+      "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP requires "
+      "EJIT_SRE_TASKPOOL_NO_RECLAIM=ON")
+  endif()
+  message(WARNING
+    "EmbeddedJIT: benchmark-only funcIndex lookup enabled; valid only when "
+    "each funcIndex has one immutable specialization")
+endif()
+
 set(LLVM_TARGETS_TO_BUILD "all"
     CACHE STRING "Semicolon-separated list of targets to build, or \"all\".")
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -78,6 +78,20 @@ constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_3D =
     "ejit_taskpool_compile_or_get_3d";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_4D =
     "ejit_taskpool_compile_or_get_4d";
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE. Thin funcIndex-only cache-hit entry
+// emitted only when the hidden wrapper option
+// -ejit-wrapper-bench-funcindex-only is set (default off => this symbol is
+// never referenced and the wrapper IR is byte-for-byte unchanged). Backed by
+// ejit_taskpool_compile_or_get_func_only, which is compiled only in an
+// EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP build (requires the shared taskpool +
+// NO_RECLAIM never-reclaim code pool). See EJitSharedTaskPool.cpp for the
+// correctness preconditions this path assumes.
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_FUNC_ONLY =
+    "ejit_taskpool_compile_or_get_func_only";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_FUNC_ONLY_1D =
+    "ejit_taskpool_compile_or_get_func_only_1d";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_FUNC_ONLY_2D =
+    "ejit_taskpool_compile_or_get_func_only_2d";
 constexpr const char *FN_TASKPOOL_RELEASE_READ = "ejit_taskpool_release_read";
 constexpr const char *FN_TASKPOOL_TRACE_NOW = "ejit_taskpool_trace_now";
 constexpr const char *FN_TASKPOOL_TRACE_WRAPPER =

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -206,6 +206,25 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
                                               uint32_t inst2, uint32_t dim3,
                                               uint32_t inst3, void **outFn,
                                               uint32_t *outBucket);
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE. Thin funcIndex-only cache-hit entry:
+// a hit needs ONLY funcIndex (no dims / identity hash / version / active checks
+// / read token); a miss falls back to compileOrGet with the entry's original
+// 0D/1D/2D dimensions.
+// This symbol exists ONLY in an EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP build (shared
+// taskpool + NO_RECLAIM). It never returns a stale or unexecutable pointer and
+// does not replace any existing generic entry. See EJitSharedTaskPool.cpp for
+// the strict correctness preconditions this experimental path assumes.
+ejit_status_t ejit_taskpool_compile_or_get_func_only(uint32_t funcIndex,
+                                                     void **outFn,
+                                                     uint32_t *outBucket);
+ejit_status_t ejit_taskpool_compile_or_get_func_only_1d(
+    uint32_t funcIndex, uint32_t dim0, uint32_t inst0, void **outFn,
+    uint32_t *outBucket);
+ejit_status_t ejit_taskpool_compile_or_get_func_only_2d(
+    uint32_t funcIndex, uint32_t dim0, uint32_t inst0, uint32_t dim1,
+    uint32_t inst1, void **outFn, uint32_t *outBucket);
+#endif
 void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
                                         uint32_t enabled);
 void ejit_taskpool_release_read(uint32_t bucketIndex);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -413,6 +413,19 @@ private:
   /// never-free safety precondition.
   SharedLookup cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
                               uint32_t numDims);
+  /// Fixed-dimension load-only seqlock specializations (0-2 dims). Same
+  /// never-free seqlock discipline as cacheLookupSeq() but with the identity
+  /// hashing, slot identity comparison, and version comparison unrolled exactly
+  /// like cacheLookup0D/1D/2D — so a NO_RECLAIM fixed-dimension caller reaches
+  /// the shared slot resolution without the generic numDims loop, the
+  /// slotIdentityMatches() call, or variable-length dims[] handling. Behavior
+  /// is identical to cacheLookupSeq() with the matching numDims. 3D/4D keep
+  /// using the generic cacheLookupSeq() (rare on the hot path).
+  SharedLookup cacheLookupSeq0D(uint32_t funcIndex);
+  SharedLookup cacheLookupSeq1D(uint32_t funcIndex, uint32_t dim0,
+                                uint32_t inst0);
+  SharedLookup cacheLookupSeq2D(uint32_t funcIndex, uint32_t dim0,
+                                uint32_t inst0, uint32_t dim1, uint32_t inst1);
 #endif
   /// Fixed-dimension specializations of cacheLookup() (0-4 dims). Identity
   /// hashing, slot identity comparison, and version comparison are all unrolled

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -339,6 +339,41 @@ public:
                                    uint32_t inst2, uint32_t dim3,
                                    uint32_t inst3);
   void releaseRead(uint32_t bucketIndex);
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+  //--- BENCHMARK ONLY / UNSAFE FOR GENERAL USE ------------------------------//
+  // funcIndex-only cache-hit fast path. Correct ONLY under the strict
+  // benchmark preconditions documented in EJitSharedTaskPool.cpp: exactly one
+  // specialization per funcIndex; cell/trp/dimensions/active state/version and
+  // may_const globals never change during the run; the code pool never
+  // reclaims (EJIT_SRE_TASKPOOL_NO_RECLAIM). It must NEVER be used on the
+  // production path — it skips the identity hash, per-dimension version and
+  // active checks, and the read-token/seqlock validation.
+
+  /// Raw funcIndex-only direct-hint probe. Returns true and writes *outFn ONLY
+  /// when the funcIndex hint resolves to a Ready, current-generation slot whose
+  /// funcIndex matches and whose code the CALLING core may already execute
+  /// (owner core, or a peer core that has already memoized execute permission
+  /// for that slot). Returns false — never a stale or unexecutable pointer — on
+  /// an out-of-range funcIndex, a missing/poisoned/stale hint, a non-Ready or
+  /// wrong-generation/wrong-funcIndex slot, a null fnPtr, or a cold (not-yet-
+  /// prepared) peer. Takes NO read token and performs NO atomic RMW on the
+  /// bucket. On a false return the caller falls back to the full lookup (which
+  /// handles cold-peer preparation and true misses).
+  bool funcIndexOnlyDirectHit(uint32_t funcIndex, void **outFn);
+
+  /// Ready-gated direct-hint probe. A hit is terminal; a hint miss is
+  /// deliberately non-terminal so dimension-aware C ABI entries can preserve
+  /// their original dimensions when they enter compileOrGet.
+  CompileOrGetResult tryFuncIndexOnlyDirect(uint32_t funcIndex);
+
+  /// Full funcIndex-only cache-hit entry with a clean fallback. Runs the Ready
+  /// gate then funcIndexOnlyDirectHit(); on a direct hit returns a terminal
+  /// CacheHit (no read token, sentinel bucketIndex, cacheHits++). On any
+  /// miss/fallback it defers to the generic 0D seqlock lookup
+  /// (cacheLookupSeq0D), which resolves a cold-peer first touch or a true miss
+  /// exactly as tryCacheHit0D would. Same terminal semantics as tryCacheHit0D.
+  CompileOrGetResult tryCacheHitFuncIndexOnly(uint32_t funcIndex);
+#endif
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read
   /// counterpart of setInstanceEnabled, and the single cross-core source of

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -45,6 +45,28 @@
 #include <type_traits>
 
 //===----------------------------------------------------------------------===//
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE — funcIndex-only cache-hit fast path.
+//
+// EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP enables a deliberately-cheating, benchmark-
+// only cache-hit query path that resolves a hit from a funcIndex -> (bucket,
+// slot) direct hint WITHOUT recomputing the identity hash, without the per-
+// dimension version/active checks, and without any read-token / atomic RMW. It
+// is correct ONLY under the strict preconditions documented in
+// EJitSharedTaskPool.cpp (one specialization per funcIndex, no version/active
+// changes, never-reclaimed code pool). It is therefore hard-gated to the
+// shared taskpool + never-reclaim build and refuses to compile otherwise so it
+// can never silently alter the production path. Default OFF: the field and code
+// below do not exist, so the shared-memory layout, ABI, and behavior are
+// byte-for-byte unchanged.
+//===----------------------------------------------------------------------===//
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+#if !defined(EJIT_SRE_SHARED_TASKPOOL) || !defined(EJIT_SRE_TASKPOOL_NO_RECLAIM)
+#error                                                                         \
+    "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP (BENCHMARK ONLY / UNSAFE FOR GENERAL USE) requires both EJIT_SRE_SHARED_TASKPOOL and EJIT_SRE_TASKPOOL_NO_RECLAIM"
+#endif
+#endif
+
+//===----------------------------------------------------------------------===//
 // Compile-time capacities (overridable by the build via -D). Defaults mirror
 // the non-shared taskpool so the two stay aligned.
 //===----------------------------------------------------------------------===//
@@ -390,6 +412,21 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
   //--- result cache (own cache line; each bucket is itself cache-line aligned)
   alignas(kEJitSharedCacheLine)
       EJitSharedCacheBucket buckets[kEJitSharedCacheBuckets];
+
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+  //--- BENCHMARK ONLY / UNSAFE FOR GENERAL USE: funcIndex -> (bucket, slot)
+  //    direct hint table for the funcIndex-only cache-hit fast path. One
+  //    EJitAtomicU32 per dense funcIndex: 0 = no hint, 0xFFFFFFFF = poisoned
+  //    (a second distinct specialization was published for this funcIndex, so
+  //    the funcIndex-only path must not mis-hit and cleanly falls back), else
+  //    the valid bit (0x80000000) OR-ed with (bucket << 8) | slot. Written only
+  //    by the single owner worker at publish; read lock-free by every core.
+  //    Memory cost: kEJitSharedMaxFuncIndex * 4 bytes (default 4096 * 4 = 16
+  //    KiB), on its own cache line so it never false-shares with the buckets.
+  //    This field ONLY exists in an EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP build; the
+  //    production (default OFF) layout is byte-for-byte unchanged.
+  alignas(kEJitSharedCacheLine) EJitAtomicU32 funcHint[kEJitSharedMaxFuncIndex];
+#endif
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -128,6 +128,15 @@ add_llvm_component_library(LLVMEJIT
   # ExecutionEngine is not listed — it's already pulled by OrcJIT.
   )
 
+if(EJIT_SRE_TASKPOOL_NO_RECLAIM)
+  target_compile_definitions(LLVMEJIT PRIVATE
+    EJIT_SRE_TASKPOOL_NO_RECLAIM)
+endif()
+if(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+  target_compile_definitions(LLVMEJIT PRIVATE
+    EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+endif()
+
 # Propagate the target triple setting to the C++ code
 if(EJIT_DEFAULT_TARGET_TRIPLE)
   target_compile_definitions(LLVMEJIT PUBLIC

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -754,6 +754,118 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
   return taskpoolStatus(r.status);
 }
 
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+//===----------------------------------------------------------------------===//
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE — thin funcIndex-only C ABI entry.
+//
+// Additive, opt-in entries that resolve a cache HIT from the funcIndex-only
+// direct-hint fast path: on a hit it needs ONLY funcIndex (no dims, no identity
+// hash, no per-dimension version/active checks, no read token). On a miss it
+// falls back to the existing generic compileOrGet with the entry's original
+// 0D/1D/2D dimensions, so enqueue / dedup / compile / publish are unchanged.
+// Under the benchmark's immutable-single-specialization preconditions, they
+// do not return a stale or unexecutable pointer. These symbols only exist in an
+// EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP build
+// (which requires the shared taskpool + NO_RECLAIM never-reclaim code pool); it
+// does not exist and cannot be called in a production build. It does not
+// replace or modify any existing generic C ABI entry.
+//===----------------------------------------------------------------------===//
+ejit_status_t ejit_taskpool_compile_or_get_func_only(uint32_t funcIndex,
+                                                     void **outFn,
+                                                     uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+
+  auto fast = tp->tryFuncIndexOnlyDirect(funcIndex);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  // True miss: fall back to the generic path with zero dims (0D identity).
+  auto r = tp->compileOrGet(funcIndex, nullptr, 0, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_func_only_1d(
+    uint32_t funcIndex, uint32_t dim0, uint32_t inst0, void **outFn,
+    uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+
+  auto fast = tp->tryFuncIndexOnlyDirect(funcIndex);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  if (!ejitTaskpoolDimInRange(dim0, inst0))
+    return EJIT_ERR_INVALID_PARAM;
+  const EJitDimPair dims[1] = {{dim0, inst0}};
+  auto r = tp->compileOrGet(funcIndex, dims, 1, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_func_only_2d(
+    uint32_t funcIndex, uint32_t dim0, uint32_t inst0, uint32_t dim1,
+    uint32_t inst1, void **outFn, uint32_t *outBucket) {
+  if (outFn)
+    *outFn = nullptr;
+  if (outBucket)
+    *outBucket = 0;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  auto *tp = activeTaskPool();
+  if (!tp)
+    return EJIT_ERR_NOT_ACTIVE;
+
+  auto fast = tp->tryFuncIndexOnlyDirect(funcIndex);
+  if (fast.fastPathTerminal) {
+    if (outFn)
+      *outFn = fast.fnPtr;
+    if (outBucket)
+      *outBucket = fast.bucketIndex;
+    return taskpoolStatus(fast.status);
+  }
+  if (!ejitTaskpoolDimInRange(dim0, inst0) ||
+      !ejitTaskpoolDimInRange(dim1, inst1))
+    return EJIT_ERR_INVALID_PARAM;
+  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
+  auto r = tp->compileOrGet(funcIndex, dims, 2, /*fallback=*/nullptr);
+  if (outFn)
+    *outFn = r.fnPtr;
+  if (outBucket)
+    *outBucket = r.bucketIndex;
+  return taskpoolStatus(r.status);
+}
+#endif // EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+
 void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
                                         uint32_t enabled) {
   EJIT_DIAG_VERBOSE("taskpool_set_instance_enabled dim=%u inst=%u enabled=%u",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -121,6 +121,33 @@ constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 /// cacheLookupNd block can also reference it.
 constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+//===----------------------------------------------------------------------===//
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE — funcIndex -> (bucket, slot) direct
+// hint encoding for the funcIndex-only cache-hit fast path. One EJitAtomicU32
+// per dense funcIndex:
+//   * kFuncHintEmpty  (0)          — no hint published yet.
+//   * kFuncHintPoison (0xFFFFFFFF) — a second, DISTINCT (bucket, slot) was
+//     published for this funcIndex (i.e. more than one specialization), so the
+//     funcIndex-only path can no longer prove which slot a request wants and
+//     MUST cleanly fall back to the full identity lookup — it never mis-hits.
+//   * otherwise                    — valid: kFuncHintValidBit | (bucket << 8) |
+//     slot. bucket < kEJitSharedCacheBuckets (<=256) and slot <
+//     kEJitSharedCacheSlots (<=256) both fit in a byte, so the value can never
+//     collide with the empty or poison sentinels.
+//===----------------------------------------------------------------------===//
+constexpr uint32_t kFuncHintEmpty = 0u;
+constexpr uint32_t kFuncHintPoison = 0xFFFFFFFFu;
+constexpr uint32_t kFuncHintValidBit = 0x80000000u;
+inline uint32_t funcHintPack(uint32_t bucket, uint32_t slot) {
+  return kFuncHintValidBit | ((bucket & 0xFFu) << 8) | (slot & 0xFFu);
+}
+inline void funcHintUnpack(uint32_t v, uint32_t &bucket, uint32_t &slot) {
+  bucket = (v >> 8) & 0xFFu;
+  slot = v & 0xFFu;
+}
+#endif
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -1201,6 +1228,26 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   target->executableCoreMask.storeRelease(
       OwnerCore < 64 ? (uint64_t{1} << OwnerCore) : 0);
   target->state.storeRelease(static_cast<uint32_t>(EJitSharedSlotState::Ready));
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+  // BENCHMARK ONLY / UNSAFE FOR GENERAL USE. Record the funcIndex -> (bucket,
+  // slot) direct hint for the funcIndex-only fast path. Only the single owner
+  // worker publishes, so no publisher/publisher race exists here; a release
+  // store is sufficient for the lock-free readers. If a DIFFERENT (bucket,
+  // slot) was already recorded for this funcIndex (a second distinct
+  // specialization / dimension set), poison the hint so the funcIndex-only path
+  // can never mis-hit and instead falls back to the full identity lookup. A
+  // same-slot recompile keeps the hint (its live fnPtr is re-read on every hit,
+  // so the fast path always returns the current pointer, never a stale one).
+  if (req.funcIndex < kEJitSharedMaxFuncIndex) {
+    const uint32_t slotIndex = static_cast<uint32_t>(target - &B.slots[0]);
+    const uint32_t desired = funcHintPack(bucket, slotIndex);
+    const uint32_t cur = state_->funcHint[req.funcIndex].loadAcquire();
+    if (cur == kFuncHintEmpty || cur == desired)
+      state_->funcHint[req.funcIndex].storeRelease(desired);
+    else
+      state_->funcHint[req.funcIndex].storeRelease(kFuncHintPoison);
+  }
+#endif
   bucketWriteRelease(B);
 
   // Release the slot's PREVIOUS code OUTSIDE the bucket lock (the callback may
@@ -1338,6 +1385,15 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
       Slot.rangeReserved = 0;
     }
   }
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+  // BENCHMARK ONLY / UNSAFE FOR GENERAL USE. Clear the funcIndex-only direct
+  // hint table on every (re)initialization so a stale hint from an earlier
+  // generation can never resolve after a shutdown/reinit. (Generation-tagged
+  // slots would already reject a stale hint, but clearing keeps the table
+  // consistent and lets a fresh generation start from a clean map.)
+  for (uint32_t i = 0; i < kEJitSharedMaxFuncIndex; ++i)
+    st->funcHint[i].storeRelaxed(kFuncHintEmpty);
+#endif
 }
 } // namespace
 
@@ -1672,6 +1728,135 @@ EJitSharedTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
                                    inst2, dim3, inst3));
 #endif
 }
+
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+//===----------------------------------------------------------------------===//
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE — funcIndex-only cache-hit fast path.
+//
+// This path INTENTIONALLY cheats for a performance experiment. It is memory-
+// and type-safe, but it is NOT a correct general cache lookup: it trusts the
+// funcIndex -> (bucket, slot) hint and validates ONLY funcIndex, generation,
+// Ready state, and the fnPtr cross-core gate. It DOES NOT recompute the
+// identity hash, DOES NOT compare the dimension identity, and DOES NOT check
+// per-instance versions or active state. It is correct ONLY when EVERY one of
+// these benchmark preconditions holds for the whole run:
+//   * exactly ONE specialization exists per funcIndex (a 2nd distinct set of
+//     dimensions poisons the hint at publish, forcing a clean fallback);
+//   * cell/trp/dimensions, instance active state, and versions never change;
+//   * may_const-associated globals never change;
+//   * the code pool never reclaims (guaranteed by
+//   EJIT_SRE_TASKPOOL_NO_RECLAIM),
+//     so a published fnPtr is never freed and a token-free read can never
+//     dangle.
+// Outside these conditions it can return a pointer that a correct lookup would
+// have rejected. It must NEVER be enabled on the production path.
+//===----------------------------------------------------------------------===//
+bool EJitSharedTaskPool::funcIndexOnlyDirectHit(uint32_t funcIndex,
+                                                void **outFn) {
+  if (outFn)
+    *outFn = nullptr;
+  if (!state_)
+    return false;
+  // funcIndex out of range: clean fallback, never index the hint table OOB.
+  if (funcIndex >= kEJitSharedMaxFuncIndex)
+    return false;
+
+  const uint32_t hint = state_->funcHint[funcIndex].loadAcquire();
+  if (hint == kFuncHintEmpty || hint == kFuncHintPoison)
+    return false; // no hint, or poisoned (2nd specialization) -> fall back.
+
+  uint32_t bucket = 0, slot = 0;
+  funcHintUnpack(hint, bucket, slot);
+  if (bucket >= kEJitSharedCacheBuckets || slot >= kEJitSharedCacheSlots)
+    return false; // corrupt/stale encoding -> fall back, never index OOB.
+
+  EJitSharedCacheSlot &Slot = state_->buckets[bucket].slots[slot];
+  // Ready gate: an acquire load of Ready synchronizes with the publisher's
+  // release store of Ready, which is written LAST — after fnPtr and identity —
+  // so every field read below is consistent.
+  if (Slot.state.loadAcquire() !=
+      static_cast<uint32_t>(EJitSharedSlotState::Ready))
+    return false;
+  // Generation gate: a hint from an earlier owner generation (an intervening
+  // shutdown/reinit) is silently rejected.
+  if (Slot.generation != state_->generation.loadAcquire())
+    return false;
+  // funcIndex gate: guards against a stale hint whose slot was reused by a
+  // different funcIndex (eviction). No identity-hash / dim / version compare.
+  if (Slot.funcIndex != funcIndex)
+    return false;
+
+  void *fn = reinterpret_cast<void *>(Slot.fnPtr.loadAcquire());
+  if (!fn)
+    return false;
+
+  // fnPtr cross-core gate (§11): only hand back a pointer the CALLING core may
+  // legally execute. NO read token and NO atomic RMW are taken here — safe only
+  // because published code is never freed in a NO_RECLAIM build.
+  const uint32_t self = EJitCoreId::current();
+  const uint32_t owner = state_->ownerCoreId.loadRelaxed();
+#if defined(EJIT_SRE_SHARED_CODE_POINTERS)
+  constexpr bool mayReadPtr = true;
+#else
+  const bool mayReadPtr = (self == owner);
+#endif
+  if (!mayReadPtr)
+    return false;
+  // Owner already sealed the code before publishing: direct return.
+  if (self == owner) {
+    if (outFn)
+      *outFn = fn;
+    return true;
+  }
+  // Peer that has already memoized execute permission for THIS slot: direct
+  // return. A cold peer (bit not yet set) returns false so the caller runs the
+  // existing prepare/fallback path — the fast path never prepares here.
+  const bool canMemoize = self < kEJitSharedMaxMemoCores;
+  const uint64_t coreBit = canMemoize ? (uint64_t{1} << self) : uint64_t{0};
+  if (canMemoize && (Slot.executableCoreMask.loadAcquire() & coreBit) != 0) {
+    if (outFn)
+      *outFn = fn;
+    return true;
+  }
+  return false; // cold peer -> caller falls back to prepare/full lookup.
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::tryFuncIndexOnlyDirect(uint32_t funcIndex) {
+  CompileOrGetResult R;
+  // Ready check (§5.2 step 0): a not-yet-Ready pool is a clean fallback.
+  if (!state_ || state_->initState.loadAcquire() != kReady) {
+    R.status = EJitCompileOrGetStatus::OffMode;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  void *fn = nullptr;
+  if (funcIndexOnlyDirectHit(funcIndex, &fn)) {
+    EJIT_STAT_INC(state_->counters.cacheHits);
+    R.status = EJitCompileOrGetStatus::CacheHit;
+    R.fnPtr = fn;
+    // No read token was taken; use the out-of-range sentinel so a wrapper
+    // releaseRead() cleanly no-ops (same convention as the seqlock hit).
+    R.bucketIndex = kEJitSharedCacheBuckets;
+    R.hasReadToken = false;
+    R.fastPathTerminal = true;
+    return R;
+  }
+  return R;
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::tryCacheHitFuncIndexOnly(uint32_t funcIndex) {
+  CompileOrGetResult R = tryFuncIndexOnlyDirect(funcIndex);
+  if (R.fastPathTerminal)
+    return R;
+  // Direct hint missed / poisoned / cold peer: fall back to the full 0D seqlock
+  // lookup, which resolves a cold-peer first touch (peerPrepareSlot) or a true
+  // miss exactly as tryCacheHit0D would. classifyHit increments cacheHits on a
+  // fallback hit, so the counter is bumped exactly once per hit.
+  return classifyHit(cacheLookupSeq0D(funcIndex));
+}
+#endif // EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
 
 EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -115,6 +115,12 @@ void bucketWriteRelease(EJitSharedCacheBucket &b) {
 
 constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 
+/// Mixing constant shared by hashIdentity() and every unrolled fixed-dimension
+/// lookup (cacheLookupNd / cacheLookupSeqNd). Kept here so the NO_RECLAIM
+/// fixed-dimension seqlock specializations defined above the generic
+/// cacheLookupNd block can also reference it.
+constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -321,12 +327,12 @@ EJitSharedTaskPool::cacheLookup(uint32_t funcIndex, const EJitDimPair *dims,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen) // stale across an owner re-init: ignore.
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (!slotIdentityMatches(Slot, funcIndex, dims, numDims))
       continue;
@@ -378,12 +384,12 @@ EJitSharedTaskPool::cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
     SharedLookup hit;
     for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
       EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue; // plain-load fast reject before the acquiring state load.
       if (Slot.state.loadAcquire() !=
           static_cast<uint32_t>(EJitSharedSlotState::Ready))
         continue;
       if (Slot.generation != curGen)
-        continue;
-      if (Slot.identityHash != key)
         continue;
       if (!slotIdentityMatches(Slot, funcIndex, dims, numDims))
         continue;
@@ -409,6 +415,149 @@ EJitSharedTaskPool::cacheLookupSeq(uint32_t funcIndex, const EJitDimPair *dims,
     return hit; // validated hit (noTokenHit) or clean miss
   }
   return R; // repeated contention -> clean fallback to the slow path
+}
+
+//===----------------------------------------------------------------------===//
+// Fixed-dimension load-only seqlock specializations (0-2 dims, NO_RECLAIM
+// build only). Each mirrors the matching cacheLookup0D/1D/2D scan (unrolled
+// identity hash, unrolled identity + version comparison, plain-identityHash
+// fast reject before the acquiring state load) wrapped in the same bounded
+// seqlock retry as cacheLookupSeq(). A NO_RECLAIM fixed-dimension caller thus
+// avoids the generic numDims loop / slotIdentityMatches() call entirely.
+// Behavior is identical to cacheLookupSeq() with the matching numDims; the
+// cross-core fnPtr gate and cold peer preparation stay shared via
+// resolveMatchedSlot().
+//===----------------------------------------------------------------------===//
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq0D(uint32_t funcIndex) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex); // hashIdentity(fi, _, 0)
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue; // plain-load fast reject before the acquiring state load.
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 0)
+        continue;
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq1D(uint32_t funcIndex, uint32_t dim0,
+                                     uint32_t inst0) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue;
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 1)
+        continue;
+      if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+        continue;
+      if (Slot.versions[0] != instanceVersion(dim0, inst0))
+        break; // identity matched but stale -> clean miss.
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
+}
+
+EJitSharedTaskPool::SharedLookup
+EJitSharedTaskPool::cacheLookupSeq2D(uint32_t funcIndex, uint32_t dim0,
+                                     uint32_t inst0, uint32_t dim1,
+                                     uint32_t inst1) {
+  SharedLookup R;
+  uint64_t key = static_cast<uint64_t>(funcIndex);
+  key ^= (static_cast<uint64_t>(dim0) << 32) | static_cast<uint64_t>(inst0);
+  key *= kHashMul;
+  key ^= (static_cast<uint64_t>(dim1) << 32) | static_cast<uint64_t>(inst1);
+  key *= kHashMul;
+  uint32_t bucket = static_cast<uint32_t>(key % kEJitSharedCacheBuckets);
+  EJitSharedCacheBucket &B = state_->buckets[bucket];
+  for (uint32_t attempt = 0; attempt < 4; ++attempt) {
+    uint32_t seq0;
+    if (!bucketSeqBegin(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    uint32_t curGen = state_->generation.loadAcquire();
+    SharedLookup hit;
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+      EJitSharedCacheSlot &Slot = B.slots[s];
+      if (Slot.identityHash != key)
+        continue;
+      if (Slot.state.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedSlotState::Ready))
+        continue;
+      if (Slot.generation != curGen)
+        continue;
+      if (Slot.funcIndex != funcIndex || Slot.numDims != 2)
+        continue;
+      if (Slot.dims[0].dimType != dim0 || Slot.dims[0].instanceId != inst0)
+        continue;
+      if (Slot.dims[1].dimType != dim1 || Slot.dims[1].instanceId != inst1)
+        continue;
+      if (Slot.versions[0] != instanceVersion(dim0, inst0))
+        break;
+      if (Slot.versions[1] != instanceVersion(dim1, inst1))
+        break;
+      hit = resolveMatchedSlot(B, bucket, s);
+      break;
+    }
+    if (hit.fnPtr && !hit.coldPrepared && !bucketSeqStable(B, seq0)) {
+      cpuRelax();
+      continue;
+    }
+    return hit;
+  }
+  return R;
 }
 #endif // EJIT_SRE_TASKPOOL_NO_RECLAIM
 
@@ -598,7 +747,6 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
 // each specialization stays small. Results are identical to cacheLookup() with
 // the matching numDims. kHashMul mirrors the mixing constant in hashIdentity().
 //===----------------------------------------------------------------------===//
-static constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
 EJitSharedTaskPool::SharedLookup
 EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
@@ -611,12 +759,12 @@ EJitSharedTaskPool::cacheLookup0D(uint32_t funcIndex) {
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 0)
       continue;
@@ -641,12 +789,12 @@ EJitSharedTaskPool::cacheLookup1D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 1)
       continue;
@@ -677,12 +825,12 @@ EJitSharedTaskPool::cacheLookup2D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 2)
       continue;
@@ -719,12 +867,12 @@ EJitSharedTaskPool::cacheLookup3D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 3)
       continue;
@@ -768,12 +916,12 @@ EJitSharedTaskPool::cacheLookup4D(uint32_t funcIndex, uint32_t dim0,
   uint32_t curGen = state_->generation.loadAcquire();
   for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
     EJitSharedCacheSlot &Slot = B.slots[s];
+    if (Slot.identityHash != key)
+      continue; // plain-load fast reject before the acquiring state load.
     if (Slot.state.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedSlotState::Ready))
       continue;
     if (Slot.generation != curGen)
-      continue;
-    if (Slot.identityHash != key)
       continue;
     if (Slot.funcIndex != funcIndex || Slot.numDims != 4)
       continue;
@@ -1420,7 +1568,7 @@ EJitSharedTaskPool::tryCacheHit0D(uint32_t funcIndex) {
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  return classifyHit(cacheLookupSeq(funcIndex, nullptr, 0));
+  return classifyHit(cacheLookupSeq0D(funcIndex));
 #else
   return classifyHit(cacheLookup0D(funcIndex));
 #endif
@@ -1442,8 +1590,7 @@ EJitSharedTaskPool::tryCacheHit1D(uint32_t funcIndex, uint32_t dim0,
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  const EJitDimPair d1[1] = {{dim0, inst0}};
-  return classifyHit(cacheLookupSeq(funcIndex, d1, 1));
+  return classifyHit(cacheLookupSeq1D(funcIndex, dim0, inst0));
 #else
   return classifyHit(cacheLookup1D(funcIndex, dim0, inst0));
 #endif
@@ -1466,8 +1613,7 @@ EJitSharedTaskPool::tryCacheHit2D(uint32_t funcIndex, uint32_t dim0,
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  const EJitDimPair d2[2] = {{dim0, inst0}, {dim1, inst1}};
-  return classifyHit(cacheLookupSeq(funcIndex, d2, 2));
+  return classifyHit(cacheLookupSeq2D(funcIndex, dim0, inst0, dim1, inst1));
 #else
   return classifyHit(cacheLookup2D(funcIndex, dim0, inst0, dim1, inst1));
 #endif

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -58,6 +58,19 @@ static cl::opt<bool> EJitWrapperTiming(
     cl::desc("Emit diagnostic timing probes around taskpool lookup, indirect "
              "JIT call, and read-token release in ejit_entry wrappers"));
 
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE. When set, a 0/1/2-dimension
+// ejit_entry wrapper calls a thin funcIndex-only cache-hit entry instead of
+// the corresponding fixed-dimension entry. Dimension scalars are retained by
+// the 1D/2D ABI only for the miss path; a hit reads only funcIndex. Default
+// OFF: the wrapper IR is byte-for-byte unchanged. The runtime symbols exist in
+// an
+// EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP build (shared taskpool + NO_RECLAIM); do not
+// enable this for a production board image.
+static cl::opt<bool> EJitWrapperBenchFuncIndexOnly(
+    "ejit-wrapper-bench-funcindex-only", cl::init(false), cl::Hidden,
+    cl::desc("BENCHMARK ONLY / UNSAFE FOR GENERAL USE: emit the funcIndex-only "
+             "cache-hit entries for 0/1/2-dim ejit_entry wrappers"));
+
 // Wrapper generation now unconditionally uses the unified taskpool API
 // (ejit_taskpool_compile_or_get + ejit_taskpool_release_read). Both Sync
 // and Async modes are runtime-configurable — the AOT wrapper code is
@@ -496,9 +509,15 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // fixed 3D/4D C APIs still exist and are semantically correct for direct
     // callers; the wrapper just does not select them.
     bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
+    // BENCHMARK ONLY / UNSAFE FOR GENERAL USE. 0/1/2-dim entries may call a
+    // thin funcIndex-only hit entry. The 1D/2D scalar dimensions are consumed
+    // only after a direct-hint miss, preserving normal compile semantics.
+    bool UseFuncOnly = EJitWrapperBenchFuncIndexOnly && DimCount <= 2;
+    if (UseFuncOnly)
+      UseFixed = false;
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
     auto *I64Ty = Type::getInt64Ty(Ctx);
-    Value *DimsAlloca = UseFixed
+    Value *DimsAlloca = (UseFixed || UseFuncOnly)
                             ? nullptr
                             : Builder.CreateAlloca(ArrayType::get(DimPairTy, 4),
                                                    nullptr, "ejit_dims");
@@ -576,6 +595,30 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       FunctionCallee FixedFn = M.getOrInsertFunction(
           FixedNames[DimCount], FunctionType::get(I32Ty, ParamTys, false));
       Status = Builder.CreateCall(FixedFn, Args);
+    } else if (UseFuncOnly) {
+      // BENCHMARK ONLY / UNSAFE FOR GENERAL USE.
+      static const char *const FuncOnlyNames[] = {
+          FN_TASKPOOL_COMPILE_OR_GET_FUNC_ONLY,
+          FN_TASKPOOL_COMPILE_OR_GET_FUNC_ONLY_1D,
+          FN_TASKPOOL_COMPILE_OR_GET_FUNC_ONLY_2D};
+      SmallVector<Type *, 8> ParamTys;
+      SmallVector<Value *, 8> Args;
+      ParamTys.push_back(I32Ty);
+      Args.push_back(FuncIdx);
+      for (unsigned I = 0; I < DimCount; ++I) {
+        ParamTys.push_back(I32Ty);
+        ParamTys.push_back(I32Ty);
+        Args.push_back(emitDimTypeVal(I));
+        Args.push_back(emitInstanceVal(I));
+      }
+      ParamTys.push_back(PtrTy);
+      ParamTys.push_back(PtrTy);
+      Args.push_back(OutFnArg);
+      Args.push_back(OutBucketArg);
+      FunctionCallee FuncOnlyFn = M.getOrInsertFunction(
+          FuncOnlyNames[DimCount],
+          FunctionType::get(I32Ty, ParamTys, false));
+      Status = Builder.CreateCall(FuncOnlyFn, Args);
     } else {
       for (unsigned I = 0; I < DimCount; ++I) {
         Value *Idxs[] = {ConstantInt::get(I32Ty, 0),

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-funcindex-only.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-funcindex-only.ll
@@ -1,0 +1,58 @@
+; BENCHMARK ONLY / UNSAFE FOR GENERAL USE: the -ejit-wrapper-bench-funcindex-only
+; hidden option makes 0/1/2-dim ejit_entry wrappers call thin funcIndex-only
+; cache-hit entries. The 1D/2D forms retain scalar dimensions only for a true
+; miss. Default (option OFF) wrapper IR is unchanged and uses fixed-dimension
+; entries — this test pins both modes.
+;
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck --check-prefix=DEFAULT %s
+; RUN: opt -passes=ejit-wrapper-gen -ejit-wrapper-bench-funcindex-only -S %s \
+; RUN:   | FileCheck --check-prefix=FUNCONLY %s
+
+define i32 @zero_dim_entry(i32 %n) !ejit.metadata !0 {
+entry:
+  ret i32 %n
+}
+
+define i32 @one_dim_entry(i32 %cell) !ejit.metadata !1 {
+entry:
+  ret i32 %cell
+}
+
+define i32 @two_dim_entry(i32 %cell, i32 %trp) !ejit.metadata !2 {
+entry:
+  %sum = add i32 %cell, %trp
+  ret i32 %sum
+}
+
+@cell_data = global i32 0, !ejit.metadata !10
+@trp_data = global i32 0, !ejit.metadata !11
+
+!0 = distinct !{!{!"ejit_entry"}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!2 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
+!11 = distinct !{!{!"ejit_period_arr", !"trp", i32 32}}
+
+; Default: the 0D fixed-dimension entry is emitted; the funcIndex-only entry is
+; never referenced (byte-for-byte the prior behavior).
+; DEFAULT-LABEL: define i32 @zero_dim_entry(i32 %n)
+; DEFAULT: jit_call:
+; DEFAULT: call i32 @ejit_taskpool_compile_or_get_0d(i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+; DEFAULT-NOT: @ejit_taskpool_compile_or_get_func_only
+; DEFAULT-LABEL: define i32 @one_dim_entry(i32 %cell)
+; DEFAULT: call i32 @ejit_taskpool_compile_or_get_1d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+; DEFAULT-LABEL: define i32 @two_dim_entry(i32 %cell, i32 %trp)
+; DEFAULT: call i32 @ejit_taskpool_compile_or_get_2d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+
+; Option ON: the funcIndex-only entry is emitted instead; the 0D fixed entry is
+; not referenced.
+; FUNCONLY-LABEL: define i32 @zero_dim_entry(i32 %n)
+; FUNCONLY: jit_call:
+; FUNCONLY: call i32 @ejit_taskpool_compile_or_get_func_only(i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+; FUNCONLY-NOT: @ejit_taskpool_compile_or_get_0d
+; FUNCONLY-LABEL: define i32 @one_dim_entry(i32 %cell)
+; FUNCONLY: call i32 @ejit_taskpool_compile_or_get_func_only_1d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+; FUNCONLY-NOT: @ejit_taskpool_compile_or_get_1d
+; FUNCONLY-LABEL: define i32 @two_dim_entry(i32 %cell, i32 %trp)
+; FUNCONLY: call i32 @ejit_taskpool_compile_or_get_func_only_2d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+; FUNCONLY-NOT: @ejit_taskpool_compile_or_get_2d

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -138,15 +138,16 @@ if(EJIT_BUILD_CACHE_QUERY_BENCH)
     EJIT_SRE_TASKPOOL
     EJIT_SRE_SHARED_TASKPOOL
     EJIT_SRE_TASKPOOL_TESTING
+    EJIT_SRE_SHARED_CODE_POINTERS
     EJIT_SRE_TASKPOOL_BUCKETS=32
     EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
     )
-  # Opt-in: build the benchmark with the load-only NO_RECLAIM seqlock hit path
-  # + cross-core code sharing (so peer hits and the fixed-dim seqlock lookups
-  # are exercised), mirroring EJIT_TEST_NO_RECLAIM above.
+  # Opt-in: build the benchmark with the load-only NO_RECLAIM seqlock hit path.
+  # Cross-core code sharing stays enabled in both variants so token and
+  # NO_RECLAIM measurements exercise the same peer-hit workload.
   if(EJIT_TEST_NO_RECLAIM)
     target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
-      EJIT_SRE_TASKPOOL_NO_RECLAIM
-      EJIT_SRE_SHARED_CODE_POINTERS)
+      EJIT_SRE_TASKPOOL_NO_RECLAIM)
   endif()
+  target_link_libraries(EJITSharedCacheQueryBench PRIVATE ${LLVM_PTHREAD_LIB})
 endif()

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -117,3 +117,36 @@ add_custom_target(check-ejit-shared-taskpool
   COMMENT "Running EmbeddedJIT cross-core shared taskpool unit tests"
   USES_TERMINAL
   )
+
+# Optional cache-query microbenchmark (NOT a gtest binary: standalone main()).
+# Off by default so it never bloats normal test builds. Enable with
+# -DEJIT_BUILD_CACHE_QUERY_BENCH=ON to build a host-runnable binary that prints a
+# machine-readable table of the 0D/1D/2D owner/peer cache-hit query cost by slot
+# depth (drive it under `perf stat -e instructions` for per-hit attribution).
+# Links only the shared-taskpool sources + platform, like the tests above.
+option(EJIT_BUILD_CACHE_QUERY_BENCH
+  "Build the EJIT shared taskpool cache-query microbenchmark" OFF)
+if(EJIT_BUILD_CACHE_QUERY_BENCH)
+  add_llvm_executable(EJITSharedCacheQueryBench
+    EJitSharedCacheQueryBench.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp
+
+    PARTIAL_SOURCES_INTENDED
+    )
+  target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
+    EJIT_SRE_TASKPOOL
+    EJIT_SRE_SHARED_TASKPOOL
+    EJIT_SRE_TASKPOOL_TESTING
+    EJIT_SRE_TASKPOOL_BUCKETS=32
+    EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
+    )
+  # Opt-in: build the benchmark with the load-only NO_RECLAIM seqlock hit path
+  # + cross-core code sharing (so peer hits and the fixed-dim seqlock lookups
+  # are exercised), mirroring EJIT_TEST_NO_RECLAIM above.
+  if(EJIT_TEST_NO_RECLAIM)
+    target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
+      EJIT_SRE_TASKPOOL_NO_RECLAIM
+      EJIT_SRE_SHARED_CODE_POINTERS)
+  endif()
+endif()

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -104,10 +104,29 @@ target_compile_definitions(EJITSharedTaskPoolTests PRIVATE
 # path.
 option(EJIT_TEST_NO_RECLAIM
   "Build EJITSharedTaskPoolTests with EJIT_SRE_TASKPOOL_NO_RECLAIM" OFF)
-if(EJIT_TEST_NO_RECLAIM)
+if(EJIT_TEST_NO_RECLAIM OR EJIT_SRE_TASKPOOL_NO_RECLAIM)
   target_compile_definitions(EJITSharedTaskPoolTests PRIVATE
     EJIT_SRE_TASKPOOL_NO_RECLAIM
     EJIT_SRE_SHARED_CODE_POINTERS)
+endif()
+
+# BENCHMARK ONLY / UNSAFE FOR GENERAL USE. Opt-in funcIndex-only cache-hit fast
+# path (a deliberately-cheating benchmark experiment). It is LEGAL ONLY together
+# with the cross-core shared taskpool + the NO_RECLAIM never-reclaim code pool.
+# Tests may get NO_RECLAIM from the test-only switch above or the product
+# EJIT_SRE_TASKPOOL_NO_RECLAIM option. Any other combination is a hard
+# configure-time error. Off by default: normal builds are unchanged.
+if(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+  if(NOT EJIT_TEST_NO_RECLAIM AND NOT EJIT_SRE_TASKPOOL_NO_RECLAIM)
+    message(FATAL_ERROR
+      "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP (BENCHMARK ONLY / UNSAFE FOR GENERAL "
+      "USE) requires EJIT_TEST_NO_RECLAIM=ON or "
+      "EJIT_SRE_TASKPOOL_NO_RECLAIM=ON. Reconfigure with one of those options "
+      "or disable "
+      "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP.")
+  endif()
+  target_compile_definitions(EJITSharedTaskPoolTests PRIVATE
+    EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
 endif()
 
 # Convenience target: build + run only the cross-core shared taskpool tests.
@@ -145,9 +164,17 @@ if(EJIT_BUILD_CACHE_QUERY_BENCH)
   # Opt-in: build the benchmark with the load-only NO_RECLAIM seqlock hit path.
   # Cross-core code sharing stays enabled in both variants so token and
   # NO_RECLAIM measurements exercise the same peer-hit workload.
-  if(EJIT_TEST_NO_RECLAIM)
+  if(EJIT_TEST_NO_RECLAIM OR EJIT_SRE_TASKPOOL_NO_RECLAIM)
     target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
       EJIT_SRE_TASKPOOL_NO_RECLAIM)
+  endif()
+  # BENCHMARK ONLY / UNSAFE FOR GENERAL USE: build the benchmark with the
+  # funcIndex-only fast path so its mt0dfunconly / single0dfunconly modes are
+  # available. Enforced above to require EJIT_TEST_NO_RECLAIM (shared taskpool +
+  # NO_RECLAIM), so the fast path's preconditions hold.
+  if(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+    target_compile_definitions(EJITSharedCacheQueryBench PRIVATE
+      EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
   endif()
   target_link_libraries(EJITSharedCacheQueryBench PRIVATE ${LLVM_PTHREAD_LIB})
 endif()

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
@@ -1,0 +1,288 @@
+//===-- EJitSharedCacheQueryBench.cpp - cache-hit query microbenchmark ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  Deterministic, single-thread microbenchmark + slot-depth diagnostics for the
+//  cross-core SHARED taskpool cache-hit query path (spec §5.2 steps 0-1). It is
+//  NOT a gtest binary: it has its own main(), links only the shared-taskpool
+//  sources + EJitSharedPlatform, and prints a machine-readable table so an
+//  external harness (perf stat, this file's own cycle counter) can attribute
+//  instructions/cycles per hit.
+//
+//  What it measures, per the audit requirements:
+//    * 0D / 1D / 2D owner-core cache hit
+//    * hit slot depth 0, 1, 5, 15 (the linear 16-slot bucket scan)
+//    * peer-core hit (code sharing on, execute-permission already memoized)
+//    * a slot-depth histogram for a synthetic mixed workload
+//
+//  Slot depth is controlled deterministically: 0D identities whose funcIndex is
+//  a multiple of kEJitSharedCacheBuckets (32) all hash to bucket 0 and fill its
+//  slots 0,1,2,... in publish order (cachePublish uses first-empty), so the Nth
+//  published collider lands at slot N.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <memory>
+#include <vector>
+
+using namespace llvm::ejit;
+
+namespace {
+
+// Deterministic, non-null "compiled code" pointer derived from funcIndex. Never
+// executed — only cached/compared/returned.
+void *codeFor(uint32_t funcIndex) {
+  return reinterpret_cast<void *>(0x100000ull +
+                                  static_cast<uintptr_t>(funcIndex) * 64u);
+}
+
+bool benchCompile(void * /*ctx*/, const EJitCompileRequest &req, void **outFn) {
+  *outFn = codeFor(req.funcIndex);
+  return true;
+}
+
+// Owner-side resolver: hand back a fixed 2MiB pool range so peer preparation
+// (4K/2M) and codeStart/codeSize metadata are exercised.
+struct RangeCtx {
+  uintptr_t poolBase = 0x40000000ull;
+  uint64_t poolSize = 0x200000ull;
+  uintptr_t codeStart = 0x40000000ull;
+  uint64_t codeSize = 64;
+  uint32_t poolId = 0;
+};
+bool benchCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
+  auto *r = static_cast<RangeCtx *>(ctx);
+  out->fnPtr = const_cast<void *>(fnPtr);
+  out->codeStart = r->codeStart;
+  out->codeSize = r->codeSize;
+  out->poolBase = r->poolBase;
+  out->poolSize = r->poolSize;
+  out->poolId = r->poolId;
+  return true;
+}
+
+// Peer execute-permission preparation always succeeds in this host harness.
+bool benchPrepareCode(void * /*ctx*/, const void * /*fnPtr*/) { return true; }
+
+uint64_t nowNs() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ull +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+
+// Global sink so the compiler cannot elide the looked-up pointer.
+volatile uintptr_t gSink = 0;
+
+struct Bench {
+  std::unique_ptr<EJitSharedTaskPoolState> state;
+  EJitSharedTaskPool pool;
+  RangeCtx range;
+
+  void bringUpOwner(bool codeSharing) {
+    EJitCoreId::resetForTest();
+    EJitCoreId::setCurrentForTest(0);
+    state.reset(new EJitSharedTaskPoolState());
+    pool.bind(state.get());
+    pool.setCompiler(&benchCompile, nullptr);
+    pool.setMode(EJitCompileMode::Async);
+    pool.setCodeSharingEnabled(codeSharing);
+    pool.setCodeRangeProvider(&benchCodeRange, &range);
+    pool.setPrepareCodeCallback(&benchPrepareCode, nullptr);
+    if (pool.init() != EJitSharedTaskPool::InitResult::BecameOwner) {
+      std::fprintf(stderr, "owner election failed\n");
+      std::exit(1);
+    }
+  }
+
+  // Publish one 0D identity on the owner core (compile inline via Async enqueue
+  // + pollOne).
+  void publish0D(uint32_t funcIndex) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.compileOrGet(funcIndex, nullptr, 0, codeFor(funcIndex));
+    pool.pollOne();
+  }
+  void publish1D(uint32_t funcIndex, uint32_t d0, uint32_t i0) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    EJitDimPair dims[1] = {{d0, i0}};
+    pool.compileOrGet(funcIndex, dims, 1, codeFor(funcIndex));
+    pool.pollOne();
+  }
+  void publish2D(uint32_t funcIndex, uint32_t d0, uint32_t i0, uint32_t d1,
+                 uint32_t i1) {
+    EJitCoreId::setCurrentForTest(0);
+    pool.setInstanceEnabled(d0, i0, true);
+    pool.setInstanceEnabled(d1, i1, true);
+    EJitDimPair dims[2] = {{d0, i0}, {d1, i1}};
+    pool.compileOrGet(funcIndex, dims, 2, codeFor(funcIndex));
+    pool.pollOne();
+  }
+};
+
+// --- 0D slot-depth sweep -----------------------------------------------------
+// Publish (depth+1) 0D colliders into bucket 0, then hammer the deepest one.
+uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(/*codeSharing=*/peer);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  uint32_t targetFunc = 0;
+  for (uint32_t d = 0; d <= depth; ++d) {
+    uint32_t fi = d * kB; // all hash to bucket 0
+    B.publish0D(fi);
+    targetFunc = fi; // deepest published so far
+  }
+  uint32_t core = 0;
+  if (peer) {
+    core = 1;
+    EJitCoreId::setCurrentForTest(core);
+    // Warm the memoized execute-permission bit for this peer core.
+    auto w = B.pool.tryCacheHit0D(targetFunc);
+    if (w.hasReadToken)
+      B.pool.releaseRead(w.bucketIndex);
+  }
+  EJitCoreId::setCurrentForTest(core);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit0D(targetFunc);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+uint64_t bench1D(uint32_t depth, uint64_t iters, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(false);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  // 1D identities colliding into one bucket: vary funcIndex by multiples that
+  // keep the same hash bucket is nontrivial, so instead vary instanceId and
+  // accept the natural bucket; publish depth+1 entries and hammer the last.
+  uint32_t targetFunc = 7;
+  for (uint32_t d = 0; d <= depth; ++d) {
+    B.publish1D(targetFunc, 0, d); // same funcIndex, distinct instanceId
+  }
+  // The deepest is instanceId=depth; ensure it is enabled and query it.
+  EJitCoreId::setCurrentForTest(0);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit1D(targetFunc, 0, depth);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+uint64_t bench2D(uint64_t iters, double *nsPerHit) {
+  Bench B;
+  B.bringUpOwner(false);
+  uint32_t targetFunc = 9;
+  B.publish2D(targetFunc, 0, 1, 1, 2);
+  EJitCoreId::setCurrentForTest(0);
+  uint64_t t0 = nowNs();
+  uint64_t hits = 0;
+  for (uint64_t i = 0; i < iters; ++i) {
+    auto r = B.pool.tryCacheHit2D(targetFunc, 0, 1, 1, 2);
+    gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
+    if (r.status == EJitCompileOrGetStatus::CacheHit)
+      ++hits;
+    if (r.hasReadToken)
+      B.pool.releaseRead(r.bucketIndex);
+  }
+  uint64_t t1 = nowNs();
+  *nsPerHit = double(t1 - t0) / double(iters);
+  return hits;
+}
+
+void runTable(uint64_t iters) {
+  std::printf("# config,dim,slotDepth,core,nsPerHit,hits/iters\n");
+  double ns;
+  uint64_t h;
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench0D(depth, iters, /*peer=*/false, &ns);
+    std::printf("owner0D,0,%u,0,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench0D(depth, iters, /*peer=*/true, &ns);
+    std::printf("peer0D,0,%u,1,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  for (uint32_t depth : {0u, 1u, 5u, 15u}) {
+    h = bench1D(depth, iters, &ns);
+    std::printf("owner1D,1,%u,0,%.3f,%llu/%llu\n", depth, ns,
+                (unsigned long long)h, (unsigned long long)iters);
+  }
+  h = bench2D(iters, &ns);
+  std::printf("owner2D,2,0,0,%.3f,%llu/%llu\n", ns, (unsigned long long)h,
+              (unsigned long long)iters);
+}
+
+} // namespace
+
+// Usage:
+//   bench                 -> full table, 20M iters each
+//   bench <iters>         -> full table with given iters
+//   bench single0d <d> <iters>   -> ONE tight loop (for perf stat attribution)
+//   bench single0dpeer <d> <iters>
+//   bench single1d <d> <iters>
+//   bench single2d <iters>
+int main(int argc, char **argv) {
+  uint64_t iters = 20000000ull;
+  if (argc >= 2 && std::strncmp(argv[1], "single", 6) == 0) {
+    double ns;
+    uint64_t h = 0;
+    const char *what = argv[1];
+    if (std::strcmp(what, "single0d") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, false, &ns);
+    } else if (std::strcmp(what, "single0dpeer") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, true, &ns);
+    } else if (std::strcmp(what, "single1d") == 0) {
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench1D(d, iters, &ns);
+    } else if (std::strcmp(what, "single2d") == 0) {
+      iters = argc >= 3 ? strtoull(argv[2], nullptr, 10) : iters;
+      h = bench2D(iters, &ns);
+    } else {
+      std::fprintf(stderr, "unknown single mode %s\n", what);
+      return 2;
+    }
+    std::printf("%s ns/hit=%.3f hits=%llu/%llu sink=%llu\n", what, ns,
+                (unsigned long long)h, (unsigned long long)iters,
+                (unsigned long long)gSink);
+    return 0;
+  }
+  if (argc >= 2)
+    iters = strtoull(argv[1], nullptr, 10);
+  runTable(iters);
+  std::printf("# sink=%llu\n", (unsigned long long)gSink);
+  return 0;
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
@@ -28,12 +28,15 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <memory>
+#include <thread>
 #include <vector>
 
 using namespace llvm::ejit;
@@ -217,6 +220,131 @@ uint64_t bench2D(uint64_t iters, double *nsPerHit) {
   return hits;
 }
 
+struct alignas(64) ThreadResult {
+  uint64_t elapsedNs = 0;
+  uint64_t hits = 0;
+  uintptr_t sink = 0;
+};
+
+struct alignas(64) StartGate {
+  std::atomic<uint32_t> ready{0};
+  std::atomic<bool> go{false};
+};
+
+// Real-thread contention test. In sameIdentity mode every thread reads the
+// same slot in bucket 0, mirroring many SRE cores calling one hot
+// specialization. In spread mode each thread reads a different 0D identity in
+// a different bucket, isolating thread/runtime overhead from bucket-line
+// contention. Each thread has its own sink/result cache line so the harness
+// does not add an unrelated shared-write bottleneck.
+void benchMultiThread0D(uint32_t threadCount, uint64_t iters, bool sameIdentity,
+                        uint32_t depth) {
+  if (threadCount == 0 || threadCount > 63 || depth >= kEJitSharedCacheSlots) {
+    std::fprintf(stderr, "invalid threads/depth: threads=%u depth=%u\n",
+                 threadCount, depth);
+    std::exit(2);
+  }
+  if (!sameIdentity && threadCount >= kEJitSharedCacheBuckets) {
+    std::fprintf(stderr, "spread mode needs fewer than %u threads\n",
+                 kEJitSharedCacheBuckets);
+    std::exit(2);
+  }
+
+  Bench B;
+  B.bringUpOwner(/*codeSharing=*/true);
+  std::vector<uint32_t> targetFuncs(threadCount);
+  if (sameIdentity) {
+    uint32_t target = 0;
+    for (uint32_t d = 0; d <= depth; ++d) {
+      target = d * kEJitSharedCacheBuckets;
+      B.publish0D(target);
+    }
+    std::fill(targetFuncs.begin(), targetFuncs.end(), target);
+  } else {
+    for (uint32_t t = 0; t < threadCount; ++t) {
+      targetFuncs[t] = t + 1u; // buckets 1..threadCount for <=31 threads.
+      B.publish0D(targetFuncs[t]);
+    }
+  }
+
+  StartGate gate;
+  std::unique_ptr<ThreadResult[]> results(new ThreadResult[threadCount]);
+  std::vector<std::thread> threads;
+  threads.reserve(threadCount);
+
+  for (uint32_t t = 0; t < threadCount; ++t) {
+    threads.emplace_back([&, t] {
+      // Core 0 owns the pool. Host workers model peer cores 1..threadCount.
+      EJitCoreId::setCurrentForTest(t + 1u);
+      const uint32_t target = targetFuncs[t];
+
+      // Prepare/memoize this peer's execute permission before timing.
+      auto warm = B.pool.tryCacheHit0D(target);
+      if (warm.hasReadToken)
+        B.pool.releaseRead(warm.bucketIndex);
+      bool warmOk = warm.status == EJitCompileOrGetStatus::CacheHit;
+
+      gate.ready.fetch_add(1, std::memory_order_release);
+      while (!gate.go.load(std::memory_order_acquire))
+        std::this_thread::yield();
+      if (!warmOk)
+        return;
+
+      uint64_t hits = 0;
+      uintptr_t sink = 0;
+      uint64_t begin = nowNs();
+      for (uint64_t i = 0; i < iters; ++i) {
+        auto r = B.pool.tryCacheHit0D(target);
+        sink += reinterpret_cast<uintptr_t>(r.fnPtr);
+        if (r.status == EJitCompileOrGetStatus::CacheHit)
+          ++hits;
+        if (r.hasReadToken)
+          B.pool.releaseRead(r.bucketIndex);
+      }
+      results[t].elapsedNs = nowNs() - begin;
+      results[t].hits = hits;
+      results[t].sink = sink;
+    });
+  }
+
+  while (gate.ready.load(std::memory_order_acquire) != threadCount)
+    std::this_thread::yield();
+  uint64_t wallBegin = nowNs();
+  gate.go.store(true, std::memory_order_release);
+  for (std::thread &T : threads)
+    T.join();
+  uint64_t wallNs = nowNs() - wallBegin;
+
+  uint64_t totalHits = 0;
+  uintptr_t sink = 0;
+  std::vector<double> perThreadNs;
+  perThreadNs.reserve(threadCount);
+  for (uint32_t t = 0; t < threadCount; ++t) {
+    totalHits += results[t].hits;
+    sink ^= results[t].sink;
+    perThreadNs.push_back(double(results[t].elapsedNs) / double(iters));
+  }
+  std::sort(perThreadNs.begin(), perThreadNs.end());
+  double median = perThreadNs[threadCount / 2u];
+  double throughputMHits =
+      double(totalHits) * 1000.0 / static_cast<double>(wallNs);
+
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+  const char *discipline = "noreclaim-seqlock";
+#else
+  const char *discipline = "read-token";
+#endif
+  std::printf("mt0d mode=%s discipline=%s threads=%u depth=%u "
+              "iters/thread=%llu min=%.3f median=%.3f max=%.3f ns/hit "
+              "throughput=%.3f Mhit/s hits=%llu/%llu sink=%llu\n",
+              sameIdentity ? "same" : "spread", discipline, threadCount,
+              sameIdentity ? depth : 0u, (unsigned long long)iters,
+              perThreadNs.front(), median, perThreadNs.back(), throughputMHits,
+              (unsigned long long)totalHits,
+              (unsigned long long)(iters * threadCount),
+              (unsigned long long)sink);
+}
+
 void runTable(uint64_t iters) {
   std::printf("# config,dim,slotDepth,core,nsPerHit,hits/iters\n");
   double ns;
@@ -250,8 +378,25 @@ void runTable(uint64_t iters) {
 //   bench single0dpeer <d> <iters>
 //   bench single1d <d> <iters>
 //   bench single2d <iters>
+//   bench mt0dsame <iters/thread> [threads=16] [slotDepth=0]
+//   bench mt0dspread <iters/thread> [threads=16]
 int main(int argc, char **argv) {
   uint64_t iters = 20000000ull;
+  if (argc >= 2 && std::strncmp(argv[1], "mt0d", 4) == 0) {
+    iters = argc >= 3 ? strtoull(argv[2], nullptr, 10) : 1000000ull;
+    uint32_t threadCount =
+        argc >= 4 ? (uint32_t)strtoul(argv[3], nullptr, 10) : 16u;
+    if (std::strcmp(argv[1], "mt0dsame") == 0) {
+      uint32_t depth = argc >= 5 ? (uint32_t)strtoul(argv[4], nullptr, 10) : 0u;
+      benchMultiThread0D(threadCount, iters, /*sameIdentity=*/true, depth);
+    } else if (std::strcmp(argv[1], "mt0dspread") == 0) {
+      benchMultiThread0D(threadCount, iters, /*sameIdentity=*/false, 0);
+    } else {
+      std::fprintf(stderr, "unknown multi-thread mode %s\n", argv[1]);
+      return 2;
+    }
+    return 0;
+  }
   if (argc >= 2 && std::strncmp(argv[1], "single", 6) == 0) {
     double ns;
     uint64_t h = 0;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedCacheQueryBench.cpp
@@ -55,6 +55,22 @@ bool benchCompile(void * /*ctx*/, const EJitCompileRequest &req, void **outFn) {
   return true;
 }
 
+// 0D cache-hit lookup selector. When funcOnly is set (only meaningful in an
+// EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP build) it drives the BENCHMARK ONLY /
+// UNSAFE FOR GENERAL USE funcIndex-only fast path; otherwise the standard 0D
+// fixed-dimension cache-hit path. Both return the same CompileOrGetResult
+// shape, so callers stay identical.
+inline EJitSharedTaskPool::CompileOrGetResult
+lookup0D(EJitSharedTaskPool &pool, uint32_t funcIndex, bool funcOnly) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+  if (funcOnly)
+    return pool.tryCacheHitFuncIndexOnly(funcIndex);
+#else
+  (void)funcOnly;
+#endif
+  return pool.tryCacheHit0D(funcIndex);
+}
+
 // Owner-side resolver: hand back a fixed 2MiB pool range so peer preparation
 // (4K/2M) and codeStart/codeSize metadata are exercised.
 struct RangeCtx {
@@ -136,7 +152,8 @@ struct Bench {
 
 // --- 0D slot-depth sweep -----------------------------------------------------
 // Publish (depth+1) 0D colliders into bucket 0, then hammer the deepest one.
-uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit) {
+uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit,
+                 bool funcOnly = false) {
   Bench B;
   B.bringUpOwner(/*codeSharing=*/peer);
   const uint32_t kB = kEJitSharedCacheBuckets;
@@ -150,7 +167,8 @@ uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit) {
   if (peer) {
     core = 1;
     EJitCoreId::setCurrentForTest(core);
-    // Warm the memoized execute-permission bit for this peer core.
+    // Warm the memoized execute-permission bit for this peer core via the full
+    // path (prepares), so the timed funcIndex-only / 0D path is a warm hit.
     auto w = B.pool.tryCacheHit0D(targetFunc);
     if (w.hasReadToken)
       B.pool.releaseRead(w.bucketIndex);
@@ -159,7 +177,7 @@ uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit) {
   uint64_t t0 = nowNs();
   uint64_t hits = 0;
   for (uint64_t i = 0; i < iters; ++i) {
-    auto r = B.pool.tryCacheHit0D(targetFunc);
+    auto r = lookup0D(B.pool, targetFunc, funcOnly);
     gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
     if (r.status == EJitCompileOrGetStatus::CacheHit)
       ++hits;
@@ -171,10 +189,16 @@ uint64_t bench0D(uint32_t depth, uint64_t iters, bool peer, double *nsPerHit) {
   return hits;
 }
 
-uint64_t bench1D(uint32_t depth, uint64_t iters, double *nsPerHit) {
+uint64_t bench1D(uint32_t depth, uint64_t iters, double *nsPerHit,
+                 bool funcOnly = false) {
+  if (funcOnly && depth != 0) {
+    std::fprintf(stderr,
+                 "funcIndex-only 1D benchmark requires slotDepth=0: distinct "
+                 "specializations deliberately poison the hint\n");
+    std::exit(2);
+  }
   Bench B;
   B.bringUpOwner(false);
-  const uint32_t kB = kEJitSharedCacheBuckets;
   // 1D identities colliding into one bucket: vary funcIndex by multiples that
   // keep the same hash bucket is nontrivial, so instead vary instanceId and
   // accept the natural bucket; publish depth+1 entries and hammer the last.
@@ -187,7 +211,13 @@ uint64_t bench1D(uint32_t depth, uint64_t iters, double *nsPerHit) {
   uint64_t t0 = nowNs();
   uint64_t hits = 0;
   for (uint64_t i = 0; i < iters; ++i) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+    auto r = funcOnly ? B.pool.tryFuncIndexOnlyDirect(targetFunc)
+                      : B.pool.tryCacheHit1D(targetFunc, 0, depth);
+#else
+    (void)funcOnly;
     auto r = B.pool.tryCacheHit1D(targetFunc, 0, depth);
+#endif
     gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
     if (r.status == EJitCompileOrGetStatus::CacheHit)
       ++hits;
@@ -199,7 +229,7 @@ uint64_t bench1D(uint32_t depth, uint64_t iters, double *nsPerHit) {
   return hits;
 }
 
-uint64_t bench2D(uint64_t iters, double *nsPerHit) {
+uint64_t bench2D(uint64_t iters, double *nsPerHit, bool funcOnly = false) {
   Bench B;
   B.bringUpOwner(false);
   uint32_t targetFunc = 9;
@@ -208,7 +238,13 @@ uint64_t bench2D(uint64_t iters, double *nsPerHit) {
   uint64_t t0 = nowNs();
   uint64_t hits = 0;
   for (uint64_t i = 0; i < iters; ++i) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+    auto r = funcOnly ? B.pool.tryFuncIndexOnlyDirect(targetFunc)
+                      : B.pool.tryCacheHit2D(targetFunc, 0, 1, 1, 2);
+#else
+    (void)funcOnly;
     auto r = B.pool.tryCacheHit2D(targetFunc, 0, 1, 1, 2);
+#endif
     gSink += reinterpret_cast<uintptr_t>(r.fnPtr);
     if (r.status == EJitCompileOrGetStatus::CacheHit)
       ++hits;
@@ -238,7 +274,7 @@ struct alignas(64) StartGate {
 // contention. Each thread has its own sink/result cache line so the harness
 // does not add an unrelated shared-write bottleneck.
 void benchMultiThread0D(uint32_t threadCount, uint64_t iters, bool sameIdentity,
-                        uint32_t depth) {
+                        uint32_t depth, bool funcOnly = false) {
   if (threadCount == 0 || threadCount > 63 || depth >= kEJitSharedCacheSlots) {
     std::fprintf(stderr, "invalid threads/depth: threads=%u depth=%u\n",
                  threadCount, depth);
@@ -278,7 +314,8 @@ void benchMultiThread0D(uint32_t threadCount, uint64_t iters, bool sameIdentity,
       EJitCoreId::setCurrentForTest(t + 1u);
       const uint32_t target = targetFuncs[t];
 
-      // Prepare/memoize this peer's execute permission before timing.
+      // Prepare/memoize this peer's execute permission before timing via the
+      // full path (which prepares), so the timed loop is a warm hit.
       auto warm = B.pool.tryCacheHit0D(target);
       if (warm.hasReadToken)
         B.pool.releaseRead(warm.bucketIndex);
@@ -294,7 +331,7 @@ void benchMultiThread0D(uint32_t threadCount, uint64_t iters, bool sameIdentity,
       uintptr_t sink = 0;
       uint64_t begin = nowNs();
       for (uint64_t i = 0; i < iters; ++i) {
-        auto r = B.pool.tryCacheHit0D(target);
+        auto r = lookup0D(B.pool, target, funcOnly);
         sink += reinterpret_cast<uintptr_t>(r.fnPtr);
         if (r.status == EJitCompileOrGetStatus::CacheHit)
           ++hits;
@@ -334,6 +371,8 @@ void benchMultiThread0D(uint32_t threadCount, uint64_t iters, bool sameIdentity,
 #else
   const char *discipline = "read-token";
 #endif
+  if (funcOnly)
+    discipline = "funcindex-only";
   std::printf("mt0d mode=%s discipline=%s threads=%u depth=%u "
               "iters/thread=%llu min=%.3f median=%.3f max=%.3f ns/hit "
               "throughput=%.3f Mhit/s hits=%llu/%llu sink=%llu\n",
@@ -380,6 +419,14 @@ void runTable(uint64_t iters) {
 //   bench single2d <iters>
 //   bench mt0dsame <iters/thread> [threads=16] [slotDepth=0]
 //   bench mt0dspread <iters/thread> [threads=16]
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE (only in an
+// EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP build):
+//   bench single0dfunconly <d> <iters>
+//   bench single0dpeerfunconly <d> <iters>
+//   bench single1dfunconly <iters>
+//   bench single2dfunconly <iters>
+//   bench mt0dsamefunconly <iters/thread> [threads=16] [slotDepth=0]
+//   bench mt0dspreadfunconly <iters/thread> [threads=16]
 int main(int argc, char **argv) {
   uint64_t iters = 20000000ull;
   if (argc >= 2 && std::strncmp(argv[1], "mt0d", 4) == 0) {
@@ -391,6 +438,25 @@ int main(int argc, char **argv) {
       benchMultiThread0D(threadCount, iters, /*sameIdentity=*/true, depth);
     } else if (std::strcmp(argv[1], "mt0dspread") == 0) {
       benchMultiThread0D(threadCount, iters, /*sameIdentity=*/false, 0);
+    } else if (std::strcmp(argv[1], "mt0dsamefunconly") == 0) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+      uint32_t depth = argc >= 5 ? (uint32_t)strtoul(argv[4], nullptr, 10) : 0u;
+      benchMultiThread0D(threadCount, iters, /*sameIdentity=*/true, depth,
+                         /*funcOnly=*/true);
+#else
+      std::fprintf(stderr, "mt0dsamefunconly needs "
+                           "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP\n");
+      return 2;
+#endif
+    } else if (std::strcmp(argv[1], "mt0dspreadfunconly") == 0) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+      benchMultiThread0D(threadCount, iters, /*sameIdentity=*/false, 0,
+                         /*funcOnly=*/true);
+#else
+      std::fprintf(stderr, "mt0dspreadfunconly needs "
+                           "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP\n");
+      return 2;
+#endif
     } else {
       std::fprintf(stderr, "unknown multi-thread mode %s\n", argv[1]);
       return 2;
@@ -416,6 +482,44 @@ int main(int argc, char **argv) {
     } else if (std::strcmp(what, "single2d") == 0) {
       iters = argc >= 3 ? strtoull(argv[2], nullptr, 10) : iters;
       h = bench2D(iters, &ns);
+    } else if (std::strcmp(what, "single0dfunconly") == 0) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, /*peer=*/false, &ns, /*funcOnly=*/true);
+#else
+      std::fprintf(stderr, "single0dfunconly needs "
+                           "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP\n");
+      return 2;
+#endif
+    } else if (std::strcmp(what, "single0dpeerfunconly") == 0) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+      uint32_t d = argc >= 3 ? (uint32_t)strtoul(argv[2], nullptr, 10) : 0;
+      iters = argc >= 4 ? strtoull(argv[3], nullptr, 10) : iters;
+      h = bench0D(d, iters, /*peer=*/true, &ns, /*funcOnly=*/true);
+#else
+      std::fprintf(stderr, "single0dpeerfunconly needs "
+                           "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP\n");
+      return 2;
+#endif
+    } else if (std::strcmp(what, "single1dfunconly") == 0) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+      iters = argc >= 3 ? strtoull(argv[2], nullptr, 10) : iters;
+      h = bench1D(/*depth=*/0, iters, &ns, /*funcOnly=*/true);
+#else
+      std::fprintf(stderr, "single1dfunconly needs "
+                           "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP\n");
+      return 2;
+#endif
+    } else if (std::strcmp(what, "single2dfunconly") == 0) {
+#ifdef EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+      iters = argc >= 3 ? strtoull(argv[2], nullptr, 10) : iters;
+      h = bench2D(iters, &ns, /*funcOnly=*/true);
+#else
+      std::fprintf(stderr, "single2dfunconly needs "
+                           "EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP\n");
+      return 2;
+#endif
     } else {
       std::fprintf(stderr, "unknown single mode %s\n", what);
       return 2;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2620,4 +2620,310 @@ TEST_F(SharedTaskPoolTest, DISABLED_HotHitContendedBench) {
 }
 #endif // __aarch64__
 
+#if defined(EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP)
+//===----------------------------------------------------------------------===//
+// BENCHMARK ONLY / UNSAFE FOR GENERAL USE — funcIndex-only cache-hit fast path.
+//
+// These tests validate that the deliberately-cheating funcIndex-only path is
+// memory-safe and never mis-hits: it hits on a valid, current-generation,
+// funcIndex-matching Ready slot the caller may execute, and cleanly falls back
+// (never returns a stale/unexecutable pointer) on every other case. They only
+// build in an EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP configuration (which requires
+// the shared taskpool + NO_RECLAIM + shared code pointers).
+//===----------------------------------------------------------------------===//
+
+// Test 1: a direct funcIndex hit returns the correct fnPtr on the owner core.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_DirectHitReturnsCorrectFnPtr) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 7);
+  EJitCoreId::setCurrentForTest(0);
+  void *fn = nullptr;
+  EXPECT_TRUE(owner.funcIndexOnlyDirectHit(7, &fn));
+  EXPECT_EQ(fn, codeFor(7));
+
+  auto r = owner.tryCacheHitFuncIndexOnly(7);
+  EXPECT_TRUE(r.fastPathTerminal);
+  EXPECT_EQ(r.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(r.fnPtr, codeFor(7));
+}
+
+// Test 2: a hit does NOT consult the identity hash. Corrupt the slot's
+// identityHash: the funcIndex-only path still hits, while the generic identity
+// lookup (which fast-rejects on identityHash) now misses.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_HitDoesNotUseIdentityHash) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 8);
+  EJitCoreId::setCurrentForTest(0);
+  EJitSharedCacheSlot *slot = findReadySlot(8);
+  ASSERT_NE(slot, nullptr);
+  slot->identityHash = 0xDEADBEEFDEADBEEFull; // corrupt: never equals key(8)
+
+  void *fn = nullptr;
+  EXPECT_TRUE(owner.funcIndexOnlyDirectHit(8, &fn));
+  EXPECT_EQ(fn, codeFor(8));
+  // The generic identity lookup fast-rejects on identityHash -> clean miss.
+  auto generic = owner.tryCacheHit0D(8);
+  EXPECT_NE(generic.status, EJitCompileOrGetStatus::CacheHit);
+}
+
+// Test 3: a hit does NOT read per-dimension versions. Publish a 1D entry (which
+// snapshots a version), corrupt the slot's versions, and confirm the
+// funcIndex-only path still hits, while the generic 1D lookup misses on the
+// version mismatch.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_HitDoesNotReadPerDimVersions) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  owner.setInstanceEnabled(0, 1, true);
+  EJitCoreId::setCurrentForTest(0);
+  EJitDimPair d1[1] = {dim(0, 1)};
+  ASSERT_EQ(owner.compileOrGet(50, d1, 1, codeFor(50)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EJitSharedCacheSlot *slot = findReadySlot(50);
+  ASSERT_NE(slot, nullptr);
+  slot->versions[0] = 0xC0FFEEu; // corrupt the snapshot version
+
+  void *fn = nullptr;
+  EXPECT_TRUE(owner.funcIndexOnlyDirectHit(50, &fn));
+  EXPECT_EQ(fn, codeFor(50));
+  // The generic 1D lookup compares versions -> clean miss on the corruption.
+  auto generic = owner.tryCacheHit1D(50, 0, 1);
+  EXPECT_NE(generic.status, EJitCompileOrGetStatus::CacheHit);
+}
+
+// Test 4: a slot whose funcIndex no longer matches the request is a clean
+// fallback (no mis-hit, no pointer).
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_FuncIndexMismatchCleanFallback) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 9);
+  EJitCoreId::setCurrentForTest(0);
+  EJitSharedCacheSlot *slot = findReadySlot(9);
+  ASSERT_NE(slot, nullptr);
+  slot->funcIndex = 999; // hint still points here, but funcIndex now differs
+
+  void *fn = reinterpret_cast<void *>(0x1);
+  EXPECT_FALSE(owner.funcIndexOnlyDirectHit(9, &fn));
+  EXPECT_EQ(fn, nullptr);
+}
+
+// Test 5: bumping the owner generation invalidates every existing hint.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_GenerationChangeInvalidatesHint) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 11);
+  EJitCoreId::setCurrentForTest(0);
+  void *fn = nullptr;
+  ASSERT_TRUE(owner.funcIndexOnlyDirectHit(11, &fn));
+
+  // A generation change (e.g. an owner re-init) makes the slot's stored
+  // generation stale, so the funcIndex-only path rejects it.
+  state_->generation.storeRelease(state_->generation.loadRelaxed() + 1);
+  fn = reinterpret_cast<void *>(0x1);
+  EXPECT_FALSE(owner.funcIndexOnlyDirectHit(11, &fn));
+  EXPECT_EQ(fn, nullptr);
+}
+
+// Test 6: after an in-place overwrite (recompile) the path returns the NEW
+// pointer, never the old one.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_OverwriteDoesNotReturnOldFnPtr) {
+  SeqCompiler seq;
+  EJitSharedTaskPool owner;
+  EJitCoreId::setCurrentForTest(0);
+  owner.bind(state_.get());
+  owner.setCompiler(&mockCompileSeq, &seq);
+  owner.setCodeSharingEnabled(true);
+  owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  owner.setInstanceEnabled(0, 1, true);
+
+  EJitDimPair d1[1] = {dim(0, 1)};
+  ASSERT_EQ(owner.compileOrGet(30, d1, 1, codeFor(30)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  void *oldFn = nullptr;
+  ASSERT_TRUE(owner.funcIndexOnlyDirectHit(30, &oldFn));
+  ASSERT_NE(oldFn, nullptr);
+
+  // Toggle off/on advances the version so the same identity recompiles into the
+  // SAME slot at a new address (SeqCompiler hands out distinct pointers).
+  owner.setInstanceEnabled(0, 1, false);
+  owner.setInstanceEnabled(0, 1, true);
+  ASSERT_EQ(owner.compileOrGet(30, d1, 1, codeFor(30)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  void *newFn = nullptr;
+  EXPECT_TRUE(owner.funcIndexOnlyDirectHit(30, &newFn));
+  EXPECT_NE(newFn, nullptr);
+  EXPECT_NE(newFn, oldFn); // never the retired pointer
+}
+
+// Test 7: an owner re-init clears the hint table; a stale hint cannot resolve.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_ReinitClearsHint) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 12);
+  EJitCoreId::setCurrentForTest(0);
+  void *fn = nullptr;
+  ASSERT_TRUE(owner.funcIndexOnlyDirectHit(12, &fn));
+
+  owner.ownerShutdown();
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_EQ(state_->funcHint[12].loadAcquire(), 0u); // cleared on reinit
+  fn = reinterpret_cast<void *>(0x1);
+  EXPECT_FALSE(owner.funcIndexOnlyDirectHit(12, &fn));
+  EXPECT_EQ(fn, nullptr);
+}
+
+// Test 8: a peer core that has NOT yet prepared execute permission gets NO
+// pointer from the fast path (it must fall back to the prepare path).
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_PeerNotPreparedReturnsNoPointer) {
+  PrepareLog plog;
+  EJitSharedTaskPool owner;
+  EJitCoreId::setCurrentForTest(0);
+  owner.bind(state_.get());
+  owner.setCompiler(&mockCompile, nullptr);
+  owner.setCodeSharingEnabled(true);
+  owner.setPrepareCodeCallback(&mockPrepareCode, &plog);
+  owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  publish(owner, 77);
+
+  EJitCoreId::setCurrentForTest(5); // cold peer core
+  void *fn = reinterpret_cast<void *>(0x1);
+  EXPECT_FALSE(owner.funcIndexOnlyDirectHit(77, &fn));
+  EXPECT_EQ(fn, nullptr);
+  EXPECT_TRUE(plog.cores.empty()); // fast path never ran a prepare callback
+}
+
+// Test 9: once a peer has prepared (memoized) execute permission, the fast path
+// hits directly without re-preparing.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_PeerPreparedHits) {
+  PrepareLog plog;
+  EJitSharedTaskPool owner;
+  EJitCoreId::setCurrentForTest(0);
+  owner.bind(state_.get());
+  owner.setCompiler(&mockCompile, nullptr);
+  owner.setCodeSharingEnabled(true);
+  owner.setPrepareCodeCallback(&mockPrepareCode, &plog);
+  owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  publish(owner, 78);
+
+  EJitCoreId::setCurrentForTest(6);
+  // Warm via the full path (prepares + memoizes this peer's permission).
+  auto warm = owner.tryCacheHit0D(78);
+  ASSERT_EQ(warm.status, EJitCompileOrGetStatus::CacheHit);
+  if (warm.hasReadToken)
+    owner.releaseRead(warm.bucketIndex);
+  ASSERT_EQ(plog.cores.size(), 1u);
+
+  void *fn = nullptr;
+  EXPECT_TRUE(owner.funcIndexOnlyDirectHit(78, &fn)); // now a direct hit
+  EXPECT_EQ(fn, codeFor(78));
+  EXPECT_EQ(plog.cores.size(), 1u); // no additional prepare
+}
+
+// Test 10: a NO_RECLAIM funcIndex-only hit takes no read token and performs no
+// RMW on the bucket reader counter.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_HitTakesNoReadToken) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  publish(owner, 13);
+  EJitCoreId::setCurrentForTest(0);
+  EJitSharedCacheSlot *slot = findReadySlot(13);
+  ASSERT_NE(slot, nullptr);
+  EJitSharedCacheBucket *bucket = nullptr;
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets && !bucket; ++b)
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s)
+      if (&state_->buckets[b].slots[s] == slot) {
+        bucket = &state_->buckets[b];
+        break;
+      }
+  ASSERT_NE(bucket, nullptr);
+  EXPECT_EQ(bucket->readers.loadAcquire(), 0u);
+
+  auto r = owner.tryCacheHitFuncIndexOnly(13);
+  EXPECT_EQ(r.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_FALSE(r.hasReadToken);
+  EXPECT_EQ(r.bucketIndex, kEJitSharedCacheBuckets); // out-of-range sentinel
+  EXPECT_EQ(bucket->readers.loadAcquire(), 0u);      // no reader RMW happened
+  owner.releaseRead(r.bucketIndex);                  // safe no-op on sentinel
+  EXPECT_EQ(bucket->readers.loadAcquire(), 0u);
+}
+
+// Test 11: an out-of-range funcIndex is a clean fallback and never indexes the
+// hint table out of bounds.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_OutOfRangeFuncIndexCleanFallback) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  void *fn = reinterpret_cast<void *>(0x1);
+  EXPECT_FALSE(owner.funcIndexOnlyDirectHit(kEJitSharedMaxFuncIndex, &fn));
+  EXPECT_EQ(fn, nullptr);
+  fn = reinterpret_cast<void *>(0x1);
+  EXPECT_FALSE(
+      owner.funcIndexOnlyDirectHit(kEJitSharedMaxFuncIndex + 123u, &fn));
+  EXPECT_EQ(fn, nullptr);
+}
+
+// Test 12: when the same funcIndex has two distinct dimension sets, the hint is
+// poisoned so the funcIndex-only path never mis-hits.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_SameFuncIndexDifferentDimsNoMisHit) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  owner.setInstanceEnabled(0, 1, true);
+  owner.setInstanceEnabled(0, 2, true);
+  EJitCoreId::setCurrentForTest(0);
+  EJitDimPair dA[1] = {dim(0, 1)};
+  EJitDimPair dB[1] = {dim(0, 2)};
+  ASSERT_EQ(owner.compileOrGet(60, dA, 1, codeFor(60)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  // Second, DISTINCT specialization of the same funcIndex -> poisons the hint.
+  ASSERT_EQ(owner.compileOrGet(60, dB, 1, codeFor(60)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  EXPECT_EQ(state_->funcHint[60].loadAcquire(), 0xFFFFFFFFu); // poisoned
+  void *fn = reinterpret_cast<void *>(0x1);
+  EXPECT_FALSE(owner.funcIndexOnlyDirectHit(60, &fn));
+  EXPECT_EQ(fn, nullptr);
+  // The generic identity lookups still resolve each specialization correctly.
+  auto hitA = owner.tryCacheHit1D(60, 0, 1);
+  EXPECT_EQ(hitA.status, EJitCompileOrGetStatus::CacheHit);
+  if (hitA.hasReadToken)
+    owner.releaseRead(hitA.bucketIndex);
+}
+
+// The direct-only wrapper helper must leave a hint miss non-terminal. This is
+// what lets the 1D/2D C ABI preserve its original dimensions when it falls
+// through to compileOrGet instead of accidentally compiling a 0D identity.
+TEST_F(SharedTaskPoolTest, FuncIndexOnly_DirectMissPreservesCallerFallback) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+
+  auto miss = owner.tryFuncIndexOnlyDirect(61);
+  EXPECT_FALSE(miss.fastPathTerminal);
+  EXPECT_EQ(miss.fnPtr, nullptr);
+
+  owner.setInstanceEnabled(0, 3, true);
+  EJitDimPair d1[1] = {dim(0, 3)};
+  ASSERT_EQ(owner.compileOrGet(61, d1, 1, codeFor(61)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  auto hit = owner.tryFuncIndexOnlyDirect(61);
+  EXPECT_TRUE(hit.fastPathTerminal);
+  EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(hit.fnPtr, codeFor(61));
+}
+#endif // EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2259,6 +2259,167 @@ TEST_F(SharedTaskPoolTest, HitTokenDisciplineAndVersionInvalidation) {
 }
 
 //===----------------------------------------------------------------------===//
+// Slot-depth diagnostics: 0D identities whose funcIndex is a multiple of
+// kEJitSharedCacheBuckets all hash to bucket 0 and fill its slots 0,1,2,... in
+// publish order (cachePublish uses first-empty). This deterministically places
+// a target at a chosen linear-scan depth, exercising the per-slot scan (and the
+// identityHash-first fast-reject reorder) and proving the deepest slot is still
+// found and correctly identified.
+//===----------------------------------------------------------------------===//
+namespace {
+// Return the linear slot index at which \p funcIndex is Ready in its bucket, or
+// -1 if not found. Pure diagnostic scan (no lock needed in the single-thread
+// test).
+int slotDepthOf(EJitSharedTaskPoolState *st, uint32_t funcIndex,
+                uint32_t numDims) {
+  uint32_t bucket = funcIndex % kEJitSharedCacheBuckets; // 0D key == funcIndex
+  auto &B = st->buckets[bucket];
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
+    auto &Slot = B.slots[s];
+    if (Slot.state.loadAcquire() ==
+            static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
+        Slot.funcIndex == funcIndex && Slot.numDims == numDims)
+      return static_cast<int>(s);
+  }
+  return -1;
+}
+} // namespace
+
+TEST_F(SharedTaskPoolTest, SlotDepthHitsAtEveryDepth) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+
+  // Fill bucket 0 slots 0..15 with distinct 0D colliders.
+  for (uint32_t d = 0; d < kEJitSharedCacheSlots; ++d) {
+    uint32_t fi = d * kB;
+    ASSERT_EQ(owner.compileOrGet(fi, nullptr, 0, codeFor(fi)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(owner.pollOne());
+    EXPECT_EQ(slotDepthOf(state_.get(), fi, 0), static_cast<int>(d));
+  }
+
+  // Every colliding identity — including the deepest slot 15 — must still be a
+  // correct cache hit with its own specialization pointer.
+  for (uint32_t d = 0; d < kEJitSharedCacheSlots; ++d) {
+    uint32_t fi = d * kB;
+    auto hit = owner.tryCacheHit0D(fi);
+    ASSERT_TRUE(hit.fastPathTerminal) << "depth " << d;
+    EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit) << "depth " << d;
+    EXPECT_EQ(hit.fnPtr, codeFor(fi)) << "depth " << d;
+    if (hit.hasReadToken)
+      owner.releaseRead(hit.bucketIndex);
+  }
+
+  // An unpublished colliding key in the same (now full) bucket is a clean miss.
+  auto miss = owner.tryCacheHit0D(kEJitSharedCacheSlots * kB);
+  EXPECT_NE(miss.status, EJitCompileOrGetStatus::CacheHit);
+  if (miss.hasReadToken)
+    owner.releaseRead(miss.bucketIndex);
+}
+
+// The identityHash-first reorder must never alias two identities that share a
+// bucket: a wrong-funcIndex query with the same bucket must miss even when a
+// different identity is Ready there.
+TEST_F(SharedTaskPoolTest, SlotDepthNoIdentityAliasAcrossBucket) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  const uint32_t kB = kEJitSharedCacheBuckets;
+  // Publish only funcIndex 5*kB at slot 0 of bucket 0.
+  uint32_t present = 5 * kB;
+  ASSERT_EQ(owner.compileOrGet(present, nullptr, 0, codeFor(present)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  // A different colliding funcIndex (same bucket, different identity) misses.
+  auto miss = owner.tryCacheHit0D(9 * kB);
+  EXPECT_NE(miss.status, EJitCompileOrGetStatus::CacheHit);
+  if (miss.hasReadToken)
+    owner.releaseRead(miss.bucketIndex);
+  // The present one still hits with the right pointer.
+  auto hit = owner.tryCacheHit0D(present);
+  EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(hit.fnPtr, codeFor(present));
+  if (hit.hasReadToken)
+    owner.releaseRead(hit.bucketIndex);
+}
+
+#ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
+//===----------------------------------------------------------------------===//
+// NO_RECLAIM fixed-dimension seqlock specializations (cacheLookupSeq0D/1D/2D):
+// the unrolled seqlock lookups reached by tryCacheHit0D/1D/2D must return the
+// SAME result as the generic seqlock path (cacheLookupSeq via tryCacheHit), for
+// hits, deep-slot hits, misses, disabled instances, and version invalidation.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, SeqFixedDimMatchesGeneric0D1D2D) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(1, 2, true);
+  owner.setInstanceEnabled(3, 4, true);
+
+  // Publish a 0D, a 1D and a 2D specialization.
+  ASSERT_EQ(owner.compileOrGet(21, nullptr, 0, codeFor(21)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EJitDimPair d1[1] = {dim(1, 2)};
+  ASSERT_EQ(owner.compileOrGet(22, d1, 1, codeFor(22)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EJitDimPair d2[2] = {dim(1, 2), dim(3, 4)};
+  ASSERT_EQ(owner.compileOrGet(23, d2, 2, codeFor(23)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+
+  // Fixed-dim seqlock entry vs generic seqlock entry: identical outcomes.
+  auto fixed0 = owner.tryCacheHit0D(21);
+  auto gen0 = owner.tryCacheHit(21, nullptr, 0);
+  EXPECT_EQ(fixed0.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed0.status, gen0.status);
+  EXPECT_EQ(fixed0.fnPtr, gen0.fnPtr);
+  EXPECT_EQ(fixed0.fnPtr, codeFor(21));
+
+  auto fixed1 = owner.tryCacheHit1D(22, 1, 2);
+  auto gen1 = owner.tryCacheHit(22, d1, 1);
+  EXPECT_EQ(fixed1.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed1.status, gen1.status);
+  EXPECT_EQ(fixed1.fnPtr, gen1.fnPtr);
+  EXPECT_EQ(fixed1.fnPtr, codeFor(22));
+
+  auto fixed2 = owner.tryCacheHit2D(23, 1, 2, 3, 4);
+  auto gen2 = owner.tryCacheHit(23, d2, 2);
+  EXPECT_EQ(fixed2.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(fixed2.status, gen2.status);
+  EXPECT_EQ(fixed2.fnPtr, gen2.fnPtr);
+  EXPECT_EQ(fixed2.fnPtr, codeFor(23));
+
+  // A miss and a wrong-dim query must also agree (both miss).
+  EXPECT_NE(owner.tryCacheHit0D(99).status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_NE(owner.tryCacheHit1D(22, 1, 3).status,
+            EJitCompileOrGetStatus::CacheHit); // wrong instanceId
+}
+
+// Version bump after a seqlock fixed-dim publish must invalidate the old slot.
+TEST_F(SharedTaskPoolTest, SeqFixedDimVersionBumpMisses) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+  owner.setInstanceEnabled(2, 7, true);
+  EJitDimPair d1[1] = {dim(2, 7)};
+  ASSERT_EQ(owner.compileOrGet(31, d1, 1, codeFor(31)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  EXPECT_EQ(owner.tryCacheHit1D(31, 2, 7).status,
+            EJitCompileOrGetStatus::CacheHit);
+  // Deactivate (bumps version): stale slot must not be served.
+  owner.setInstanceEnabled(2, 7, false);
+  EXPECT_NE(owner.tryCacheHit1D(31, 2, 7).status,
+            EJitCompileOrGetStatus::CacheHit);
+}
+#endif // EJIT_SRE_TASKPOOL_NO_RECLAIM
+
+//===----------------------------------------------------------------------===//
 // Phase-1 hot-hit micro-benchmark (DISABLED by default; run explicitly with
 //   --gtest_also_run_disabled_tests --gtest_filter='*HotHitMicroBench*'
 // on an aarch64 host). Measures the per-hit cost of the shared taskpool hit


### PR DESCRIPTION
## 中文说明

这是一个独立的 benchmark/WIP 分支，用来评估在严格固定 workload 下仅凭 `funcIndex` 命中 shared taskpool cache 的收益。

### 基线

- PR base：`FUNCINDEX_ONLY`
- base commit：`d60b61f8da65`，即 PR #85 合并之前、PR #78 合并之后
- 明确不包含 PR #85 的 hash 修改，避免其已观察到的负优化干扰 benchmark

### 改动

- 增加 shared cache-query 与 16-thread benchmark
- 优化 NO_RECLAIM 下的 fixed-dimension cache lookup
- 增加 benchmark-only funcIndex hint
- 支持 0D/1D/2D wrapper；hit 只读取 funcIndex，miss 仍携带原始维度进入正常 compileOrGet
- 将 `EJIT_SRE_TASKPOOL_NO_RECLAIM` 和 `EJIT_BENCH_FUNCINDEX_ONLY_LOOKUP` 接入真实 LLVMEJIT 构建
- 默认关闭，不改变正常产品路径

### Host AArch64 microbenchmark

Warm hit, 1,000,000 iterations:

| Path | Normal | funcIndex-only |
|---|---:|---:|
| 0D | 10.604 ns | 9.891 ns |
| 1D | 13.495 ns | 10.163 ns |
| 2D | 16.940 ns | 10.209 ns |

这是内部 lookup 微基准，不等同于板上 wrapper 端到端收益。

### 严格限制

仅适用于 benchmark：每个 funcIndex 必须只有一个不可变 specialization，运行期间维度、active/version、may_const 关联状态均不得变化，并且 code pool 必须 NO_RECLAIM。不能直接作为通用生产语义。

### 验证

- LLVMEJIT / opt / EJITSharedTaskPoolTests / EJITSharedCacheQueryBench 构建通过（-j8）
- funcIndex-only focused tests：13/13
- wrapper FileCheck：0D/1D/2D default 与 func-only 两种输出通过
- libLLVMEJIT.a 包含 0D/1D/2D 三个 func-only C ABI

---

## English Summary

This draft PR isolates a benchmark-only funcIndex cache-hit experiment on a branch based immediately before PR #85. It intentionally excludes PR #85's hash changes so their observed regression does not affect the measurement.

The experiment provides 0D/1D/2D wrapper entries. A warm hit consults only a direct funcIndex hint; a true miss preserves the original dimensions and falls back to normal `compileOrGet`. The feature is OFF by default and requires the NO_RECLAIM lifetime contract.

This is not production semantics: it is valid only for one immutable specialization per funcIndex with stable activation/version/may_const state.