### PR TITLE
[EJIT] Introduce IPSCCP pass to the EJITOptimizer pipeline

### DIFF
--- a/ejit_test/ejit_perf_bench.c
+++ b/ejit_test/ejit_perf_bench.c
@@ -81,6 +81,47 @@ uint64_t compute_cell_nojit(uint8_t ci)
   return sum;
 }
 
+//===-- Interprocedural: noinline 被调函数读 may_const 字段 -------------------===//
+//
+// The AOT inliner keeps this call edge (noinline), so the entry's specialized
+// cell index reaches the callee only as an ordinary argument. Without
+// interprocedural propagation (pipeline phase 1d) the callee re-loads the six
+// may_const fields and re-tests both guards on every call — the JIT run then
+// matches AOT. With phase 1d the callee folds to `sum + constant`.
+
+__attribute__((noinline))
+static uint64_t cell_step(uint8_t ci, uint64_t sum)
+{
+  struct CellCfg *p = &g_cfg[ci];
+  if (p->cellType == 0xFD) {
+    if (p->priority > 10)
+      return sum + p->maxPower * p->bandWidth / (p->timeSlot + 1);
+    return sum + p->minPower * p->bandWidth / (p->timeSlot + 1);
+  } else if (p->cellType == 0xEC) {
+    return sum + (p->maxPower + p->minPower) * p->bandWidth / (p->timeSlot + 1);
+  }
+  return sum;
+}
+
+ejit_entry
+uint64_t compute_cell_ip(
+    ejit_period_arr_ind(cell) uint8_t ci)
+{
+  uint64_t sum = 0;
+  for (uint64_t i = 0; i < LOOP_ITERS; i++)
+    sum = cell_step(ci, sum);
+  return sum;
+}
+
+// 纯 AOT 对照（无 attribute），同样经过 noinline 调用边界
+uint64_t compute_cell_ip_nojit(uint8_t ci)
+{
+  uint64_t sum = 0;
+  for (uint64_t i = 0; i < LOOP_ITERS; i++)
+    sum = cell_step(ci, sum);
+  return sum;
+}
+
 //===-- 运行时 API -----------------------------------------------------------===//
 
 extern void ejit_shutdown(void);
@@ -166,6 +207,42 @@ int main(int argc, char **argv) {
     }
   }
 
+  printf("\n--- Interproc AOT (noinline 调用边界, 无 attribute) ---\n");
+
+  uint64_t ip_pure_sum = 0;
+  double ip_pure_time = 0;
+  for (int w = 0; w < n_warmup; w++) {
+    double t0 = now_ms();
+    uint64_t r = compute_cell_ip_nojit(ci);
+    double t1 = now_ms();
+    ip_pure_time = t1 - t0;
+    ip_pure_sum = r;
+    if (w == n_warmup - 1) {
+      printf("  result=%llu  time=%.1f ms\n",
+             (unsigned long long)r, ip_pure_time);
+    }
+  }
+
+  printf("\n--- Interproc JIT (常量跨调用边界传播) ---\n");
+
+  // 预热: 触发编译并等待完成，再计时（异步模式下首个调用会走 AOT fallback）
+  compute_cell_ip(ci);
+  ejit_drain_taskpool();
+
+  uint64_t ip_jit_sum = 0;
+  double ip_jit_time = 0;
+  for (int w = 0; w < n_warmup; w++) {
+    double t0 = now_ms();
+    uint64_t r = compute_cell_ip(ci);
+    double t1 = now_ms();
+    ip_jit_time = t1 - t0;
+    ip_jit_sum = r;
+    if (w == n_warmup - 1) {
+      printf("  result=%llu  time=%.1f ms\n",
+             (unsigned long long)r, ip_jit_time);
+    }
+  }
+
   ejit_drain_taskpool();
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   ejit_taskpool_stats_t ts; memset(&ts, 0, sizeof(ts));
@@ -206,6 +283,19 @@ int main(int argc, char **argv) {
     printf("  JIT vs Pure AOT 加速: %.1fx\n", pure_time / jit_time);
     printf("  AOT Fallback vs Pure overhead: %.1fx\n", aot_time / pure_time);
   }
+
+  if (ip_jit_sum == ip_pure_sum) {
+    printf("\n  Interproc Result MATCH: Pure=%llu JIT=%llu\n",
+           (unsigned long long)ip_pure_sum, (unsigned long long)ip_jit_sum);
+  } else {
+    printf("\n  Interproc Result MISMATCH: Pure=%llu JIT=%llu\n",
+           (unsigned long long)ip_pure_sum, (unsigned long long)ip_jit_sum);
+  }
+  printf("  Interproc Pure AOT: %.1f ms\n", ip_pure_time);
+  printf("  Interproc JIT:      %.1f ms\n", ip_jit_time);
+  if (ip_jit_time > 0)
+    printf("  Interproc JIT vs Pure AOT 加速: %.1fx\n",
+           ip_pure_time / ip_jit_time);
 
   printf("\n=== Benchmark Complete ===\n");
   return 0;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -51,6 +51,17 @@ private:
   /// Run EJitStructFieldPass on all functions.
   void runStructFieldPass(Module &M);
 
+  /// Push the specialized constants across call edges. The AOT inliner keeps a
+  /// call edge wherever it chose not to inline, so after phase 1 every call
+  /// site passes the period dims (and values derived from them) as ordinary
+  /// constant arguments — but the callee bodies still re-derive cell addressing
+  /// and re-test guards the entry already resolved. Internalizes every defined
+  /// non-ejit_entry function (IPSCCP only reasons about arguments of functions
+  /// whose call sites it can enumerate: local linkage, not address-taken), then
+  /// runs IPSCCP to propagate constant arguments into callee bodies and
+  /// constant returns back to call sites.
+  void runInterproceduralPropagation(Module &M);
+
   /// Run the EJIT optimization pipeline: a single fused sequence that exploits
   /// the just-substituted period-index / may_const constants to their fixed
   /// point (scalar fold/propagate/simplify), folds loops whose bounds became

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -12,6 +12,7 @@
 // JIT Inline disabled: AOT pre-optimization already inlines.
 // #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/IPO/SCCP.h"
 #include "llvm/Transforms/Scalar/ADCE.h"
 #include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
@@ -124,6 +125,20 @@ void EJitOptimizer::runPipeline(Module &M,
   //   (c) Replace the may_const loads with their runtime constant values.
   runStructFieldPass(M);
   EJIT_DIAG_DEBUG("pipeline phase1c done: StructFieldPass");
+  //   (d) Push the constants across call edges. Wherever the AOT inliner kept
+  //       a call, the callee still re-derives cell addressing and re-tests
+  //       guards from its arguments — which phases 1a-1c just made constant at
+  //       every call site. IPSCCP propagates them into the callee bodies (and
+  //       constant returns back out).
+  runInterproceduralPropagation(M);
+  EJIT_DIAG_DEBUG("pipeline phase1d done: IPSCCP");
+  //   (e,f) The propagated arguments expose callee GEP chains exactly as 1a
+  //       did for the entry: fold them, then substitute the callee may_const
+  //       loads they root, so phases 2-4 exploit the constants in every
+  //       function, not just the entry.
+  runInstCombine(M);
+  runStructFieldPass(M);
+  EJIT_DIAG_DEBUG("pipeline phase1ef done: callee InstCombine+StructFieldPass");
 
   // Phases 2-4 — exploit those constants (scalar fixed point → loops →
   // re-specialize → cleanup). ctx.optLevel is accepted for ABI compatibility
@@ -179,6 +194,30 @@ void EJitOptimizer::runInstCombine(Module &M) {
   for (Function &F : M.functions())
     if (!F.isDeclaration())
       FPM.run(F, FAM_);
+}
+
+void EJitOptimizer::runInterproceduralPropagation(Module &M) {
+  // IPSCCP only reasons about a function's arguments when it can enumerate
+  // every call site: local linkage and no address-taken uses. The
+  // specialization module is self-contained — the JIT looks up only the
+  // ejit_entry symbols; every other definition is called module-internally and
+  // external references resolve to AOT symbols — so all non-entry definitions
+  // can be internalized. (Address-taken callees are internalized too; IPSCCP
+  // itself skips their arguments, and their symbols are still resolved
+  // module-internally.)
+  for (Function &F : M.functions()) {
+    if (F.isDeclaration() || F.hasLocalLinkage())
+      continue;
+    if (hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY))
+      continue;
+    // The IR verifier requires default visibility with local linkage.
+    F.setVisibility(GlobalValue::DefaultVisibility);
+    F.setLinkage(GlobalValue::InternalLinkage);
+  }
+
+  ModulePassManager MPM;
+  MPM.addPass(IPSCCPPass());
+  MPM.run(M, MAM_);
 }
 
 void EJitOptimizer::runStructFieldPass(Module &M) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -28,12 +28,14 @@
 #ifdef EJIT_SRE_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h"
 #endif
+#include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 #ifndef EJIT_FREESTANDING
@@ -55,6 +57,7 @@ struct EJitOptimizerTestAccess : EJitOptimizer {
   using EJitOptimizer::EJitOptimizer;
   using EJitOptimizer::preReplacePeriodIndices;
   using EJitOptimizer::runInstCombine;
+  using EJitOptimizer::runInterproceduralPropagation;
   using EJitOptimizer::runOptimizationPipeline;
   using EJitOptimizer::runStructFieldPass;
 };
@@ -2463,6 +2466,140 @@ TEST(EJitEndToEnd, PipelineLevelEquivalenceBranch) {
   EXPECT_EQ(L2, L3) << "L2 vs L3 IR differs — level changed the pipeline";
   EXPECT_NE(L1.find("ret i32 100"), std::string::npos)
       << "pipeline did not fold the may_const branch to the constant 100";
+}
+
+//===----------------------------------------------------------------------===//
+// Interprocedural propagation (phase 1d)
+//===----------------------------------------------------------------------===//
+
+// The AOT inliner keeps a call edge wherever it chose not to inline, so a
+// specialization used to stop at every such edge: the entry's substituted
+// dims arrive at the callee as ordinary constant arguments, but the callee
+// body still indexes the period array with a runtime value and re-tests
+// guards. These tests pin phase 1d (internalize + IPSCCP): the constants
+// cross the edge, the callee's may_const load becomes substitutable, and the
+// callee folds to a constant return like the entry does.
+namespace {
+
+/// Entry (has ejit_entry metadata) calls a callee with a constant cell index
+/// — the shape phase 1a leaves behind. The callee loads field 1 of
+/// g_ipcfg[cell] (may_const) and branches on it.
+std::unique_ptr<Module> parseInterprocModule(LLVMContext &Ctx) {
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    target datalayout = "e-m:e-i64:64-i128:128-n32:64-S128"
+    %S = type { i32, i32 }
+    @g_ipcfg = external global [4 x %S], !ejit.metadata !0
+
+    define i32 @ip_callee(i8 noundef %cell) {
+      %idx = zext i8 %cell to i64
+      %gep = getelementptr inbounds [4 x %S], ptr @g_ipcfg, i64 0, i64 %idx, i32 1
+      %v = load i32, ptr %gep, align 4, !ejit.may_const !2
+      %c = icmp eq i32 %v, 7
+      br i1 %c, label %then, label %else
+    then:
+      ret i32 100
+    else:
+      ret i32 200
+    }
+
+    define i32 @ip_entry() !ejit.metadata !3 {
+      %r = call i32 @ip_callee(i8 noundef 2)
+      ret i32 %r
+    }
+
+    !0 = !{!1}
+    !1 = !{!"ejit_period_arr", !"cell", i32 4}
+    !2 = !{}
+    !3 = !{!4}
+    !4 = !{!"ejit_entry"}
+  )",
+                              Err, Ctx);
+  if (!M)
+    Err.print("parseInterprocModule", errs());
+  return M;
+}
+
+/// Per-cell mock backing for @g_ipcfg; cell 2 has field 1 == 7 → callee
+/// returns 100 when specialized for cell 2.
+struct IpMockElem {
+  int32_t a, b;
+};
+
+unsigned countLoadsIn(const Function &F) {
+  unsigned n = 0;
+  for (const BasicBlock &BB : F)
+    for (const Instruction &I : BB)
+      n += isa<LoadInst>(&I);
+  return n;
+}
+
+} // anonymous namespace
+
+// Without phase 1d the callee is untouched: its load survives the whole
+// pipeline because the cell index stays a runtime argument inside it. This is
+// the baseline that motivates the pass.
+TEST(EJitInterprocedural, ConstantsStopAtCallEdgeWithoutIPSCCP) {
+  LLVMContext Ctx;
+  auto M = parseInterprocModule(Ctx);
+  ASSERT_NE(M, nullptr);
+
+  IpMockElem mock[4] = {{0, 1}, {0, 3}, {0, 7}, {0, 9}};
+  PeriodArrayRegistry reg;
+  reg.registerArray("cell", "g_ipcfg", mock, 4);
+
+  EJitOptimizerTestAccess opt(reg);
+  opt.runInstCombine(*M);
+  opt.runStructFieldPass(*M);
+  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
+
+  Function *Callee = M->getFunction("ip_callee");
+  ASSERT_NE(Callee, nullptr);
+  EXPECT_EQ(countLoadsIn(*Callee), 1u)
+      << "callee folded without IPSCCP — baseline assumption changed";
+}
+
+// With phase 1d in its pipeline position (after 1c, before the 1e/1f
+// re-fold), the constant argument crosses the edge, the callee's may_const
+// load folds against cell 2's runtime value, and the guard collapses: the
+// callee body becomes `ret i32 100`.
+TEST(EJitInterprocedural, IPSCCPPropagatesDimsIntoCallee) {
+  LLVMContext Ctx;
+  auto M = parseInterprocModule(Ctx);
+  ASSERT_NE(M, nullptr);
+
+  IpMockElem mock[4] = {{0, 1}, {0, 3}, {0, 7}, {0, 9}};
+  PeriodArrayRegistry reg;
+  reg.registerArray("cell", "g_ipcfg", mock, 4);
+
+  EJitOptimizerTestAccess opt(reg);
+  // Same order as runPipeline: 1b InstCombine, 1c StructField, 1d IPSCCP,
+  // 1e/1f re-fold, phases 2-4.
+  opt.runInstCombine(*M);
+  opt.runStructFieldPass(*M);
+  opt.runInterproceduralPropagation(*M);
+  opt.runInstCombine(*M);
+  opt.runStructFieldPass(*M);
+  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
+
+  Function *Callee = M->getFunction("ip_callee");
+  Function *Entry = M->getFunction("ip_entry");
+  ASSERT_NE(Callee, nullptr);
+  ASSERT_NE(Entry, nullptr);
+
+  // The callee was internalized so IPSCCP could trust its call-site set; the
+  // entry must stay externally visible — it is the symbol the JIT looks up.
+  EXPECT_TRUE(Callee->hasLocalLinkage());
+  EXPECT_FALSE(Entry->hasLocalLinkage());
+
+  // The callee's period load and guard folded to the constant return.
+  EXPECT_EQ(countLoadsIn(*Callee), 0u) << "callee may_const load survived";
+  ASSERT_EQ(Callee->size(), 1u) << "callee guard branch survived";
+  auto *Ret = dyn_cast<ReturnInst>(Callee->getEntryBlock().getTerminator());
+  ASSERT_NE(Ret, nullptr);
+  auto *RetVal = dyn_cast<ConstantInt>(Ret->getReturnValue());
+  ASSERT_NE(RetVal, nullptr) << "callee return did not fold";
+  EXPECT_EQ(RetVal->getSExtValue(), 100); // mock[2].b == 7 → then-branch
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Currently, specialization optimizes `may_const` fields in the entry function but stops at call boundaries. When callees receive constant arguments derived from the entry's specialization, they still re-read `may_const` fields as runtime values instead of folding them as constants.

This adds IPSCCP to push specialized constants across call edges. Where the AOT inliner kept a call edge, the callee now receives the entry's substituted dimensions as ordinary constant arguments. 

The IPSCCP pass propagates them into callee bodies (and constants back to call sites), then a second `InstCombine+StructFieldPass` cycle specializes each callee's `may_const` loads.

Note: This optimization only activates when a function's call sites all pass the same constant value for a given argument.