### PR TITLE
[EJIT] inline-cache && EJIT Ox pipeline && __clear_cache && GV load model && some aarch64_be CMake CFG.

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -377,7 +377,15 @@ def doit_gc_merge(args):
         "ejit_taskpool_set_instance_enabled", "ejit_taskpool_pending_count",
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
-        "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped"
+        "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped",
+        # Inline-cache: ejit_register_icache_slot is called from
+        # ejit_auto_register (AOT) when -ejit-inline-cache is on, not from the
+        # runtime, so gc-merge's --gc-sections would discard it without this GC
+        # root. The production wrapper reads @__ejit_icache_fn_<name> directly
+        # (no ejit_icache_try call). ejitIcacheRegisterSlot/gIcacheFnSlots are
+        # reachable from this root + ejit_init's .ejit_period walk, no explicit
+        # root needed.
+        "ejit_register_icache_slot",
     ]
 
     defined = set()

--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -78,8 +78,10 @@ allocate(RW, 来自 2MiB 池)
    -> 返回函数指针（此时指向 RX 内存，可安全执行）
 ```
 
-> 注意：`enable_ex` 内部已完成权限/cache 同步，所以本实现在 SRE 模式下
-> **不调用 `__builtin___clear_cache`**。
+> 注意：`enable_ex` 只置页面可执行，**不做** cache 同步。因此 SRE 模式下由 seal
+> 路径（`EJitSrePlatform.cpp` 的 `sealAndSyncCache`）显式做 cache 同步（清 D-cache
+> + 失效 I-cache），**不依赖 `enable_ex`**，也不用 `__clear_cache` 外部符号
+> （freestanding SRE 链接里没有）。
 
 ---
 
@@ -156,8 +158,8 @@ allocate(RW, 来自 2MiB 池)
 - `EJitCodePoolMemoryManager::allocate` 仿照 `InProcessMemoryManager`，用
   `BasicLayout` 计算各 segment 大小，但 slab **来自 `EJitCodePoolManager` 的 2MiB 对齐
   池**（而非 mmap）；**allocate 阶段绝不 `enable_ex`**。
-- `finalize()` **刻意不做任何 mprotect**；也不调用 `InvalidateInstructionCache`（由
-  `enable_ex` 负责）。
+- `finalize()` **刻意不做任何 mprotect**；也不调用 `InvalidateInstructionCache`
+  （由 SRE seal 回调 `sealAndSyncCache` 负责：置可执行 + cache 同步，见 §3）。
 - 真正的 RW→RX 封固时机按模式不同：
   - **4K 模式（默认）**：在 `finalize()` 中（所有写入/relocation/fixup 完成后）对该
     allocation 覆盖到的 4K 页逐页 `enable_ex`；任一页失败则 `finalize` 返回 Error，
@@ -361,7 +363,7 @@ for (page = pageStart; page < pageEnd; page += 4KiB)
 - **任何一页 `enable_ex` 失败 → 返回 Error，绝不返回可调用函数指针。** 封固发生在
   JITLink memory manager 的 `finalize` 中，失败会让 `finalize`（进而 `lookup`）返回
   Error。
-- 封固后**不**调用 `__builtin___clear_cache`：`enable_ex` 自身完成权限/cache 同步。
+- 封固后**不**调用 `__builtin___clear_cache`：cache 同步由 seal 回调 `sealAndSyncCache` 完成（`enable_ex` 只置可执行，不做 cache 同步）。
 
 ### 13.4 避免写入已 RX 页（分配策略）
 

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -86,7 +86,8 @@
         "EJIT_SHARED_SECTION_ATTR": "__attribute__((section(\".mc_shared\")))",
         "EJIT_DIAG_ENABLE": "ON",
         "EJIT_SRE_DIAG": "ON",
-        "EJIT_DUMP_ASM": "ON"
+        "EJIT_DUMP_ASM": "ON",
+        "EJIT_STATS_ENABLE": "ON"
       }
     },
     {

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -64,6 +64,13 @@ constexpr const char *FN_REGISTER_PERIOD_ARRAY = "ejit_register_period_array";
 constexpr const char *FN_REGISTER_STATIC_VAR = "ejit_register_static_var";
 constexpr const char *FN_REGISTER_LIFECYCLE = "ejit_register_lifecycle";
 constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
+// Per-function inline-cache slot registration: the wrapper's per-function
+// @__ejit_icache_fn_<name> global (a frozen, sticky specialization pointer) is
+// registered by name so the runtime can backfill it on a successful resolve
+// (icacheFill). The wrapper reads it directly with an inline atomic load - no
+// ejit_icache_try call - so the hit path is one load + null-check + indirect
+// call. Signature: void ejit_register_icache_slot(const char *name, void *slot).
+constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper
@@ -82,6 +89,12 @@ constexpr const char *FN_TASKPOOL_RELEASE_READ = "ejit_taskpool_release_read";
 constexpr const char *FN_TASKPOOL_TRACE_NOW = "ejit_taskpool_trace_now";
 constexpr const char *FN_TASKPOOL_TRACE_WRAPPER =
     "ejit_taskpool_trace_wrapper";
+// Wrapper-timing sentinel status passed to ejit_taskpool_trace_wrapper for
+// icache-hit samples so they aggregate as their own report line (get_fn_avg =
+// probe cost, release_avg = 0), separate from the slow-path compile_or_get
+// samples. Collision-free: real ejit_status_t as uint32_t is 0 or
+// 0xFFFFFFF6..0xFFFFFFFF (EJIT_OK / EJIT_ERR_* = -1..-10).
+constexpr uint32_t kEJitIcacheHitTimingStatus = 0xFEu;
 // Lifecycle activation is keyed by period/lifecycle name + instance index only.
 // PASS4 emits these name-level calls at ejit_period_lc entry/exit; there is no
 // array-pointer dimension in the active-state hot path.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -51,13 +51,16 @@ private:
   /// Run EJitStructFieldPass on all functions.
   void runStructFieldPass(Module &M);
 
-  /// Run the EJIT optimization pipeline: a single fused sequence that exploits
-  /// the just-substituted period-index / may_const constants to their fixed
-  /// point (scalar fold/propagate/simplify), folds loops whose bounds became
-  /// constant, re-specializes the array accesses that unrolling turns into
-  /// constant-index GEPs, then does a final cleanup. `level` is accepted for ABI
-  /// compatibility and does not affect the pipeline.
+  /// Run the post-specialization optimization pipeline: lower llvm.expect, then
+  /// the real LLVM -Ox function-simplification pipeline (selected by `level`:
+  /// L1->O1, L2->O2, L3->O3) to exploit the just-substituted period-index /
+  /// may_const constants (fold/DCE/loop-unroll), re-specialize the array
+  /// accesses that unrolling turns into constant-index GEPs (second
+  /// StructFieldPass), then a light cleanup fold.
   void runOptimizationPipeline(Module &M, OptimizationLevel level);
+
+  /// Pick the cached function-simplification FPM for an EJIT optimization tier.
+  FunctionPassManager &simplifyFPMForLevel(OptimizationLevel level);
 
   PeriodArrayRegistry &registry_;
 
@@ -69,11 +72,15 @@ private:
   ModuleAnalysisManager MAM_;
 
   // Cached pass managers, built once and reused across compilations:
-  //   mainFPM_    scalar fold/propagate/simplify to a fixed point, then loop
-  //               fold-to-constant (Phases 2-3).
-  //   cleanupFPM_ fold/propagate/simplify after unrolling re-exposes constant
-  //               array accesses and the second StructFieldPass (Phase 4).
-  FunctionPassManager mainFPM_;
+  //   lowerExpectFPM_ lower llvm.expect (not in buildFunctionSimplification
+  //                   Pipeline); runs before the O2 pipeline (Phase 2).
+  //   simplifyO1/2/3_ the real LLVM -O1/-O2/-O3 function-simplification pipeline
+  //                   (Phase 3), one per tier; NO vectorization.
+  //   cleanupFPM_     light fold after the second StructFieldPass (Phase 5).
+  FunctionPassManager lowerExpectFPM_;
+  FunctionPassManager simplifyO1_;
+  FunctionPassManager simplifyO2_;
+  FunctionPassManager simplifyO3_;
   FunctionPassManager cleanupFPM_;
 
   // Grant the unit-test accessor visibility into the private pipeline steps.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
@@ -30,7 +30,8 @@ typedef enum {
   EJIT_REG_SYMBOL = 3,
   EJIT_REG_NONE = 4,      // sentinel (kept at 4 for table ABI stability)
   EJIT_REG_LIFECYCLE = 5, // lifecycle dimType-slot fixup (additive)
-  EJIT_REG_FUNCINDEX = 6  // function dense-funcIndex fixup (additive)
+  EJIT_REG_FUNCINDEX = 6, // function dense-funcIndex fixup (additive)
+  EJIT_REG_ICACHE_SLOT = 7 // function inline-cache slot-pointer fixup (additive)
 } ejit_reg_type_t;
 
 typedef struct {
@@ -38,7 +39,8 @@ typedef struct {
   const char
       *name1; // funcName / periodName / varName / symbolName / lifecycleName
   const char *name2; // varName (period/static), NULL otherwise
-  const void *ptr;   // bitcode data / baseAddr / symbol addr / &i32 slot
+  const void *ptr;   // bitcode data / baseAddr / symbol addr / &i32 slot /
+                     //   &ptr icache slot (EJIT_REG_ICACHE_SLOT)
   uint64_t size;     // bitcode size / array size / 0
 } ejit_reg_entry_t;
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -154,6 +154,15 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut);
 // funcIndex global; a capacity failure is recorded so ejit_init can fail.
 void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 
+// Register the wrapper's per-function inline-cache slot (@__ejit_icache_fn_<name>
+// global address) by name. The runtime writes the frozen specialization pointer
+// through it on a successful resolve (icacheFill); the wrapper reads it directly
+// on the hit path (one atomic load + null-check + indirect call, no
+// ejit_icache_try call). Keys the slot by the SAME registry funcIndex assigned
+// by ejit_register_funcindex. Called by AOT auto-registration. A null slot or
+// capacity exhaustion is recorded; the slot stays null and the probe misses.
+void ejit_register_icache_slot(const char *funcName, void *slot);
+
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index
 // only; there is no array-pointer dimension in the active state (a period name
 // with multiple arrays is activated as a whole for that instance).
@@ -209,6 +218,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
 void ejit_taskpool_set_instance_enabled(uint32_t dimType, uint32_t instanceId,
                                         uint32_t enabled);
 void ejit_taskpool_release_read(uint32_t bucketIndex);
+
 unsigned ejit_taskpool_pending_count(void);
 
 // Diagnostic wrapper timing helpers. AOT wrappers only call these when built

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -222,7 +222,6 @@ void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
                                  void *fnPtr, uint32_t bucketIndex,
                                  uint64_t tBeforeLookup,
                                  uint64_t tAfterLookup,
-                                 uint64_t tBeforeFn,
                                  uint64_t tAfterFn,
                                  uint64_t tAfterRelease);
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -79,6 +79,48 @@ enum class EJitWorkerStep : uint32_t {
   Exit,     ///< Failed/Stopping/Uninitialized: leave the loop.
 };
 
+//===----------------------------------------------------------------------===//
+// Per-function inline cache (v2: sticky monomorphic).
+//
+// A single global slot per funcIndex holding a FROZEN specialization pointer:
+// written once (first resolution, one-shot CAS) and read forever. No version /
+// dims / generation re-validation, no refill, and no release_read on the hit
+// path - the probe is a single acquire load + null check.
+//
+// Correctness rests on a hard precondition: every ejit_entry's specialization
+// is invariant for process lifetime (period toggles do not change the baked
+// code; each entry is monomorphic - always called with one dim identity). If
+// that ever fails the cache silently runs a stale specialization; the safety
+// gate below does NOT cover that, only UAF.
+//
+// Lifetime safety: JIT code is never physically freed in production (NO_RECLAIM
+// + no releaseFn_ wired), so a cached pointer can never dangle. v2 does NO
+// hazard-pointer retire and never will: if a releaser IS wired (code may be
+// freed) the safety gate (icacheReclamationSafe_) auto-disables the cache
+// (icacheTry always misses, icacheFill no-ops) to avoid UAF.
+//
+// The code-sharing gate is retained: a non-owner core may only read a cached
+// pointer when EJIT_SRE_SHARED_CODE_POINTERS is platform-validated; otherwise it
+// misses and falls back to ejit_taskpool_compile_or_get. Under sharing=OFF only
+// the owner core uses the cache, so one global slot suffices.
+//===----------------------------------------------------------------------===//
+#ifndef EJIT_ICACHE_FUNC_SLOTS
+#define EJIT_ICACHE_FUNC_SLOTS 64u
+#endif
+
+// Test/diagnostic: clear every icache slot. The slot-pointer table is
+// process-static storage shared across pool instances, so tests clear it
+// between cases to avoid stale cross-test leakage.
+void ejitIcacheClearAll();
+
+// Register a per-function icache slot: \p slot is the address of the wrapper's
+// @__ejit_icache_fn_<name> global (an EJitAtomicUPtr). The runtime writes the
+// frozen specialization pointer through it on a successful resolve (icacheFill);
+// the wrapper reads it directly. Called from ejit_register_icache_slot (name->
+// funcIndex resolution) at ejit_auto_register / .ejit_period time. No-op for an
+// out-of-range funcIndex or null slot.
+void ejitIcacheRegisterSlot(uint32_t funcIndex, void *slot);
+
 class EJitSharedTaskPool {
 public:
   /// Owner-private compile callback (reaches the owner's EJit/ORC). Returns
@@ -215,6 +257,11 @@ public:
   void setReleaser(ReleaseCallback fn, void *ctx) {
     releaseFn_ = fn;
     releaseCtx_ = ctx;
+    // v2 inline cache never reclaims (no HP-scan retire, ever). A wired
+    // releaser means code may be freed while a cached fnPtr still pins it ->
+    // UAF. Auto-disable the cache while a releaser is wired. Production wires
+    // no releaser, so the gate stays open and the cache is unconditionally safe.
+    icacheReclamationSafe_ = (fn == nullptr);
   }
   void setPrepareCodeCallback(PrepareCodeCallback fn, void *ctx) {
     prepareCodeFn_ = fn;
@@ -362,6 +409,26 @@ public:
   /// truth the compile gate (compileCold) and ejit_is_active consult. Returns
   /// false for an out-of-range dimType/instanceId (never reads out of bounds).
   bool isInstanceActive(uint32_t dimType, uint32_t instanceId) const;
+
+  //--- per-function inline cache (v2 sticky monomorphic) ---------------------
+  // NOTE: the production hit path does NOT use icacheTry. With -ejit-inline-cache
+  // the ejit_entry wrapper reads its per-function @__ejit_icache_fn_<name> slot
+  // directly - one acquire load + null-check + indirect call, NO ejit_icache_try
+  // call, NO per-call guards. icacheTry is retained for unit tests / diagnostics:
+  // on a hit it sets *outFn to the frozen specialization (call with NO
+  // releaseRead) and returns true; on a miss returns false. It keeps the
+  // reclamation-safety, pool-Ready, range, and cross-core code-sharing gates
+  // (the latter matters in non-shared test builds; the wrapper's inline probe is
+  // only enabled under EJIT_SRE_SHARED_CODE_POINTERS, where the gate is
+  // compile-time true).
+  bool icacheTry(uint32_t funcIndex, void **outFn);
+  // Fill the per-function icache slot (the wrapper's @__ejit_icache_fn_<name>
+  // global, reached through the registered slot pointer) with a freshly
+  // resolved specialization (call on a taskpool cache hit or a successful
+  // compile). One-shot: the first resolver wins; later resolves (same pointer,
+  // invariant) no-op. No-op when reclamation is not safe, the function is
+  // unregistered (no slot wired), funcIndex is out of range, or fnPtr is null.
+  void icacheFill(uint32_t funcIndex, void *fnPtr);
 
   //--- consumer path (worker / test) -----------------------------------------
   bool pollOne();
@@ -567,6 +634,11 @@ private:
   EJitCompileMode configuredMode_ = EJitCompileMode::Async;
   bool codeSharingEnabled_ = false;
   bool isOwner_ = false;
+  // Inline-cache safety gate: true while the cache is safe to use (no releaser
+  // wired - the production default). v2 does no HP-scan retire, so a wired
+  // releaser (code may be freed) + the cache = UAF; the gate then auto-disables
+  // the cache. See setReleaser().
+  bool icacheReclamationSafe_ = true;
 
   // Worker observability + startup-wait bound (owner-local).
   EJitAtomicU64 workerConsumeLoops_{0};

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -12,6 +12,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
@@ -195,6 +196,30 @@ EJit::EJit(const Config &config) : config_(config) {
           if (idx == kEJitInvalidFuncIndex)
             recordInitError(EJIT_ERR_CACHE_FULL,
                             "funcIndex capacity exhausted for function",
+                            e->name1);
+          break;
+        }
+        case EJIT_REG_ICACHE_SLOT: {
+          // Wire the wrapper's per-function @__ejit_icache_fn_<name> slot into
+          // the runtime's slot-pointer table (gIcacheFnSlots), keyed by the
+          // SAME registry funcIndex assigned above. The wrapper reads this slot
+          // directly on the icache hit path (no ejit_icache_try call); icacheFill
+          // writes the frozen specialization pointer through it on resolve. A
+          // null fixup pointer or an exhausted funcIndex capacity is a hard init
+          // failure (the slot stays null -> probe misses -> taskpool fallback,
+          // correct but without the icache fast path).
+          if (!e->name1 || !e->ptr) {
+            recordInitError(EJIT_ERR_INVALID_PARAM,
+                            "icache slot registration has a null fixup pointer",
+                            e->name1 ? e->name1 : "");
+            break;
+          }
+          uint32_t idx = EJitFuncRegistry::instance().resolveAssign(e->name1);
+          if (idx != kEJitInvalidFuncIndex)
+            ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr));
+          else
+            recordInitError(EJIT_ERR_CACHE_FULL,
+                            "funcIndex capacity exhausted for icache slot",
                             e->name1);
           break;
         }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -142,8 +142,9 @@ Error EJitCodePoolManager::sealPoolLocked(CodePool &P) {
   ++SealInvocations_;
   EJIT_DIAG("sealPool OK: base=%p (invocations=%zu)",
             static_cast<void *>(P.base), SealInvocations_);
-  // Per platform guidance, enable_ex performs its own permission/cache
-  // synchronization, so we deliberately do NOT call __builtin___clear_cache.
+  // The SRE seal callback (sealAndSyncCache) makes the page executable and
+  // synchronizes caches; the code pool layer does not call
+  // __builtin___clear_cache itself.
   return Error::success();
 }
 
@@ -319,8 +320,9 @@ Error EJitCodePoolManager::sealCodeRange(const void *Start, size_t Size) {
   }
   EJIT_DIAG("sealCodeRange OK: start=%p size=%zu (invocations=%zu)", Start, Size,
             SealInvocations_);
-  // Per platform guidance, enable_ex performs its own permission/cache
-  // synchronization, so we deliberately do NOT call __builtin___clear_cache.
+  // The SRE seal callback (sealAndSyncCache) makes the page executable and
+  // synchronizes caches; the code pool layer does not call
+  // __builtin___clear_cache itself.
   return Error::success();
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -59,7 +59,8 @@ public:
     // be looked up. If any page fails to seal we must not hand back a callable
     // allocation. (Legacy whole-pool seal is driven later, at lookup, by the
     // engine.) We do not invalidate the instruction cache here either \u2014
-    // enable_ex performs that sync on the target.
+    // the SRE seal callback does it (sealAndSyncCache: make page executable +
+    // sync caches).
     if (Pool->usesPageSeal()) {
       for (const ExecSegRange &R : ExecRanges)
         if (auto Err = Pool->sealCodeRange(reinterpret_cast<void *>(R.Addr),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -7,21 +7,16 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
-#include "llvm/ExecutionEngine/EJIT/EJitPassBuilder.h"
+#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Debug.h"
-// JIT Inline disabled: AOT pre-optimization already inlines.
-// #include "llvm/Transforms/IPO/AlwaysInliner.h"
+// The post-specialization cleanup is the real LLVM -O2 function-simplification
+// pipeline (PassBuilder::buildFunctionSimplificationPipeline); only the light
+// cleanupFPM_ and the LowerExpect prefix are hand-added below.
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar/ADCE.h"
 #include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
-#include "llvm/Transforms/Scalar/IndVarSimplify.h"
-#include "llvm/Transforms/Scalar/LoopDeletion.h"
-#include "llvm/Transforms/Scalar/LoopPassManager.h"
-#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
-#include "llvm/Transforms/Utils/LoopSimplify.h"
-#include "llvm/Transforms/Utils/Mem2Reg.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -30,56 +25,39 @@ using namespace llvm::ejit;
 
 EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
     : registry_(reg) {
-  EJitPassBuilder::registerFunctionAnalyses(FAM_);
-  EJitPassBuilder::registerLoopAnalyses(LAM_);
-  EJitPassBuilder::registerCGSCCAnalyses(CGAM_);
-  EJitPassBuilder::registerModuleAnalyses(MAM_);
-  EJitPassBuilder::crossRegisterProxies(LAM_, FAM_, CGAM_, MAM_);
+  // Use the real llvm::PassBuilder to register the FULL analysis set. The O2
+  // function-simplification pipeline (GVN, CorrelatedValuePropagation, etc.)
+  // needs analyses the minimal EJitPassBuilder does not register (~13 vs ~40).
+  PassBuilder PB;
+  PB.registerFunctionAnalyses(FAM_);
+  PB.registerLoopAnalyses(LAM_);
+  PB.registerCGSCCAnalyses(CGAM_);
+  PB.registerModuleAnalyses(MAM_);
+  PB.crossRegisterProxies(LAM_, FAM_, CGAM_, MAM_);
 
-  // Pre-build the two cached FunctionPassManagers of the optimization pipeline.
+  // Pre-build the cached FunctionPassManagers, reused across compilations.
   //
   // By the time these run, runPipeline has turned the period-index argument and
-  // every may_const field into a compile-time constant. The pipeline's whole job
-  // is to exploit those constants maximally, so it is structured as a fold →
-  // propagate → simplify fixed point followed by loop folding.
+  // every may_const field into a compile-time constant. The post-specialization
+  // cleanup is the real LLVM -O2 function-simplification pipeline (SROA,
+  // InstCombine, SCCP, GVN, CorrelatedValuePropagation, BDCE, DSE, loop-rotate,
+  // LICM, loop-unroll, ... - NO vectorization), which exploits those constants
+  // far more aggressively than the old hand-rolled 8-pass sequence. One cached
+  // FPM per tier; runOptimizationPipeline picks by ctx.optLevel.
   //
-  // mainFPM_ — Phase 2 (scalar) then Phase 3 (loops):
-  //
-  //   Phase 2 drives the substituted constants to a fixed point. The first round
-  //   peephole-folds the constants (InstCombine), propagates them and folds the
-  //   now-constant branches (SCCP), and deletes the unreachable blocks
-  //   (SimplifyCFG). Folding a branch merges blocks and exposes fresh constants
-  //   and dead code, so a second InstCombine + SimplifyCFG round catches that
-  //   cascade; ADCE then removes whatever became dead.
-  //   LowerExpectIntrinsic must run FIRST: the AOT IR carries llvm.expect
-  //   guards (__builtin_expect / LIKELY) on top of may_const conditions. Once
-  //   StructFieldPass (phase 1c) turns those conditions into constants, the
-  //   expect intrinsic is the only thing preventing InstCombine/SCCP from
-  //   folding the branch - without lowering it the constant branches stay,
-  //   their dead blocks/calls survive ADCE, and the specialization does the
-  //   same work as AOT (plus JIT overhead), i.e. a slowdown. Lowering
-  //   expect(x,y) -> x lets the rest of the pipeline fold and DCE.
-  mainFPM_.addPass(LowerExpectIntrinsicPass());
-  mainFPM_.addPass(InstCombinePass());
-  mainFPM_.addPass(SCCPPass());
-  mainFPM_.addPass(SimplifyCFGPass());
-  mainFPM_.addPass(InstCombinePass());
-  mainFPM_.addPass(SimplifyCFGPass());
-  mainFPM_.addPass(ADCEPass());
-  //   Phase 3 folds loops whose bounds became constant (a no-op on loopless
-  //   functions). LoopSimplify canonicalizes; LoopFullUnroll unrolls small
-  //   bounded loops; IndVarSimplify uses SCEV to replace a larger loop's
-  //   accumulator phi with its closed-form exit value; LoopDeletion removes the
-  //   emptied loop; Promote returns any loop-created allocas to SSA.
-  mainFPM_.addPass(LoopSimplifyPass());
-  {
-    LoopPassManager LPM;
-    LPM.addPass(LoopFullUnrollPass());
-    LPM.addPass(IndVarSimplifyPass());
-    LPM.addPass(LoopDeletionPass());
-    mainFPM_.addPass(createFunctionToLoopPassAdaptor(std::move(LPM)));
-  }
-  mainFPM_.addPass(PromotePass());
+  // LowerExpectIntrinsic must run FIRST: it is NOT in
+  // buildFunctionSimplificationPipeline, and the AOT IR carries llvm.expect
+  // guards (__builtin_expect / LIKELY) on top of may_const conditions. Once
+  // StructFieldPass (phase 1c) turns those conditions into constants, lowering
+  // expect(x,y) -> x lets the O2 pipeline fold the branch and DCE its dead half.
+  lowerExpectFPM_.addPass(LowerExpectIntrinsicPass());
+
+  simplifyO1_ = PB.buildFunctionSimplificationPipeline(
+      llvm::OptimizationLevel::O1, ThinOrFullLTOPhase::None);
+  simplifyO2_ = PB.buildFunctionSimplificationPipeline(
+      llvm::OptimizationLevel::O2, ThinOrFullLTOPhase::None);
+  simplifyO3_ = PB.buildFunctionSimplificationPipeline(
+      llvm::OptimizationLevel::O3, ThinOrFullLTOPhase::None);
 
   // cleanupFPM_ — Phase 4, run after the second StructFieldPass. Unrolling turns
   // a loop-variant array access g_arr[k].field into constant-index GEPs
@@ -189,23 +167,42 @@ void EJitOptimizer::runStructFieldPass(Module &M) {
       structField.run(F, FAM_);
 }
 
-void EJitOptimizer::runOptimizationPipeline(Module &M,
-                                            OptimizationLevel level) {
-  // One fixed pipeline; `level` does not affect it.
-  (void)level;
-  EJIT_DIAG_DEBUG("pipeline stage5: optimization pipeline module=%s",
-                  M.getName().str().c_str());
+FunctionPassManager &
+EJitOptimizer::simplifyFPMForLevel(ejit::OptimizationLevel level) {
+  switch (level) {
+  case ejit::OptimizationLevel::L1:
+    return simplifyO1_;
+  case ejit::OptimizationLevel::L3:
+    return simplifyO3_;
+  case ejit::OptimizationLevel::L2:
+  default:
+    return simplifyO2_;
+  }
+}
 
-  // Phases 2-3: scalar fold/propagate/simplify fixed point, then loop folding.
+void EJitOptimizer::runOptimizationPipeline(Module &M,
+                                            ejit::OptimizationLevel level) {
+  EJIT_DIAG_DEBUG("pipeline stage5: optimization pipeline module=%s opt=%d",
+                  M.getName().str().c_str(), static_cast<int>(level));
+
+  // Phase 2: lower llvm.expect (not in buildFunctionSimplificationPipeline).
+  // Phase 3: the real LLVM -Ox function-simplification pipeline, selected by
+  // level (L1->O1, L2->O2, L3->O3). It folds the substituted constants, DCEs
+  // the dead branches, and unrolls loops whose bounds became constant; this is
+  // the bulk of the post-specialization optimization.
+  FunctionPassManager &simplifyFPM = simplifyFPMForLevel(level);
   for (Function &F : M.functions())
-    if (!F.isDeclaration())
-      mainFPM_.run(F, FAM_);
+    if (!F.isDeclaration()) {
+      lowerExpectFPM_.run(F, FAM_);
+      simplifyFPM.run(F, FAM_);
+    }
 
   // Phase 4: unrolling exposed new constant-index array accesses
-  // (g_arr[k].field → g_arr[0].field, g_arr[1].field, ...). Substitute them,
+  // (g_arr[k].field -> g_arr[0].field, g_arr[1].field, ...). Substitute them,
   // then fold/propagate/simplify the freshly-constant values.
   runStructFieldPass(M);
   for (Function &F : M.functions())
     if (!F.isDeclaration())
       cleanupFPM_.run(F, FAM_);
 }
+

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -845,16 +845,21 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
 
   Triple TT((*ModuleOrErr)->getTargetTriple());
   if (TT.isAArch64() && TT.isOSBinFormatELF()) {
-    // These declarations resolve to process addresses, not co-located JIT
-    // storage. Clearing dso_local forces AArch64 PIC codegen to use GOT/PLT
-    // style indirection instead of near-page ADRP relocations.
+    // External-symbol access from JIT specializations. The JIT slab is
+    // SRE_MemAlloc'd ~2-3GB from the main binary's .text/.data - beyond the
+    // AArch64 BL reach (±128MB) but within ADRP reach (±4GB). Treat the two
+    // kinds differently rather than clearing dso_local on both:
+    //   * Functions: clear dso_local so calls route through JITLink PLT stubs
+    //     (PointerJumpStub = ADRP x16; LDR x16,[x16]; BR x16), which bridge the
+    //     ±128MB BL gap via a GOT entry. A direct BL to a 2-3GB-distant target
+    //     would overflow.
+    //   * Globals: keep dso_local so data access is ADRP+LDR (direct, ±4GB
+    //     reaches the slab). Clearing them forced a per-global GOT load (62 GOT
+    //     loads / ~1700c on DlschCcScheduler vs 0 in AOT) for no reach benefit,
+    //     since ADRP already reaches. So globals are NOT cleared.
     for (Function &F : (*ModuleOrErr)->functions()) {
       if (F.isDeclaration() && !F.isIntrinsic())
         F.setDSOLocal(false);
-    }
-    for (GlobalVariable &GV : (*ModuleOrErr)->globals()) {
-      if (GV.isDeclaration())
-        GV.setDSOLocal(false);
     }
   }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -151,7 +151,7 @@ using DumpMutexType = std::mutex;
 #endif
 
 #ifndef EJIT_DUMP_PRINT_THROTTLE_TICKS
-#define EJIT_DUMP_PRINT_THROTTLE_TICKS 1
+#define EJIT_DUMP_PRINT_THROTTLE_TICKS 50
 #endif
 
 static void throttleDumpPrint(unsigned printedLines) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -604,8 +604,15 @@ EJitOrcEngine::Create(const Config &config,
     return JTMBOrErr.takeError();
   }
 
-  // Use Large code model so JITLink can generate 64-bit absolute relocations.
-  JTMBOrErr->setCodeModel(CodeModel::Large);
+  // Use Small code model so data accesses use ADRP+LDR (2 insns/global, ±4GB
+  // PC-relative) instead of movz/movk absolute (5 insns/global). The JIT slab
+  // is ~1.5-2.2GB from .text (within ADRP's ±4GB range), confirmed by
+  // compileFailed=0 with dso_local=true. Function calls are always BL on
+  // AArch64 (unaffected by code model); JITLink auto-stubs out-of-range BL.
+  // With Large, the 3 extra movz/movk instructions per global access eaten
+  // the specialization savings (fewer BBs / folded branches). Small makes
+  // the per-global cost match AOT (ADRP+LDR), so specialization gains show.
+  JTMBOrErr->setCodeModel(CodeModel::Small);
 
   // Build a TargetMachine (same options the JIT compiles with) for the
   // name-filtered ASM diagnostic dump. Failure is non-fatal — the dump is

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -328,6 +328,43 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
   }
 }
 
+void ejit_register_icache_slot(const char *funcName, void *slot) {
+  // Wire the wrapper's per-function @__ejit_icache_fn_<name> slot into the
+  // runtime slot-pointer table, keyed by the SAME registry funcIndex
+  // ejit_register_funcindex assigns by name. The wrapper reads this slot
+  // directly on the icache hit path; icacheFill writes the frozen specialization
+  // pointer through it on resolve. Idempotent by name (resolveAssign is).
+  // A null slot or unresolvable name is recorded; the slot stays null and the
+  // wrapper's probe cleanly misses -> taskpool fallback.
+  if (!funcName || !slot) {
+    EJIT_DIAG("register_icache_slot reject: name=%p slot=%p",
+              (const void *)funcName, slot);
+    return;
+  }
+  EJIT_DIAG_VERBOSE("register_icache_slot name=%s", funcName);
+#ifdef EJIT_SRE_TASKPOOL
+  if (gEJIT && gEJIT->registrationFrozen()) {
+    EJitRegistrationStore::instance().recordError(
+        EJIT_ERR_INVALID_PARAM, "icache slot registration after init is frozen",
+        funcName);
+    EJIT_DIAG("register_icache_slot reject name=%s: registration frozen",
+              funcName);
+    return;
+  }
+#endif
+  uint32_t idx = EJitFuncRegistry::instance().resolveAssign(funcName);
+  if (idx == kEJitInvalidFuncIndex) {
+    EJitRegistrationStore::instance().recordError(
+        EJIT_ERR_CACHE_FULL, "funcIndex capacity exhausted for icache slot",
+        funcName);
+    EJIT_DIAG("register_icache_slot FAIL name=%s: funcIndex capacity exhausted",
+              funcName);
+    return;
+  }
+  ejitIcacheRegisterSlot(idx, slot);
+  EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u", funcName, idx);
+}
+
 ejit_status_t ejit_activate(const char *periodName, uint8_t cellIdx) {
   if (!gEJIT) {
     EJIT_DIAG("activate(%s,%u) failed: not initialized", periodName, cellIdx);
@@ -481,6 +518,25 @@ inline EJitTaskPool *activeTaskPool() {
   return gEJIT ? gEJIT->taskPool() : nullptr;
 }
 #endif
+
+// Fill the calling core's icache slot on a successful taskpool resolve (cache
+// hit or fresh compile), so a cold icache is filled on the first taskpool hit,
+// not only on a fresh compile. v2: one-shot, fnPtr-only (the specialization is
+// invariant - no dims/version snapshot). No-op without the shared pool or a
+// null fnPtr. Always defined (a no-op without the shared taskpool) so call sites
+// need no #ifdef guards.
+inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr) {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (!fnPtr)
+    return;
+  EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr;
+  if (sp)
+    sp->icacheFill(funcIndex, fnPtr);
+#else
+  (void)funcIndex;
+  (void)fnPtr;
+#endif
+}
 } // namespace
 
 ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
@@ -548,6 +604,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u fast status=%u fn=%p",
                       funcIndex, static_cast<unsigned>(fast.status),
                       fast.fnPtr);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
     return taskpoolStatus(fast.status);
   }
 
@@ -559,6 +616,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     *outBucket = r.bucketIndex;
   EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u status=%u fn=%p",
                     funcIndex, static_cast<unsigned>(r.status), r.fnPtr);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
   return taskpoolStatus(r.status);
 }
 
@@ -601,6 +659,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, nullptr, 0, /*fallback=*/nullptr);
@@ -608,6 +667,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
   return taskpoolStatus(r.status);
 }
 
@@ -632,6 +692,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
     return taskpoolStatus(fast.status);
   }
   const EJitDimPair dims[1] = {{dim0, inst0}};
@@ -640,6 +701,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
   return taskpoolStatus(r.status);
 }
 
@@ -666,6 +728,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
     return taskpoolStatus(fast.status);
   }
   const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
@@ -674,6 +737,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
   return taskpoolStatus(r.status);
 }
 
@@ -703,6 +767,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
     return taskpoolStatus(fast.status);
   }
   const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
@@ -711,6 +776,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
   return taskpoolStatus(r.status);
 }
 
@@ -742,6 +808,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
     return taskpoolStatus(fast.status);
   }
   const EJitDimPair dims[4] = {
@@ -751,6 +818,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
   return taskpoolStatus(r.status);
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -31,7 +31,7 @@ extern "C" uint64_t SRE_CycleCountGet64(void);
 #endif
 
 #ifndef EJIT_WRAPPER_TIMING_REPORT_EVERY
-#define EJIT_WRAPPER_TIMING_REPORT_EVERY 10000u
+#define EJIT_WRAPPER_TIMING_REPORT_EVERY 100000u
 #endif
 
 namespace {
@@ -850,13 +850,14 @@ void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
                                  void *fnPtr, uint32_t bucketIndex,
                                  uint64_t tBeforeLookup,
                                  uint64_t tAfterLookup,
-                                 uint64_t tBeforeFn, uint64_t tAfterFn,
+                                 uint64_t tAfterFn,
                                  uint64_t tAfterRelease) {
   uint64_t getFn = tAfterLookup - tBeforeLookup;
-  uint64_t fnCall = tAfterFn - tBeforeFn;
+  uint64_t fnCall = tAfterFn - tAfterLookup;
   uint64_t release = tAfterRelease - tAfterFn;
   uint64_t total = tAfterRelease - tBeforeLookup;
-  gWrapperTimingLock.lock();
+  // No lock: under per-core BSS each core has its own gWrapperTimingSlots,
+  // so there is no cross-core contention on the slot.
   unsigned SlotIdx = funcIndex % (sizeof(gWrapperTimingSlots) /
                                   sizeof(gWrapperTimingSlots[0]));
   WrapperTimingSlot &S = gWrapperTimingSlots[SlotIdx];
@@ -898,7 +899,6 @@ void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
 #else
   (void)tAfterRelease;
 #endif
-  gWrapperTimingLock.unlock();
 }
 
 ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -121,7 +121,38 @@ constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 /// cacheLookupNd block can also reference it.
 constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
+// Per-function inline-cache slot-pointer table (v2 sticky monomorphic). Each
+// entry points at the wrapper's per-function @__ejit_icache_fn_<name> global -
+// an EJitAtomicUPtr holding the frozen specialization pointer - registered by
+// name at ejit_auto_register / .ejit_period time via ejit_register_icache_slot
+// (which calls ejitIcacheRegisterSlot). The wrapper reads its OWN global
+// directly (one acquire load + null-check + indirect call) with NO
+// ejit_icache_try call and NO per-call guards: the hit path is just a pointer
+// non-null check. icacheFill writes the specialization pointer THROUGH the
+// registered slot pointer on a successful resolve (one-shot CAS); icacheTry
+// (test/diagnostic only) reads it. Process-static, zero-filled by the loader
+// (entries start null = unregistered = probe misses = taskpool fallback). See
+// the header for the safety model.
+EJitAtomicUPtr *gIcacheFnSlots[EJIT_ICACHE_FUNC_SLOTS];
+
 } // namespace
+
+void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *slot) {
+  if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !slot)
+    return;
+  gIcacheFnSlots[funcIndex] = reinterpret_cast<EJitAtomicUPtr *>(slot);
+}
+
+void llvm::ejit::ejitIcacheClearAll() {
+  // Unregister every slot: nulling the table entries makes all probes miss
+  // (icacheTry/icacheFill see no slot and bail), which is the "empty" state.
+  // We do NOT dereference the slot pointers here: in tests the slots are
+  // stack locals that may already be destroyed by the time a later test clears
+  // (e.g. if an ASSERT returned early and skipped the prior test's end-clear),
+  // so dereferencing would be a use-after-free. Production never calls this.
+  for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f)
+    gIcacheFnSlots[f] = nullptr;
+}
 
 //===----------------------------------------------------------------------===//
 // Switch controller helpers (§5.1) over shared arrays.
@@ -147,6 +178,78 @@ uint32_t EJitSharedTaskPool::instanceVersion(uint32_t dimType,
   if (dimType >= kEJitSharedDimTypes || instanceId >= kEJitSharedInstances)
     return 0;
   return state_->version[dimType][instanceId].loadAcquire();
+}
+
+//===----------------------------------------------------------------------===//
+// Per-function inline cache (v2 sticky monomorphic).
+//
+// The production hit path does NOT call icacheTry: the ejit_entry wrapper reads
+// its own @__ejit_icache_fn_<name> global directly (one acquire load + null
+// check + indirect call, no call, no per-call guards). icacheTry is retained
+// for unit tests and diagnostics. icacheFill writes the specialization pointer
+// THROUGH the registered slot pointer (gIcacheFnSlots[funcIndex]) on a
+// successful resolve; it is a frozen, one-shot fill - the slot is written once
+// and never refilled, so the pointer is always the correct (invariant)
+// specialization. Lifetime is safe because JIT code is never freed in
+// production; the safety gate auto-disables the cache if a releaser is wired
+// (v2 does no HP-scan retire). The code-sharing gate retains the cross-core
+// pointer discipline of resolveMatchedSlot (relevant to icacheTry in non-shared
+// test builds; the wrapper's inline probe is only enabled under
+// EJIT_SRE_SHARED_CODE_POINTERS, where the gate is compile-time true).
+//===----------------------------------------------------------------------===//
+bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, void **outFn) {
+  if (!outFn)
+    return false;
+  *outFn = nullptr;
+  // Safety gate: auto-disable while a releaser is wired (v2 does no HP-scan
+  // retire, so freeing code + a cached fnPtr = UAF). Production wires no
+  // releaser, so this never trips and the cache is unconditionally safe.
+  if (!icacheReclamationSafe_)
+    return false;
+  if (!state_ || funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
+    return false;
+  // Unregistered function (no per-function slot global wired up): miss.
+  EJitAtomicUPtr *slot = gIcacheFnSlots[funcIndex];
+  if (!slot)
+    return false;
+  // The cache is only meaningful once the pool is Ready.
+  if (state_->initState.loadAcquire() != kReady)
+    return false;
+  // Cross-core fnPtr gate (compile-time, mirrors resolveMatchedSlot): a
+  // non-owner core may only read a cached pointer when code sharing is
+  // platform-validated.
+  uint32_t self = EJitCoreId::current();
+  uint32_t owner = state_->ownerCoreId.loadRelaxed();
+#if defined(EJIT_SRE_SHARED_CODE_POINTERS)
+  constexpr bool mayReadPtr = true;
+#else
+  bool mayReadPtr = (self == owner);
+#endif
+  if (!mayReadPtr)
+    return false;
+  // Frozen read: the slot is immutable after the one-shot fill, so a single
+  // acquire load is correct with no re-validation.
+  uintptr_t p = slot->loadAcquire();
+  if (p == 0)
+    return false;
+  *outFn = reinterpret_cast<void *>(p);
+  return true;
+}
+
+void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr) {
+  if (!icacheReclamationSafe_)
+    return;
+  if (!state_ || !fnPtr || funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
+    return;
+  EJitAtomicUPtr *slot = gIcacheFnSlots[funcIndex];
+  if (!slot)
+    return; // unregistered function: nowhere to write.
+  // One-shot: the first resolver wins. Later resolves carry the same invariant
+  // pointer and no-op. compareExchange is acq_rel on success / acquire on
+  // failure, pairing with the wrapper's / icacheTry's acquire load.
+  uintptr_t desired = reinterpret_cast<uintptr_t>(fnPtr);
+  uintptr_t expected = 0;
+  (void)slot->compareExchange(expected, desired);
 }
 
 void EJitSharedTaskPool::forEachCompiled(CompiledFuncCallback cb,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -23,6 +23,8 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 
+#include <cstdint>
+
 #ifndef EJIT_SRE_CODE_POOL_SIZE
 #define EJIT_SRE_CODE_POOL_SIZE                                                \
   (static_cast<unsigned long long>(2) * 1024 * 1024)
@@ -72,6 +74,58 @@ extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
                                  unsigned long size, const char *func,
                                  unsigned int line);
 
+namespace {
+/// Make newly-written JIT code in [Va, Va + Size) observable to instruction
+/// fetch. On AArch64 the I-cache does not snoop D-cache writes, so code
+/// written into a RW page is not executable until the D-cache is cleaned and
+/// the I-cache invalidated for that range, then the core context-syncs.
+/// enable_ex makes the page executable but does NOT perform this cache sync,
+/// so the seal path does it explicitly before making the page executable.
+///
+/// Per-core: every core that executes JIT code seals in its own translation
+/// context, so each executing core syncs its own I-cache before first
+/// execution.
+///
+/// Inline asm rather than __builtin___clear_cache / llvm::sys::Memory::
+/// InvalidateInstructionCache: both resolve to the external __clear_cache
+/// symbol, which the freestanding SRE link does not provide.
+void syncCodeCaches(uintptr_t Va, size_t Size) {
+  if (Size == 0)
+    return;
+#ifdef __aarch64__
+  uint64_t Ctr;
+  __asm__ __volatile__("mrs %0, ctr_el0" : "=r"(Ctr));
+  size_t DLine = static_cast<size_t>(4) << ((Ctr >> 16) & 0xF);
+  size_t ILine = static_cast<size_t>(4) << (Ctr & 0xF);
+
+  uintptr_t End = Va + Size;
+  uintptr_t P = Va & ~static_cast<uintptr_t>(DLine - 1);
+  for (; P < End; P += DLine)
+    __asm__ __volatile__("dc cvau, %0" :: "r"(P) : "memory");
+  __asm__ __volatile__("dsb ish" ::: "memory");
+
+  P = Va & ~static_cast<uintptr_t>(ILine - 1);
+  for (; P < End; P += ILine)
+    __asm__ __volatile__("ic ivau, %0" :: "r"(P) : "memory");
+  __asm__ __volatile__("dsb ish" ::: "memory");
+  __asm__ __volatile__("isb" ::: "memory");
+#else
+  // Non-AArch64 (host) fallback: compiler-rt/libgcc is available here, so the
+  // builtin's __clear_cache resolves. The SRE target is always AArch64.
+  __builtin___clear_cache(reinterpret_cast<char *>(Va),
+                          reinterpret_cast<char *>(Va + Size));
+#endif
+}
+
+/// Seal one code range on the calling core: make the just-written JIT code
+/// observable to instruction fetch (syncCodeCaches), then make the page
+/// executable (enable_ex). Returns enable_ex's rc (0 = success).
+unsigned sealAndSyncCache(uintptr_t Va, size_t Size) {
+  syncCodeCaches(Va, Size);
+  return ejit_sre_enable_ex(1, static_cast<unsigned long long>(Va));
+}
+} // namespace
+
 std::unique_ptr<llvm::ejit::EJitCodePoolManager>
 llvm::ejit::makeSreCodePoolManager() {
   EJitCodePoolManager::Options Opts;
@@ -95,8 +149,14 @@ llvm::ejit::makeSreCodePoolManager() {
   auto Seal = [](void *Va) -> unsigned {
 #ifdef EJIT_SRE_ENABLE_EX
     // In 4K seal mode Va is a single 4KiB page; in legacy mode it is the 2MiB
-    // pool base. enable_ex flips the page containing Va to RX either way.
-    return ejit_sre_enable_ex(1, reinterpret_cast<unsigned long long>(Va));
+    // pool base. sealAndSyncCache syncs caches for the written range then makes
+    // the page executable (enable_ex does not sync caches).
+#ifdef EJIT_CODE_POOL_4K_SEAL
+    return sealAndSyncCache(reinterpret_cast<uintptr_t>(Va), k4KiB);
+#else
+    return sealAndSyncCache(reinterpret_cast<uintptr_t>(Va),
+                            static_cast<size_t>(kSrePoolSize));
+#endif
 #else
     // Code-pool routing without permission flips (bring-up / measurement).
     (void)Va;
@@ -131,7 +191,7 @@ bool llvm::ejit::prepareSreCodeForCurrentCore(const void *FnPtr) {
   }
   const auto Address = reinterpret_cast<uintptr_t>(FnPtr);
   const auto PoolBase = Address & ~(static_cast<uintptr_t>(k2MiB) - 1);
-  unsigned Rc = ejit_sre_enable_ex(1, static_cast<unsigned long long>(PoolBase));
+  unsigned Rc = sealAndSyncCache(PoolBase, static_cast<size_t>(kSrePoolSize));
   if (Rc != 0) {
     EJIT_DIAG("prepareSreCode FAIL: enable_ex poolBase=0x%llx rc=%u",
               static_cast<unsigned long long>(PoolBase), Rc);
@@ -179,9 +239,11 @@ bool llvm::ejit::ejitSreSealPageForCurrentCore(uintptr_t PageVA) {
     return false;
   }
   // Per-core: flips the 4KiB page containing PageVA to RX in the calling core's
-  // translation context. enable_ex performs its own permission/cache sync, so
-  // no __builtin___clear_cache here.
-  unsigned Rc = ejit_sre_enable_ex(1, static_cast<unsigned long long>(PageVA));
+  // translation context AND syncs its I-cache for that page. enable_ex does NOT
+  // do the cache sync, so it is done here (see sealAndSyncCache). Every core
+  // that executes shared JIT code seals its own translation context here before
+  // first execution.
+  unsigned Rc = sealAndSyncCache(PageVA, k4KiB);
   if (Rc != 0) {
     EJIT_DIAG("sealPageForCurrentCore FAIL: enable_ex pageVA=0x%llx rc=%u",
               static_cast<unsigned long long>(PageVA), Rc);

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -58,6 +58,26 @@ static cl::opt<bool> EJitWrapperTiming(
     cl::desc("Emit diagnostic timing probes around taskpool lookup, indirect "
              "JIT call, and read-token release in ejit_entry wrappers"));
 
+// Emit a per-function inline-cache probe DIRECTLY in the ejit_entry wrapper
+// (not a call). On a hit the wrapper loads its per-function @__ejit_icache_fn_
+// <name> slot (one atomic acquire load), null-checks it, and tail-calls the
+// cached specialization - NO ejit_icache_try call, NO read-token, NO per-call
+// guards, NO funcIndex/IdxValid on the hit path. Just "pointer non-null? jump".
+// On a miss it falls through to jit_slow -> ejit_taskpool_compile_or_get, which
+// fills the slot on success (icacheFill). v2: sticky monomorphic - the slot is
+// filled once (first resolution) and read forever, so the probe needs no
+// version/dims re-validation. Default off. Requires the runtime to be built
+// with EJIT_SRE_SHARED_CODE_POINTERS (production preset): the inline probe has
+// no per-call cross-core gate, so it is only safe when a cached pointer is
+// callable on any core. When combined with -ejit-wrapper-timing the icache hit
+// path is instrumented too (its own sentinel-status report line) so the wrapper
+// log still shows the fast path's ejit/fn overhead.
+static cl::opt<bool> EJitInlineCache(
+    "ejit-inline-cache", cl::init(false), cl::Hidden,
+    cl::desc("Emit a per-function inline-cache probe (a direct load of the "
+             "cached specialization pointer) before the taskpool "
+             "compile_or_get call in ejit_entry wrappers"));
+
 // Wrapper generation now unconditionally uses the unified taskpool API
 // (ejit_taskpool_compile_or_get + ejit_taskpool_release_read). Both Sync
 // and Async modes are runtime-configurable — the AOT wrapper code is
@@ -203,6 +223,26 @@ static GlobalVariable *getOrCreateFuncIndexGlobal(Module &M,
       ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), GVName);
 }
 
+// Per-function pointer-typed global holding the frozen inline-cache slot: the
+// specialization pointer once resolved, null until then. Internal linkage (each
+// module's copy is wired into the runtime slot-pointer table by name at
+// registration). 8-byte aligned so the atomic acquire load / one-shot CAS the
+// runtime pairs against it are lock-free on aarch64. The wrapper reads it
+// DIRECTLY (load atomic acquire + null-check + indirect call) - no
+// ejit_icache_try call, no per-call guards - so the hit path is one load.
+static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
+                                                 StringRef FuncName) {
+  std::string GVName = ("__ejit_icache_fn_" + FuncName).str();
+  if (auto *Existing = M.getGlobalVariable(GVName))
+    return Existing;
+  auto *PtrTy = PointerType::getUnqual(M.getContext());
+  auto *GV = new GlobalVariable(M, PtrTy, /*isConstant=*/false,
+                                GlobalValue::InternalLinkage,
+                                ConstantPointerNull::get(PtrTy), GVName);
+  GV->setAlignment(Align(8));
+  return GV;
+}
+
 // Emit registration that fills each per-function dense-funcIndex global with
 // the index the process-global EJitFuncRegistry assigns by name: ejit_register_
 // funcindex() calls in ejit_auto_register (constructor path) plus private
@@ -279,6 +319,80 @@ emitFuncIndexRegistration(Module &M,
   appendToUsed(M, {GV});
 }
 
+// Emit registration that wires each per-function inline-cache slot global
+// (@__ejit_icache_fn_<name>) into the runtime slot-pointer table by name:
+// ejit_register_icache_slot() calls in ejit_auto_register (constructor path)
+// plus private .ejit_period section entries (bare-metal / test fallback). The
+// runtime keys the slot by the SAME registry funcIndex ejit_register_funcindex
+// assigns, then writes the frozen specialization pointer through it on resolve
+// (icacheFill); the wrapper reads it directly on the hit path. Idempotent:
+// skips if the static section payload already exists.
+static void
+emitIcacheSlotRegistration(Module &M,
+                           const std::map<std::string, GlobalVariable *> &Fns) {
+  if (Fns.empty() || M.getGlobalVariable(".ejit.registry.icache"))
+    return;
+  LLVMContext &Ctx = M.getContext();
+  auto *PtrTy = PointerType::getUnqual(Ctx);
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  // void ejit_register_icache_slot(const char *name, void *slot)
+  M.getOrInsertFunction(
+      FN_REGISTER_ICACHE_SLOT,
+      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy}, false));
+
+  Function *AutoReg = M.getFunction(FN_AUTO_REGISTER);
+  bool CreatedAutoReg = false;
+  if (!AutoReg) {
+    auto *AutoRegTy = FunctionType::get(Type::getVoidTy(Ctx), false);
+    AutoReg = Function::Create(AutoRegTy, GlobalValue::InternalLinkage,
+                               FN_AUTO_REGISTER, &M);
+    BasicBlock::Create(Ctx, "entry", AutoReg);
+    ReturnInst::Create(Ctx, &AutoReg->getEntryBlock());
+    CreatedAutoReg = true;
+  }
+  Instruction *Ret = AutoReg->getEntryBlock().getTerminator();
+  FunctionCallee FnReg = M.getFunction(FN_REGISTER_ICACHE_SLOT);
+  for (auto &KV : Fns) {
+    IRBuilder<> Builder(Ret);
+    Value *Name = Builder.CreateGlobalString(KV.first);
+    Builder.CreateCall(FnReg, {Name, Builder.CreateBitCast(KV.second, PtrTy)});
+  }
+
+  if (EnableEJitGlobalCtors && CreatedAutoReg)
+    appendToGlobalCtors(M, AutoReg, EJIT_CTOR_PRIORITY);
+
+  // Static registry entries for bare-metal / testing fallback (same linker-
+  // concatenated .ejit_period model as funcindex above).
+  StructType *EntryTy = StructType::get(
+      Ctx, {I32Ty, PtrTy, PtrTy, PtrTy, I64Ty}, /*isPacked=*/false);
+  auto makeStrGV = [&](const std::string &S) -> Constant * {
+    Constant *Str = ConstantDataArray::getString(Ctx, S, true);
+    auto *GV =
+        new GlobalVariable(M, Str->getType(), true, GlobalValue::PrivateLinkage,
+                           Str, ".ejit.str.");
+    return ConstantExpr::getBitCast(GV, PtrTy);
+  };
+  SmallVector<Constant *, 16> Entries;
+  for (auto &KV : Fns) {
+    Entries.push_back(ConstantStruct::get(
+        EntryTy, {ConstantInt::get(I32Ty, 7), // EJIT_REG_ICACHE_SLOT
+                  makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
+                  ConstantExpr::getBitCast(KV.second, PtrTy),
+                  ConstantInt::get(I64Ty, 0)}));
+  }
+  if (Entries.empty())
+    return;
+  ArrayType *ArrayTy = ArrayType::get(EntryTy, Entries.size());
+  auto *GV = new GlobalVariable(
+      M, ArrayTy, /*isConstant=*/true, GlobalValue::PrivateLinkage,
+      ConstantArray::get(ArrayTy, Entries), ".ejit.registry.icache");
+  GV->setSection(".ejit_period");
+  GV->setAlignment(M.getDataLayout().getABITypeAlign(EntryTy));
+  appendToUsed(M, {GV});
+}
+
 } // anonymous namespace
 
 PreservedAnalyses EJitWrapperGenPass::run(Module &M,
@@ -311,16 +425,23 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
   M.getOrInsertFunction(
       FN_TASKPOOL_RELEASE_READ,
       FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false));
+  // With -ejit-inline-cache the wrapper reads its per-function
+  // @__ejit_icache_fn_<name> slot directly (one atomic load + null-check +
+  // indirect call) - no ejit_icache_try call, no per-call guards.
 
   auto isAlreadyWrapped = [](Function &F) -> bool {
     if (!F.getEntryBlock().getName().starts_with("jit_entry"))
       return false;
-    // The wrapper's jit_entry loads this function's @__ejit_funcidx_<name>
-    // global; that load uniquely identifies an already-wrapped function.
+    // The wrapper's jit_entry loads a per-function global that uniquely
+    // identifies an already-wrapped function: @__ejit_icache_fn_<name> (when
+    // -ejit-inline-cache hoists the probe to the entry block) or, with the
+    // cache off, @__ejit_funcidx_<name> (the funcIndex load that heads jit_entry
+    // in that layout).
     for (Instruction &I : F.getEntryBlock())
       if (auto *LI = dyn_cast<LoadInst>(&I))
         if (auto *GV = dyn_cast<GlobalVariable>(LI->getPointerOperand()))
-          if (GV->getName().starts_with("__ejit_funcidx_"))
+          if (GV->getName().starts_with("__ejit_funcidx_") ||
+              GV->getName().starts_with("__ejit_icache_fn_"))
             return true;
     return false;
   };
@@ -369,6 +490,21 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     FuncIndexGlobals.emplace(F->getName().str(),
                              getOrCreateFuncIndexGlobal(M, F->getName()));
   emitFuncIndexRegistration(M, FuncIndexGlobals);
+
+  // Per-function inline-cache slot globals (@__ejit_icache_fn_<name>), created
+  // and registered only when -ejit-inline-cache is on. The wrapper reads its
+  // slot directly (one atomic load + null-check + indirect call) on the hit
+  // path; the runtime writes the frozen specialization pointer through it on
+  // resolve. Requires the runtime to be built with EJIT_SRE_SHARED_CODE_POINTERS
+  // (production preset) - the inline probe has no per-call cross-core gate, so
+  // it is only safe when a cached pointer is callable on any core.
+  std::map<std::string, GlobalVariable *> IcacheFnGlobals;
+  if (EJitInlineCache) {
+    for (Function *F : EntryFuncs)
+      IcacheFnGlobals.emplace(F->getName().str(),
+                              getOrCreateIcacheFnGlobal(M, F->getName()));
+    emitIcacheSlotRegistration(M, IcacheFnGlobals);
+  }
 
   LLVM_DEBUG(dbgs() << "ejit-wrapper-gen: " << EntryFuncs.size()
                     << " entry function(s)\n");
@@ -447,9 +583,16 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // Save original entry block
     BasicBlock &OrigEntry = F->getEntryBlock();
 
-    // Create four new blocks: jit_entry (funcIndex guard), jit_call (taskpool
-    // request), jit_fallback (AOT body) and jit_dispatch (run JIT code).
+    // Create the wrapper blocks. jit_entry is the new entry block. With
+    // -ejit-inline-cache ON, jit_entry is the inline probe (load the per-function
+    // cached specialization pointer, null-check, hit -> call it directly + return;
+    // miss -> jit_slow), and jit_slow runs the funcIndex guard -> jit_call (taskpool
+    // request) / jit_fallback (AOT body). With the cache OFF, jit_entry runs the
+    // funcIndex guard directly (no probe, no jit_slow). jit_dispatch runs the
+    // taskpool-resolved specialization.
     auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F, &OrigEntry);
+    BasicBlock *JitSlow =
+        EJitInlineCache ? BasicBlock::Create(Ctx, "jit_slow", F) : nullptr;
     auto *JitCall = BasicBlock::Create(Ctx, "jit_call", F);
     auto *JitFallback = BasicBlock::Create(Ctx, "jit_fallback", F);
     auto *JitDispatch = BasicBlock::Create(Ctx, "jit_dispatch", F);
@@ -481,9 +624,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // Delete the now-empty original entry block
     OrigEntry.eraseFromParent();
 
-    // jit_entry: load the registration-backfilled dense funcIndex. While it is
-    // invalid, branch straight to the AOT fallback without entering either
-    // compile path.
+    // jit_entry (new entry block): allocas + timing decls live here so they
+    // dominate the taskpool path. With -ejit-inline-cache ON, jit_entry IS the
+    // inline probe (see below); with it OFF, jit_entry runs the funcIndex guard
+    // directly (the original layout).
     IRBuilder<> Builder(JitEntry);
     // Emit the fixed-dimension fast-path C API only for 0/1/2-dim entries when
     // the opt-in flag is set. Rationale (measured on aarch64, -Os): 0D/1D/2D
@@ -506,11 +650,105 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         Builder.CreateAlloca(PtrTy, nullptr, "ejit_out_fn");
     Value *OutBucketAlloca =
         Builder.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
-    Value *FuncIdx = Builder.CreateLoad(
-        I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
-    Value *IdxValid = Builder.CreateICmpNE(
-        FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
-    Builder.CreateCondBr(IdxValid, JitCall, JitFallback);
+    Value *OutFnArg = Builder.CreatePointerCast(OutFnAlloca, PtrTy);
+    // Timing callees are shared by the icache hit path and the slow taskpool
+    // path, so declare them once here (idempotent getOrInsertFunction).
+    FunctionCallee TraceNow{};
+    FunctionCallee TraceWrapper{};
+    if (EJitWrapperTiming) {
+      TraceNow = M.getOrInsertFunction(FN_TASKPOOL_TRACE_NOW,
+                                       FunctionType::get(I64Ty, false));
+      SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty,
+                                         I64Ty, I64Ty, I64Ty, I64Ty};
+      TraceWrapper = M.getOrInsertFunction(
+          FN_TASKPOOL_TRACE_WRAPPER,
+          FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
+    }
+    // funcIndex is loaded on the miss path (jit_slow / the cache-off guard); the
+    // hit path does not need it. Declared here so jit_call (below) can use it.
+    Value *FuncIdx = nullptr;
+
+    if (EJitInlineCache) {
+      // --- inline probe (the hit path) ---
+      // One atomic acquire load of the per-function cached specialization
+      // pointer (@__ejit_icache_fn_<name>), null-check, hit -> call it directly
+      // + return. NO ejit_icache_try call, NO per-call guards, NO funcIndex /
+      // IdxValid, NO dim loads on the hit path - just "pointer non-null? jump".
+      // The slot is null until the first successful resolve fills it (icacheFill,
+      // on the jit_call path); a null slot falls through to jit_slow. Timing (when
+      // -ejit-wrapper-timing): probe cost (the load) + fn-call cost are logged via
+      // ejit_taskpool_trace_wrapper with the icache-hit sentinel. funcIndex is
+      // loaded here ONLY for trace attribution (diagnostic, off in production) so
+      // the non-timing hit path stays a single load.
+      Value *TBeforeIcache = nullptr;
+      Value *FuncIdxForTiming = nullptr;
+      if (EJitWrapperTiming) {
+        TBeforeIcache = Builder.CreateCall(TraceNow, {}, "ejit_t_before_icache");
+        FuncIdxForTiming = Builder.CreateLoad(
+            I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx_t");
+      }
+      // The one-shot frozen slot: acquire load pairs with icacheFill's acq_rel
+      // CAS. 8-byte aligned for a lock-free atomic on aarch64.
+      GlobalVariable *IcacheSlot = IcacheFnGlobals[F->getName().str()];
+      LoadInst *ICSlotLoad =
+          Builder.CreateLoad(PtrTy, IcacheSlot, "ejit_ic_fn");
+      ICSlotLoad->setAtomic(AtomicOrdering::Acquire);
+      ICSlotLoad->setAlignment(Align(8));
+      Value *TAfterIcache = nullptr;
+      if (EJitWrapperTiming)
+        TAfterIcache = Builder.CreateCall(TraceNow, {}, "ejit_t_after_icache");
+      Value *IHit = Builder.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
+      // jit_icache_dispatch: call the cached specialization directly. NO
+      // ejit_taskpool_release_read - the inline cache never frees code in
+      // production.
+      auto *JitIcacheDispatch =
+          BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
+      Builder.CreateCondBr(IHit, JitIcacheDispatch, JitSlow);
+
+      Builder.SetInsertPoint(JitIcacheDispatch);
+      SmallVector<Value *, 8> ICArgs;
+      for (auto &Arg : F->args())
+        ICArgs.push_back(&Arg);
+      auto emitIcacheTiming = [&] {
+        Value *TAfterFn = Builder.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+        Builder.CreateCall(TraceWrapper,
+                           {FuncIdxForTiming,
+                            ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
+                            ICSlotLoad, ConstantInt::get(I32Ty, 0),
+                            TBeforeIcache, TAfterIcache, TAfterFn, TAfterFn});
+      };
+      if (F->getReturnType()->isVoidTy()) {
+        Builder.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
+        if (EJitWrapperTiming)
+          emitIcacheTiming();
+        Builder.CreateRetVoid();
+      } else {
+        Value *RetVal =
+            Builder.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
+        if (EJitWrapperTiming)
+          emitIcacheTiming();
+        Builder.CreateRet(RetVal);
+      }
+
+      // --- jit_slow: funcIndex guard (miss path) ---
+      // Load the registration-backfilled dense funcIndex. While it is invalid,
+      // branch straight to the AOT fallback without entering the taskpool;
+      // otherwise enter the taskpool (jit_call), which fills the icache slot on
+      // a successful resolve.
+      Builder.SetInsertPoint(JitSlow);
+      FuncIdx = Builder.CreateLoad(
+          I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
+      Value *IdxValid = Builder.CreateICmpNE(
+          FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
+      Builder.CreateCondBr(IdxValid, JitCall, JitFallback);
+    } else {
+      // icache OFF: jit_entry runs the funcIndex guard directly.
+      FuncIdx = Builder.CreateLoad(
+          I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
+      Value *IdxValid = Builder.CreateICmpNE(
+          FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
+      Builder.CreateCondBr(IdxValid, JitCall, JitFallback);
+    }
 
     // jit_call: unified taskpool API. Both Sync and Async modes share the same
     // AOT wrapper — the runtime compile mode controls whether compilation is
@@ -532,21 +770,11 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       return ArgVal;
     };
 
-    Value *OutFnArg = Builder.CreatePointerCast(OutFnAlloca, PtrTy);
     Value *OutBucketArg = Builder.CreatePointerCast(OutBucketAlloca, PtrTy);
     Value *Status = nullptr;
-    FunctionCallee TraceNow{};
-    FunctionCallee TraceWrapper{};
     Value *TBeforeLookup = nullptr;
     Value *TAfterLookup = nullptr;
     if (EJitWrapperTiming) {
-      TraceNow = M.getOrInsertFunction(FN_TASKPOOL_TRACE_NOW,
-                                       FunctionType::get(I64Ty, false));
-      SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty,
-                                         I64Ty, I64Ty, I64Ty, I64Ty};
-      TraceWrapper = M.getOrInsertFunction(
-          FN_TASKPOOL_TRACE_WRAPPER,
-          FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
       TBeforeLookup =
           Builder.CreateCall(TraceNow, {}, "ejit_t_before_lookup");
     }

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -542,8 +542,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     if (EJitWrapperTiming) {
       TraceNow = M.getOrInsertFunction(FN_TASKPOOL_TRACE_NOW,
                                        FunctionType::get(I64Ty, false));
-      SmallVector<Type *, 9> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty,
-                                         I64Ty, I64Ty, I64Ty, I64Ty, I64Ty};
+      SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty,
+                                         I64Ty, I64Ty, I64Ty, I64Ty};
       TraceWrapper = M.getOrInsertFunction(
           FN_TASKPOOL_TRACE_WRAPPER,
           FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
@@ -615,9 +615,6 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       Args.push_back(&Arg);
 
     if (F->getReturnType()->isVoidTy()) {
-      Value *TBeforeFn = nullptr;
-      if (EJitWrapperTiming)
-        TBeforeFn = Builder.CreateCall(TraceNow, {}, "ejit_t_before_fn");
       Builder.CreateCall(F->getFunctionType(), OutFn, Args);
       Value *TAfterFn = nullptr;
       if (EJitWrapperTiming)
@@ -630,13 +627,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
             Builder.CreateCall(TraceNow, {}, "ejit_t_after_release");
         Builder.CreateCall(TraceWrapper,
                            {FuncIdx, Status, OutFn, Bucket, TBeforeLookup,
-                            TAfterLookup, TBeforeFn, TAfterFn, TAfterRelease});
+                            TAfterLookup, TAfterFn, TAfterRelease});
       }
       Builder.CreateRetVoid();
     } else {
-      Value *TBeforeFn = nullptr;
-      if (EJitWrapperTiming)
-        TBeforeFn = Builder.CreateCall(TraceNow, {}, "ejit_t_before_fn");
       Value *RetVal = Builder.CreateCall(F->getFunctionType(), OutFn, Args);
       Value *TAfterFn = nullptr;
       if (EJitWrapperTiming)
@@ -649,7 +643,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
             Builder.CreateCall(TraceNow, {}, "ejit_t_after_release");
         Builder.CreateCall(TraceWrapper,
                            {FuncIdx, Status, OutFn, Bucket, TBeforeLookup,
-                            TAfterLookup, TBeforeFn, TAfterFn, TAfterRelease});
+                            TAfterLookup, TAfterFn, TAfterRelease});
       }
       Builder.CreateRet(RetVal);
     }

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -1,0 +1,75 @@
+; -ejit-inline-cache (ON): emits an inline probe DIRECTLY in the ejit_entry
+; wrapper - a load atomic of the per-function @__ejit_icache_fn_<name> slot +
+; null-check; the hit path (jit_icache_dispatch) calls the cached specialization
+; directly with NO ejit_icache_try call and NO ejit_taskpool_release_read. The
+; probe takes no dims, so a hit pays no dim loads. Default (OFF): the original
+; 4-block wrapper, no icache. Idempotent: running the pass twice does not
+; duplicate the probe. With -ejit-wrapper-timing the icache hit path is
+; instrumented (trace_now + trace_wrapper, sentinel status).
+
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s --check-prefix=ICACHE
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s --check-prefix=NOICACHE
+; RUN: opt -passes=ejit-wrapper-gen,ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s --check-prefix=IDEM
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-wrapper-timing -S %s | FileCheck %s --check-prefix=TIMING
+
+; --- 1D entry: inline probe = load atomic @__ejit_icache_fn + null-check; hit
+; --- calls the cached ptr directly (NO release_read). NO ejit_icache_try call. ---
+; ICACHE-LABEL: define i32 @one_dim_entry(
+; ICACHE-NOT: ejit_icache_try
+; ICACHE: load atomic ptr, ptr @__ejit_icache_fn_one_dim_entry acquire, align 8
+; ICACHE-LABEL: jit_icache_dispatch:
+; ICACHE-NOT: call void @ejit_taskpool_release_read
+; ICACHE: call {{.*}} %ejit_ic_fn
+; ICACHE: ret
+
+; --- 3D entry: same probe shape (load atomic, no dims in the probe). ---
+; ICACHE-LABEL: define i32 @three_dim_entry(
+; ICACHE-NOT: ejit_icache_try
+; ICACHE: load atomic ptr, ptr @__ejit_icache_fn_three_dim_entry acquire, align 8
+
+; --- Default (flag OFF): no icache anywhere; original compile_or_get path. ---
+; NOICACHE-LABEL: define i32 @one_dim_entry(
+; NOICACHE-NOT: ejit_icache_try
+; NOICACHE-NOT: __ejit_icache_fn
+; NOICACHE-NOT: ejit_register_icache_slot
+; NOICACHE: call i32 @ejit_taskpool_compile_or_get_1d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
+; NOICACHE-NOT: ejit_icache_try
+
+; --- Idempotent: two passes emit the probe exactly once. ---
+; IDEM-LABEL: define i32 @one_dim_entry(
+; IDEM-COUNT-1: load atomic ptr, ptr @__ejit_icache_fn_one_dim_entry acquire, align 8
+
+; --- Timing: the icache hit path is instrumented (trace_now + trace_wrapper). ---
+; TIMING-LABEL: define i32 @one_dim_entry(
+; TIMING: call i64 @ejit_taskpool_trace_now()
+; TIMING: load atomic ptr, ptr @__ejit_icache_fn_one_dim_entry acquire, align 8
+; TIMING: call i64 @ejit_taskpool_trace_now()
+; TIMING-LABEL: jit_icache_dispatch:
+; TIMING: call i64 @ejit_taskpool_trace_now()
+; TIMING: call void @ejit_taskpool_trace_wrapper(i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, i32 {{.*}}, i64 {{.*}}, i64 {{.*}}, i64 {{.*}}, i64 {{.*}})
+; TIMING-NOT: call void @ejit_taskpool_release_read
+; TIMING: ret
+
+define i32 @one_dim_entry(i32 %idx1) !ejit.metadata !0 {
+entry:
+  %v1 = load i32, ptr @data
+  ret i32 0
+}
+
+define i32 @three_dim_entry(i32 %a, i32 %b, i32 %c) !ejit.metadata !1 {
+entry:
+  %v1 = load i32, ptr @data
+  %v2 = load i32, ptr @data2
+  %v3 = load i32, ptr @data3
+  ret i32 0
+}
+
+@data = global i32 0, !ejit.metadata !10
+@data2 = global i32 0, !ejit.metadata !11
+@data3 = global i32 0, !ejit.metadata !12
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}, !{!"ejit_period_arr_ind", !"grp", i32 2}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
+!11 = distinct !{!{!"ejit_period_arr", !"trp", i32 32}}
+!12 = distinct !{!{!"ejit_period_arr", !"grp", i32 48}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-timing.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-timing.ll
@@ -8,7 +8,6 @@
 ; ON: call i64 @ejit_taskpool_trace_now()
 ; ON: call i32 @ejit_taskpool_compile_or_get_1d
 ; ON: call i64 @ejit_taskpool_trace_now()
-; ON: call i64 @ejit_taskpool_trace_now()
 ; ON: call i32 %ejit_fn
 ; ON: call i64 @ejit_taskpool_trace_now()
 ; ON: call void @ejit_taskpool_release_read

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -2147,16 +2147,23 @@ static Function *createDeadCodeFunc(LLVMContext &Ctx, Module &M) {
   BasicBlock *BB = BasicBlock::Create(Ctx, "entry", F);
   B.SetInsertPoint(BB);
 
-  // Unreachable block
+  // Live block: the false target of the constant branch, so it is always taken.
+  BasicBlock *Live = BasicBlock::Create(Ctx, "live", F);
+  {
+    IRBuilder<> LB(Live);
+    LB.CreateRet(LB.getInt32(42));
+  }
+
+  // Unreachable block: the true target of `br false` (never taken).
   auto *DeadBB = BasicBlock::Create(Ctx, "dead", F);
   {
     IRBuilder<> DB(DeadBB);
     DB.CreateRet(DB.getInt32(999));
   }
 
-  // br on constant false -> unreachable branch should be eliminated
-  B.CreateCondBr(B.getFalse(), DeadBB, DeadBB);
-  B.CreateRet(B.getInt32(42));
+  // br i1 false -> always the false target (live); the true target (dead) is
+  // unreachable and should be eliminated.
+  B.CreateCondBr(B.getFalse(), DeadBB, Live);
 
   return F;
 }
@@ -2314,20 +2321,20 @@ static std::string optimizeLoopFnAt(llvm::ejit::OptimizationLevel lvl) {
   return Out;
 }
 
-TEST(EJitOptimizer, PipelineCollapseLevelEquivalence) {
+TEST(EJitOptimizer, OptimizationFoldsConstantLoopAtAllLevels) {
   std::string L1 = optimizeLoopFnAt(llvm::ejit::OptimizationLevel::L1);
   std::string L2 = optimizeLoopFnAt(llvm::ejit::OptimizationLevel::L2);
   std::string L3 = optimizeLoopFnAt(llvm::ejit::OptimizationLevel::L3);
 
-  // Collapse proof: every level runs the identical single pipeline.
-  EXPECT_EQ(L1, L2) << "L1 vs L2 IR differs — the tiers were not collapsed";
-  EXPECT_EQ(L2, L3) << "L2 vs L3 IR differs — the tiers were not collapsed";
-
-  // No-regression proof: the single pipeline still fully optimizes at EVERY
-  // level (loop unrolled + folded to constant 6 — the old L3 outcome). Under the
-  // old tiers, L1 kept the loop and this find() would fail.
+  // No-regression: each tier (L1->O1, L2->O2, L3->O3) unrolls + folds the
+  // constant-bound loop to `ret i32 6`. Tiers are now distinct O1/O2/O3
+  // pipelines; byte-identical IR across tiers is no longer asserted.
   EXPECT_NE(L1.find("ret i32 6"), std::string::npos)
-      << "collapsed pipeline did not fold the loop at L1 (regressed vs old L3)";
+      << "L1 (O1) did not fold the constant loop";
+  EXPECT_NE(L2.find("ret i32 6"), std::string::npos)
+      << "L2 (O2) did not fold the constant loop";
+  EXPECT_NE(L3.find("ret i32 6"), std::string::npos)
+      << "L3 (O3) did not fold the constant loop";
 }
 
 //===----------------------------------------------------------------------===//
@@ -2454,15 +2461,20 @@ static std::string specializeBranchAt(llvm::ejit::OptimizationLevel lvl) {
   return Out;
 }
 
-TEST(EJitEndToEnd, PipelineLevelEquivalenceBranch) {
+TEST(EJitEndToEnd, PipelineFoldsMayConstBranchAtAllLevels) {
   std::string L1 = specializeBranchAt(llvm::ejit::OptimizationLevel::L1);
   std::string L2 = specializeBranchAt(llvm::ejit::OptimizationLevel::L2);
   std::string L3 = specializeBranchAt(llvm::ejit::OptimizationLevel::L3);
 
-  EXPECT_EQ(L1, L2) << "L1 vs L2 IR differs — level changed the pipeline";
-  EXPECT_EQ(L2, L3) << "L2 vs L3 IR differs — level changed the pipeline";
+  // No-regression: each tier (L1->O1, L2->O2, L3->O3) folds the may_const
+  // branch to the constant 100. Tiers are now distinct O1/O2/O3 pipelines;
+  // byte-identical IR across tiers is no longer asserted.
   EXPECT_NE(L1.find("ret i32 100"), std::string::npos)
-      << "pipeline did not fold the may_const branch to the constant 100";
+      << "L1 (O1) did not fold the may_const branch";
+  EXPECT_NE(L2.find("ret i32 100"), std::string::npos)
+      << "L2 (O2) did not fold the may_const branch";
+  EXPECT_NE(L3.find("ret i32 100"), std::string::npos)
+      << "L3 (O3) did not fold the may_const branch";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "gtest/gtest.h"
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
@@ -2619,5 +2620,89 @@ TEST_F(SharedTaskPoolTest, DISABLED_HotHitContendedBench) {
   }
 }
 #endif // __aarch64__
+
+//===----------------------------------------------------------------------===//
+// Per-function inline cache (v2 sticky monomorphic): frozen read, one-shot
+// fill, range guards, and the reclamation safety gate. Asserts behavior
+// (boolean + pointer), not stats.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, InlineCacheStickyFrozen) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool); // core 0 owner, Ready, code sharing off (owner-only).
+  constexpr uint32_t kFunc = 3;
+  // Register a per-function icache slot (the wrapper's @__ejit_icache_fn_
+  // global, here a test-local stand-in) so icacheFill has somewhere to write.
+  std::atomic<uintptr_t> slot{0};
+  ejitIcacheRegisterSlot(kFunc, &slot);
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  // Cold icache misses (empty slot).
+  EXPECT_FALSE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, nullptr);
+
+  // Fill on a resolve -> subsequent probe hits, returning the frozen fnPtr.
+  pool.icacheFill(kFunc, fn);
+  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, fn);
+
+  // Frozen: a period toggle bumps the version, but v2 does NOT re-validate, so
+  // the cached specialization is still served (the slot is never refilled or
+  // invalidated). This is the v2 contract - the specialization is invariant.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, false)); // bump version
+  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, fn);
+
+  // One-shot: a later fill with a DIFFERENT pointer does not overwrite - the
+  // first resolver wins and the slot is frozen.
+  void *fn2 = codeFor(1000);
+  pool.icacheFill(kFunc, fn2);
+  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, fn); // still the first pointer
+
+  // Out-of-range funcIndex misses without touching memory.
+  EXPECT_FALSE(pool.icacheTry(EJIT_ICACHE_FUNC_SLOTS, &out));
+  EXPECT_EQ(out, nullptr);
+
+  ejitIcacheClearAll();
+}
+
+// Safety gate: wiring a releaser means code may be freed, and v2 does no
+// HP-scan retire, so the cache auto-disables (icacheTry always misses,
+// icacheFill no-op) to avoid UAF. Unwiring the releaser re-enables it.
+TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  std::atomic<uintptr_t> slot{0};
+  ejitIcacheRegisterSlot(kFunc, &slot);
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  // Before a releaser: fill -> hit.
+  pool.icacheFill(kFunc, fn);
+  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, fn);
+
+  // Wire a releaser: icache auto-disables (miss + no-op fill).
+  ReleaseLog rel;
+  pool.setReleaser(&mockRelease, &rel);
+  EXPECT_FALSE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, nullptr);
+  pool.icacheFill(kFunc, fn); // no-op: the gate blocks the fill
+  EXPECT_FALSE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, nullptr);
+
+  // Unwire the releaser: the gate re-opens; fill -> hit works again.
+  pool.setReleaser(nullptr, nullptr);
+  pool.icacheFill(kFunc, fn);
+  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  EXPECT_EQ(out, fn);
+
+  ejitIcacheClearAll();
+}
 
 } // namespace


### PR DESCRIPTION
## Performance
Currently, EJIT cost model list below(only includes EJIT cost):

|section| cycles |
| -- | -- |
| EJIT hit(one line inline-cache) | 8 |
| EJIT fallback | 16 |

---

Consolidates a batch of recent EJIT runtime / performance / correctness changes onto `ejit_dev_spec4` as 7 commits. The centerpiece is the **inline-cache hit-path simplification** (per-function slot direct-load + null-check + indirect call, eliminating the cross-TU `ejit_icache_try` call and all per-call guards), plus accompanying JIT codegen / link-addressing / cache-sync fixes. No debug demos or dump tooling are included (those stay separate).

## Changes

### 1. Per-function inline cache: direct-load hit path + lipo GC root
- The hit path now has the wrapper read its per-function `@__ejit_icache_fn_<name>` slot directly: **one atomic acquire load + null-check + indirect call** (aarch64: `ldar; cbz; blr`). No `ejit_icache_try` call, no per-call guards, no funcIndex/IdxValid on the hit path (those move to the miss path, `jit_slow`).
- Runtime: the `gEJitICache[]` array is replaced by a per-function global address table `gIcacheFnSlots[]`; `icacheFill` writes through it with a one-shot CAS. Adds `ejit_register_icache_slot` + `EJIT_REG_ICACHE_SLOT` (mirrors the funcIndex backfill).
- lipo: `ejit_register_icache_slot` is called from AOT `ejit_auto_register`, not from the runtime, so `gc-merge --gc-sections` would discard it; added to `lipo.py optional_api` GC roots.
- Benefit: hit-path JIT-dispatch overhead drops from ~25-45 cyc to ~4-7 cyc in-order (4-6x), ~12-18 cyc to ~4-7 cyc OoO (2-3x). Dominated by eliminating the cross-TU call + the serial guard chain.
- Safety contract: the inline probe has no per-call cross-core gate, so it requires `EJIT_SRE_SHARED_CODE_POINTERS` (production preset already ON); non-shared configs leave slots null -> probe always misses -> taskpool fallback (correct).
- Also removes the dead `ejit_icache_try` chain left after Scope B superseded it (C function / declaration / `FN_ICACHE_TRY` / lipo GC root / stale `ejit_icache_design.md`); the `icacheTry` C++ method is retained for unit tests (gc-dropped from production ejit.o).

### 2. JIT post-specialization pipeline switched to real LLVM -Ox
Post-specialization optimization now runs through the real LLVM `-Ox` pipeline (replacing the simplified path), so specialized code gets AOT-equivalent optimization quality.

### 3. Sync I-cache in the SRE seal path
`enable_ex` only makes the page executable; it does not synchronize caches. On AArch64 the I-cache does not snoop D-cache writes, so newly-written JIT code is not executable until the D-cache is cleaned and the I-cache invalidated. Adds `sealAndSyncCache()` (clean D-cache + invalidate I-cache, then `enable_ex`) called from all three seal entry points. The per-core seal model ensures each executing core syncs its own I-cache before first execution. Implemented with inline asm (the freestanding SRE link provides no external `__clear_cache` symbol).

### 4. JIT CodeModel Large -> Small
JIT data addressing switches from Large (movz/movk, 5 insns/global) to Small (ADRP+LDR, 2 insns/global, ±4GB). Saves 3 instructions per global; affects data addressJIT data addressing switches from Large (movz/movk, 5 insns/global) to Small (ADRP+LDR, 2 insns/global, ±4GB). Saves 3 instructions per global; affects data addressing only (function calls remain BL + JITLink stubs).

### 5. dso_local: functions via PLT / globals via ADRP
The JIT slab sits ~2-3GB from the main binary's .text/.data: beyond BL ±128MB, within ADRP ±4GB. The dso_local clearing is split: **functions** cleared -> calls route through JITLink PLT stubs (BL safe); **globals** not cleared -> data access stays ADRP+LDR (±4GB reaches). Eliminates the per-global GOT load (62 loads / ~1700c on DlschCcScheduler). A safer middle ground than "clear both" (slow data) or "clear none" (relies on unverified out-of-range BL stubbing).

### 6. Slim wrapper timing
Wrapper timing slimmed to 4 `trace_now` calls, no lock, 100000-sample interval.

### 7. Build config
`ejit-minimal-aarch64_be` preset enables `EJIT_STATS_ENABLE=ON` (bring-up / field diagnosis; the option is opt-in, default OFF elsewhere). `EJIT_DUMP_PRINT_THROTTLE_TICKS` default 1 -> 50 (freestanding dump calls `SRE_TaskDelay` every 16 lines; 1 tick was too short to drain).

## Verification

- `ninja -C build_release_x86 opt LLVMEJIT EJITSharedTaskPoolTests`: builds clean (only pre-existing warnings).
- lit `ejit-wrapper-gen-icache.ll`: PASS (ICACHE/NOICACHE/IDEM/TIMING).
- icache unit tests `InlineCacheStickyFrozen`, `InlineCacheAutoDisablesWhenReclamationWired`: PASSED.
- icache hit-path IR confirmed to be a single `load atomic` + `icmp ne null` + `call ptr` + `ret`.
- No regressions: the 14 pre-existing `FourK*`/`CodeSharing*` failures are unchanged (they require `EJIT_TEST_NO_RECLAIM`, unrelated to this PR).

## Notes for merging

- The inline cache (`-ejit-inline-cache`) is enabled only in the production preset (`EJIT_SRE_SHARED_CODE_POINTERS=ON`); dev/test presets leave it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)