### PR TITLE
[EJIT] Keep dump-all IR/ASM payloads worker-local

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -378,6 +378,7 @@ def doit_gc_merge(args):
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
         "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped",
+        "ejit_dump_all",
         # Inline-cache: ejit_register_icache_slot is called from
         # ejit_auto_register (AOT) when -ejit-inline-cache is on, not from the
         # runtime, so gc-merge's --gc-sections would discard it without this GC

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -28,16 +28,16 @@ struct EJitSharedTaskPoolState;
 
 /// Set a function-name filter for JIT IR+ASM diagnostic capture. When non-
 /// empty, the engine captures (saves in memory) the post-optimization IR and
-/// the emitted assembly of any specialization whose entry name exactly
-/// matches, the next time it is compiled. Empty/null disables further
-/// capture (already-captured entries are retained). Captured entries are
-/// printed on demand via printDumped(). Used for performance analysis.
+/// the emitted assembly of any specialization whose entry name matches, the
+/// next time it is compiled. "*" matches every specialization. Empty/null
+/// disables further capture (already-captured entries are retained). Captured
+/// entries are printed on demand via printDumped().
 void setDumpFuncFilter(const std::string &name);
 
-/// Bind the optional shared taskpool dump state. In a shared-taskpool build this
-/// lets any core set the dump filter and print the last worker-captured IR/ASM
-/// result. Passing nullptr disables the shared path and falls back to the local
-/// process-static dump store.
+/// Bind the optional shared taskpool dump state. In a shared-taskpool build
+/// this lets any core set the dump filter and discover which worker core owns
+/// the latest capture. Full IR/ASM payloads remain in the worker-local dump
+/// store. Passing nullptr disables shared filter and ownership metadata.
 void setDumpSharedState(EJitSharedTaskPoolState *state);
 
 /// Print the saved IR+ASM for \p name (or all saved entries when \p name is

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -273,13 +273,19 @@ uint32_t ejit_taskpool_get_worker_core();
 /// \p name is JIT-compiled, the engine saves (in memory) its post-optimization
 /// IR and emitted assembly for later printing. Pass NULL or "" to disable
 /// further capture (already-saved entries are retained). Capture is exact-name
-/// only, and shared IR/ASM payloads are allocated to the generated text size.
+/// unless name is "*", which captures every specialization. Full payloads stay
+/// on the worker core and are never copied into shared taskpool memory.
 void ejit_dump_func(const char *name);
 
-/// Print the saved IR+ASM for \p name through the platform log, one line per
-/// IR/ASM line. Names with no saved capture are reported as missing. Passing
-/// NULL or "" only lists captured names; it does not dump all payloads.
+/// Print the saved worker-local IR+ASM for \p name through the platform log.
+/// Passing NULL or "" prints every entry saved on the calling core. A
+/// non-worker core reports which worker owns the latest matching capture.
 void ejit_print_dumped(const char *name);
+
+/// Enable or disable capture of every JIT-compiled specialization. Equivalent
+/// to ejit_dump_func("*") when enabled. Captures are keyed by function name in
+/// the worker-local store and replaced when the same function is recompiled.
+void ejit_dump_all(bool enable);
 
 /// Runtime diagnostic log level. Mirrors the EJIT_DIAG* macro thresholds.
 ///   EJIT_LOG_OFF    — no diagnostic output

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -68,10 +68,10 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// mode can split its pool once and seal exactly the pages the code covers.
 /// v6: dump slots carry dynamic IR/ASM payload pointers instead of fixed text
 /// buffers, and each cache bucket carries a monotonic publishSeq word used by
-/// the optional EJIT_SRE_TASKPOOL_NO_RECLAIM seqlock reader (load-only hot-hit
-/// path with no per-hit read-token RMW). The field exists in every build for a
-/// stable layout; it is only written when NO_RECLAIM is enabled.
-constexpr uint32_t kEJitSharedAbiVersion = 6u;
+/// the optional EJIT_SRE_TASKPOOL_NO_RECLAIM seqlock reader.
+/// v7: full IR/ASM payloads are worker-local again; shared dump state contains
+/// only a bounded filter and latest-capture metadata. publishSeq is unchanged.
+constexpr uint32_t kEJitSharedAbiVersion = 7u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -73,15 +73,6 @@
 #ifndef EJIT_SRE_SHARED_DUMP_NAME_BYTES
 #define EJIT_SRE_SHARED_DUMP_NAME_BYTES 128u
 #endif
-// Number of per-name result slots in the cross-core dump table. Each captured
-// specialization occupies one slot keyed by entry name; when full, the oldest
-// slot is round-robin evicted. Covers this many distinct functions for
-// cross-core ejit_print_dumped(name) retrieval. The table stores pointers to
-// dynamically allocated IR/ASM payloads, not fixed text buffers.
-#ifndef EJIT_SRE_SHARED_DUMP_SLOT_COUNT
-#define EJIT_SRE_SHARED_DUMP_SLOT_COUNT 50u
-#endif
-
 namespace llvm {
 namespace ejit {
 
@@ -95,10 +86,7 @@ constexpr uint32_t kEJitSharedCacheBuckets = EJIT_SRE_TASKPOOL_BUCKETS;
 constexpr uint32_t kEJitSharedCacheSlots = EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS;
 constexpr uint32_t kEJitSharedQueueSlots = EJIT_SRE_TASKPOOL_QUEUE_CAPACITY;
 constexpr uint32_t kEJitSharedPoolSlots = EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS;
-constexpr uint32_t kEJitSharedDumpNameBytes =
-    EJIT_SRE_SHARED_DUMP_NAME_BYTES;
-constexpr uint32_t kEJitSharedDumpSlotCount =
-    EJIT_SRE_SHARED_DUMP_SLOT_COUNT;
+constexpr uint32_t kEJitSharedDumpNameBytes = EJIT_SRE_SHARED_DUMP_NAME_BYTES;
 constexpr uint32_t kEJitSharedCacheLine = 64u;
 /// Execute-permission seal granularity (the platform's per-page enable_ex unit)
 /// and the large-page / split granularity. Fixed platform constants.
@@ -220,38 +208,27 @@ struct EJitSharedPoolSplit {
 };
 
 //===----------------------------------------------------------------------===//
-// EJitSharedDumpState: cross-core diagnostic exchange.
+// EJitSharedDumpState: fixed-size cross-core diagnostic metadata.
 //
-// The owner worker captures IR/ASM in its private ORC path, but shell/debug
-// requests can arrive on a different core. std::map/std::string cannot live in
-// shared memory, so the shared path uses one bounded filter plus a bounded
-// per-name result TABLE: each captured specialization occupies one slot keyed
-// by entry name; when the table is full the oldest slot is round-robin
-// evicted. IR/ASM payloads are allocated dynamically to their actual text size,
-// and the slot stores shared-visible pointers plus sizes.
+// Full IR/ASM text remains in the owner worker's private gDumpStore. Shared
+// memory carries only the active filter and enough metadata to direct a
+// non-owner caller to the worker core that owns the latest capture.
 //===----------------------------------------------------------------------===//
-struct alignas(kEJitSharedCacheLine) EJitSharedDumpSlot {
-  EJitAtomicU32 valid;       ///< 1 => name/ir/asm hold a capture
-  EJitAtomicU32 truncated;   ///< bit2 name truncated
-  uint32_t nameLen;
+struct alignas(kEJitSharedCacheLine) EJitSharedDumpState {
+  EJitAtomicU32 lock;          ///< 0 free, 1 locked by filter/capture/print
+  EJitAtomicU32 filterEnabled; ///< 1 => filterName is active
+  EJitAtomicU32 hasDump;       ///< 1 => latest-capture metadata is valid
+  EJitAtomicU32 status;        ///< bit2 => resultName was truncated
+  uint32_t filterLen;
+  uint32_t resultNameLen;
   uint32_t irSize;
   uint32_t asmSize;
   uint32_t keyHi;
   uint32_t keyLo;
-  uint32_t reserved0;
-  uintptr_t irPtr;
-  uintptr_t asmPtr;
-  char name[kEJitSharedDumpNameBytes];
-};
-
-struct alignas(kEJitSharedCacheLine) EJitSharedDumpState {
-  EJitAtomicU32 lock;          ///< 0 free, 1 locked by filter/capture/print
-  EJitAtomicU32 filterEnabled; ///< 1 => filterName is active
-  uint32_t filterLen;
-  uint32_t nextSlot;           ///< round-robin eviction cursor (under lock)
+  uint32_t workerCore;
   uint32_t reserved0;
   char filterName[kEJitSharedDumpNameBytes];
-  EJitSharedDumpSlot slots[kEJitSharedDumpSlotCount];
+  char resultName[kEJitSharedDumpNameBytes];
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -1,30 +1,28 @@
 //===-- EJitOrcEngine.cpp - OrcJIT Engine Wrapper -------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
-#include "llvm/Bitcode/BitcodeReader.h"
-#include "llvm/ExecutionEngine/Orc/LLJIT.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/PassManager.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
-#include <cstdlib>
-#include <cstring>
 #include <map>
 #include <string>
 
@@ -165,24 +163,22 @@ static void throttleDumpPrint(unsigned printedLines) {
 #endif
 }
 
-// Process-wide function-name filter for the IR+ASM diagnostic dump. Set via
-// ejit_dump_func() / setDumpFuncFilter(). Read in the IR transform layer.
-// A diagnostic: set before triggering the compile of interest; concurrent
-// set/read is benign (worst case a missed or extra dump).
+// Process-wide function-name filter and payload store. The mutex protects both
+// because the shell may update/print while the worker captures.
+static DumpMutexType gDumpMutex;
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 EJitSharedTaskPoolState *gDumpSharedState = nullptr;
-static void clearSharedDumpSlots(EJitSharedDumpState &D);
 #endif
 static std::string gDumpFuncFilter;
-static void clearLocalDumpStore();
 
 void setDumpFuncFilter(const std::string &name) {
-  gDumpFuncFilter = name;
-  if (name.empty())
-    clearLocalDumpStore();
-  EJIT_DIAG_DEBUG("set_dump_filter value=%s &filter=%p",
-            gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
-            (void *)&gDumpFuncFilter);
+  {
+    std::lock_guard<DumpMutexType> lock(gDumpMutex);
+    gDumpFuncFilter = name;
+    EJIT_DIAG_DEBUG("set_dump_filter value=%s &filter=%p",
+                    gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
+                    (void *)&gDumpFuncFilter);
+  }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (gDumpSharedState) {
     EJitSharedDumpState &D = gDumpSharedState->dump;
@@ -198,9 +194,15 @@ void setDumpFuncFilter(const std::string &name) {
     }
     D.filterName[len] = 0;
     D.filterLen = len;
-    // A filter change invalidates all captured slots so stale results don't
-    // surface after re-arming. It also releases dynamic dump payloads.
-    clearSharedDumpSlots(D);
+    D.hasDump.storeRelease(0);
+    D.status.storeRelease(0);
+    D.resultNameLen = 0;
+    D.irSize = 0;
+    D.asmSize = 0;
+    D.keyHi = 0;
+    D.keyLo = 0;
+    D.workerCore = kEJitInvalidCoreId;
+    D.resultName[0] = 0;
     D.filterEnabled.storeRelease(len ? 1u : 0u);
     D.lock.storeRelease(0);
     EJIT_DIAG_DEBUG("set_dump_filter shared enabled=%u len=%u &shared=%p",
@@ -218,8 +220,13 @@ void setDumpSharedState(EJitSharedTaskPoolState *state) {
   // propagate it into the now-bound shared state. Otherwise the owner worker
   // (possibly a different core) sees an empty shared filter and never captures,
   // even though the producer thinks dump is armed.
-  if (gDumpSharedState && !gDumpFuncFilter.empty())
-    setDumpFuncFilter(gDumpFuncFilter);
+  std::string filter;
+  {
+    std::lock_guard<DumpMutexType> lock(gDumpMutex);
+    filter = gDumpFuncFilter;
+  }
+  if (gDumpSharedState && !filter.empty())
+    setDumpFuncFilter(filter);
 }
 
 static void sharedDumpLock(EJitSharedDumpState &D) {
@@ -256,6 +263,7 @@ static bool getActiveDumpFilter(std::string &out) {
   if (getSharedDumpFilter(out))
     return true;
 #endif
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
   if (gDumpFuncFilter.empty())
     return false;
   out = gDumpFuncFilter;
@@ -274,13 +282,7 @@ struct DumpEntry {
 // thread). Guarded by gDumpMutex. These are ordinary process statics, not part
 // of the shared taskpool state; cross-core visibility depends on the worker
 // running in the same process image (addresses are logged to diagnose this).
-static DumpMutexType gDumpMutex;
 static std::map<std::string, DumpEntry> gDumpStore;
-
-static void clearLocalDumpStore() {
-  std::lock_guard<DumpMutexType> lock(gDumpMutex);
-  gDumpStore.clear();
-}
 
 static void dumpBytesSafe(const char *label, const char *data, size_t n) {
   EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)n);
@@ -333,157 +335,82 @@ static uint32_t copyDumpBytes(char *dst, uint32_t cap, const char *src,
   return n;
 }
 
-static void freeSharedDumpPayload(EJitSharedDumpSlot &Slot) {
-  if (Slot.irPtr)
-    std::free(reinterpret_cast<void *>(Slot.irPtr));
-  if (Slot.asmPtr)
-    std::free(reinterpret_cast<void *>(Slot.asmPtr));
-  Slot.irPtr = 0;
-  Slot.asmPtr = 0;
-  Slot.irSize = 0;
-  Slot.asmSize = 0;
-}
-
-static void clearSharedDumpSlots(EJitSharedDumpState &D) {
-  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-    EJitSharedDumpSlot &Slot = D.slots[s];
-    Slot.valid.storeRelease(0);
-    Slot.truncated.storeRelease(0);
-    Slot.nameLen = 0;
-    freeSharedDumpPayload(Slot);
-    Slot.keyHi = 0;
-    Slot.keyLo = 0;
-    Slot.reserved0 = 0;
-    for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
-      Slot.name[i] = 0;
-  }
-  D.nextSlot = 0;
-}
-
-static bool allocSharedDumpPayload(const std::string &Text, uintptr_t &Ptr,
-                                   uint32_t &Size) {
-  Ptr = 0;
-  Size = 0;
-  if (Text.empty())
-    return true;
-  if (Text.size() > 0xffffffffu)
-    return false;
-  char *Buf = static_cast<char *>(std::malloc(Text.size() + 1));
-  if (!Buf)
-    return false;
-  std::memcpy(Buf, Text.data(), Text.size());
-  Buf[Text.size()] = 0;
-  Ptr = reinterpret_cast<uintptr_t>(Buf);
-  Size = static_cast<uint32_t>(Text.size());
-  return true;
-}
-
-static void captureSharedDump(const std::string &fnName, uint64_t cacheKey,
-                              const std::string &IR, const std::string &ASM) {
+static void captureSharedDumpMetadata(const std::string &fnName,
+                                      uint64_t cacheKey, size_t irSize,
+                                      size_t asmSize) {
   if (!gDumpSharedState)
     return;
-  uintptr_t NewIR = 0;
-  uintptr_t NewASM = 0;
-  uint32_t NewIRSize = 0;
-  uint32_t NewASMSize = 0;
-  if (!allocSharedDumpPayload(IR, NewIR, NewIRSize) ||
-      !allocSharedDumpPayload(ASM, NewASM, NewASMSize)) {
-    if (NewIR)
-      std::free(reinterpret_cast<void *>(NewIR));
-    if (NewASM)
-      std::free(reinterpret_cast<void *>(NewASM));
-    EJIT_DIAG("capture shared failed func=%s ir=%u asm=%u: alloc failed",
-              fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size());
-    return;
-  }
-
   EJitSharedDumpState &D = gDumpSharedState->dump;
+  uint32_t core = EJitCoreId::current();
   sharedDumpLock(D);
-  // Find an existing slot for fnName (overwrite it in place). Distinct names
-  // accumulate; a repeat re-capture refreshes the same slot rather than
-  // consuming another.
-  uint32_t target = kEJitSharedDumpSlotCount;
-  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-    if (D.slots[s].valid.loadRelaxed() != 0 &&
-        D.slots[s].nameLen == fnName.size() &&
-        std::memcmp(D.slots[s].name, fnName.data(), fnName.size()) == 0) {
-      target = s;
-      break;
-    }
-  }
-  if (target == kEJitSharedDumpSlotCount) {
-    // New name: prefer a free slot, else round-robin evict the oldest.
-    target = D.nextSlot;
-    for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-      uint32_t idx = (D.nextSlot + s) % kEJitSharedDumpSlotCount;
-      if (D.slots[idx].valid.loadRelaxed() == 0) {
-        target = idx;
-        break;
-      }
-    }
-    D.nextSlot = (target + 1) % kEJitSharedDumpSlotCount;
-  }
-  EJitSharedDumpSlot &Slot = D.slots[target];
   bool nameTrunc = false;
-  Slot.valid.storeRelease(0); // invalidate while writing (readers hold the lock)
-  freeSharedDumpPayload(Slot);
-  Slot.nameLen = copyDumpBytes(Slot.name, kEJitSharedDumpNameBytes,
-                               fnName.data(), fnName.size(), nameTrunc);
-  Slot.irPtr = NewIR;
-  Slot.asmPtr = NewASM;
-  Slot.irSize = NewIRSize;
-  Slot.asmSize = NewASMSize;
-  Slot.keyHi = (uint32_t)(cacheKey >> 32);
-  Slot.keyLo = (uint32_t)(cacheKey & 0xffffffffu);
-  Slot.truncated.storeRelease(nameTrunc ? 4u : 0u);
-  Slot.valid.storeRelease(1);
+  D.hasDump.storeRelease(0);
+  D.resultNameLen = copyDumpBytes(D.resultName, kEJitSharedDumpNameBytes,
+                                  fnName.data(), fnName.size(), nameTrunc);
+  D.irSize = irSize > 0xffffffffu ? 0xffffffffu : (uint32_t)irSize;
+  D.asmSize = asmSize > 0xffffffffu ? 0xffffffffu : (uint32_t)asmSize;
+  D.keyHi = (uint32_t)(cacheKey >> 32);
+  D.keyLo = (uint32_t)(cacheKey & 0xffffffffu);
+  D.workerCore = core;
+  D.status.storeRelease(nameTrunc ? 4u : 0u);
+  D.hasDump.storeRelease(1);
   sharedDumpUnlock(D);
-  EJIT_DIAG_DEBUG("capture shared func=%s slot=%u ir=%u asm=%u trunc=0x%x &shared=%p",
-            fnName.c_str(), target, (unsigned)IR.size(), (unsigned)ASM.size(),
-            nameTrunc ? 4u : 0u,
-            (void *)gDumpSharedState);
+  EJIT_DIAG_DEBUG(
+      "capture shared metadata func=%s core=%u ir=%u asm=%u &shared=%p",
+      fnName.c_str(), core, (unsigned)irSize, (unsigned)asmSize,
+      (void *)gDumpSharedState);
 }
 
-static bool printSharedDumped(const char *name) {
+static bool printSharedDumpHint(const char *name) {
   if (!gDumpSharedState)
     return false;
   EJitSharedDumpState &D = gDumpSharedState->dump;
-  bool hasName = name && name[0];
   sharedDumpLock(D);
-  bool any = false;
-  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-    EJitSharedDumpSlot &Slot = D.slots[s];
-    if (Slot.valid.loadAcquire() == 0)
-      continue;
-    bool match = true;
-    if (hasName) {
-      uint32_t i = 0;
-      while (i < Slot.nameLen && name[i] && name[i] == Slot.name[i])
-        ++i;
-      match = (i == Slot.nameLen && name[i] == 0);
-    }
-    if (!match)
-      continue;
-    uint32_t trunc = Slot.truncated.loadAcquire();
-    EJIT_DIAG("print_dumped shared hit requested=%s stored=%s slot=%u "
-              "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u trunc=0x%x",
-              hasName ? name : "(list)", Slot.name, s, Slot.keyHi, Slot.keyLo,
-              Slot.irSize, Slot.asmSize, trunc);
-    if (hasName && Slot.irSize && Slot.irPtr)
-      dumpBytesSafe("dump IR", reinterpret_cast<const char *>(Slot.irPtr),
-                    Slot.irSize);
-    if (hasName && Slot.asmSize && Slot.asmPtr)
-      dumpBytesSafe("dump ASM", reinterpret_cast<const char *>(Slot.asmPtr),
-                    Slot.asmSize);
-    any = true;
-    if (hasName)
-      break; // single-name query: done after the first match
+  if (D.hasDump.loadAcquire() == 0) {
+    sharedDumpUnlock(D);
+    return false;
   }
+  bool hasName = name && name[0];
+  bool match = true;
+  if (hasName) {
+    uint32_t i = 0;
+    while (i < D.resultNameLen && name[i] && name[i] == D.resultName[i])
+      ++i;
+    match = i == D.resultNameLen && name[i] == 0;
+  }
+  if (!match) {
+    sharedDumpUnlock(D);
+    return false;
+  }
+  uint32_t workerCore = D.workerCore;
+  uint32_t irSize = D.irSize;
+  uint32_t asmSize = D.asmSize;
+  uint32_t keyHi = D.keyHi;
+  uint32_t keyLo = D.keyLo;
+  char stored[kEJitSharedDumpNameBytes];
+  uint32_t n = D.resultNameLen;
+  if (n >= kEJitSharedDumpNameBytes)
+    n = kEJitSharedDumpNameBytes - 1;
+  for (uint32_t i = 0; i < n; ++i)
+    stored[i] = D.resultName[i];
+  stored[n] = 0;
   sharedDumpUnlock(D);
-  if (!any)
-    EJIT_DIAG_DEBUG("print_dumped shared miss name=%s &shared=%p",
-                    hasName ? name : "(list)", (void *)gDumpSharedState);
-  return any;
+  (void)irSize;
+  (void)asmSize;
+  (void)keyHi;
+  (void)keyLo;
+  (void)stored;
+  if (workerCore == kEJitInvalidCoreId)
+    EJIT_DIAG("print_dumped: dump for \"%s\" is worker-local; run "
+              "ejit_print_dumped(\"%s\") on the worker core. ir_size=%u "
+              "asm_size=%u key_hi=0x%08x key_lo=0x%08x",
+              stored, stored, irSize, asmSize, keyHi, keyLo);
+  else
+    EJIT_DIAG("print_dumped: dump for \"%s\" is stored on worker core %u; "
+              "run ejit_print_dumped(\"%s\") on that core. ir_size=%u "
+              "asm_size=%u key_hi=0x%08x key_lo=0x%08x",
+              stored, workerCore, stored, irSize, asmSize, keyHi, keyLo);
+  return true;
 }
 #endif
 
@@ -499,8 +426,9 @@ static void captureDump(const std::string &fnName, uint64_t cacheKey,
   gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
   EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
+  // Publish only small metadata. Full text remains in the worker-local map.
   const DumpEntry &E = gDumpStore[fnName];
-  captureSharedDump(fnName, cacheKey, E.IR, E.ASM);
+  captureSharedDumpMetadata(fnName, cacheKey, E.IR.size(), E.ASM.size());
 #endif
 }
 
@@ -523,16 +451,15 @@ static void printOneDumpSafe(const char *requestedName,
     dumpLinesSafe("dump ASM", e.ASM);
 }
 
-/// Print the saved IR+ASM for \p name through EJIT_DIAG, one line per IR/ASM
-/// line. A null/empty name only lists saved entry names to avoid accidental
-/// large log storms.
+/// Print saved IR+ASM through EJIT_DIAG, one line per IR/ASM line. A null/empty
+/// name prints all payloads available on this core.
 void printDumped(const char *name) {
   EJIT_DIAG_DEBUG("print_dumped enter name=%s &filter=%p &store=%p",
-            (name && name[0]) ? name : "(list)", (void *)&gDumpFuncFilter,
-            (void *)&gDumpStore);
+                  (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
+                  (void *)&gDumpStore);
   bool hasName = name && name[0];
-  // Try the local store first. A specific name prints the full local payload;
-  // an empty name only lists available entries.
+  // The complete payloads are worker-local. A specific name prints one entry;
+  // an empty name prints every entry captured by this core.
   {
     std::lock_guard<DumpMutexType> lock(gDumpMutex);
     if (hasName) {
@@ -543,23 +470,15 @@ void printDumped(const char *name) {
       }
     } else if (!gDumpStore.empty()) {
       EJIT_DIAG("print_dumped saved entries=%u", (unsigned)gDumpStore.size());
-      for (auto &kv : gDumpStore) {
-        (void)kv;
-        EJIT_DIAG("print_dumped saved name=%s key_hi=0x%08x key_lo=0x%08x "
-                  "ir_size=%u asm_size=%u",
-                  kv.first.c_str(), (uint32_t)(kv.second.cacheKey >> 32),
-                  (uint32_t)(kv.second.cacheKey & 0xffffffffu),
-                  (unsigned)kv.second.IR.size(), (unsigned)kv.second.ASM.size());
-      }
+      for (auto &kv : gDumpStore)
+        printOneDumpSafe(nullptr, kv.first, kv.second);
       return;
     }
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
-  // Local miss / empty (e.g. a non-owner core, whose per-core gDumpStore is
-  // empty): serve from the cross-core shared per-name table. The table holds
-  // the last N captured functions. A specific name retrieves its payload;
-  // NULL lists metadata only.
-  if (printSharedDumped(name))
+  // A non-worker core cannot read the worker-private payload. Shared state
+  // carries only enough metadata to direct the caller to the owning core.
+  if (printSharedDumpHint(name))
     return;
 #endif
   if (hasName)
@@ -755,7 +674,8 @@ EJitOrcEngine::Create(const Config &config,
           {
             std::string DumpFilter;
             bool hasFilter = getActiveDumpFilter(DumpFilter);
-            bool match = hasFilter && ctx->fnName == DumpFilter;
+            bool match =
+                hasFilter && (DumpFilter == "*" || ctx->fnName == DumpFilter);
             EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
                             "key_lo=0x%08x match=%d &filter=%p",
                             hasFilter ? DumpFilter.c_str() : "(off)",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1113,8 +1113,13 @@ void ejit_dump_func(const char *name) {
 
 void ejit_print_dumped(const char *name) {
   // gDumpSharedState is bound once in ejit_init; no per-call rebind needed.
-  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(list)");
+  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(all)");
   printDumped(name);
+}
+
+void ejit_dump_all(bool enable) {
+  EJIT_DIAG("dump_all enable=%u", enable ? 1u : 0u);
+  setDumpFuncFilter(enable ? std::string("*") : std::string());
 }
 
 // Sentinel returned when no owner core is elected (e.g. not initialized or the

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -20,7 +20,6 @@
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
-#include <cstdlib>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -1345,10 +1344,6 @@ namespace {
 // the non-shared EJitRuntimeState::isActive default (no entry => inactive).
 // setInstanceEnabled(true) flips 0->1 and bumps version on first activate.
 void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
-  bool canFreeDumpPayload =
-      st->magic == kEJitSharedAbiMagic &&
-      st->abiVersion == kEJitSharedAbiVersion &&
-      st->structSize == sizeof(EJitSharedTaskPoolState);
   for (uint32_t d = 0; d < kEJitSharedDimTypes; ++d)
     for (uint32_t i = 0; i < kEJitSharedInstances; ++i) {
       st->enabled[d][i].storeRelaxed(0);
@@ -1396,29 +1391,19 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
   }
   st->dump.lock.storeRelaxed(0);
   st->dump.filterEnabled.storeRelaxed(0);
+  st->dump.hasDump.storeRelaxed(0);
+  st->dump.status.storeRelaxed(0);
   st->dump.filterLen = 0;
-  st->dump.nextSlot = 0;
+  st->dump.resultNameLen = 0;
+  st->dump.irSize = 0;
+  st->dump.asmSize = 0;
+  st->dump.keyHi = 0;
+  st->dump.keyLo = 0;
+  st->dump.workerCore = kEJitInvalidCoreId;
   st->dump.reserved0 = 0;
-  for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
+  for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i) {
     st->dump.filterName[i] = 0;
-  for (uint32_t s = 0; s < kEJitSharedDumpSlotCount; ++s) {
-    EJitSharedDumpSlot &Slot = st->dump.slots[s];
-    Slot.valid.storeRelaxed(0);
-    Slot.truncated.storeRelaxed(0);
-    Slot.nameLen = 0;
-    Slot.irSize = 0;
-    Slot.asmSize = 0;
-    Slot.keyHi = 0;
-    Slot.keyLo = 0;
-    Slot.reserved0 = 0;
-    if (canFreeDumpPayload && Slot.irPtr)
-      std::free(reinterpret_cast<void *>(Slot.irPtr));
-    if (canFreeDumpPayload && Slot.asmPtr)
-      std::free(reinterpret_cast<void *>(Slot.asmPtr));
-    Slot.irPtr = 0;
-    Slot.asmPtr = 0;
-    for (uint32_t i = 0; i < kEJitSharedDumpNameBytes; ++i)
-      Slot.name[i] = 0;
+    st->dump.resultName[i] = 0;
   }
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     st->buckets[b].writeFlag.storeRelaxed(0);

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdio>
-#include <cstdlib>
 #include <memory>
 #include <thread>
 #include <type_traits>
@@ -1595,12 +1594,12 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
   EXPECT_TRUE(r.readyButNotShareable);
 }
 
-// 16/17 ABI v6 layout: the slot carries the executable range as fixed-width,
+// 16/17 ABI v7 layout: the slot carries the executable range as fixed-width,
 // naturally-aligned scalars (read back by value — endian-safe), the pool-split
-// table is POD, dump slots use dynamic payload pointers, and each bucket
-// carries the NO_RECLAIM seqlock publishSeq word.
+// table is POD, dump state contains metadata only, and each bucket carries the
+// NO_RECLAIM seqlock publishSeq word.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 6u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 7u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -1628,41 +1627,40 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   EXPECT_EQ(slot->rangeReserved, 0u);
 }
 
-TEST_F(SharedTaskPoolTest, DumpDynamicPayloadsClearedOnInit) {
-  state_->magic = kEJitSharedAbiMagic;
-  state_->abiVersion = kEJitSharedAbiVersion;
-  state_->structSize = sizeof(EJitSharedTaskPoolState);
+TEST_F(SharedTaskPoolTest, DumpStateHoldsOnlySmallMetadata) {
+  EXPECT_TRUE(std::is_standard_layout<EJitSharedDumpState>::value);
+  EXPECT_TRUE(std::is_trivially_destructible<EJitSharedDumpState>::value);
+  EXPECT_LE(sizeof(EJitSharedDumpState), 2u * kEJitSharedDumpNameBytes + 256u);
+}
 
-  char *IR = static_cast<char *>(std::malloc(8));
-  char *ASM = static_cast<char *>(std::malloc(8));
-  ASSERT_NE(IR, nullptr);
-  ASSERT_NE(ASM, nullptr);
-  state_->dump.slots[0].valid.storeRelaxed(1);
-  state_->dump.slots[0].truncated.storeRelaxed(7);
-  state_->dump.slots[0].nameLen = 4;
-  state_->dump.slots[0].irPtr = reinterpret_cast<uintptr_t>(IR);
-  state_->dump.slots[0].asmPtr = reinterpret_cast<uintptr_t>(ASM);
-  state_->dump.slots[0].irSize = 7;
-  state_->dump.slots[0].asmSize = 7;
-  state_->dump.slots[0].keyHi = 0x12;
-  state_->dump.slots[0].keyLo = 0x34;
-  state_->dump.slots[0].name[0] = 'f';
-  state_->dump.nextSlot = 1;
-
+TEST_F(SharedTaskPoolTest, DumpMetadataClearedOnInit) {
+  state_->dump.filterEnabled.storeRelaxed(1);
+  state_->dump.hasDump.storeRelaxed(1);
+  state_->dump.status.storeRelaxed(4);
+  state_->dump.filterLen = 4;
+  state_->dump.resultNameLen = 4;
+  state_->dump.irSize = 123;
+  state_->dump.asmSize = 456;
+  state_->dump.keyHi = 0x12;
+  state_->dump.keyLo = 0x34;
+  state_->dump.workerCore = 7;
+  state_->dump.filterName[0] = 'f';
+  state_->dump.resultName[0] = 'g';
   EJitSharedTaskPool owner;
   bringUpOwner(owner);
 
-  EXPECT_EQ(state_->dump.slots[0].valid.loadRelaxed(), 0u);
-  EXPECT_EQ(state_->dump.slots[0].truncated.loadRelaxed(), 0u);
-  EXPECT_EQ(state_->dump.slots[0].nameLen, 0u);
-  EXPECT_EQ(state_->dump.slots[0].irPtr, 0u);
-  EXPECT_EQ(state_->dump.slots[0].asmPtr, 0u);
-  EXPECT_EQ(state_->dump.slots[0].irSize, 0u);
-  EXPECT_EQ(state_->dump.slots[0].asmSize, 0u);
-  EXPECT_EQ(state_->dump.slots[0].keyHi, 0u);
-  EXPECT_EQ(state_->dump.slots[0].keyLo, 0u);
-  EXPECT_EQ(state_->dump.slots[0].name[0], 0);
-  EXPECT_EQ(state_->dump.nextSlot, 0u);
+  EXPECT_EQ(state_->dump.filterEnabled.loadRelaxed(), 0u);
+  EXPECT_EQ(state_->dump.hasDump.loadRelaxed(), 0u);
+  EXPECT_EQ(state_->dump.status.loadRelaxed(), 0u);
+  EXPECT_EQ(state_->dump.filterLen, 0u);
+  EXPECT_EQ(state_->dump.resultNameLen, 0u);
+  EXPECT_EQ(state_->dump.irSize, 0u);
+  EXPECT_EQ(state_->dump.asmSize, 0u);
+  EXPECT_EQ(state_->dump.keyHi, 0u);
+  EXPECT_EQ(state_->dump.keyLo, 0u);
+  EXPECT_EQ(state_->dump.workerCore, kEJitInvalidCoreId);
+  EXPECT_EQ(state_->dump.filterName[0], 0);
+  EXPECT_EQ(state_->dump.resultName[0], 0);
 }
 
 // 18/ Code-sharing OFF in 4K mode: a non-owner cleanly rejects and triggers NO


### PR DESCRIPTION
## 中文

### 改动
- 恢复 `ejit_dump_all(bool)`：开启时以 `"*"` 捕获所有 specialization；`ejit_dump_func(name)` 继续支持精确函数名过滤。
- 完整 IR/ASM 只保存在 worker 核本地 `gDumpStore`；worker 核调用 `ejit_print_dumped(NULL)` 可打印全部已捕获内容。
- shared taskpool 只共享固定大小的过滤器和最新捕获 metadata（函数名、IR/ASM 大小、cache key、worker core）。非 worker 核只提示应到哪个 worker 核打印，不读取大文本。
- 删除 shared dump 的动态 payload 指针、`malloc/free` 及 slot/eviction 表；shared ABI 升级至 v7。
- 用 dump mutex 保护本地 filter 的并发读写，并将 `ejit_dump_all` 加入 `ejit_test/lipo/lipo.py` optional API roots。

### 验证
- `ninja -C build_host LLVMEJIT -j8` ✅
- 新增 shared dump layout/reset 测试：2/2 PASS ✅
- `EJITSharedTaskPoolTests`：60/74；其余 14 个为当前未启用 `EJIT_SRE_SHARED_CODE_POINTERS` 时已有的 peer/4K 配置失败集合
- `libLLVMEJIT.a` 中 `ejit_dump_all`、`ejit_dump_func`、`ejit_print_dumped` 均为全局 `T` 符号 ✅
- `python3 -m py_compile ejit_test/lipo/lipo.py` ✅
- `git diff --check` ✅

### 板上验证
1. 调用 `ejit_dump_all(true)`，或用 `ejit_dump_func(name)` 设置过滤器。
2. 触发异步编译。
3. 在 worker 核执行 `ejit_print_dumped(NULL)` 或 `ejit_print_dumped(name)`，确认输出完整 IR/ASM。
4. 在非 worker 核执行相同命令，确认仅输出 worker-core 提示，不访问完整 payload。

## English

### Changes
- Restores `ejit_dump_all(bool)` with `"*"` as the wildcard while preserving exact-name `ejit_dump_func` filtering.
- Keeps complete IR/ASM payloads in the worker-local `gDumpStore`.
- Shares only bounded latest-capture metadata and a worker-core ownership hint.
- Removes shared dynamic payload pointers, allocation, and eviction slots; bumps the shared ABI to v7.
- Serializes local filter access and retains the new C API through lipo GC merging.

### Validation
- `LLVMEJIT` links successfully with `-j8`.
- New dump layout/reset tests pass (2/2).
- The three dump C APIs are present as global symbols in `libLLVMEJIT.a`.
- `lipo.py` syntax and staged diff checks pass.
- The remaining 14 shared-taskpool failures are the existing peer/4K configuration set when shared code pointers are disabled.