### PR TITLE
[EJIT] Inline resolved AArch64 long calls

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -192,6 +192,7 @@ ALL_TESTS=(
   ejit_ptr_period_test
   ejit_trace_test
   ejit_volatile_test
+  ejit_direct_stub_test
 )
 
 # Per-test compile flags (e.g. for disabling global constructors)
@@ -230,6 +231,10 @@ declare -A EXTRA_SRCS
 EXTRA_SRCS[ejit_multi_tu_test]="ejit_multi_tu_test_b.c"
 EXTRA_SRCS[ejit_baremetal_link_test]="ejit_multi_tu_test_b.c"
 EXTRA_SRCS[ejit_lto_inline_test]="ejit_lto_inline_test_b.c"
+# Two-TU test: the AOT helper lives in a separate TU so the JIT entry sees it
+# as an external declaration and routes the call through a PLT stub (the stub
+# EJitDirectCallStubsPlugin rewrites on AArch64).
+EXTRA_SRCS[ejit_direct_stub_test]="ejit_direct_stub_helper.c"
 
 declare -A TEST_ARGS
 TEST_ARGS[ejit_complex_test]="0 1 2 3"
@@ -255,6 +260,7 @@ TEST_ARGS[ejit_baremetal_link_test]="0 3"
 TEST_ARGS[ejit_sync_mode_test]="0"
 TEST_ARGS[ejit_new_attr_test]="0"
 TEST_ARGS[ejit_fixed_dim_test]="0 1"
+TEST_ARGS[ejit_direct_stub_test]="0"
 
 if [[ ${#SELECTED[@]} -eq 0 ]]; then
   SELECTED=("${ALL_TESTS[@]}")

--- a/ejit_test/ejit_direct_stub_helper.c
+++ b/ejit_test/ejit_direct_stub_helper.c
@@ -1,0 +1,24 @@
+/**
+ * EJIT direct-call-stub test - second TU: an AOT-resident helper.
+ *
+ * ejit_direct_stub_test.c's JIT entry calls aot_helper(). Because this TU is
+ * compiled separately, aot_helper appears as an external declaration in the
+ * JIT entry's bitcode - it is NOT pulled into the JIT closure (the closure
+ * collector skips declarations), so JITLink routes the call through a PLT
+ * pointer-jump stub. That stub is exactly what EJitDirectCallStubsPlugin
+ * rewrites from ADRP+LDR+BR (via GOT) to ADRP+ADD+BR (direct) on AArch64.
+ *
+ * This TU has no ejit_entry / ejit_period annotations: it is plain AOT code.
+ */
+
+#include <stdint.h>
+
+/* noinline + used: keep it a real out-of-line AOT call (not inlined into the
+ * JIT entry, not eliminated by the linker). */
+__attribute__((noinline, used))
+uint32_t aot_helper(uint32_t x) {
+  /* Non-trivial body so the call is not trivially folded away. The volatile
+   * read also defeats any constant-propagation that would elide the call. */
+  volatile uint32_t y = x;
+  return y * 7U + 3U;
+}

--- a/ejit_test/ejit_direct_stub_test.c
+++ b/ejit_test/ejit_direct_stub_test.c
@@ -1,0 +1,131 @@
+/**
+ * EJIT direct-call-stub test - main TU.
+ *
+ * Verifies that a JIT specialization can call an AOT-resident function via a
+ * PLT stub, and (on AArch64) that EJitDirectCallStubsPlugin rewrites that stub
+ * without breaking the call.
+ *
+ * aot_helper is defined in ejit_direct_stub_helper.c (separate TU), so from the
+ * JIT entry's bitcode it is an external declaration -> JITLink emits a PLT
+ * pointer-jump stub (ADRP+LDR+BR via a GOT entry) for the call. The plugin
+ * rewrites it to a direct ADRP+ADD+BR stub on AArch64 when the target is within
+ * +-4GiB (dropping the GOT data load); on x86 it is a no-op. Either way the
+ * call must return the correct value - this test is a correctness regression
+ * guard for the stub path.
+ *
+ * On AArch64, to confirm the rewrite fired, build with EJIT_DIAG_ENABLE and
+ * look for this line in the log (rewritten>=1, fallback==0 when the slab is
+ * within +-4GiB of .text):
+ *   [EJIT] ... direct-stub: rewritten=N fallback=M in spec_...
+ *
+ * Build/run:
+ *   ./build.sh release x86            # (or aarch64) - static libs
+ *   cd ejit_test && ./build.sh --run ejit_direct_stub_test 0
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ejit_test_helpers.h"
+
+//===-- EJIT 属性 -----------------------------------------------------------===//
+
+struct CellCfg {
+  ejit_may_const uint32_t cellType;
+  uint32_t trafficLoad;
+};
+
+ejit_period(static) uint32_t g_sysVer;
+
+#define N_CELL 8
+ejit_period_arr(cell) struct CellCfg g_cellCfg[N_CELL];
+
+//===-- AOT helper (defined in ejit_direct_stub_helper.c) ------------------===//
+
+extern uint32_t aot_helper(uint32_t x);
+
+//===-- JIT entry ----------------------------------------------------------===//
+
+// JIT folds cellType to a constant (may_const), then calls the AOT helper via a
+// PLT stub (external call). On AArch64 the stub is the direct-rewrite target.
+ejit_entry
+uint32_t jit_calls_aot(ejit_period_arr_ind(cell) uint8_t cellIdx) {
+  uint32_t base = g_cellCfg[cellIdx].cellType;  // may_const -> JIT folds
+  return aot_helper(base);
+}
+
+//===-- 断言 ---------------------------------------------------------------===//
+
+static int g_failures = 0;
+
+#define VERIFY(cond, fmt, ...) do {                                \
+  if (!(cond)) {                                                    \
+    printf("  FAIL: " fmt "\n", ##__VA_ARGS__);                    \
+    g_failures++;                                                   \
+  } else {                                                          \
+    printf("  OK:   " fmt "\n", ##__VA_ARGS__);                    \
+  }                                                                 \
+} while (0)
+
+extern void ejit_shutdown(void);
+
+//===-- main ---------------------------------------------------------------===//
+
+int main(int argc, char **argv)
+{
+  uint8_t ci = (argc >= 2) ? (uint8_t)atoi(argv[1]) : 0;
+  if (ci >= N_CELL)
+    ci = 0;
+
+  printf("=== EJIT Direct-Call-Stub Test ===\n");
+  printf("cellIdx=%u\n\n", ci);
+
+  g_cellCfg[ci].cellType = 0xFD;  /* 253 */
+  g_cellCfg[ci].trafficLoad = 0;
+
+  ejit_config_t cfg;
+  ejit_default_config(&cfg);
+  int rc = ejit_init(&cfg);
+  VERIFY(rc == 0, "ejit_init returned %d", rc);
+
+  ejit_activate("cell", ci);
+
+  /* AOT-side reference (direct AOT call, no stub). */
+  uint32_t expected = aot_helper(0xFD);
+
+  /*--- 验证 1: JIT 调用 AOT 函数（经 PLT 桩）结果正确 ---*/
+  printf("\n--- 验证 1: JIT 经桩调用 AOT 函数 ---\n");
+  uint32_t r1 = jit_calls_aot(ci);
+  VERIFY(r1 == expected, "jit_calls_aot(%u) = %u (expected %u)", ci, r1, expected);
+
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  ejit_drain_taskpool();
+  ejit_taskpool_stats_t s1; memset(&s1, 0, sizeof(s1));
+  ejit_taskpool_get_stats(&s1);
+  printf("  stats: ready=%u hits=%llu compiles=%llu\n",
+         s1.readyEntries, (unsigned long long)s1.cacheHits,
+         (unsigned long long)s1.asyncCompiles);
+  VERIFY(s1.asyncCompiles >= 1, "JIT compiles >= 1 (actual %llu)",
+         (unsigned long long)s1.asyncCompiles);
+#else
+  ejit_stats_t s1;
+  ejit_get_stats(&s1);
+  printf("  stats: entries=%zu hits=%llu misses=%llu\n", s1.entryCount,
+         (unsigned long long)s1.hits, (unsigned long long)s1.misses);
+  VERIFY(s1.entryCount >= 1, "JIT entries >= 1 (actual %zu)", s1.entryCount);
+#endif
+
+  /*--- 验证 2: 第二次调用（缓存命中）结果一致 ---*/
+  printf("\n--- 验证 2: 第二次调用 (缓存命中) ---\n");
+  uint32_t r2 = jit_calls_aot(ci);
+  VERIFY(r2 == expected, "jit_calls_aot(%u) 2nd call = %u (expected %u)",
+         ci, r2, expected);
+
+  ejit_shutdown();
+
+  printf("\n%s\n", g_failures ? "FAIL" : "ALL OK");
+  return g_failures ? 1 : 0;
+}

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -661,6 +661,22 @@ if(EJIT_SRE_CODE_POOL AND EJIT_CODE_POOL_4K_SEAL)
   message(STATUS "EmbeddedJIT: SRE code pool uses 4K-granular page sealing")
 endif()
 
+#===-- EmbeddedJIT direct PLT stubs (drop GOT load) ------------------------===#
+# Rewrite AArch64 JITLink PLT pointer-jump stubs (ADRP x16; LDR x16,[x16]; BR
+# x16, which load the target address from a GOT entry) into direct PC-relative
+# stubs (ADRP x16; ADD x16,x16; BR x16) that address the target directly. This
+# drops the per-call GOT data load. The JIT slab is ~1.5-2.2GB from AOT .text:
+# beyond BL's +-128MB (so a stub is unavoidable) but within ADRP's +-4GB reach.
+# If a target is ever beyond +-4GB (slab base is SRE_MemAlloc'd and uncontrolled)
+# the stub auto-falls back to the original GOT-indirect form - zero regression.
+# AArch64 ELF only; the pass is a no-op on other targets. Default ON (safe via
+# fallback); turn OFF to bisect. See EJitDirectCallStubs.{h,cpp}.
+option(EJIT_DIRECT_CALL_STUBS
+  "EJIT: rewrite AArch64 JITLink PLT stubs to direct ADRP+ADD+BR (drop GOT load); auto-fallback to GOT stub beyond +-4GiB" ON)
+if(EJIT_DIRECT_CALL_STUBS)
+  add_definitions(-DEJIT_DIRECT_CALL_STUBS)
+endif()
+
 #===-- EmbeddedJIT per-function inline cache (multi-version) -------------===#
 # EJIT_ICACHE_DIM_SIZE: the per-dimension bound D of the per-function
 # @__ejit_icache_fn_<name> [D]^numDims inline-cache array. MUST be a power of 2

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -677,6 +677,18 @@ if(EJIT_DIRECT_CALL_STUBS)
   add_definitions(-DEJIT_DIRECT_CALL_STUBS)
 endif()
 
+# Emit external AArch64 calls as an inline GOT sequence
+# (ADRP+LDR+BLR), then let the EJIT JITLink plugin relax it to
+# ADRP+ADD+BLR when the resolved AOT target is within +-4GiB. Compared with
+# BL+ADRP+ADD+BR through a direct stub this removes the extra branch into the
+# stub and executes three instructions instead of four. The original GOT
+# sequence remains a safe fallback for targets outside ADRP range.
+option(EJIT_INLINE_LONG_CALLS
+  "EJIT: inline AArch64 far calls as ADRP+ADD+BLR when the resolved target is within +-4GiB" OFF)
+if(EJIT_INLINE_LONG_CALLS)
+  add_definitions(-DEJIT_INLINE_LONG_CALLS)
+endif()
+
 #===-- EmbeddedJIT per-function inline cache (multi-version) -------------===#
 # EJIT_ICACHE_DIM_SIZE: the per-dimension bound D of the per-function
 # @__ejit_icache_fn_<name> [D]^numDims inline-cache array. MUST be a power of 2

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -88,7 +88,8 @@
         "EJIT_SRE_DIAG": "ON",
         "EJIT_DUMP_ASM": "ON",
         "EJIT_STATS_ENABLE": "ON",
-        "EJIT_ICACHE_DIM_SIZE": "16"
+        "EJIT_ICACHE_DIM_SIZE": "16",
+        "EJIT_DIRECT_CALL_STUBS": "ON"
       }
     },
     {

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h
@@ -6,23 +6,29 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// ORC ObjectLinkingLayer plugin that rewrites AArch64 JITLink PLT
-// pointer-jump stubs into direct PC-relative stubs.
+// ORC ObjectLinkingLayer plugin that optimizes AArch64 far calls after external
+// symbols have been resolved.
 //
 // Background: the JIT code slab is SRE_MemAlloc'd ~1.5-2.2GB above AOT .text,
-// beyond AArch64 BL's +-128MB reach (so a call stub is unavoidable) but within
-// ADRP's +-4GB reach. JITLink therefore routes external calls through a
-// PointerJumpStub (ADRP x16,page; LDR x16,[x16,#off]; BR x16) that loads the
+// beyond AArch64 BL's +-128MB reach (so a register-indirect long-call sequence
+// is unavoidable) but within ADRP's +-4GB reach. JITLink normally routes
+// external calls through a PointerJumpStub (ADRP x16,page;
+// LDR x16,[x16,#off]; BR x16) that loads the
 // target address from a GOT entry - one data memory load + one indirect branch
 // per call. This plugin rewrites such stubs, when the target is within +-4GB,
 // into a direct form (ADRP x16,page; ADD x16,x16,#off; BR x16) that addresses
 // the target directly, dropping the GOT data load. The indirect branch remains
-// (unavoidable for >128MB calls on AArch64); eliminating it entirely requires
-// co-locating the slab within +-128MB (a separate, deferred platform change).
+// unavoidable unless the slab can be placed within BL's +-128MB range.
 //
-// Safety: if a target is beyond +-4GB (the slab base is uncontrolled) or its
-// address is unavailable, the stub is left as the original GOT-indirect form -
-// zero regression. AArch64 ELF only; no-op on other targets.
+// With EJIT_INLINE_LONG_CALLS, CodeGen emits ADRP+LDR+BLR at the call site. The
+// plugin resolves the GOT edge and rewrites the LDR to ADD, producing
+// ADRP+ADD+BLR with no separate stub. If the same helper is called repeatedly,
+// CodeGen may hoist ADRP+LDR and reuse the resolved register, leaving only BLR
+// at subsequent calls.
+//
+// Safety: if a target is beyond +-4GB (the slab base is uncontrolled), its
+// address is unavailable, or the relocation/instruction shape is unexpected,
+// the original GOT form is retained. AArch64 ELF only; no-op on other targets.
 //
 //===----------------------------------------------------------------------===//
 
@@ -36,13 +42,16 @@
 namespace llvm {
 namespace ejit {
 
+/// Rewrite inline AArch64 GOT address materializations that target callable
+/// symbols from ADRP+LDR to ADRP+ADD. Exposed for deterministic LinkGraph unit
+/// tests; production invokes it through EJitDirectCallStubsPlugin.
+Error relaxAArch64InlineGOTCalls(jitlink::LinkGraph &G);
+
 /// Plugin installed on the ORC ObjectLinkingLayer (when
-/// EJIT_DIRECT_CALL_STUBS is defined) to rewrite AArch64 PLT stubs as
-/// described above. The rewrite runs as a PreFixup JITLink pass: by then
-/// external symbols have been resolved to absolute addresses (lookup +
-/// applyLookupResult complete) and block content is still mutable, but
-/// fixups have not yet been applied - so retargeted edges are fixed up with
-/// the real target address.
+/// EJIT_DIRECT_CALL_STUBS or EJIT_INLINE_LONG_CALLS is defined) to run the
+/// selected AArch64 rewrites. The rewrite runs as a PreFixup JITLink pass: by
+/// then external symbols have been resolved to absolute addresses and block
+/// content is still mutable, but fixups have not yet been applied.
 class EJitDirectCallStubsPlugin : public orc::LinkGraphLinkingLayer::Plugin {
 public:
   void modifyPassConfig(orc::MaterializationResponsibility &MR,

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h
@@ -1,0 +1,73 @@
+//===-- EJitDirectCallStubs.h - AArch64 direct PLT stub rewrite plugin ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// ORC ObjectLinkingLayer plugin that rewrites AArch64 JITLink PLT
+// pointer-jump stubs into direct PC-relative stubs.
+//
+// Background: the JIT code slab is SRE_MemAlloc'd ~1.5-2.2GB above AOT .text,
+// beyond AArch64 BL's +-128MB reach (so a call stub is unavoidable) but within
+// ADRP's +-4GB reach. JITLink therefore routes external calls through a
+// PointerJumpStub (ADRP x16,page; LDR x16,[x16,#off]; BR x16) that loads the
+// target address from a GOT entry - one data memory load + one indirect branch
+// per call. This plugin rewrites such stubs, when the target is within +-4GB,
+// into a direct form (ADRP x16,page; ADD x16,x16,#off; BR x16) that addresses
+// the target directly, dropping the GOT data load. The indirect branch remains
+// (unavoidable for >128MB calls on AArch64); eliminating it entirely requires
+// co-locating the slab within +-128MB (a separate, deferred platform change).
+//
+// Safety: if a target is beyond +-4GB (the slab base is uncontrolled) or its
+// address is unavailable, the stub is left as the original GOT-indirect form -
+// zero regression. AArch64 ELF only; no-op on other targets.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITDIRECTCALLSTUBS_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITDIRECTCALLSTUBS_H
+
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+
+namespace llvm {
+namespace ejit {
+
+/// Plugin installed on the ORC ObjectLinkingLayer (when
+/// EJIT_DIRECT_CALL_STUBS is defined) to rewrite AArch64 PLT stubs as
+/// described above. The rewrite runs as a PreFixup JITLink pass: by then
+/// external symbols have been resolved to absolute addresses (lookup +
+/// applyLookupResult complete) and block content is still mutable, but
+/// fixups have not yet been applied - so retargeted edges are fixed up with
+/// the real target address.
+class EJitDirectCallStubsPlugin : public orc::LinkGraphLinkingLayer::Plugin {
+public:
+  void modifyPassConfig(orc::MaterializationResponsibility &MR,
+                        jitlink::LinkGraph &G,
+                        jitlink::PassConfiguration &Config) override;
+
+  Error notifyFailed(orc::MaterializationResponsibility &MR) override {
+    return Error::success();
+  }
+  Error notifyEmitted(orc::MaterializationResponsibility &MR) override {
+    return Error::success();
+  }
+  Error notifyRemovingResources(orc::JITDylib &JD,
+                                orc::ResourceKey K) override {
+    return Error::success();
+  }
+  void notifyTransferringResources(orc::JITDylib &JD, orc::ResourceKey DstKey,
+                                   orc::ResourceKey SrcKey) override {}
+
+  static std::shared_ptr<EJitDirectCallStubsPlugin> create() {
+    return std::make_shared<EJitDirectCallStubsPlugin>();
+  }
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITDIRECTCALLSTUBS_H

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -72,6 +72,12 @@ set(EJIT_SOURCES
   EJitSrePlatform.cpp
 )
 
+# AArch64 direct-call-stub rewrite plugin (drop GOT load from PLT stubs).
+# Self-contained JITLink pass; only linked in when the option is on.
+if(EJIT_DIRECT_CALL_STUBS)
+  list(APPEND EJIT_SOURCES EJitDirectCallStubs.cpp)
+endif()
+
 # EJitLogger has its own #ifndef EJIT_FREESTANDING no-op stubs, so always include it.
 list(APPEND EJIT_SOURCES
   EJitLogger.cpp

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -72,9 +72,9 @@ set(EJIT_SOURCES
   EJitSrePlatform.cpp
 )
 
-# AArch64 direct-call-stub rewrite plugin (drop GOT load from PLT stubs).
-# Self-contained JITLink pass; only linked in when the option is on.
-if(EJIT_DIRECT_CALL_STUBS)
+# AArch64 far-call rewrite plugin. It can optimize PLT stubs, inline GOT call
+# sequences, or both, depending on the two independent top-level options.
+if(EJIT_DIRECT_CALL_STUBS OR EJIT_INLINE_LONG_CALLS)
   list(APPEND EJIT_SOURCES EJitDirectCallStubs.cpp)
 endif()
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitDirectCallStubs.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitDirectCallStubs.cpp
@@ -1,0 +1,172 @@
+//===-- EJitDirectCallStubs.cpp - AArch64 direct PLT stub rewrite ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements EJitDirectCallStubsPlugin. See the header for background.
+//
+// The rewrite runs as a PreFixup JITLink pass. By that phase external symbols
+// have been resolved to absolute addresses (lookup + applyLookupResult are
+// done in linkPhase2/3, before PreFixup) and block content is still the
+// mutable working memory set by BasicLayout::apply, but no fixup has been
+// applied yet. So we can retarget the stub's edges to the real target and
+// let the subsequent fixUpBlocks pass apply Page21/PageOffset12 with the
+// target's address - exactly as it would for a natively-emitted direct stub.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h"
+
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <cstring>
+
+using namespace llvm;
+using namespace llvm::jitlink;
+
+namespace llvm {
+namespace ejit {
+
+namespace {
+
+// ADRP x16, <target>@page21       (identical to PointerJumpStubContent[0..3])
+// ADD  x16, x16, <target>@pageoff12  (replaces LDR x16,[x16,#off])
+// BR   x16                        (identical to PointerJumpStubContent[8..11])
+//
+// Only the middle instruction differs from aarch64::PointerJumpStubContent
+// (LDR 0xf9400210 -> ADD 0x91000210). Page21 applies to the ADRP, PageOffset12
+// to the ADD (getPageOffset12Shift returns 0 for non-LD/ST, so the 12-bit
+// immediate lands in bits[21:10] - the ADD imm12 field). Both fixups are
+// already supported by aarch64::applyFixup; no new edge kind is needed.
+constexpr char DirectJumpStubContent[12] = {
+    0x10, 0x00, 0x00, (char)0x90u, // ADRP x16, <imm>@page21
+    0x10, 0x02, 0x00, (char)0x91u, // ADD  x16, x16, <imm>@pageoff12
+    0x00, 0x02, 0x1f, (char)0xd6u  // BR   x16
+};
+
+// Resolve the real target symbol T that a GOT-indirect PLT stub jumps to.
+//
+// A PointerJumpStub block (createPointerJumpStubBlock) has two edges -
+// Page21@0 and PageOffset12@4 - both targeting the same GOT-entry symbol G.
+// G is an anonymous symbol on an 8-byte block in $__GOT whose Pointer64@0 edge
+// points at the real target T (createAnonymousPointer). Returns T or nullptr
+// if the block is not a standard GOT-indirect PLT stub.
+static Symbol *resolveStubTarget(Block &B, Symbol *&GOTEntryOut,
+                                 Edge *&Page21EdgeOut,
+                                 Edge *&PageOff12EdgeOut) {
+  if (B.getSize() != sizeof(aarch64::PointerJumpStubContent))
+    return nullptr;
+  if (memcmp(B.getContent().data(), aarch64::PointerJumpStubContent,
+             sizeof(aarch64::PointerJumpStubContent)) != 0)
+    return nullptr;
+
+  Edge *Page21 = nullptr;
+  Edge *PageOff12 = nullptr;
+  for (Edge &E : B.edges()) {
+    if (E.getOffset() == 0 && E.getKind() == aarch64::Page21) {
+      if (Page21)
+        return nullptr; // duplicate
+      Page21 = &E;
+    } else if (E.getOffset() == 4 && E.getKind() == aarch64::PageOffset12) {
+      if (PageOff12)
+        return nullptr; // duplicate
+      PageOff12 = &E;
+    }
+  }
+  if (!Page21 || !PageOff12)
+    return nullptr;
+  if (&Page21->getTarget() != &PageOff12->getTarget())
+    return nullptr; // both edges must share the same GOT entry
+
+  Symbol &G = Page21->getTarget();
+  if (!G.isDefined())
+    return nullptr;
+  Block &GOTBlock = G.getBlock();
+  for (Edge &E : GOTBlock.edges()) {
+    if (E.getOffset() == 0 && E.getKind() == aarch64::Pointer64) {
+      GOTEntryOut = &G;
+      Page21EdgeOut = Page21;
+      PageOff12EdgeOut = PageOff12;
+      return &E.getTarget();
+    }
+  }
+  return nullptr;
+}
+
+static Error rewriteDirectCallStubs(LinkGraph &G) {
+  // AArch64 ELF only. No-op (and avoid touching $__STUBS semantics) elsewhere.
+  if (!G.getTargetTriple().isAArch64())
+    return Error::success();
+
+  Section *Stubs = G.findSectionByName(aarch64::PLTTableManager::getSectionName());
+  if (!Stubs)
+    return Error::success();
+
+  uint64_t Rewritten = 0, Fallback = 0;
+
+  for (Block *B : Stubs->blocks()) {
+    Symbol *GOTEntry = nullptr;
+    Edge *Page21Edge = nullptr;
+    Edge *PageOff12Edge = nullptr;
+    Symbol *T = resolveStubTarget(*B, GOTEntry, Page21Edge, PageOff12Edge);
+    if (!T)
+      continue; // not a standard GOT-indirect PLT stub - leave untouched
+
+    orc::ExecutorAddr tAddr = T->getAddress();
+    if (tAddr.isNull()) {
+      ++Fallback; // target unresolved - keep the GOT-indirect stub
+      continue;
+    }
+
+    // Reachability: mirror aarch64::applyFixup's Page21 check exactly so a
+    // rewritten stub never triggers a fixup-time out-of-range error. The ADRP
+    // sits at offset 0, so PCPage = stub address & ~0xfff; addend is 0.
+    uint64_t TargetPage = tAddr.getValue() & ~static_cast<uint64_t>(0xfff);
+    uint64_t PCPage = B->getAddress().getValue() & ~static_cast<uint64_t>(0xfff);
+    int64_t PageDelta = static_cast<int64_t>(TargetPage - PCPage);
+    if (!isInt<33>(PageDelta)) {
+      ++Fallback; // beyond ADRP's +-4GiB - keep the GOT-indirect stub
+      continue;
+    }
+
+    // Rewrite the middle instruction LDR -> ADD in the mutable working memory
+    // (the same buffer applyFixup writes to). ADRP/BR bytes are identical, so
+    // only bytes [4..7] change.
+    MutableArrayRef<char> Content = B->getAlreadyMutableContent();
+    std::memcpy(&Content[0], DirectJumpStubContent, sizeof(DirectJumpStubContent));
+
+    // Retarget both edges from the GOT entry to the real target. addend stays
+    // 0; the fixup phase will apply Page21 (ADRP -> target page) and
+    // PageOffset12 (ADD -> target page offset) with T's address.
+    Page21Edge->setTarget(*T);
+    PageOff12Edge->setTarget(*T);
+
+    // The GOT entry is left in place (its Pointer64 edge is still fixed up as a
+    // harmless dead write). v1 does not reclaim it - see plan section 4/11.
+    ++Rewritten;
+  }
+
+  if (Rewritten || Fallback)
+    EJIT_DIAG_VERBOSE("direct-stub: rewritten=%lu fallback=%lu in %s",
+                      (unsigned long)Rewritten, (unsigned long)Fallback,
+                      G.getName().c_str());
+
+  return Error::success();
+}
+
+} // namespace
+
+void EJitDirectCallStubsPlugin::modifyPassConfig(
+    orc::MaterializationResponsibility &MR, jitlink::LinkGraph &G,
+    jitlink::PassConfiguration &Config) {
+  Config.PreFixupPasses.push_back(rewriteDirectCallStubs);
+}
+
+} // namespace ejit
+} // namespace llvm

--- a/llvm/lib/ExecutionEngine/EJIT/EJitDirectCallStubs.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitDirectCallStubs.cpp
@@ -20,9 +20,11 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <cstring>
@@ -49,6 +51,23 @@ constexpr char DirectJumpStubContent[12] = {
     0x10, 0x02, 0x00, (char)0x91u, // ADD  x16, x16, <imm>@pageoff12
     0x00, 0x02, 0x1f, (char)0xd6u  // BR   x16
 };
+
+static Symbol *resolveGOTTarget(Symbol &GOTEntry) {
+  if (!GOTEntry.isDefined())
+    return nullptr;
+  for (Edge &E : GOTEntry.getBlock().edges())
+    if (E.getOffset() == 0 && E.getKind() == aarch64::Pointer64)
+      return &E.getTarget();
+  return nullptr;
+}
+
+static bool isPageReachable(orc::ExecutorAddr PC, orc::ExecutorAddr Target) {
+  if (PC.isNull() || Target.isNull())
+    return false;
+  uint64_t TargetPage = Target.getValue() & ~static_cast<uint64_t>(0xfff);
+  uint64_t PCPage = PC.getValue() & ~static_cast<uint64_t>(0xfff);
+  return isInt<33>(static_cast<int64_t>(TargetPage - PCPage));
+}
 
 // Resolve the real target symbol T that a GOT-indirect PLT stub jumps to.
 //
@@ -85,18 +104,13 @@ static Symbol *resolveStubTarget(Block &B, Symbol *&GOTEntryOut,
     return nullptr; // both edges must share the same GOT entry
 
   Symbol &G = Page21->getTarget();
-  if (!G.isDefined())
+  Symbol *Target = resolveGOTTarget(G);
+  if (!Target)
     return nullptr;
-  Block &GOTBlock = G.getBlock();
-  for (Edge &E : GOTBlock.edges()) {
-    if (E.getOffset() == 0 && E.getKind() == aarch64::Pointer64) {
-      GOTEntryOut = &G;
-      Page21EdgeOut = Page21;
-      PageOff12EdgeOut = PageOff12;
-      return &E.getTarget();
-    }
-  }
-  return nullptr;
+  GOTEntryOut = &G;
+  Page21EdgeOut = Page21;
+  PageOff12EdgeOut = PageOff12;
+  return Target;
 }
 
 static Error rewriteDirectCallStubs(LinkGraph &G) {
@@ -104,7 +118,8 @@ static Error rewriteDirectCallStubs(LinkGraph &G) {
   if (!G.getTargetTriple().isAArch64())
     return Error::success();
 
-  Section *Stubs = G.findSectionByName(aarch64::PLTTableManager::getSectionName());
+  Section *Stubs =
+      G.findSectionByName(aarch64::PLTTableManager::getSectionName());
   if (!Stubs)
     return Error::success();
 
@@ -127,10 +142,7 @@ static Error rewriteDirectCallStubs(LinkGraph &G) {
     // Reachability: mirror aarch64::applyFixup's Page21 check exactly so a
     // rewritten stub never triggers a fixup-time out-of-range error. The ADRP
     // sits at offset 0, so PCPage = stub address & ~0xfff; addend is 0.
-    uint64_t TargetPage = tAddr.getValue() & ~static_cast<uint64_t>(0xfff);
-    uint64_t PCPage = B->getAddress().getValue() & ~static_cast<uint64_t>(0xfff);
-    int64_t PageDelta = static_cast<int64_t>(TargetPage - PCPage);
-    if (!isInt<33>(PageDelta)) {
+    if (!isPageReachable(B->getAddress(), tAddr)) {
       ++Fallback; // beyond ADRP's +-4GiB - keep the GOT-indirect stub
       continue;
     }
@@ -139,7 +151,8 @@ static Error rewriteDirectCallStubs(LinkGraph &G) {
     // (the same buffer applyFixup writes to). ADRP/BR bytes are identical, so
     // only bytes [4..7] change.
     MutableArrayRef<char> Content = B->getAlreadyMutableContent();
-    std::memcpy(&Content[0], DirectJumpStubContent, sizeof(DirectJumpStubContent));
+    std::memcpy(&Content[0], DirectJumpStubContent,
+                sizeof(DirectJumpStubContent));
 
     // Retarget both edges from the GOT entry to the real target. addend stays
     // 0; the fixup phase will apply Page21 (ADRP -> target page) and
@@ -162,10 +175,106 @@ static Error rewriteDirectCallStubs(LinkGraph &G) {
 
 } // namespace
 
+Error relaxAArch64InlineGOTCalls(LinkGraph &G) {
+  if (!G.getTargetTriple().isAArch64() ||
+      !G.getTargetTriple().isOSBinFormatELF())
+    return Error::success();
+
+  struct Candidate {
+    Block *B;
+    Edge *Page;
+    Edge *Offset;
+    Symbol *Target;
+  };
+  SmallVector<Candidate, 16> Candidates;
+
+  // Collect before mutating edges. CodeGen may hoist one ADRP+LDR pair away
+  // from its BLR users, so relocation identity and register flow are the
+  // contract; adjacency to BLR is deliberately not required.
+  for (Section &Sec : G.sections()) {
+    if (Sec.getName() == aarch64::PLTTableManager::getSectionName())
+      continue;
+    for (Block *B : Sec.blocks()) {
+      ArrayRef<char> Content = B->getContent();
+      for (Edge &Low : B->edges()) {
+        if (Low.getKind() != aarch64::PageOffset12 || Low.getAddend() != 0 ||
+            Low.getOffset() + 4 > Content.size())
+          continue;
+
+        uint32_t Ldr = support::endian::read32le(
+            Content.data() + static_cast<size_t>(Low.getOffset()));
+        if ((Ldr & 0xffc00000u) != 0xf9400000u)
+          continue; // not LDR Xt, [Xn, #imm12]
+        unsigned BaseReg = (Ldr >> 5) & 0x1fu;
+
+        Edge *BestPage = nullptr;
+        for (Edge &Page : B->edges()) {
+          if (Page.getKind() != aarch64::Page21 || Page.getAddend() != 0 ||
+              &Page.getTarget() != &Low.getTarget() ||
+              Page.getOffset() > Low.getOffset() ||
+              Page.getOffset() + 4 > Content.size())
+            continue;
+          uint32_t Adrp = support::endian::read32le(
+              Content.data() + static_cast<size_t>(Page.getOffset()));
+          if ((Adrp & 0x9f000000u) != 0x90000000u || (Adrp & 0x1fu) != BaseReg)
+            continue;
+          if (!BestPage || Page.getOffset() > BestPage->getOffset())
+            BestPage = &Page;
+        }
+        if (!BestPage)
+          continue;
+
+        Symbol *Target = resolveGOTTarget(Low.getTarget());
+        if (!Target || !Target->isCallable())
+          continue;
+        Candidates.push_back({B, BestPage, &Low, Target});
+      }
+    }
+  }
+
+  uint64_t Rewritten = 0;
+  uint64_t Fallback = 0;
+  for (Candidate &C : Candidates) {
+    orc::ExecutorAddr PagePC = C.B->getAddress() + C.Page->getOffset();
+    if (!isPageReachable(PagePC, C.Target->getAddress())) {
+      ++Fallback;
+      continue;
+    }
+
+    MutableArrayRef<char> Content = C.B->getAlreadyMutableContent();
+    char *LdrPtr = Content.data() + static_cast<size_t>(C.Offset->getOffset());
+    uint32_t Ldr = support::endian::read32le(LdrPtr);
+    unsigned Rt = Ldr & 0x1fu;
+    unsigned Rn = (Ldr >> 5) & 0x1fu;
+    uint32_t Add = 0x91000000u | (Rn << 5) | Rt;
+    support::endian::write32le(LdrPtr, Add);
+
+    C.Page->setTarget(*C.Target);
+    C.Offset->setTarget(*C.Target);
+    ++Rewritten;
+  }
+
+  if (Rewritten || Fallback)
+    EJIT_DIAG_VERBOSE("inline-long-call: rewritten=%lu fallback=%lu in %s",
+                      (unsigned long)Rewritten, (unsigned long)Fallback,
+                      G.getName().c_str());
+  return Error::success();
+}
+
 void EJitDirectCallStubsPlugin::modifyPassConfig(
     orc::MaterializationResponsibility &MR, jitlink::LinkGraph &G,
     jitlink::PassConfiguration &Config) {
-  Config.PreFixupPasses.push_back(rewriteDirectCallStubs);
+  Config.PreFixupPasses.push_back([](LinkGraph &G) -> Error {
+#ifdef EJIT_INLINE_LONG_CALLS
+    if (auto Err = relaxAArch64InlineGOTCalls(G))
+      return Err;
+#endif
+#ifdef EJIT_DIRECT_CALL_STUBS
+    return rewriteDirectCallStubs(G);
+#else
+    return Error::success();
+#endif
+  });
 }
 
 } // namespace ejit

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -44,6 +44,10 @@ extern "C" uint32_t SRE_TaskDelay(uint32_t tick);
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
 #endif
+#ifdef EJIT_DIRECT_CALL_STUBS
+#include "llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h"
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
+#endif
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -581,6 +585,17 @@ EJitOrcEngine::Create(const Config &config,
   }
 
   engine->P->J = std::move(*J);
+
+#ifdef EJIT_DIRECT_CALL_STUBS
+  // Install the direct-call-stub rewrite plugin on the ObjectLinkingLayer. It
+  // rewrites AArch64 PLT pointer-jump stubs (ADRP+LDR+BR via GOT) into direct
+  // ADRP+ADD+BR stubs when the target is within ADRP's +-4GiB reach, dropping
+  // the per-call GOT data load. No-op on non-AArch64; auto-falls back to the
+  // GOT-indirect stub beyond +-4GiB. See EJitDirectCallStubs.{h,cpp}.
+  if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
+          &engine->P->J->getObjLinkingLayer()))
+    OLL->addPlugin(EJitDirectCallStubsPlugin::create());
+#endif
 
   // Override the default error reporter (logErrorsToStdErr → errs() →
   // raw_fd_ostream) with a bare-metal-safe version using EJIT_DIAG.  On

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -44,7 +44,7 @@ extern "C" uint32_t SRE_TaskDelay(uint32_t tick);
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
 #endif
-#ifdef EJIT_DIRECT_CALL_STUBS
+#if defined(EJIT_DIRECT_CALL_STUBS) || defined(EJIT_INLINE_LONG_CALLS)
 #include "llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h"
 #include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #endif
@@ -586,12 +586,9 @@ EJitOrcEngine::Create(const Config &config,
 
   engine->P->J = std::move(*J);
 
-#ifdef EJIT_DIRECT_CALL_STUBS
-  // Install the direct-call-stub rewrite plugin on the ObjectLinkingLayer. It
-  // rewrites AArch64 PLT pointer-jump stubs (ADRP+LDR+BR via GOT) into direct
-  // ADRP+ADD+BR stubs when the target is within ADRP's +-4GiB reach, dropping
-  // the per-call GOT data load. No-op on non-AArch64; auto-falls back to the
-  // GOT-indirect stub beyond +-4GiB. See EJitDirectCallStubs.{h,cpp}.
+#if defined(EJIT_DIRECT_CALL_STUBS) || defined(EJIT_INLINE_LONG_CALLS)
+  // Install the configured AArch64 stub and inline far-call rewrites. Both are
+  // no-ops on other targets and retain their GOT fallback beyond +-4GiB.
   if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
           &engine->P->J->getObjLinkingLayer()))
     OLL->addPlugin(EJitDirectCallStubsPlugin::create());
@@ -793,9 +790,20 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     //     loads / ~1700c on DlschCcScheduler vs 0 in AOT) for no reach benefit,
     //     since ADRP already reaches. So globals are NOT cleared.
     for (Function &F : (*ModuleOrErr)->functions()) {
-      if (F.isDeclaration() && !F.isIntrinsic())
+      if (F.isDeclaration() && !F.isIntrinsic()) {
         F.setDSOLocal(false);
+#ifdef EJIT_INLINE_LONG_CALLS
+        // Emit ADRP+LDR+BLR at the call site. JITLink resolves the GOT target
+        // and rewrites LDR to ADD when the AOT address is within +-4GiB.
+        F.addFnAttr(Attribute::NonLazyBind);
+#endif
+      }
     }
+#ifdef EJIT_INLINE_LONG_CALLS
+    // Apply the inline-GOT policy to runtime libcalls introduced during
+    // CodeGen, which may not have an IR Function declaration.
+    (*ModuleOrErr)->setRtLibUseGOT();
+#endif
   }
 
   // ejit_entry functions may have internal linkage (e.g. declared `static` in

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -11,9 +11,16 @@ set(LLVM_LINK_COMPONENTS
   TargetParser
   )
 
-add_llvm_unittest(EJITTests
+set(EJIT_UNITTEST_SOURCES
   EJitRuntimeTest.cpp
   EJitFieldOffsetTest.cpp
+  )
+if(EJIT_DIRECT_CALL_STUBS OR EJIT_INLINE_LONG_CALLS)
+  list(APPEND EJIT_UNITTEST_SOURCES EJitDirectCallStubsTest.cpp)
+endif()
+
+add_llvm_unittest(EJITTests
+  ${EJIT_UNITTEST_SOURCES}
 
   PARTIAL_SOURCES_INTENDED
   )

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitDirectCallStubsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitDirectCallStubsTest.cpp
@@ -1,0 +1,105 @@
+//===-- EJitDirectCallStubsTest.cpp ---------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitDirectCallStubs.h"
+
+#include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "llvm/Support/Endian.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::jitlink;
+
+namespace {
+
+class EJitInlineLongCallTest : public testing::Test {
+protected:
+  EJitInlineLongCallTest()
+      : G("inline-long-call", std::make_shared<orc::SymbolStringPool>(),
+          Triple("aarch64_be-unknown-linux-gnu"), SubtargetFeatures(),
+          aarch64::getEdgeKindName),
+        Text(G.createSection(".text", orc::MemProt::Read | orc::MemProt::Exec)),
+        GOT(G.createSection(aarch64::GOTTableManager::getSectionName(),
+                            orc::MemProt::Read | orc::MemProt::Exec)) {}
+
+  Symbol &createGOTEntry(uint64_t TargetAddress, bool Callable = true) {
+    auto &Target =
+        G.addAbsoluteSymbol("aot_target", orc::ExecutorAddr(TargetAddress), 0,
+                            Linkage::Strong, Scope::Default, true);
+    Target.setCallable(Callable);
+    auto &GOTBlock = G.createMutableContentBlock(
+        GOT, 8, orc::ExecutorAddr(0x20000000), 8, 0);
+    GOTBlock.addEdge(aarch64::Pointer64, 0, Target, 0);
+    return G.addAnonymousSymbol(GOTBlock, 0, 8, false, false);
+  }
+
+  Block &createCallBlock(Symbol &GOTEntry, bool SeparateLdr = false) {
+    size_t Size = SeparateLdr ? 16 : 12;
+    auto &B = G.createMutableContentBlock(Text, Size,
+                                          orc::ExecutorAddr(0x10000000), 4, 0);
+    MutableArrayRef<char> C = B.getAlreadyMutableContent();
+    support::endian::write32le(C.data(), 0x90000015u); // ADRP x21
+    size_t LdrOffset = SeparateLdr ? 8 : 4;
+    if (SeparateLdr)
+      support::endian::write32le(C.data() + 4,
+                                 0x2a0003f3u); // MOV w19, w0
+    support::endian::write32le(C.data() + LdrOffset,
+                               0xf94002b5u); // LDR x21, [x21]
+    support::endian::write32le(C.data() + LdrOffset + 4,
+                               0xd63f02a0u); // BLR x21
+    B.addEdge(aarch64::Page21, 0, GOTEntry, 0);
+    B.addEdge(aarch64::PageOffset12, LdrOffset, GOTEntry, 0);
+    return B;
+  }
+
+  LinkGraph G;
+  Section &Text;
+  Section &GOT;
+};
+
+static void expectSuccess(Error Err) {
+  if (Err) {
+    ADD_FAILURE() << toString(std::move(Err));
+  }
+}
+
+TEST_F(EJitInlineLongCallTest, RewritesInRangeCallSite) {
+  // 0xb0000000 - 0x10000000 = 2.5GiB: outside BL, inside ADRP.
+  Symbol &GOTEntry = createGOTEntry(0xb0000000);
+  Block &B = createCallBlock(GOTEntry);
+
+  expectSuccess(ejit::relaxAArch64InlineGOTCalls(G));
+  EXPECT_EQ(support::endian::read32le(B.getContent().data() + 4),
+            0x910002b5u); // ADD x21, x21, #lo12
+  for (Edge &E : B.edges())
+    EXPECT_EQ(E.getTarget().getAddress(), orc::ExecutorAddr(0xb0000000));
+}
+
+TEST_F(EJitInlineLongCallTest, MatchesHoistedNonAdjacentAddressLoad) {
+  Symbol &GOTEntry = createGOTEntry(0xb0000000);
+  Block &B = createCallBlock(GOTEntry, true);
+
+  expectSuccess(ejit::relaxAArch64InlineGOTCalls(G));
+  EXPECT_EQ(support::endian::read32le(B.getContent().data() + 4),
+            0x2a0003f3u); // intervening instruction unchanged
+  EXPECT_EQ(support::endian::read32le(B.getContent().data() + 8), 0x910002b5u);
+}
+
+TEST_F(EJitInlineLongCallTest, KeepsGOTCallBeyondAdrpRange) {
+  Symbol &GOTEntry = createGOTEntry(0x210000000);
+  Block &B = createCallBlock(GOTEntry);
+
+  expectSuccess(ejit::relaxAArch64InlineGOTCalls(G));
+  EXPECT_EQ(support::endian::read32le(B.getContent().data() + 4), 0xf94002b5u);
+  for (Edge &E : B.edges())
+    EXPECT_EQ(&E.getTarget(), &GOTEntry);
+}
+
+TEST_F(EJitInlineLongCallTest, IgnoresNonCallableGOTTarget) {
+  Symbol &GOTEntry = createGOTEntry(0xb0000000, false);
+  Block &B = createCallBlock(GOTEntry);
+
+  expectSuccess(ejit::relaxAArch64InlineGOTCalls(G));
+  EXPECT_EQ(support::endian::read32le(B.getContent().data() + 4), 0xf94002b5u);
+}
+
+} // namespace


### PR DESCRIPTION
## 中文说明

本 PR 已 rebase 到最新 `ejit_dev_spec4`（包含 PR #101 的 multi-version inline cache 与 musttail 修复）。因此 rebase 后不再重复携带这两项，当前仅保留两个仍有独立价值的提交：

1. Homme AArch64 direct PLT stub：将 stub 内的 `ADRP+LDR+BR` 改写为 `ADRP+ADD+BR`，去掉 GOT 数据加载。
2. Inline long-call：在调用点生成 `ADRP+LDR+BLR`，JITLink 在符号解析后将其放松为 `ADRP+ADD+BLR`，从而去掉跳入独立 stub 的额外 `BL`。

主线现有 `optimizePointerJumpStubBranches` 仅能把 ±128 MiB 内的调用直接改为 `BL target`；本 PR 继续优化超出 `BL` 范围、但仍处于 `ADRP` 约 ±4 GiB 范围内的场景，例如当前约 2.7 GiB 的 JIT→AOT 距离。

### 动态执行路径

Homme direct-stub 路径：

```asm
BL   stub
ADRP target_page
ADD  target_addr
BR   target
```

新增 inline 路径：

```asm
ADRP target_page
ADD  target_addr
BLR  target
```

动态执行指令由 4 条降为 3 条。它不能把 2.7 GiB 调用变成单条 `BL`，但可以消除独立 stub 这一跳。

### 安全边界

- `EJIT_DIRECT_CALL_STUBS` 与新增的 `EJIT_INLINE_LONG_CALLS` 相互独立；inline 开关默认 `OFF`。
- 仅处理 AArch64 ELF、可调用目标以及可确认的 `Page21/PageOffset12` GOT 重定位。
- 目标超出 ADRP 范围、符号未解析或指令/重定位形态不匹配时，保留原 `ADRP+LDR+BLR` 路径。
- 支持 CodeGen 提前计算地址或将地址加载与 `BLR` 分离，不要求三条指令相邻。
- 不修改 shared-taskpool、code-pool、4K seal 或 C ABI。

## English summary

This PR is rebased onto the latest `ejit_dev_spec4`, which already contains PR #101's multi-version inline cache and musttail fix. Those duplicated prerequisite commits were dropped during the rebase. The PR now contains only Homme's direct PLT-stub rewrite and the new inline AArch64 long-call relaxation.

The mainline `optimizePointerJumpStubBranches` handles targets within `BL`'s ±128 MiB range. This PR complements it for targets outside that range but inside `ADRP`'s approximately ±4 GiB range. CodeGen emits `ADRP+LDR+BLR`; after symbol resolution, the JITLink pre-fixup plugin rewrites the GOT load to `ADD`, producing `ADRP+ADD+BLR` directly at the call site.

Unresolved, out-of-range, non-callable, or unrecognized cases retain the original GOT-indirect sequence.

## Validation

- Before rebase: `libLLVMEJIT.a` built successfully with both options enabled; four new LinkGraph tests passed; full `EJITTests` was 105/107 with two unrelated pre-existing StructField failures.
- After rebase onto `92d60d3415f9`: `EJitDirectCallStubs.cpp`, `EJitOrcEngine.cpp`, and `EJitDirectCallStubsTest.cpp` compile successfully against the latest generated headers.
- Conflict resolution preserved mainline `EJIT_ICACHE_DIM_SIZE=16` and the new LTO test mapping.
- `git diff --check`, clang-format, `bash -n ejit_test/build.sh`, and CMake preset JSON validation passed.

Real board validation is still required to measure the JIT→AOT cycle reduction and inspect the final post-link sequence.