### PR TITLE
[JITLink][AArch64] Bypass in-range pointer jump stubs

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/aarch64.h
@@ -918,6 +918,11 @@ public:
   Section *StubsSection = nullptr;
 };
 
+/// Replace branches through a standard AArch64 pointer-jump stub with a direct
+/// Branch26PCRel edge when the resolved target is within range. Out-of-range
+/// and unresolved targets retain the original stub path.
+LLVM_ABI Error optimizePointerJumpStubBranches(LinkGraph &G);
+
 /// Returns the name of the pointer signing function section.
 LLVM_ABI const char *getPointerSigningFunctionSectionName();
 

--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
@@ -734,6 +734,10 @@ void link_ELF_aarch64(std::unique_ptr<LinkGraph> G,
 
     // Add an in-place GOT/TLS/Stubs build pass.
     Config.PostPrunePasses.push_back(buildTables_ELF_aarch64);
+
+    // Once external symbols have resolved and block addresses are final, bypass
+    // pointer-jump stubs for Branch26 targets within the architectural range.
+    Config.PreFixupPasses.push_back(aarch64::optimizePointerJumpStubBranches);
   }
 
   if (auto Err = Ctx->modifyPassConfig(*G, Config))

--- a/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
@@ -224,6 +224,71 @@ void PLTTableManager::registerExistingEntries() {
   }
 }
 
+Error optimizePointerJumpStubBranches(LinkGraph &G) {
+  LLVM_DEBUG(dbgs() << "Optimizing AArch64 pointer-jump stubs:\n");
+
+  auto *StubsSection = G.findSectionByName(PLTTableManager::getSectionName());
+  if (!StubsSection)
+    return Error::success();
+
+  for (auto *B : G.blocks()) {
+    for (auto &E : B->edges()) {
+      if (E.getKind() != Branch26PCRel || !E.getTarget().isDefined())
+        continue;
+
+      Block &StubBlock = E.getTarget().getBlock();
+      if (&StubBlock.getSection() != StubsSection ||
+          StubBlock.getSize() != sizeof(PointerJumpStubContent) ||
+          StubBlock.edges_size() != 2)
+        continue;
+
+      Edge *PageEdge = nullptr;
+      Edge *OffsetEdge = nullptr;
+      for (auto &StubEdge : StubBlock.edges()) {
+        if (StubEdge.getKind() == Page21 && StubEdge.getOffset() == 0)
+          PageEdge = &StubEdge;
+        else if (StubEdge.getKind() == PageOffset12 &&
+                 StubEdge.getOffset() == 4)
+          OffsetEdge = &StubEdge;
+      }
+      if (!PageEdge || !OffsetEdge ||
+          &PageEdge->getTarget() != &OffsetEdge->getTarget())
+        continue;
+
+      Symbol &GOTEntry = PageEdge->getTarget();
+      if (!GOTEntry.isDefined())
+        continue;
+      Block &GOTBlock = GOTEntry.getBlock();
+      if (GOTBlock.getSize() != G.getPointerSize() ||
+          GOTBlock.edges_size() != 1)
+        continue;
+
+      Edge &PointerEdge = *GOTBlock.edges().begin();
+      if (PointerEdge.getKind() != Pointer64 || PointerEdge.getAddend() != 0)
+        continue;
+
+      Symbol &Target = PointerEdge.getTarget();
+      if (Target.isExternal())
+        continue;
+
+      orc::ExecutorAddr FixupAddress = B->getFixupAddress(E);
+      int64_t Displacement = Target.getAddress() - FixupAddress + E.getAddend();
+      if ((static_cast<uint64_t>(Displacement) & 0x3) != 0 ||
+          Displacement < -(1LL << 27) || Displacement > ((1LL << 27) - 1))
+        continue;
+
+      E.setTarget(Target);
+      LLVM_DEBUG({
+        dbgs() << "  Replaced stub branch with direct branch:\n    ";
+        printEdge(dbgs(), *B, E, getEdgeKindName(E.getKind()));
+        dbgs() << "\n";
+      });
+    }
+  }
+
+  return Error::success();
+}
+
 const char *getPointerSigningFunctionSectionName() { return "$__ptrauth_sign"; }
 
 /// Creates a pointer signing function section, block, and symbol to reserve

--- a/llvm/unittests/ExecutionEngine/JITLink/AArch64Tests.cpp
+++ b/llvm/unittests/ExecutionEngine/JITLink/AArch64Tests.cpp
@@ -88,3 +88,49 @@ TEST(AArch64, GOTAndStubs) {
     EXPECT_EQ(PLTSec->blocks_size(), 1U);
   }
 }
+
+static void checkPointerJumpStubRelaxation(StringRef TripleName,
+                                           uint64_t CallAddress,
+                                           uint64_t TargetAddress,
+                                           bool ExpectDirect) {
+  LinkGraph G("stub-relax", std::make_shared<orc::SymbolStringPool>(),
+              Triple(TripleName), SubtargetFeatures(), getEdgeKindName);
+
+  auto &Text =
+      G.createSection("__text", orc::MemProt::Read | orc::MemProt::Exec);
+  const char CallContent[4] = {0x00, 0x00, 0x00, (char)0x94u};
+  auto &CallBlock = G.createContentBlock(Text, CallContent,
+                                         orc::ExecutorAddr(CallAddress), 4, 0);
+  auto &Target = G.addExternalSymbol("aot_target", 0, true);
+  CallBlock.addEdge(Branch26PCRel, 0, Target, 0);
+  Edge &CallEdge = *CallBlock.edges().begin();
+
+  GOTTableManager GOT(G);
+  PLTTableManager PLT(G, GOT);
+  ASSERT_TRUE(PLT.visitEdge(G, &CallBlock, CallEdge));
+  Symbol *Stub = &CallEdge.getTarget();
+  ASSERT_NE(Stub, &Target);
+
+  G.makeAbsolute(Target, orc::ExecutorAddr(TargetAddress));
+  cantFail(optimizePointerJumpStubBranches(G));
+
+  if (ExpectDirect)
+    EXPECT_EQ(&CallEdge.getTarget(), &Target);
+  else
+    EXPECT_EQ(&CallEdge.getTarget(), Stub);
+}
+
+TEST(AArch64, PointerJumpStubBranchRelaxedInRange) {
+  checkPointerJumpStubRelaxation("aarch64-unknown-linux-gnu", 0x10000000,
+                                 0x17fffffc, true);
+}
+
+TEST(AArch64, PointerJumpStubBranchRetainedOutOfRange) {
+  checkPointerJumpStubRelaxation("aarch64-unknown-linux-gnu", 0x10000000,
+                                 0x18000000, false);
+}
+
+TEST(AArch64, PointerJumpStubBranchRelaxedInRangeBigEndian) {
+  checkPointerJumpStubRelaxation("aarch64_be-unknown-linux-gnu", 0x10000000,
+                                 0x10004000, true);
+}


### PR DESCRIPTION
## Closed / 已关闭

### 中文

当前真实产品布局中，JIT code pool 与 AOT `.text` 的距离约为 **2.7 GB**，远超 AArch64 `Branch26`/`BL` 的 **±128 MiB** 硬件范围。因此本 PR 的直接 `BL target` 优化在当前场景不会命中，实际调用仍会保留原有远跳 stub。

该实现本身具备安全回退且测试通过，但对当前产品没有实际收益，故关闭。当前更适合的方向是针对 ±4 GiB 范围，将远跳 stub 从 `ADRP+LDR+BR` 改为 `ADRP+ADD+BR`，消除 GOT 数据读取。

### English

In the real product layout, the JIT code pool is approximately **2.7 GB** away from the AOT `.text` section, which is well beyond AArch64 `Branch26`/`BL`'s **±128 MiB** architectural range. This direct `BL target` relaxation therefore cannot trigger in the current deployment, and calls retain the existing long-range stub path.

The implementation has a safe fallback and passes its tests, but it provides no practical benefit for the current product layout, so this PR is being closed. The more relevant direction is the ±4 GiB stub rewrite from `ADRP+LDR+BR` to `ADRP+ADD+BR`, which removes the GOT data load.