### PR TITLE
[EJIT] Cache the bitcode parse across specializations of the same blob

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
@@ -32,6 +32,11 @@ struct Config {
   size_t maxCacheEntries = 4096;
   size_t maxCacheSize = 32 * 1024 * 1024;
   size_t maxSingleFuncSize = 512 * 1024;
+  /// Ceiling on host memory retained by the parsed-bitcode cache, evicted
+  /// least-recently-used. Parsed IR runs ~20x the size of its bitcode, so
+  /// without a bound this grows with the number of translation units ever
+  /// compiled. 0 disables the cache.
+  size_t maxPreloadCacheSize = 1 * 1024 * 1024;
   bool enableLogger = true;
   /// If true, skip the constructor-based registration path and use the
   /// static registry table (__ejit_registry_*[]).  For bare-metal where

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -25,6 +25,7 @@ namespace ejit {
 class PeriodArrayRegistry;
 class EJitRuntimeState;
 struct EJitSharedTaskPoolState;
+struct PreloadedBitcode;
 
 /// Set a function-name filter for JIT IR+ASM diagnostic capture. When non-
 /// empty, the engine captures (saves in memory) the post-optimization IR and
@@ -70,6 +71,17 @@ public:
          PeriodArrayRegistry &periodReg,
          EJitRuntimeState &runtimeState);
 
+  /// Pre-parse \p bitcodeData and cache everything loadBitcodeModule() would
+  /// otherwise recompute for every specialization built from the same blob:
+  /// the parsed module (kept as a template that is cloned per compile) and the
+  /// external function/global declarations needing symbol resolution.
+  ///
+  /// Purely an optimization — loadBitcodeModule() warms the same cache lazily
+  /// on its first call for a blob. Calling this ahead of time moves that
+  /// one-off cost (the dominant part of loadBitcodeModule) off the first
+  /// compile. Idempotent; safe to call repeatedly for the same blob.
+  Error preLoadBitcodeUtil(StringRef bitcodeData);
+
   /// Load a bitcode module into a per-specialization JITDylib identified
   /// by cacheKey. Each specialization gets its own JITDylib so symbols
   /// from the same TU bitcode can be defined multiple times without conflict.
@@ -105,6 +117,11 @@ public:
 #endif
 
 private:
+  /// Parse \p bitcodeData and install the derived template + symbol
+  /// scaffolding in the per-blob cache, replacing any existing entry.
+  /// Returns a pointer into the cache, valid until the entry is replaced.
+  Expected<PreloadedBitcode *> buildPreloadedBitcode(StringRef bitcodeData);
+
   struct Impl;
   std::unique_ptr<Impl> P;
 };

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -71,20 +71,39 @@ public:
          PeriodArrayRegistry &periodReg,
          EJitRuntimeState &runtimeState);
 
-  /// Pre-parse \p bitcodeData and cache everything loadBitcodeModule() would
-  /// otherwise recompute for every specialization built from the same blob:
-  /// the parsed module (kept as a template that is cloned per compile) and the
-  /// external function/global declarations needing symbol resolution.
-  ///
-  /// Purely an optimization — loadBitcodeModule() warms the same cache lazily
-  /// on its first call for a blob. Calling this ahead of time moves that
-  /// one-off cost (the dominant part of loadBitcodeModule) off the first
-  /// compile. Idempotent; safe to call repeatedly for the same blob.
+  /// Parse \p bitcodeData now and cache the template loadBitcodeModule() would
+  /// otherwise build later. Unlike loadBitcodeModule(), which only caches a
+  /// blob seen twice, this caches immediately — use it for blobs known to
+  /// produce several specializations. Idempotent; same storage contract as
+  /// loadBitcodeModule(). Not safe to call concurrently with a compile: call
+  /// it during init, before the taskpool worker starts.
   Error preLoadBitcodeUtil(StringRef bitcodeData);
+
+  /// Parsed-bitcode cache footprint and hit rate.
+  struct BitcodeCacheStats {
+    size_t entries = 0;
+    /// Derived from bitcode size, not measured from the allocator.
+    size_t approxBytes = 0;
+    /// Without caching this would equal the number of cold compiles.
+    uint64_t parses = 0;
+    uint64_t templateHits = 0;
+    uint64_t evictions = 0;
+  };
+  BitcodeCacheStats getBitcodeCacheStats() const;
+
+  /// Drop every cached template. In-flight modules are unaffected: each holds
+  /// its own reference to the context it was cloned into.
+  void clearBitcodeCache();
 
   /// Load a bitcode module into a per-specialization JITDylib identified
   /// by cacheKey. Each specialization gets its own JITDylib so symbols
   /// from the same TU bitcode can be defined multiple times without conflict.
+  ///
+  /// STORAGE CONTRACT: a blob is identified by its address and size, so
+  /// \p bitcodeData must stay alive and unmodified while the engine may
+  /// compile from it — rewriting it in place would compile the stale module.
+  /// AOT bitcode lives in a const image section and satisfies this; callers
+  /// with their own buffers must call clearBitcodeCache() after changing them.
   Error loadBitcodeModule(StringRef bitcodeData,
                           uint64_t cacheKey,
                           const std::string &origFnName);
@@ -117,10 +136,14 @@ public:
 #endif
 
 private:
-  /// Parse \p bitcodeData and install the derived template + symbol
-  /// scaffolding in the per-blob cache, replacing any existing entry.
-  /// Returns a pointer into the cache, valid until the entry is replaced.
-  Expected<PreloadedBitcode *> buildPreloadedBitcode(StringRef bitcodeData);
+  /// Derive the template module + symbol scaffolding. Does not touch the
+  /// cache; the caller decides whether to retain the result.
+  Error buildPreloadedBitcode(StringRef bitcodeData, PreloadedBitcode &Out);
+
+  /// Retain \p PB, evicting least-recently-used entries to stay under
+  /// Config::maxPreloadCacheSize. Null if it does not fit at all.
+  PreloadedBitcode *retainPreloadedBitcode(StringRef bitcodeData,
+                                           PreloadedBitcode &&PB);
 
   struct Impl;
   std::unique_ptr<Impl> P;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -90,33 +90,46 @@ static void collectReferencedExternalDecls(
 namespace llvm {
 namespace ejit {
 
-/// One external declaration that a bitcode module needs resolved, with the
-/// parts that do not change between specializations already computed: the
-/// name, its interned/mangled JIT symbol, and whether any reachable use
-/// actually references it (drives the unresolved-external diagnostic).
+/// An external declaration needing resolution, with the parts that do not
+/// change between specializations precomputed. `referenced` means a reachable
+/// use exists, and drives only the unresolved-external diagnostic.
 struct PreResolvedSym {
   std::string name;
   orc::SymbolStringPtr mangled;
   bool referenced = false;
 };
 
-/// Everything derivable from one bitcode blob that is identical for every
-/// specialization compiled from it. loadBitcodeModule() re-parsed the same
-/// bytes and re-walked the same IR on every cold compile; this caches the
-/// parse (as a pristine template module that is cloned per specialization)
-/// and the external-symbol scaffolding.
+/// The per-blob invariants: a pristine template module cloned per
+/// specialization, plus the external-symbol scaffolding.
 ///
-/// The template and all modules cloned from it share one LLVMContext. That is
-/// safe because EJIT compiles on a single worker (LLJIT is built with
-/// setNumCompileThreads(0), so materialization runs on the caller), and
-/// loadBitcodeModule is already serialized — it mutates Impl::specDylibs
+/// The template and its clones share one LLVMContext, which is safe because
+/// EJIT compiles on a single worker (LLJIT uses setNumCompileThreads(0)) and
+/// loadBitcodeModule was already serialized — it mutates Impl::specDylibs
 /// without a lock.
 struct PreloadedBitcode {
   orc::ThreadSafeContext TSCtx;
   std::unique_ptr<Module> Template;
   SmallVector<PreResolvedSym, 16> extFuncs;
   SmallVector<PreResolvedSym, 16> extGlobals;
+  size_t approxBytes = 0;
+  /// Monotonic tick of last use, for LRU eviction.
+  uint64_t lastUsed = 0;
 };
+
+/// Address *and* size: address alone would alias a recycled allocation onto a
+/// stale template.
+struct BlobKey {
+  const char *data = nullptr;
+  size_t size = 0;
+  bool operator<(const BlobKey &O) const {
+    return data != O.data ? data < O.data : size < O.size;
+  }
+};
+
+/// Measured at ~20x on representative EJIT translation units (a 3.5 KB blob
+/// retains ~70 KB). Charges entries against the budget without walking the
+/// module.
+static constexpr size_t kIRExpansionFactor = 20;
 
 } // namespace ejit
 } // namespace llvm
@@ -139,10 +152,16 @@ struct EJitOrcEngine::Impl {
   /// User-registered symbols (functions + globals) for bare-metal.
   /// Populated via ejit_register_symbol() / addUserSymbol().
   std::map<std::string, void *> userSymbols;
-  /// Parse + external-decl scaffolding cached per bitcode blob, keyed by the
-  /// blob's address. AOT bitcode lives in a static image section, so the
-  /// address is a stable identity for the bytes.
-  std::map<const char *, PreloadedBitcode> preloaded;
+  /// Parse + external-decl scaffolding cached per bitcode blob.
+  std::map<BlobKey, PreloadedBitcode> preloaded;
+  /// Load counts for blobs not yet cached; a few dozen bytes each, not a
+  /// parsed module. See the second-load gate in loadBitcodeModule().
+  std::map<BlobKey, unsigned> blobSeen;
+  /// Config::maxPreloadCacheSize; 0 disables caching.
+  size_t preloadBudget = 0;
+  size_t preloadBytes = 0;
+  uint64_t preloadClock = 0;
+  BitcodeCacheStats preloadStats;
   /// Codegen-synthesized runtime symbols (memset/memcpy/... and the stack
   /// protector). Engine-wide and never change, so mangle/intern them once.
   orc::SymbolMap libcallSymbols;
@@ -627,6 +646,7 @@ EJitOrcEngine::Create(const Config &config,
   engine->P->periodReg = &periodReg;
   engine->P->runtimeState = &runtimeState;
   engine->P->dumpJITDir = config.dumpJITDir;
+  engine->P->preloadBudget = config.maxPreloadCacheSize;
 
   // Bare-metal / cross-compiled: use compile-time target triple.
   // Native host: auto-detect via detectHost().
@@ -863,17 +883,14 @@ EJitOrcEngine::Create(const Config &config,
   return engine;
 }
 
-/// Parse \p bitcodeData once and derive everything about it that is invariant
-/// across specializations: a normalized template module to clone per compile,
-/// and the external function/global declarations that need symbol resolution
-/// (interned up-front, with the reachability flag the diagnostic path needs).
+/// Derive the per-specialization invariants of \p bitcodeData.
 ///
-/// Note that the entry-linkage fixup is deliberately NOT baked into the
-/// template: it depends on origFnName, and the AOT pass emits bitcode per
-/// translation unit, so one blob is shared by every ejit_entry in that TU.
-/// It is applied per clone instead, where it costs one symbol-table lookup.
-Expected<PreloadedBitcode *>
-EJitOrcEngine::buildPreloadedBitcode(StringRef bitcodeData) {
+/// The entry-linkage fixup is deliberately NOT baked into the template: it
+/// depends on origFnName, and AOT emits bitcode per translation unit, so one
+/// blob is shared by every ejit_entry in that TU. It is applied per clone.
+Error EJitOrcEngine::buildPreloadedBitcode(StringRef bitcodeData,
+                                          PreloadedBitcode &Out) {
+  ++P->preloadStats.parses;
   auto Ctx = std::make_unique<LLVMContext>();
   auto Buf = MemoryBuffer::getMemBuffer(bitcodeData, "ejit_preload.bc");
   auto ModuleOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
@@ -896,15 +913,14 @@ EJitOrcEngine::buildPreloadedBitcode(StringRef bitcodeData) {
     }
   }
 
-  // Which external decls are actually referenced by reachable code. Only the
-  // unresolved-external diagnostic consumes this, but it is a full walk of
-  // every instruction operand in the module — precisely the kind of work that
-  // must not repeat per specialization.
+  // A full walk of every instruction operand, so it must not repeat per
+  // specialization even though only the diagnostic below consumes it.
   SmallPtrSet<const Function *, 16> ReferencedFuncs;
   SmallPtrSet<const GlobalVariable *, 16> ReferencedGlobals;
   collectReferencedExternalDecls(*M, ReferencedFuncs, ReferencedGlobals);
 
-  PreloadedBitcode PB;
+  Out.extFuncs.clear();
+  Out.extGlobals.clear();
   for (Function &F : M->functions()) {
     if (!F.isDeclaration() || F.getName().empty() || F.isIntrinsic())
       continue;
@@ -912,7 +928,7 @@ EJitOrcEngine::buildPreloadedBitcode(StringRef bitcodeData) {
     S.name = F.getName().str();
     S.mangled = P->J->mangleAndIntern(S.name);
     S.referenced = ReferencedFuncs.contains(&F);
-    PB.extFuncs.push_back(std::move(S));
+    Out.extFuncs.push_back(std::move(S));
   }
   for (GlobalVariable &GV : M->globals()) {
     if (!GV.isDeclaration() || GV.getName().empty())
@@ -921,34 +937,81 @@ EJitOrcEngine::buildPreloadedBitcode(StringRef bitcodeData) {
     S.name = GV.getName().str();
     S.mangled = P->J->mangleAndIntern(S.name);
     S.referenced = ReferencedGlobals.contains(&GV);
-    PB.extGlobals.push_back(std::move(S));
+    Out.extGlobals.push_back(std::move(S));
   }
 
-  PB.TSCtx = orc::ThreadSafeContext(std::move(Ctx));
-  PB.Template = std::move(M);
+  Out.TSCtx = orc::ThreadSafeContext(std::move(Ctx));
+  Out.Template = std::move(M);
+  Out.approxBytes = bitcodeData.size() * kIRExpansionFactor;
+  return Error::success();
+}
 
-  // Erase any existing entry before inserting rather than move-assigning over
-  // it. Move-assignment would overwrite the members in declaration order —
-  // dropping the old TSCtx (and with it the old LLVMContext) before the old
-  // Template module that lives in that context is destroyed, which is a
-  // use-after-free. Erasing destroys the entry in reverse declaration order,
-  // so the module goes first.
-  P->preloaded.erase(bitcodeData.data());
-  auto &Slot = P->preloaded[bitcodeData.data()];
+PreloadedBitcode *
+EJitOrcEngine::retainPreloadedBitcode(StringRef bitcodeData,
+                                      PreloadedBitcode &&PB) {
+  const BlobKey Key{bitcodeData.data(), bitcodeData.size()};
+  // A single entry over budget is never worth holding.
+  if (PB.approxBytes > P->preloadBudget)
+    return nullptr;
+
+  // Dropping a template only costs a re-parse later; it cannot affect an
+  // in-flight compile, whose module holds its own reference to the context.
+  while (P->preloadBytes + PB.approxBytes > P->preloadBudget &&
+         !P->preloaded.empty()) {
+    auto Victim = P->preloaded.begin();
+    for (auto It = P->preloaded.begin(); It != P->preloaded.end(); ++It)
+      if (It->second.lastUsed < Victim->second.lastUsed)
+        Victim = It;
+    P->preloadBytes -= Victim->second.approxBytes;
+    ++P->preloadStats.evictions;
+    P->preloaded.erase(Victim);
+  }
+  if (P->preloadBytes + PB.approxBytes > P->preloadBudget)
+    return nullptr;
+
+  PB.lastUsed = ++P->preloadClock;
+  P->preloadBytes += PB.approxBytes;
+  // Erase before inserting: move-assigning over a live entry would overwrite
+  // members in declaration order, dropping the old TSCtx before the Template
+  // living in that context — a use-after-free. Erasing destroys in reverse
+  // declaration order, module before context.
+  auto Existing = P->preloaded.find(Key);
+  if (Existing != P->preloaded.end()) {
+    P->preloadBytes -= Existing->second.approxBytes;
+    P->preloaded.erase(Existing);
+  }
+  auto &Slot = P->preloaded[Key];
   Slot = std::move(PB);
   return &Slot;
 }
 
 Error EJitOrcEngine::preLoadBitcodeUtil(StringRef bitcodeData) {
-  if (P->preloaded.count(bitcodeData.data()))
+  const BlobKey Key{bitcodeData.data(), bitcodeData.size()};
+  if (P->preloaded.count(Key))
     return Error::success();
-  auto PBOrErr = buildPreloadedBitcode(bitcodeData);
-  if (!PBOrErr)
-    return PBOrErr.takeError();
-  EJIT_DIAG_VERBOSE("preLoadBitcode OK size=%zu funcs=%u globals=%u",
-                    bitcodeData.size(), (unsigned)(*PBOrErr)->extFuncs.size(),
-                    (unsigned)(*PBOrErr)->extGlobals.size());
+
+  PreloadedBitcode PB;
+  if (auto Err = buildPreloadedBitcode(bitcodeData, PB))
+    return Err;
+  size_t Bytes = PB.approxBytes;
+  bool Kept = retainPreloadedBitcode(bitcodeData, std::move(PB)) != nullptr;
+  EJIT_DIAG_VERBOSE("preLoadBitcode size=%zu approx=%zuB retained=%u",
+                    bitcodeData.size(), Bytes, (unsigned)Kept);
   return Error::success();
+}
+
+EJitOrcEngine::BitcodeCacheStats
+EJitOrcEngine::getBitcodeCacheStats() const {
+  BitcodeCacheStats S = P->preloadStats;
+  S.entries = P->preloaded.size();
+  S.approxBytes = P->preloadBytes;
+  return S;
+}
+
+void EJitOrcEngine::clearBitcodeCache() {
+  P->preloaded.clear();
+  P->blobSeen.clear();
+  P->preloadBytes = 0;
 }
 
 Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
@@ -956,24 +1019,40 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
                                        const std::string &origFnName) {
   EJIT_DIAG_VERBOSE("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
                     origFnName.c_str(), bitcodeData.size());
-  // Parse + IR-walk once per bitcode blob; every specialization after the
-  // first only pays for a clone of the resulting template module.
+  // A template is retained only on a blob's *second* load: parsed IR costs
+  // ~20x the bitcode, so a blob yielding one specialization must not pay that.
+  // The first load therefore behaves as it did before this cache existed.
+  const BlobKey Key{bitcodeData.data(), bitcodeData.size()};
   PreloadedBitcode *PB = nullptr;
-  {
-    auto it = P->preloaded.find(bitcodeData.data());
-    if (it != P->preloaded.end()) {
-      PB = &it->second;
+  PreloadedBitcode Local;
+  std::unique_ptr<Module> M;
+  orc::ThreadSafeContext TSCtx;
+
+  if (auto It = P->preloaded.find(Key); It != P->preloaded.end()) {
+    PB = &It->second;
+    PB->lastUsed = ++P->preloadClock;
+    ++P->preloadStats.templateHits;
+    M = CloneModule(*PB->Template);
+    TSCtx = PB->TSCtx;
+  } else {
+    if (auto Err = buildPreloadedBitcode(bitcodeData, Local)) {
+      EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error", cacheKey);
+      return Err;
+    }
+    const bool Reused = ++P->blobSeen[Key] >= 2;
+    if (Reused && P->preloadBudget)
+      PB = retainPreloadedBitcode(bitcodeData, std::move(Local));
+    if (PB) {
+      P->blobSeen.erase(Key);
+      M = CloneModule(*PB->Template);
+      TSCtx = PB->TSCtx;
     } else {
-      auto PBOrErr = buildPreloadedBitcode(bitcodeData);
-      if (!PBOrErr) {
-        EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error",
-                  cacheKey);
-        return PBOrErr.takeError();
-      }
-      PB = *PBOrErr;
+      // Not cached: hand the parsed module straight over, no clone.
+      PB = &Local;
+      M = std::move(Local.Template);
+      TSCtx = Local.TSCtx;
     }
   }
-  std::unique_ptr<Module> M = CloneModule(*PB->Template);
   M->setModuleIdentifier("spec_" + std::to_string(cacheKey) + ".bc");
 
   // ejit_entry functions may have internal linkage (e.g. declared `static` in
@@ -987,10 +1066,8 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     if (!EntryF->isDeclaration() && EntryF->hasLocalLinkage())
       EntryF->setLinkage(GlobalValue::ExternalLinkage);
 
-  // Collect global variable addresses from the registry for symbols that
-  // appear as external declarations in the bitcode module. The decl list and
-  // its interned names are precomputed; only the address lookups are redone,
-  // since registrations can arrive between compiles.
+  // The decl list and its interned names are precomputed; only the address
+  // lookups are redone, since registrations can arrive between compiles.
   orc::SymbolMap globalSymbols;
   for (const PreResolvedSym &S : PB->extGlobals) {
     void *addr = nullptr;
@@ -1080,8 +1157,7 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   // disabled, so without these every JIT compilation fails at link time.
   // They go into the spec JITDylib (which is isolated: it does not link back
   // to the main JITDylib) so each specialization resolves them locally.
-  // The set is fixed for the life of the engine, so it is mangled/interned
-  // once and merged in wholesale here.
+  // Fixed for the life of the engine: mangled once, merged in wholesale.
   if (P->libcallSymbols.empty()) {
     for (const LibcallSymbol &LCS : getLibcallSymbols())
       P->libcallSymbols[P->J->mangleAndIntern(LCS.name)] =
@@ -1102,9 +1178,10 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
                 cacheKey, nGlobals, toString(std::move(Err)).c_str());
   }
 
-  // The spec module shares the template's context (see PreloadedBitcode).
+  // The TSM holds a reference either way, so the context outlives
+  // materialization even if the cache entry is later evicted.
   if (auto Err = P->J->addIRModule(
-          *JDOrErr, orc::ThreadSafeModule(std::move(M), PB->TSCtx))) {
+          *JDOrErr, orc::ThreadSafeModule(std::move(M), TSCtx))) {
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: add IR module error", cacheKey);
     return Err;
   }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -87,6 +87,40 @@ static void collectReferencedExternalDecls(
   }
 }
 
+namespace llvm {
+namespace ejit {
+
+/// One external declaration that a bitcode module needs resolved, with the
+/// parts that do not change between specializations already computed: the
+/// name, its interned/mangled JIT symbol, and whether any reachable use
+/// actually references it (drives the unresolved-external diagnostic).
+struct PreResolvedSym {
+  std::string name;
+  orc::SymbolStringPtr mangled;
+  bool referenced = false;
+};
+
+/// Everything derivable from one bitcode blob that is identical for every
+/// specialization compiled from it. loadBitcodeModule() re-parsed the same
+/// bytes and re-walked the same IR on every cold compile; this caches the
+/// parse (as a pristine template module that is cloned per specialization)
+/// and the external-symbol scaffolding.
+///
+/// The template and all modules cloned from it share one LLVMContext. That is
+/// safe because EJIT compiles on a single worker (LLJIT is built with
+/// setNumCompileThreads(0), so materialization runs on the caller), and
+/// loadBitcodeModule is already serialized — it mutates Impl::specDylibs
+/// without a lock.
+struct PreloadedBitcode {
+  orc::ThreadSafeContext TSCtx;
+  std::unique_ptr<Module> Template;
+  SmallVector<PreResolvedSym, 16> extFuncs;
+  SmallVector<PreResolvedSym, 16> extGlobals;
+};
+
+} // namespace ejit
+} // namespace llvm
+
 struct EJitOrcEngine::Impl {
 #ifdef EJIT_SRE_CODE_POOL
   /// Dedicated 2MiB code pools backing all JIT machine code. Declared before
@@ -105,6 +139,13 @@ struct EJitOrcEngine::Impl {
   /// User-registered symbols (functions + globals) for bare-metal.
   /// Populated via ejit_register_symbol() / addUserSymbol().
   std::map<std::string, void *> userSymbols;
+  /// Parse + external-decl scaffolding cached per bitcode blob, keyed by the
+  /// blob's address. AOT bitcode lives in a static image section, so the
+  /// address is a stable identity for the bytes.
+  std::map<const char *, PreloadedBitcode> preloaded;
+  /// Codegen-synthesized runtime symbols (memset/memcpy/... and the stack
+  /// protector). Engine-wide and never change, so mangle/intern them once.
+  orc::SymbolMap libcallSymbols;
   /// If non-empty, dump JIT-optimized IR to this directory.
   std::string dumpJITDir;
   /// Persistent optimizer — analysis managers are registered once and reused.
@@ -822,34 +863,118 @@ EJitOrcEngine::Create(const Config &config,
   return engine;
 }
 
+/// Parse \p bitcodeData once and derive everything about it that is invariant
+/// across specializations: a normalized template module to clone per compile,
+/// and the external function/global declarations that need symbol resolution
+/// (interned up-front, with the reachability flag the diagnostic path needs).
+///
+/// Note that the entry-linkage fixup is deliberately NOT baked into the
+/// template: it depends on origFnName, and the AOT pass emits bitcode per
+/// translation unit, so one blob is shared by every ejit_entry in that TU.
+/// It is applied per clone instead, where it costs one symbol-table lookup.
+Expected<PreloadedBitcode *>
+EJitOrcEngine::buildPreloadedBitcode(StringRef bitcodeData) {
+  auto Ctx = std::make_unique<LLVMContext>();
+  auto Buf = MemoryBuffer::getMemBuffer(bitcodeData, "ejit_preload.bc");
+  auto ModuleOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
+  if (!ModuleOrErr)
+    return ModuleOrErr.takeError();
+  std::unique_ptr<Module> M = std::move(*ModuleOrErr);
+
+  Triple TT(M->getTargetTriple());
+  if (TT.isAArch64() && TT.isOSBinFormatELF()) {
+    // These declarations resolve to process addresses, not co-located JIT
+    // storage. Clearing dso_local forces AArch64 PIC codegen to use GOT/PLT
+    // style indirection instead of near-page ADRP relocations.
+    for (Function &F : M->functions()) {
+      if (F.isDeclaration() && !F.isIntrinsic())
+        F.setDSOLocal(false);
+    }
+    for (GlobalVariable &GV : M->globals()) {
+      if (GV.isDeclaration())
+        GV.setDSOLocal(false);
+    }
+  }
+
+  // Which external decls are actually referenced by reachable code. Only the
+  // unresolved-external diagnostic consumes this, but it is a full walk of
+  // every instruction operand in the module — precisely the kind of work that
+  // must not repeat per specialization.
+  SmallPtrSet<const Function *, 16> ReferencedFuncs;
+  SmallPtrSet<const GlobalVariable *, 16> ReferencedGlobals;
+  collectReferencedExternalDecls(*M, ReferencedFuncs, ReferencedGlobals);
+
+  PreloadedBitcode PB;
+  for (Function &F : M->functions()) {
+    if (!F.isDeclaration() || F.getName().empty() || F.isIntrinsic())
+      continue;
+    PreResolvedSym S;
+    S.name = F.getName().str();
+    S.mangled = P->J->mangleAndIntern(S.name);
+    S.referenced = ReferencedFuncs.contains(&F);
+    PB.extFuncs.push_back(std::move(S));
+  }
+  for (GlobalVariable &GV : M->globals()) {
+    if (!GV.isDeclaration() || GV.getName().empty())
+      continue;
+    PreResolvedSym S;
+    S.name = GV.getName().str();
+    S.mangled = P->J->mangleAndIntern(S.name);
+    S.referenced = ReferencedGlobals.contains(&GV);
+    PB.extGlobals.push_back(std::move(S));
+  }
+
+  PB.TSCtx = orc::ThreadSafeContext(std::move(Ctx));
+  PB.Template = std::move(M);
+
+  // Erase any existing entry before inserting rather than move-assigning over
+  // it. Move-assignment would overwrite the members in declaration order —
+  // dropping the old TSCtx (and with it the old LLVMContext) before the old
+  // Template module that lives in that context is destroyed, which is a
+  // use-after-free. Erasing destroys the entry in reverse declaration order,
+  // so the module goes first.
+  P->preloaded.erase(bitcodeData.data());
+  auto &Slot = P->preloaded[bitcodeData.data()];
+  Slot = std::move(PB);
+  return &Slot;
+}
+
+Error EJitOrcEngine::preLoadBitcodeUtil(StringRef bitcodeData) {
+  if (P->preloaded.count(bitcodeData.data()))
+    return Error::success();
+  auto PBOrErr = buildPreloadedBitcode(bitcodeData);
+  if (!PBOrErr)
+    return PBOrErr.takeError();
+  EJIT_DIAG_VERBOSE("preLoadBitcode OK size=%zu funcs=%u globals=%u",
+                    bitcodeData.size(), (unsigned)(*PBOrErr)->extFuncs.size(),
+                    (unsigned)(*PBOrErr)->extGlobals.size());
+  return Error::success();
+}
+
 Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
                                        uint64_t cacheKey,
                                        const std::string &origFnName) {
   EJIT_DIAG_VERBOSE("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
                     origFnName.c_str(), bitcodeData.size());
-  auto Ctx = std::make_unique<LLVMContext>();
-  auto Buf = MemoryBuffer::getMemBuffer(
-      bitcodeData, ("spec_" + std::to_string(cacheKey) + ".bc"));
-  auto ModuleOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
-  if (!ModuleOrErr) {
-    EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error", cacheKey);
-    return ModuleOrErr.takeError();
-  }
-
-  Triple TT((*ModuleOrErr)->getTargetTriple());
-  if (TT.isAArch64() && TT.isOSBinFormatELF()) {
-    // These declarations resolve to process addresses, not co-located JIT
-    // storage. Clearing dso_local forces AArch64 PIC codegen to use GOT/PLT
-    // style indirection instead of near-page ADRP relocations.
-    for (Function &F : (*ModuleOrErr)->functions()) {
-      if (F.isDeclaration() && !F.isIntrinsic())
-        F.setDSOLocal(false);
-    }
-    for (GlobalVariable &GV : (*ModuleOrErr)->globals()) {
-      if (GV.isDeclaration())
-        GV.setDSOLocal(false);
+  // Parse + IR-walk once per bitcode blob; every specialization after the
+  // first only pays for a clone of the resulting template module.
+  PreloadedBitcode *PB = nullptr;
+  {
+    auto it = P->preloaded.find(bitcodeData.data());
+    if (it != P->preloaded.end()) {
+      PB = &it->second;
+    } else {
+      auto PBOrErr = buildPreloadedBitcode(bitcodeData);
+      if (!PBOrErr) {
+        EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error",
+                  cacheKey);
+        return PBOrErr.takeError();
+      }
+      PB = *PBOrErr;
     }
   }
+  std::unique_ptr<Module> M = CloneModule(*PB->Template);
+  M->setModuleIdentifier("spec_" + std::to_string(cacheKey) + ".bc");
 
   // ejit_entry functions may have internal linkage (e.g. declared `static` in
   // source). ORC's IR layer excludes local-linkage symbols from the JITDylib
@@ -858,26 +983,25 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   // being compiled (origFnName) is the JIT lookup target — force it to
   // external linkage so ORC registers and can materialize it. Spec JITDylibs
   // are isolated, so this cannot collide with other specializations.
-  if (Function *EntryF = (*ModuleOrErr)->getFunction(origFnName))
+  if (Function *EntryF = M->getFunction(origFnName))
     if (!EntryF->isDeclaration() && EntryF->hasLocalLinkage())
       EntryF->setLinkage(GlobalValue::ExternalLinkage);
 
-  // Collect global variable addresses from the registry for symbols
-  // that appear as external declarations in the bitcode module.
+  // Collect global variable addresses from the registry for symbols that
+  // appear as external declarations in the bitcode module. The decl list and
+  // its interned names are precomputed; only the address lookups are redone,
+  // since registrations can arrive between compiles.
   orc::SymbolMap globalSymbols;
-  for (GlobalVariable &GV : (*ModuleOrErr)->globals()) {
-    if (!GV.isDeclaration() || GV.getName().empty())
-      continue;
+  for (const PreResolvedSym &S : PB->extGlobals) {
     void *addr = nullptr;
-    if (const auto *info = P->periodReg->getArrayInfo(GV.getName().str()))
+    if (const auto *info = P->periodReg->getArrayInfo(S.name))
       addr = info->baseAddr;
     else
-      addr = P->periodReg->getStaticVarAddr(GV.getName().str());
+      addr = P->periodReg->getStaticVarAddr(S.name);
     if (!addr)
       continue;
-    globalSymbols[P->J->mangleAndIntern(GV.getName())] =
-        orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(addr),
-                               JITSymbolFlags::Exported);
+    globalSymbols[S.mangled] = orc::ExecutorSymbolDef(
+        orc::ExecutorAddr::fromPtr(addr), JITSymbolFlags::Exported);
   }
 
   // Each specialization gets its own JITDylib so that symbols from
@@ -907,47 +1031,35 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   size_t unresolvedGlobals = 0;
   SmallVector<std::string, 16> unresolvedNames;
   static constexpr size_t kMaxUnresolvedNames = 32;
-  SmallPtrSet<const Function *, 16> ReferencedExternalFuncs;
-  SmallPtrSet<const GlobalVariable *, 16> ReferencedExternalGlobals;
-  collectReferencedExternalDecls(**ModuleOrErr, ReferencedExternalFuncs,
-                                 ReferencedExternalGlobals);
-  for (Function &F : (*ModuleOrErr)->functions()) {
-    if (!F.isDeclaration() || F.getName().empty())
+  for (const PreResolvedSym &S : PB->extFuncs) {
+    if (globalSymbols.count(S.mangled))
       continue;
-    std::string name = F.getName().str();
-    if (globalSymbols.count(P->J->mangleAndIntern(name)))
-      continue;
-    auto it = P->userSymbols.find(name);
+    auto it = P->userSymbols.find(S.name);
     if (it == P->userSymbols.end()) {
-      if (!F.isIntrinsic() && ReferencedExternalFuncs.contains(&F)) {
+      if (S.referenced) {
         ++unresolvedFuncs;
         if (unresolvedNames.size() < kMaxUnresolvedNames)
-          unresolvedNames.push_back("f:" + name);
+          unresolvedNames.push_back("f:" + S.name);
       }
       continue;
     }
-    globalSymbols[P->J->mangleAndIntern(name)] =
-        orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(it->second),
-                               JITSymbolFlags::Exported);
+    globalSymbols[S.mangled] = orc::ExecutorSymbolDef(
+        orc::ExecutorAddr::fromPtr(it->second), JITSymbolFlags::Exported);
   }
-  for (GlobalVariable &GV : (*ModuleOrErr)->globals()) {
-    if (!GV.isDeclaration() || GV.getName().empty())
+  for (const PreResolvedSym &S : PB->extGlobals) {
+    if (globalSymbols.count(S.mangled))
       continue;
-    std::string name = GV.getName().str();
-    if (globalSymbols.count(P->J->mangleAndIntern(name)))
-      continue;
-    auto it = P->userSymbols.find(name);
+    auto it = P->userSymbols.find(S.name);
     if (it == P->userSymbols.end()) {
-      if (ReferencedExternalGlobals.contains(&GV)) {
+      if (S.referenced) {
         ++unresolvedGlobals;
         if (unresolvedNames.size() < kMaxUnresolvedNames)
-          unresolvedNames.push_back("g:" + name);
+          unresolvedNames.push_back("g:" + S.name);
       }
       continue;
     }
-    globalSymbols[P->J->mangleAndIntern(name)] =
-        orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(it->second),
-                               JITSymbolFlags::Exported);
+    globalSymbols[S.mangled] = orc::ExecutorSymbolDef(
+        orc::ExecutorAddr::fromPtr(it->second), JITSymbolFlags::Exported);
   }
   if (unresolvedFuncs || unresolvedGlobals)
     EJIT_DIAG("loadBitcode: %zu unresolved external(s) not registered "
@@ -968,10 +1080,16 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   // disabled, so without these every JIT compilation fails at link time.
   // They go into the spec JITDylib (which is isolated: it does not link back
   // to the main JITDylib) so each specialization resolves them locally.
-  for (const LibcallSymbol &LCS : getLibcallSymbols())
-    globalSymbols[P->J->mangleAndIntern(LCS.name)] =
-        orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(LCS.addr),
-                               JITSymbolFlags::Exported);
+  // The set is fixed for the life of the engine, so it is mangled/interned
+  // once and merged in wholesale here.
+  if (P->libcallSymbols.empty()) {
+    for (const LibcallSymbol &LCS : getLibcallSymbols())
+      P->libcallSymbols[P->J->mangleAndIntern(LCS.name)] =
+          orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(LCS.addr),
+                                 JITSymbolFlags::Exported);
+  }
+  for (const auto &KV : P->libcallSymbols)
+    globalSymbols[KV.first] = KV.second;
 
   // Define all collected symbols in the spec JITDylib before loading the
   // IR module so the JIT linker can resolve external references.
@@ -984,8 +1102,9 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
                 cacheKey, nGlobals, toString(std::move(Err)).c_str());
   }
 
-  if (auto Err = P->J->addIRModule(*JDOrErr,
-      orc::ThreadSafeModule(std::move(*ModuleOrErr), std::move(Ctx)))) {
+  // The spec module shares the template's context (see PreloadedBitcode).
+  if (auto Err = P->J->addIRModule(
+          *JDOrErr, orc::ThreadSafeModule(std::move(M), PB->TSCtx))) {
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: add IR module error", cacheKey);
     return Err;
   }
@@ -1048,7 +1167,6 @@ void EJitOrcEngine::setActiveContext(const SpecializationContext *ctx) {
 const SpecializationContext *EJitOrcEngine::getActiveContext() const {
   return P->activeCtx;
 }
-
 
 void EJitOrcEngine::addUserSymbol(const std::string &name, void *addr) {
   P->userSymbols[name] = addr;

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   Analysis
   AsmParser
+  BitWriter
   Core
   EmbeddedJIT
   EJIT
@@ -9,11 +10,13 @@ set(LLVM_LINK_COMPONENTS
   Passes
   Support
   TargetParser
+  native
   )
 
 add_llvm_unittest(EJITTests
   EJitRuntimeTest.cpp
   EJitFieldOffsetTest.cpp
+  EJitOrcEnginePreloadTest.cpp
 
   PARTIAL_SOURCES_INTENDED
   )

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEnginePreloadTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEnginePreloadTest.cpp
@@ -6,12 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// EJitOrcEngine parses each bitcode blob once and clones the resulting template
-// module per specialization. A cache hit and a re-parse produce identical JIT
-// output, so these tests make the *input* observable instead: the bitcode is
-// loaded from a mutable buffer whose bytes are rewritten between loads while
-// its address (the cache key) stays fixed. A cached load keeps returning the
-// original function; a re-parse would pick up the new bytes.
+// Tests the parsed-bitcode cache. Parse count and retained footprint are
+// observable through getBitcodeCacheStats(), so these assert on that directly
+// rather than inferring caching from JIT output.
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,7 +23,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 
-#include <cstring>
 #include <string>
 #include <vector>
 
@@ -35,15 +31,51 @@ using namespace llvm::ejit;
 
 namespace {
 
-/// Bitcode for a module defining `i32 @spec_entry()` returning \p RetVal.
-std::string makeEntryBitcode(uint32_t RetVal) {
+/// A module with `NEntries` entry points, each returning \p Base plus its
+/// index. Mirrors AOT layout: one blob holds every ejit_entry in a TU.
+std::string makeBitcode(uint32_t Base, unsigned NEntries = 1) {
   LLVMContext Ctx;
   auto M = std::make_unique<Module>("ejit_preload_test", Ctx);
-  auto *FT = FunctionType::get(Type::getInt32Ty(Ctx), /*isVarArg=*/false);
-  auto *F = Function::Create(FT, GlobalValue::ExternalLinkage, "spec_entry",
+  auto *I32 = Type::getInt32Ty(Ctx);
+  for (unsigned I = 0; I < NEntries; ++I) {
+    auto *F = Function::Create(FunctionType::get(I32, /*isVarArg=*/false),
+                               GlobalValue::ExternalLinkage,
+                               "spec_entry" + std::to_string(I), M.get());
+    IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
+    B.CreateRet(B.getInt32(Base + I));
+  }
+  std::string Buf;
+  raw_string_ostream OS(Buf);
+  WriteBitcodeToFile(*M, OS);
+  OS.flush();
+  return Buf;
+}
+
+/// Calls an external function through a bitcast (so it only resolves via
+/// stripPointerCasts) and reads an external global.
+std::string makeBitcodeWithExternals() {
+  LLVMContext Ctx;
+  auto M = std::make_unique<Module>("ejit_preload_ext", Ctx);
+  auto *I32 = Type::getInt32Ty(Ctx);
+
+  auto *GV = new GlobalVariable(*M, I32, /*isConstant=*/false,
+                                GlobalValue::ExternalLinkage,
+                                /*Initializer=*/nullptr, "ext_global");
+  // Declared with a different signature than it is called through, forcing
+  // the call through a bitcast.
+  auto *DeclFT = FunctionType::get(I32, {I32, I32}, false);
+  auto *Helper = Function::Create(DeclFT, GlobalValue::ExternalLinkage,
+                                  "ext_helper", M.get());
+
+  auto *F = Function::Create(FunctionType::get(I32, false),
+                             GlobalValue::ExternalLinkage, "spec_entry0",
                              M.get());
   IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
-  B.CreateRet(B.getInt32(RetVal));
+  auto *CallFT = FunctionType::get(I32, {I32}, false);
+  auto *Cast = ConstantExpr::getBitCast(Helper, CallFT->getPointerTo());
+  Value *G = B.CreateLoad(I32, GV);
+  Value *R = B.CreateCall(CallFT, Cast, {G});
+  B.CreateRet(R);
 
   std::string Buf;
   raw_string_ostream OS(Buf);
@@ -54,8 +86,8 @@ std::string makeEntryBitcode(uint32_t RetVal) {
 
 using EntryFn = uint32_t (*)();
 
-/// These tests never set an active SpecializationContext, so the IR transform
-/// layer skips the JIT optimization pipeline; codegen still runs.
+/// No active SpecializationContext is set, so the IR transform layer skips
+/// the JIT optimization pipeline; codegen still runs.
 class EJitPreloadTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
@@ -63,16 +95,20 @@ protected:
     InitializeNativeTargetAsmPrinter();
   }
 
-  void SetUp() override {
-    auto EngOrErr = EJitOrcEngine::Create(Cfg, Reg, State);
+  void SetUp() override { reset(Cfg); }
+
+  void reset(const Config &C) {
+    Eng.reset();
+    auto EngOrErr = EJitOrcEngine::Create(C, Reg, State);
     ASSERT_TRUE(!!EngOrErr) << toString(EngOrErr.takeError());
     Eng = std::move(*EngOrErr);
   }
 
-  uint32_t compileAndRun(StringRef Blob, uint64_t Key) {
-    EXPECT_FALSE(errorToBool(Eng->loadBitcodeModule(Blob, Key, "spec_entry")))
+  uint32_t compileAndRun(StringRef Blob, uint64_t Key,
+                         const char *Entry = "spec_entry0") {
+    EXPECT_FALSE(errorToBool(Eng->loadBitcodeModule(Blob, Key, Entry)))
         << "loadBitcodeModule failed for key " << Key;
-    auto AddrOrErr = Eng->lookup(Key, "spec_entry");
+    auto AddrOrErr = Eng->lookup(Key, Entry);
     EXPECT_TRUE(!!AddrOrErr) << "lookup failed for key " << Key;
     if (!AddrOrErr) {
       consumeError(AddrOrErr.takeError());
@@ -81,76 +117,187 @@ protected:
     return reinterpret_cast<EntryFn>(*AddrOrErr)();
   }
 
+  uint64_t parses() const { return Eng->getBitcodeCacheStats().parses; }
+
   Config Cfg;
   PeriodArrayRegistry Reg;
   EJitRuntimeState State;
   std::unique_ptr<EJitOrcEngine> Eng;
 };
 
-TEST_F(EJitPreloadTest, SameBlobAddressIsParsedOnlyOnce) {
-  const std::string BC1 = makeEntryBitcode(111);
-  const std::string BC2 = makeEntryBitcode(222);
+// Two parses, not one: the first load deliberately retains nothing, so the
+// template is built on the second. Everything after that is a clone.
+TEST_F(EJitPreloadTest, ParseCountIsBoundedAcrossSpecializations) {
+  const std::string BC = makeBitcode(111);
+  const uint64_t N = 8;
 
-  // One stable allocation, so both loads present the same address.
-  std::vector<char> Blob(std::max(BC1.size(), BC2.size()));
-  std::memcpy(Blob.data(), BC1.data(), BC1.size());
+  for (uint64_t Key = 1; Key <= N; ++Key)
+    EXPECT_EQ(compileAndRun(BC, Key), 111u);
 
-  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC1.size()), 1), 111u);
-
-  // Same address, different bytes. Only a re-parse would observe 222.
-  std::memcpy(Blob.data(), BC2.data(), BC2.size());
-  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC2.size()), 2), 111u)
-      << "second specialization re-parsed the bitcode instead of cloning the "
-         "cached template";
+  EXPECT_EQ(parses(), 2u) << "blob was re-parsed per specialization";
+  EXPECT_EQ(Eng->getBitcodeCacheStats().templateHits, N - 2);
 }
 
-// Control for the test above, which would also pass if the cache returned one
-// stale module for everything.
-TEST_F(EJitPreloadTest, DistinctBlobAddressIsParsedIndependently) {
-  const std::string BC1 = makeEntryBitcode(111);
-  const std::string BC2 = makeEntryBitcode(222);
+// Parsed IR costs ~20x the bitcode; a one-shot blob must not pay that.
+TEST_F(EJitPreloadTest, SingleSpecializationRetainsNothing) {
+  const std::string BC = makeBitcode(111);
 
-  std::vector<char> BlobA(BC1.begin(), BC1.end());
-  std::vector<char> BlobB(BC2.begin(), BC2.end());
-  ASSERT_NE(BlobA.data(), BlobB.data());
+  EXPECT_EQ(compileAndRun(BC, 1), 111u);
 
-  EXPECT_EQ(compileAndRun(StringRef(BlobA.data(), BlobA.size()), 1), 111u);
-  EXPECT_EQ(compileAndRun(StringRef(BlobB.data(), BlobB.size()), 2), 222u);
+  auto S = Eng->getBitcodeCacheStats();
+  EXPECT_EQ(S.entries, 0u) << "a one-shot blob was retained";
+  EXPECT_EQ(S.approxBytes, 0u);
+  EXPECT_EQ(S.parses, 1u);
 }
 
-TEST_F(EJitPreloadTest, PreLoadBitcodeUtilPopulatesTheCache) {
-  const std::string BC1 = makeEntryBitcode(111);
-  const std::string BC2 = makeEntryBitcode(222);
+// The template is built on the second load, not the first.
+TEST_F(EJitPreloadTest, TemplateIsRetainedOnSecondLoad) {
+  const std::string BC = makeBitcode(111);
 
-  std::vector<char> Blob(std::max(BC1.size(), BC2.size()));
-  std::memcpy(Blob.data(), BC1.data(), BC1.size());
+  EXPECT_EQ(compileAndRun(BC, 1), 111u);
+  EXPECT_EQ(Eng->getBitcodeCacheStats().entries, 0u);
 
-  ASSERT_FALSE(
-      errorToBool(Eng->preLoadBitcodeUtil(StringRef(Blob.data(), BC1.size()))));
+  EXPECT_EQ(compileAndRun(BC, 2), 111u);
+  auto S = Eng->getBitcodeCacheStats();
+  EXPECT_EQ(S.entries, 1u);
+  EXPECT_GT(S.approxBytes, 0u);
+  EXPECT_EQ(S.parses, 2u) << "second load should parse once more, then cache";
 
-  // Rewritten before any loadBitcodeModule call: the preload already holds the
-  // template.
-  std::memcpy(Blob.data(), BC2.data(), BC2.size());
-  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC2.size()), 1), 111u)
-      << "preLoadBitcodeUtil did not populate the cache";
+  // Third load is served from the template.
+  EXPECT_EQ(compileAndRun(BC, 3), 111u);
+  EXPECT_EQ(parses(), 2u);
 }
 
-// Preloading twice is idempotent and must not discard the existing template.
+// preLoadBitcodeUtil skips the second-load gate.
+TEST_F(EJitPreloadTest, PreLoadBitcodeUtilCachesImmediately) {
+  const std::string BC = makeBitcode(111);
+
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(BC)));
+  auto S = Eng->getBitcodeCacheStats();
+  EXPECT_EQ(S.entries, 1u);
+  EXPECT_EQ(S.parses, 1u);
+
+  EXPECT_EQ(compileAndRun(BC, 1), 111u);
+  EXPECT_EQ(parses(), 1u) << "preloaded blob was parsed again on first compile";
+}
+
 TEST_F(EJitPreloadTest, PreLoadBitcodeUtilIsIdempotent) {
-  const std::string BC1 = makeEntryBitcode(111);
-  const std::string BC2 = makeEntryBitcode(222);
+  const std::string BC = makeBitcode(111);
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(BC)));
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(BC)));
+  EXPECT_EQ(parses(), 1u);
+  EXPECT_EQ(Eng->getBitcodeCacheStats().entries, 1u);
+}
 
-  std::vector<char> Blob(std::max(BC1.size(), BC2.size()));
-  std::memcpy(Blob.data(), BC1.data(), BC1.size());
-  ASSERT_FALSE(
-      errorToBool(Eng->preLoadBitcodeUtil(StringRef(Blob.data(), BC1.size()))));
+// A cached template is never handed out for different bitcode.
+TEST_F(EJitPreloadTest, DistinctBlobsAreCachedIndependently) {
+  const std::string A = makeBitcode(111);
+  const std::string B = makeBitcode(222);
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(A)));
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(B)));
 
-  std::memcpy(Blob.data(), BC2.data(), BC2.size());
-  ASSERT_FALSE(
-      errorToBool(Eng->preLoadBitcodeUtil(StringRef(Blob.data(), BC2.size()))));
+  EXPECT_EQ(compileAndRun(A, 1), 111u);
+  EXPECT_EQ(compileAndRun(B, 2), 222u);
+  EXPECT_EQ(Eng->getBitcodeCacheStats().entries, 2u);
+}
 
-  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC2.size()), 1), 111u)
-      << "a second preLoadBitcodeUtil rebuilt the template from new bytes";
+// Identity is address *and* size, so a buffer that changes length is not
+// mistaken for the cached entry.
+TEST_F(EJitPreloadTest, SizeIsPartOfBlobIdentity) {
+  const std::string One = makeBitcode(111, /*NEntries=*/1);
+  const std::string Two = makeBitcode(222, /*NEntries=*/2);
+  ASSERT_NE(One.size(), Two.size());
+
+  std::vector<char> Buf(std::max(One.size(), Two.size()));
+  std::copy(One.begin(), One.end(), Buf.begin());
+  ASSERT_FALSE(errorToBool(
+      Eng->preLoadBitcodeUtil(StringRef(Buf.data(), One.size()))));
+
+  // Same address, different length: a fresh parse, not the cached template.
+  std::copy(Two.begin(), Two.end(), Buf.begin());
+  EXPECT_EQ(compileAndRun(StringRef(Buf.data(), Two.size()), 1), 222u);
+  EXPECT_EQ(parses(), 2u);
+}
+
+// One blob holds every ejit_entry of a TU, which is why the entry-linkage
+// fixup is applied per clone rather than baked into the template.
+TEST_F(EJitPreloadTest, MultipleEntryPointsShareOneTemplate) {
+  const std::string BC = makeBitcode(500, /*NEntries=*/3);
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(BC)));
+
+  EXPECT_EQ(compileAndRun(BC, 1, "spec_entry0"), 500u);
+  EXPECT_EQ(compileAndRun(BC, 2, "spec_entry1"), 501u);
+  EXPECT_EQ(compileAndRun(BC, 3, "spec_entry2"), 502u);
+  EXPECT_EQ(parses(), 1u);
+}
+
+// Declarations are discovered once, but addresses must be re-resolved per
+// compile: a symbol registered after the template was built still has to bind.
+TEST_F(EJitPreloadTest, SymbolsRegisteredAfterCachingStillResolve) {
+  static uint32_t GlobalStorage = 7;
+  const std::string BC = makeBitcodeWithExternals();
+
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(BC)));
+
+  // Registered only after the template exists.
+  Eng->addUserSymbol("ext_helper", reinterpret_cast<void *>(+[](uint32_t V) {
+                       return V * 3;
+                     }));
+  Eng->addUserSymbol("ext_global", &GlobalStorage);
+
+  EXPECT_EQ(compileAndRun(BC, 1), 21u) << "late-registered symbols did not bind";
+  EXPECT_EQ(parses(), 1u);
+}
+
+// With room for one entry, caching a second blob evicts the first.
+TEST_F(EJitPreloadTest, CacheStaysWithinItsByteBudget) {
+  const std::string A = makeBitcode(111);
+  const std::string B = makeBitcode(222);
+
+  Config Small = Cfg;
+  Small.maxPreloadCacheSize = A.size() * 20 + 16; // room for ~one entry
+  ASSERT_NO_FATAL_FAILURE(reset(Small));
+
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(A)));
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(B)));
+
+  auto S = Eng->getBitcodeCacheStats();
+  EXPECT_EQ(S.entries, 1u);
+  EXPECT_LE(S.approxBytes, Small.maxPreloadCacheSize);
+  EXPECT_EQ(S.evictions, 1u);
+
+  // The evicted blob still compiles, just via a fresh parse.
+  EXPECT_EQ(compileAndRun(A, 1), 111u);
+}
+
+// A zero budget disables retention outright.
+TEST_F(EJitPreloadTest, ZeroBudgetDisablesTheCache) {
+  const std::string BC = makeBitcode(111);
+
+  Config Off = Cfg;
+  Off.maxPreloadCacheSize = 0;
+  ASSERT_NO_FATAL_FAILURE(reset(Off));
+
+  for (uint64_t Key = 1; Key <= 3; ++Key)
+    EXPECT_EQ(compileAndRun(BC, Key), 111u);
+
+  auto S = Eng->getBitcodeCacheStats();
+  EXPECT_EQ(S.entries, 0u);
+  EXPECT_EQ(S.approxBytes, 0u);
+  EXPECT_EQ(S.parses, 3u) << "every compile should re-parse with no cache";
+}
+
+TEST_F(EJitPreloadTest, ClearBitcodeCacheReleasesEverything) {
+  const std::string BC = makeBitcode(111);
+  ASSERT_FALSE(errorToBool(Eng->preLoadBitcodeUtil(BC)));
+  ASSERT_EQ(Eng->getBitcodeCacheStats().entries, 1u);
+
+  Eng->clearBitcodeCache();
+  auto S = Eng->getBitcodeCacheStats();
+  EXPECT_EQ(S.entries, 0u);
+  EXPECT_EQ(S.approxBytes, 0u);
+
+  EXPECT_EQ(compileAndRun(BC, 1), 111u);
 }
 
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEnginePreloadTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEnginePreloadTest.cpp
@@ -1,0 +1,156 @@
+//===-- EJitOrcEnginePreloadTest.cpp - bitcode preload cache -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// EJitOrcEngine parses each bitcode blob once and clones the resulting template
+// module per specialization. A cache hit and a re-parse produce identical JIT
+// output, so these tests make the *input* observable instead: the bitcode is
+// loaded from a mutable buffer whose bytes are rewritten between loads while
+// its address (the cache key) stays fixed. A cached load keeps returning the
+// original function; a re-parse would pick up the new bytes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
+#include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace llvm;
+using namespace llvm::ejit;
+
+namespace {
+
+/// Bitcode for a module defining `i32 @spec_entry()` returning \p RetVal.
+std::string makeEntryBitcode(uint32_t RetVal) {
+  LLVMContext Ctx;
+  auto M = std::make_unique<Module>("ejit_preload_test", Ctx);
+  auto *FT = FunctionType::get(Type::getInt32Ty(Ctx), /*isVarArg=*/false);
+  auto *F = Function::Create(FT, GlobalValue::ExternalLinkage, "spec_entry",
+                             M.get());
+  IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
+  B.CreateRet(B.getInt32(RetVal));
+
+  std::string Buf;
+  raw_string_ostream OS(Buf);
+  WriteBitcodeToFile(*M, OS);
+  OS.flush();
+  return Buf;
+}
+
+using EntryFn = uint32_t (*)();
+
+/// These tests never set an active SpecializationContext, so the IR transform
+/// layer skips the JIT optimization pipeline; codegen still runs.
+class EJitPreloadTest : public ::testing::Test {
+protected:
+  static void SetUpTestSuite() {
+    InitializeNativeTarget();
+    InitializeNativeTargetAsmPrinter();
+  }
+
+  void SetUp() override {
+    auto EngOrErr = EJitOrcEngine::Create(Cfg, Reg, State);
+    ASSERT_TRUE(!!EngOrErr) << toString(EngOrErr.takeError());
+    Eng = std::move(*EngOrErr);
+  }
+
+  uint32_t compileAndRun(StringRef Blob, uint64_t Key) {
+    EXPECT_FALSE(errorToBool(Eng->loadBitcodeModule(Blob, Key, "spec_entry")))
+        << "loadBitcodeModule failed for key " << Key;
+    auto AddrOrErr = Eng->lookup(Key, "spec_entry");
+    EXPECT_TRUE(!!AddrOrErr) << "lookup failed for key " << Key;
+    if (!AddrOrErr) {
+      consumeError(AddrOrErr.takeError());
+      return 0;
+    }
+    return reinterpret_cast<EntryFn>(*AddrOrErr)();
+  }
+
+  Config Cfg;
+  PeriodArrayRegistry Reg;
+  EJitRuntimeState State;
+  std::unique_ptr<EJitOrcEngine> Eng;
+};
+
+TEST_F(EJitPreloadTest, SameBlobAddressIsParsedOnlyOnce) {
+  const std::string BC1 = makeEntryBitcode(111);
+  const std::string BC2 = makeEntryBitcode(222);
+
+  // One stable allocation, so both loads present the same address.
+  std::vector<char> Blob(std::max(BC1.size(), BC2.size()));
+  std::memcpy(Blob.data(), BC1.data(), BC1.size());
+
+  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC1.size()), 1), 111u);
+
+  // Same address, different bytes. Only a re-parse would observe 222.
+  std::memcpy(Blob.data(), BC2.data(), BC2.size());
+  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC2.size()), 2), 111u)
+      << "second specialization re-parsed the bitcode instead of cloning the "
+         "cached template";
+}
+
+// Control for the test above, which would also pass if the cache returned one
+// stale module for everything.
+TEST_F(EJitPreloadTest, DistinctBlobAddressIsParsedIndependently) {
+  const std::string BC1 = makeEntryBitcode(111);
+  const std::string BC2 = makeEntryBitcode(222);
+
+  std::vector<char> BlobA(BC1.begin(), BC1.end());
+  std::vector<char> BlobB(BC2.begin(), BC2.end());
+  ASSERT_NE(BlobA.data(), BlobB.data());
+
+  EXPECT_EQ(compileAndRun(StringRef(BlobA.data(), BlobA.size()), 1), 111u);
+  EXPECT_EQ(compileAndRun(StringRef(BlobB.data(), BlobB.size()), 2), 222u);
+}
+
+TEST_F(EJitPreloadTest, PreLoadBitcodeUtilPopulatesTheCache) {
+  const std::string BC1 = makeEntryBitcode(111);
+  const std::string BC2 = makeEntryBitcode(222);
+
+  std::vector<char> Blob(std::max(BC1.size(), BC2.size()));
+  std::memcpy(Blob.data(), BC1.data(), BC1.size());
+
+  ASSERT_FALSE(
+      errorToBool(Eng->preLoadBitcodeUtil(StringRef(Blob.data(), BC1.size()))));
+
+  // Rewritten before any loadBitcodeModule call: the preload already holds the
+  // template.
+  std::memcpy(Blob.data(), BC2.data(), BC2.size());
+  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC2.size()), 1), 111u)
+      << "preLoadBitcodeUtil did not populate the cache";
+}
+
+// Preloading twice is idempotent and must not discard the existing template.
+TEST_F(EJitPreloadTest, PreLoadBitcodeUtilIsIdempotent) {
+  const std::string BC1 = makeEntryBitcode(111);
+  const std::string BC2 = makeEntryBitcode(222);
+
+  std::vector<char> Blob(std::max(BC1.size(), BC2.size()));
+  std::memcpy(Blob.data(), BC1.data(), BC1.size());
+  ASSERT_FALSE(
+      errorToBool(Eng->preLoadBitcodeUtil(StringRef(Blob.data(), BC1.size()))));
+
+  std::memcpy(Blob.data(), BC2.data(), BC2.size());
+  ASSERT_FALSE(
+      errorToBool(Eng->preLoadBitcodeUtil(StringRef(Blob.data(), BC2.size()))));
+
+  EXPECT_EQ(compileAndRun(StringRef(Blob.data(), BC2.size()), 1), 111u)
+      << "a second preLoadBitcodeUtil rebuilt the template from new bytes";
+}
+
+} // namespace


### PR DESCRIPTION
Currently, `EJitOrcEngine::loadBitcodeModule()` recomputes, on every cold compile, work that is identical for every specialization built from the same bitcode: it re-parsed the bitcode bytes, re-walked the IR to find the external declarations referenced by reachable code, cleared `dso_local` on external declarations, and re-interned every external symbol name.

This patch introduces `buildPreloadedBitcode()`, which does that work once per bitcode blob and caches the result.

This is particularly useful when many cold compiles come from the same bitcode blob: -13.0% per cold compile on `ejit_compile_perf_bench`. Workloads whose blobs are compiled only once show no measurable change.