### PR TITLE
[EJIT] Add safe post-link machine-code dump

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -381,7 +381,7 @@ def doit_gc_merge(args):
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
         "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped",
-        "ejit_dump_all",
+        "ejit_print_dumped_code", "ejit_dump_all",
         # Inline-cache: ejit_register_icache_slot is called from
         # ejit_auto_register (AOT) when -ejit-inline-cache is on, not from the
         # runtime, so gc-merge's --gc-sections would discard it without this GC

--- a/ejit_test/parse_dump.py
+++ b/ejit_test/parse_dump.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""
+Parse EJIT dump logs: extract post-link hex + pre-link ASM, disassemble, compare.
+
+Usage:
+    ./parse_dump.py <log_file> [--objdump <path>] [--outdir <dir>] [--name <func>]
+
+Parses a board log containing:
+  - ejit_print_dumped("name")       -> pre-link .s ASM (dump ASM:N: <text>)
+  - ejit_print_dumped_code("name")  -> post-link hex (  00000000: 1f 00 00 91)
+
+For each function found:
+  1. Extracts the post-link hex, writes a .bin file
+  2. Disassembles with objdump (auto-detected or --objdump)
+  3. Extracts the pre-link ASM, writes a .s file
+  4. Prints a summary (instruction counts, stub count, addressing mode)
+  5. Optionally prints side-by-side comparison
+
+The script requires a GNU AArch64 objdump because llvm-objdump does not accept
+raw binary input. It tries --objdump, then $EJIT_OBJDUMP, then the common GNU
+cross-objdump names.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+# ── Data structures ──────────────────────────────────────────────────────────
+
+DumpData = namedtuple("DumpData", ["name", "hex_bytes", "pre_asm", "code_size_log"])
+
+# ── Log parsing ──────────────────────────────────────────────────────────────
+
+# Board-log exports may collapse all records onto one physical line. Split on
+# timestamps first so each prefixed EJIT record can be parsed independently.
+LOG_TIMESTAMP_RE = re.compile(r"(?=\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\])")
+
+# Post-link hex line: "  00000000: 1f 00 00 91" (with optional prefix)
+HEX_LINE_RE = re.compile(
+    r"\b[0-9a-fA-F]{8,16}:\s+([0-9a-fA-F]{2})\s+([0-9a-fA-F]{2})\s+([0-9a-fA-F]{2})\s+([0-9a-fA-F]{2})(?![0-9a-fA-F])"
+)
+HEX_HEADER_RE = re.compile(
+    r"post-link code hex dump\s+name=(\S+)\s+start=0x([0-9a-fA-F]+)\s+"
+    r"fn=0x([0-9a-fA-F]+)\s+fn_offset=0x([0-9a-fA-F]+)\s+size=(\d+)"
+)
+HEX_END_RE = re.compile(r"post-link code hex dump end")
+
+# Pre-link ASM line: "dump ASM:123: <text>" (with optional prefix)
+ASM_LINE_RE = re.compile(r"dump\s+ASM:\d+:\s?(.*)$")
+ASM_HEADER_RE = re.compile(r"dump ASM begin\s+size=\d+")
+ASM_END_RE = re.compile(r"dump ASM end")
+
+# Code size log from compileCold
+CODE_SIZE_RE = re.compile(
+    r"dump:\s+codeStart=0x([0-9a-fA-F]+)\s+codeSize=(\d+)\s+poolBase=0x([0-9a-fA-F]+)\s+poolSize=(\d+)"
+)
+
+# Compile OK line (has func name + pfn)
+COMPILE_OK_RE = re.compile(r"compile OK.*func=(\S+).*pfn=(0x[0-9a-fA-F]+)")
+
+
+def parse_log(log_path):
+    """Parse the log file, return dict[name] -> DumpData."""
+    funcs = {}  # name -> {hex_bytes, pre_asm, code_size_log, pfn}
+
+    with open(log_path, "r", errors="replace") as f:
+        text = f.read()
+
+    # Preserve ordinary line-oriented logs while also handling copied logs in
+    # which the collector removed all newlines between timestamped records.
+    lines = []
+    for physical_line in text.splitlines():
+        lines.extend(part for part in LOG_TIMESTAMP_RE.split(physical_line) if part)
+
+    state = None  # None | "hex" | "asm"
+    cur_name = None
+
+    for line in lines:
+        # ── Detect code size log ──
+        m = CODE_SIZE_RE.search(line)
+        if m:
+            cs = int(m.group(2))
+            # Store against whatever function was last compiled
+            # (will be associated by name below)
+            for name in funcs:
+                if "code_size_log" not in funcs[name] or not funcs[name]["code_size_log"]:
+                    funcs[name]["code_size_log"] = {
+                        "codeStart": int(m.group(1), 16),
+                        "codeSize": cs,
+                        "poolBase": int(m.group(3), 16),
+                        "poolSize": int(m.group(4), 16),
+                    }
+            continue
+
+        # ── Detect compile OK (capture pfn) ──
+        m = COMPILE_OK_RE.search(line)
+        if m:
+            name = m.group(1)
+            pfn = m.group(2)
+            if name not in funcs:
+                funcs[name] = {
+                    "hex_bytes": b"",
+                    "pre_asm": [],
+                    "code_size_log": None,
+                    "pfn": pfn,
+                }
+            else:
+                funcs[name]["pfn"] = pfn
+            continue
+
+        # ── Post-link hex dump ──
+        m = HEX_HEADER_RE.search(line)
+        if m:
+            state = "hex"
+            cur_name = m.group(1)
+            if cur_name not in funcs:
+                funcs[cur_name] = {
+                    "hex_bytes": b"",
+                    "hex_size_log": None,
+                    "pre_asm": [],
+                    "code_size_log": None,
+                    "pfn": None,
+                }
+            funcs[cur_name]["hex_bytes"] = b""
+            funcs[cur_name]["code_start"] = int(m.group(2), 16)
+            funcs[cur_name]["pfn"] = f"0x{int(m.group(3), 16):x}"
+            funcs[cur_name]["fn_offset"] = int(m.group(4), 16)
+            funcs[cur_name]["hex_size_log"] = int(m.group(5))
+            continue
+
+        if state == "hex":
+            if HEX_END_RE.search(line):
+                state = None
+                cur_name = None
+                continue
+            m = HEX_LINE_RE.search(line)
+            if m and cur_name:
+                byte_vals = bytes(int(g, 16) for g in m.groups())
+                funcs[cur_name]["hex_bytes"] += byte_vals
+            continue
+
+        # ── Pre-link ASM dump ──
+        if ASM_HEADER_RE.search(line):
+            state = "asm"
+            continue
+
+        if state == "asm":
+            if ASM_END_RE.search(line):
+                state = None
+                continue
+            m = ASM_LINE_RE.search(line)
+            if m:
+                # Associate with the most recently compiled function
+                # (or the one set by ejit_dump_func)
+                target = cur_name or (list(funcs.keys())[-1] if funcs else None)
+                if target:
+                    if target not in funcs:
+                        funcs[target] = {
+                            "hex_bytes": b"",
+                            "hex_size_log": None,
+                            "pre_asm": [],
+                            "code_size_log": None,
+                            "pfn": None,
+                        }
+                    funcs[target]["pre_asm"].append(m.group(1).rstrip())
+            continue
+
+    return funcs
+
+
+# ── Objdump detection ────────────────────────────────────────────────────────
+
+def find_objdump(explicit=None):
+    """Find an objdump that can disassemble AArch64 (LE instructions)."""
+    candidates = []
+    if explicit:
+        candidates.append(explicit)
+    env = os.environ.get("EJIT_OBJDUMP")
+    if env:
+        candidates.append(env)
+    # System cross objdumps
+    for name in [
+        "aarch64-linux-gnu-objdump",
+        "aarch64_be-linux-gnu-objdump",
+    ]:
+        import shutil
+
+        path = shutil.which(name)
+        if path:
+            candidates.append(path)
+
+    for c in candidates:
+        if "llvm-objdump" in Path(c).name:
+            continue
+        try:
+            r = subprocess.run(
+                [c, "--version"], capture_output=True, text=True, timeout=5
+            )
+            if r.returncode == 0:
+                return c
+        except Exception:
+            pass
+    return None
+
+
+# ── Disassembly ──────────────────────────────────────────────────────────────
+
+def disassemble(hex_bytes, objdump, base_addr=0):
+    """Disassemble raw bytes, return list of (addr_hex, bytes_hex, mnemonic)."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        f.write(hex_bytes)
+        bin_path = f.name
+
+    try:
+        cmd = [
+            objdump,
+            "-D",
+            "-b",
+            "binary",
+            "-m",
+            "aarch64",
+            f"--adjust-vma=0x{base_addr:x}",
+            bin_path,
+        ]
+
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"objdump failed ({r.returncode}): {r.stderr.strip()}"
+            )
+        return r.stdout
+    finally:
+        os.unlink(bin_path)
+
+
+# ── Stub detection ───────────────────────────────────────────────────────────
+
+# AArch64 instruction encodings (LE in memory):
+#   ADRP x16, ...: 0x90xxxxx0 (bit pattern: 1 immlo[2] 10000 immhi[19] Rd[5]=10000)
+#   LDR  x16, [x16, #...]: 0xF940xxxx (1111100101 imm12 Rn=10000 Rt=10000)
+#   BR   x16: 0xD61F0200 (1101011 0000 1 1111100000 0 Rn=10000 00000)
+ADRP_X16 = re.compile(r"adrp\s+x16", re.IGNORECASE)
+LDR_X16_FROM_X16 = re.compile(r"ldr\s+x16,\s*\[x16", re.IGNORECASE)
+BR_X16 = re.compile(r"^\s*[0-9a-f]+:\s+.*br\s+x16", re.IGNORECASE)
+
+
+def count_stubs(disasm_text):
+    """Count PointerJumpStub patterns (ADRP x16 + LDR x16 + BR x16) in disasm."""
+    lines = disasm_text.split("\n")
+    stub_count = 0
+    stub_addrs = []
+    i = 0
+    while i < len(lines) - 2:
+        l1, l2, l3 = lines[i], lines[i + 1], lines[i + 2]
+        if (
+            ADRP_X16.search(l1)
+            and LDR_X16_FROM_X16.search(l2)
+            and BR_X16.search(l3)
+        ):
+            stub_count += 1
+            # Extract address from first line
+            m = re.match(r"\s*([0-9a-f]+):", l1)
+            if m:
+                stub_addrs.append(int(m.group(1), 16))
+            i += 3
+        else:
+            i += 1
+    return stub_count, stub_addrs
+
+
+# ── Addressing mode detection ────────────────────────────────────────────────
+
+MOVZ_ABS_RE = re.compile(r"movz\s+\w+,\s+#:abs_g", re.IGNORECASE)
+ADRP_RE = re.compile(r"adrp\s+", re.IGNORECASE)
+GOT_RE = re.compile(r":got:", re.IGNORECASE)
+
+
+def analyze_addressing(disasm_text):
+    """Detect addressing modes used."""
+    movz_count = len(MOVZ_ABS_RE.findall(disasm_text))
+    adrp_count = len(ADRP_RE.findall(disasm_text))
+    got_count = len(GOT_RE.findall(disasm_text))
+    return {
+        "movz_abs": movz_count,
+        "adrp": adrp_count,
+        "got": got_count,
+    }
+
+
+# ── BL call detection ────────────────────────────────────────────────────────
+
+BL_RE = re.compile(r"^\s*[0-9a-f]+:\s+.*\bbl\s+", re.IGNORECASE)
+TRANSFER_RE = re.compile(
+    r"^\s*[0-9a-f]+:\s+.*\b(?:b|bl|br|blr)\b.*$", re.IGNORECASE
+)
+
+
+def count_bl(disasm_text):
+    """Count BL instructions (function calls)."""
+    return len(BL_RE.findall(disasm_text))
+
+
+def control_transfers(disasm_text):
+    """Return direct and indirect branch/call instructions for inspection."""
+    return [line.strip() for line in disasm_text.splitlines() if TRANSFER_RE.match(line)]
+
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+def process_function(name, data, objdump, outdir):
+    """Process one function: disassemble, analyze, print summary."""
+    print(f"\n{'='*72}")
+    print(f"Function: {name}")
+    print(f"{'='*72}")
+
+    pfn = data.get("pfn")
+    code_start = data.get("code_start")
+    fn_offset = data.get("fn_offset")
+    csl = data.get("code_size_log")
+    hex_bytes = data.get("hex_bytes", b"")
+    hex_size_log = data.get("hex_size_log")
+    pre_asm = data.get("pre_asm", [])
+
+    if csl:
+        print(f"  codeStart=0x{csl['codeStart']:x}  codeSize={csl['codeSize']}")
+        print(f"  poolBase=0x{csl['poolBase']:x}  poolSize={csl['poolSize']}")
+    if pfn:
+        print(f"  pfn={pfn}")
+    if code_start is not None:
+        print(f"  dumpStart=0x{code_start:x}  fnOffset=0x{fn_offset:x}")
+
+    # Pre-link ASM
+    if pre_asm:
+        print(f"\n  Pre-link ASM: {len(pre_asm)} lines")
+        asm_path = outdir / f"{name}_prelink.s"
+        with open(asm_path, "w") as f:
+            f.write("\n".join(pre_asm) + "\n")
+        print(f"    -> {asm_path}")
+    else:
+        print("\n  Pre-link ASM: (none)")
+
+    # Post-link hex
+    if not hex_bytes:
+        print("  Post-link hex: (none)")
+        return
+
+    print(f"  Post-link hex: {len(hex_bytes)} bytes")
+    if hex_size_log is not None and len(hex_bytes) != hex_size_log:
+        print(
+            f"  WARNING: truncated/incomplete dump: expected {hex_size_log} "
+            f"bytes, parsed {len(hex_bytes)}"
+        )
+
+    # Write binary
+    bin_path = outdir / f"{name}_postlink.bin"
+    with open(bin_path, "wb") as f:
+        f.write(hex_bytes)
+    print(f"    -> {bin_path}")
+
+    # Disassemble
+    base = code_start or 0
+    if not base and csl:
+        base = csl["codeStart"]
+
+    disasm = disassemble(hex_bytes, objdump, base)
+    disasm_path = outdir / f"{name}_postlink.disasm"
+    with open(disasm_path, "w") as f:
+        f.write(disasm)
+    print(f"  Disasm: -> {disasm_path}")
+
+    # Analysis
+    stubs, stub_addrs = count_stubs(disasm)
+    addr_modes = analyze_addressing(disasm)
+    bl_count = count_bl(disasm)
+    transfers = control_transfers(disasm)
+
+    # Count total instructions in disasm
+    insn_lines = [
+        l for l in disasm.split("\n") if re.match(r"^\s*[0-9a-f]+:\s+[0-9a-f]{8}", l)
+    ]
+
+    print(f"\n  ── Analysis ──")
+    print(f"  Total instructions (post-link): {len(insn_lines)}")
+    print(f"  Pre-link ASM lines:             {len(pre_asm)}")
+    print(f"  BL calls:                       {bl_count}")
+    print(f"  Stubs (ADRP+LDR+BR x16):        {stubs}")
+    if stub_addrs:
+        for a in stub_addrs:
+            print(f"    @ 0x{a:x}")
+    print(f"  Addressing: ADRP={addr_modes['adrp']}  movz/abs={addr_modes['movz_abs']}  GOT={addr_modes['got']}")
+    if transfers:
+        print("\n  -- Branch/call instructions --")
+        for line in transfers:
+            print(f"  {line}")
+
+    if stubs > 0:
+        stub_cycles = stubs * 5  # rough: ~5c per stub (2 insns + 1 mem + BR)
+        print(f"\n  ⚠ {stubs} stubs ≈ ~{stub_cycles}c overhead (each: ADRP+LDR+BR via GOT)")
+        print(f"    (AOT has 0 stubs - direct BL to .text)")
+
+    # Print first 30 lines of disasm for quick view
+    print(f"\n  ── First 30 lines of post-link disasm ──")
+    for line in disasm.split("\n")[:30]:
+        print(f"  {line}")
+    if len(insn_lines) > 30:
+        print(f"  ... ({len(insn_lines) - 30} more)")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Parse EJIT dump logs, disassemble post-link code, compare."
+    )
+    parser.add_argument("log_file", help="Board log file containing dump output")
+    parser.add_argument(
+        "--objdump", default=None, help="Path to objdump (auto-detected if omitted)"
+    )
+    parser.add_argument(
+        "--outdir", default=None, help="Output directory (default: <log>_out/)"
+    )
+    parser.add_argument(
+        "--name", default=None, help="Process only this function (default: all)"
+    )
+    args = parser.parse_args()
+
+    log_path = Path(args.log_file)
+    if not log_path.exists():
+        print(f"Error: {log_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    outdir = Path(args.outdir) if args.outdir else log_path.parent / f"{log_path.stem}_out"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    objdump = find_objdump(args.objdump)
+    if not objdump:
+        print(
+            "Error: no GNU AArch64 objdump found. Use --objdump or set "
+            "$EJIT_OBJDUMP. llvm-objdump cannot disassemble raw binary input.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(f"Using objdump: {objdump}")
+
+    funcs = parse_log(log_path)
+    if not funcs:
+        print("No dump data found in log.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Found {len(funcs)} function(s): {', '.join(funcs.keys())}")
+
+    for name, data in funcs.items():
+        if args.name and args.name != name:
+            continue
+        process_function(name, data, objdump, outdir)
+
+    print(f"\nOutput files in: {outdir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -46,6 +46,16 @@ void setDumpSharedState(EJitSharedTaskPoolState *state);
 /// capture at compile time, print selectively later.
 void printDumped(const char *name);
 
+/// Allocation-free exact-name/wildcard check used after JITLink. This avoids
+/// constructing a temporary std::string on the SRE compile worker.
+bool isDumpTarget(const char *name);
+
+/// Save and print the final relocated bytes for a JITLink executable range.
+/// \p fnPtr may point inside [\p codeStart, \p codeStart + \p size).
+void captureCodeDump(const std::string &fnName, const void *fnPtr,
+                     const void *codeStart, uint32_t size);
+void printDumpedCode(const char *name);
+
 struct SpecializationContext {
   std::string fnName;
   uint64_t cacheKey = 0;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -285,6 +285,12 @@ void ejit_dump_func(const char *name);
 /// non-worker core reports which worker owns the latest matching capture.
 void ejit_print_dumped(const char *name);
 
+/// Print final post-JITLink machine-code bytes captured for \p name. The dump
+/// includes the executable allocation start, function pointer, and function
+/// offset so PC-relative branches can be decoded accurately. Pass NULL or ""
+/// to list available captures on the calling (normally worker) core.
+void ejit_print_dumped_code(const char *name);
+
 /// Enable or disable capture of every JIT-compiled specialization. Equivalent
 /// to ejit_dump_func("*") when enabled. Captures are keyed by function name in
 /// the worker-local store and replaced when the same function is recompiled.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -417,6 +417,27 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, bool storeLru) {
 
   EJIT_DIAG("compile OK key=0x%016lx func=%s → pfn=%p", cacheKey,
             funcName.c_str(), funcPtr);
+
+  // Capture only an authoritative finalized executable range. A function may
+  // start inside the allocation (after stubs/helpers), so preserve both the
+  // range base and fnPtr for correct PC-relative offline disassembly.
+  if (isDumpTarget(funcName.c_str())) {
+#ifdef EJIT_SRE_CODE_POOL
+    EJitCompiledCodeInfo info;
+    if (jitEngine_->findCodeRange(funcPtr, info) && info.codeStart &&
+        info.codeSize > 0 && info.codeSize <= UINT32_MAX) {
+      captureCodeDump(funcName, funcPtr,
+                      reinterpret_cast<const void *>(info.codeStart),
+                      static_cast<uint32_t>(info.codeSize));
+    } else {
+      EJIT_DIAG("dump code unavailable func=%s: no finalized code range",
+                funcName.c_str());
+    }
+#else
+    EJIT_DIAG("dump code unavailable func=%s: code pool disabled",
+              funcName.c_str());
+#endif
+  }
   return funcPtr;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -275,11 +275,48 @@ static bool getActiveDumpFilter(std::string &out) {
   return true;
 }
 
-/// Saved IR+ASM for a captured specialization (latest per function name).
+bool isDumpTarget(const char *name) {
+  if (!name || !name[0])
+    return false;
+
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (gDumpSharedState) {
+    EJitSharedDumpState &D = gDumpSharedState->dump;
+    sharedDumpLock(D);
+    bool enabled = D.filterEnabled.loadAcquire() != 0;
+    bool wildcard = enabled && D.filterLen == 1 && D.filterName[0] == '*';
+    bool match = wildcard;
+    if (enabled && !wildcard) {
+      uint32_t i = 0;
+      while (i < D.filterLen && name[i] && name[i] == D.filterName[i])
+        ++i;
+      match = i == D.filterLen && name[i] == 0;
+    }
+    sharedDumpUnlock(D);
+    // Once shared state is bound it is authoritative. Falling back to a stale
+    // core-local filter after another core disables the shared filter could
+    // unexpectedly re-arm capture on the worker.
+    return enabled && match;
+  }
+#endif
+
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  if (gDumpFuncFilter.size() == 1 && gDumpFuncFilter[0] == '*')
+    return true;
+  size_t i = 0;
+  while (i < gDumpFuncFilter.size() && name[i] && name[i] == gDumpFuncFilter[i])
+    ++i;
+  return i == gDumpFuncFilter.size() && name[i] == 0;
+}
+
+/// Saved IR+ASM+post-link code for a captured specialization.
 struct DumpEntry {
   uint64_t cacheKey = 0;
   std::string IR;
   std::string ASM;
+  std::string Code;
+  uintptr_t codeStart = 0;
+  uintptr_t fnPtr = 0;
 };
 
 // Process-wide store of captured IR+ASM, filled by the IR transform layer
@@ -288,6 +325,76 @@ struct DumpEntry {
 // of the shared taskpool state; cross-core visibility depends on the worker
 // running in the same process image (addresses are logged to diagnose this).
 static std::map<std::string, DumpEntry> gDumpStore;
+
+void captureCodeDump(const std::string &fnName, const void *fnPtr,
+                     const void *codeStart, uint32_t size) {
+  if (!fnPtr || !codeStart || size == 0)
+    return;
+  uintptr_t start = reinterpret_cast<uintptr_t>(codeStart);
+  uintptr_t fn = reinterpret_cast<uintptr_t>(fnPtr);
+  if (fn < start || fn - start >= size) {
+    EJIT_DIAG("capture code rejected func=%s: fn=%p outside [%p,+%u)",
+              fnName.c_str(), fnPtr, codeStart, size);
+    return;
+  }
+
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  auto it = gDumpStore.find(fnName);
+  if (it == gDumpStore.end()) {
+    EJIT_DIAG("capture code skipped func=%s: no matching IR/ASM capture",
+              fnName.c_str());
+    return;
+  }
+  const auto *bytes = static_cast<const char *>(codeStart);
+  it->second.Code.assign(bytes, size);
+  it->second.codeStart = start;
+  it->second.fnPtr = fn;
+  EJIT_DIAG_DEBUG("capture code func=%s start=%p fn=%p offset=%u size=%u",
+                  fnName.c_str(), codeStart, fnPtr,
+                  static_cast<unsigned>(fn - start), size);
+}
+
+void printDumpedCode(const char *name) {
+  bool hasName = name && name[0];
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  if (!hasName) {
+    EJIT_DIAG("print_dumped_code: %u entries", (unsigned)gDumpStore.size());
+    for (const auto &kv : gDumpStore) {
+      (void)kv;
+      EJIT_DIAG("  %s: code=%u bytes", kv.first.c_str(),
+                (unsigned)kv.second.Code.size());
+    }
+    return;
+  }
+
+  auto it = gDumpStore.find(name);
+  if (it == gDumpStore.end() || it->second.Code.empty()) {
+    EJIT_DIAG("print_dumped_code: no code capture for %s", name);
+    return;
+  }
+
+  const DumpEntry &entry = it->second;
+  uint64_t fnOffset = entry.fnPtr - entry.codeStart;
+  (void)fnOffset;
+  EJIT_DIAG("=== post-link code hex dump name=%s start=0x%llx fn=0x%llx "
+            "fn_offset=0x%llx size=%u ===",
+            name, static_cast<unsigned long long>(entry.codeStart),
+            static_cast<unsigned long long>(entry.fnPtr),
+            static_cast<unsigned long long>(fnOffset),
+            (unsigned)entry.Code.size());
+  unsigned printedLines = 0;
+  for (size_t i = 0; i < entry.Code.size(); i += 4) {
+    uint8_t bytes[4] = {};
+    size_t count = std::min<size_t>(4, entry.Code.size() - i);
+    for (size_t j = 0; j < count; ++j)
+      bytes[j] = static_cast<uint8_t>(entry.Code[i + j]);
+    EJIT_DIAG("  %016llx: %02x %02x %02x %02x",
+              static_cast<unsigned long long>(entry.codeStart + i), bytes[0],
+              bytes[1], bytes[2], bytes[3]);
+    throttleDumpPrint(++printedLines);
+  }
+  EJIT_DIAG("=== post-link code hex dump end ===");
+}
 
 static void dumpBytesSafe(const char *label, const char *data, size_t n) {
   EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)n);
@@ -428,7 +535,8 @@ static void captureDump(const std::string &fnName, uint64_t cacheKey,
             (void *)&gDumpStore);
   std::lock_guard<DumpMutexType> lock(gDumpMutex);
   EJIT_DIAG_DEBUG("capture store_size before=%u", (unsigned)gDumpStore.size());
-  gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
+  gDumpStore[fnName] =
+      DumpEntry{cacheKey, std::move(IR), std::move(ASM), {}, 0, 0};
   EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   // Publish only small metadata. Full text remains in the worker-local map.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1220,6 +1220,11 @@ void ejit_print_dumped(const char *name) {
   printDumped(name);
 }
 
+void ejit_print_dumped_code(const char *name) {
+  EJIT_DIAG("print_dumped_code name=%s", (name && name[0]) ? name : "(list)");
+  printDumpedCode(name);
+}
+
 void ejit_dump_all(bool enable) {
   EJIT_DIAG("dump_all enable=%u", enable ? 1u : 0u);
   setDumpFuncFilter(enable ? std::string("*") : std::string());

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
+#include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #ifdef EJIT_SRE_SHARED_TASKPOOL
@@ -3077,6 +3078,21 @@ TEST(EJitDiagnostics, PrintCodePoolStatsNoCrash) {
 
 TEST(EJitDiagnostics, PrintActiveNoCrash) {
   ejit_print_active(); // uninitialized: prints a notice
+}
+
+TEST(EJitDumpTarget, ExactAndWildcardMatch) {
+  setDumpFuncFilter("dump_me");
+  EXPECT_TRUE(isDumpTarget("dump_me"));
+  EXPECT_FALSE(isDumpTarget("dump_m"));
+  EXPECT_FALSE(isDumpTarget("dump_me_too"));
+  EXPECT_FALSE(isDumpTarget(nullptr));
+
+  setDumpFuncFilter("*");
+  EXPECT_TRUE(isDumpTarget("dump_me"));
+  EXPECT_TRUE(isDumpTarget("another_function"));
+
+  setDumpFuncFilter("");
+  EXPECT_FALSE(isDumpTarget("dump_me"));
 }
 
 // ejit_print_version() prints the LLVM release version + source git commit


### PR DESCRIPTION
## 中文

基于当前 `ejit_dev_spec4` 主线，仅保留 post-link 机器码 dump 功能；旧的 Homme 实验提交链已移除并压成 **1 个 commit**。

### 改动
- 新增 `ejit_print_dumped_code(name)`，在 worker 核打印最终 JITLink 后的机器码十六进制。
- 捕获范围严格使用 code pool 记录的 finalized executable range，不再猜测固定 padding，避免尾部大量 `00` 和越界读取。
- worker 的 dump-target 匹配改为固定缓冲区精确比较，不构造 `std::string`、不分配堆内存，并修复本地 filter 的无锁读写竞态。
- 大块 IR/ASM/code payload 仍保存在 worker 本地；shared state 布局未改变，ABI 仍为 v6。
- `parse_dump.py` 支持时间戳前缀和被拼成单行的板端日志，并在 dump 不完整时报警。
- lipo GC roots 增加 `ejit_print_dumped_code`。

### 验证
- `LLVMEJIT` 构建成功（AArch64，taskpool + shared taskpool + code pool，`-j8`）。
- 新增 shared 固定缓冲区匹配测试通过。
- `EJITSharedTaskPoolTests`: 60 passed / 14 pre-existing configuration-dependent failures；新增测试通过。
- 解析器成功解析现有板端日志：恢复 236 bytes，并识别旧 header 的 648-byte 长度不一致。
- Host `EJITTests` 最终链接受平台强符号 `enable_ex / SRE_MemDbgAlloc / split_2m_to_4k` 缺失阻塞；不是本 PR 引入的编译错误。

## English

Rebased on the current `ejit_dev_spec4` mainline and reduced to the post-link machine-code dump feature only. The previous Homme experimental commit chain has been removed and replaced with **one commit**.

### Changes
- Add `ejit_print_dumped_code(name)` to print final post-JITLink machine code on the worker core.
- Capture the exact finalized executable range reported by the code pool; no guessed padding or trailing zero flood.
- Use allocation-free fixed-buffer matching on the worker path and fix the local filter read/write race.
- Keep large IR/ASM/code payloads worker-local; shared-state layout and ABI v6 remain unchanged.
- Make `parse_dump.py` handle timestamp-prefixed and single-line board logs, with incomplete-dump warnings.
- Preserve the new public API in lipo GC roots.

### Validation
- `LLVMEJIT` builds successfully for AArch64 with taskpool, shared taskpool, and code pool (`-j8`).
- New shared exact-match test passes.
- `EJITSharedTaskPoolTests`: 60 passed; the same 14 configuration-dependent failures remain, with no new failure.
- The parser recovers 236 bytes from the supplied board log and reports the legacy 648-byte header mismatch.
- Host `EJITTests` final linking is blocked by missing platform strong symbols (`enable_ex`, `SRE_MemDbgAlloc`, `split_2m_to_4k`), not by this change.