### PR TITLE
[EJIT] Add ejit_print_version() runtime API: LLVM version + git commit

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -367,6 +367,9 @@ def doit_gc_merge(args):
         "ejit_print_registry", "ejit_print_func_meta",
         "ejit_get_code_pool_stats", "ejit_print_code_pool_stats",
         "ejit_print_active",
+        # Build identity (LLVM version + git commit). Called from user app
+        # code, never from AOT, so it needs a GC root to survive --gc-sections.
+        "ejit_print_version",
     ]
     optional_api = [
         "ejit_register_lifecycle", "ejit_register_funcindex",

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -336,6 +336,16 @@ void ejit_print_code_pool_stats(void);
 /// "why did/didn't this period instance compile".
 void ejit_print_active(void);
 
+/// Print the EJIT runtime's build identity through the platform log: the LLVM
+/// release version (major.minor.patch, from llvm/Config/llvm-config.h) and the
+/// git commit + branch of the llvm-project source tree the runtime was built
+/// from. The commit is captured at build time, so it tracks the source HEAD
+/// even across incremental rebuilds. Needs no initialized runtime and is not
+/// gated on the diagnostic log level, so the build identity is always
+/// recoverable - useful for correlating a field device's behavior with the
+/// exact source it was compiled from.
+void ejit_print_version(void);
+
 // Cache
 void ejit_clear_cache(void);
 void ejit_invalidate(const char *periodName, uint8_t cellIdx);

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -155,6 +155,33 @@ if(EJIT_FREESTANDING)
   target_compile_definitions(LLVMJITLink PUBLIC EJIT_FREESTANDING)
 endif()
 
+#===-- Build-version header (ejit_print_version) -------------------------===#
+# Generate EJitVersion.h carrying the llvm-project git commit + branch of the
+# source tree the runtime was built from. The LLVM release version itself is
+# read at runtime from llvm/Config/llvm-config.h (LLVM_VERSION_STRING), so it
+# is not duplicated here.
+#
+# The header is regenerated on every build by a custom target, but the
+# generator script writes it with copy_if_different: the file's mtime (and
+# therefore EJitRuntime.cpp, the only includer) only changes when the commit
+# actually changes. This keeps ejit_print_version() fresh across rebuilds
+# (a rebuild after `git commit` picks up the new hash) without forcing a full
+# CMake reconfigure, and without recompiling on every no-op build.
+find_package(Git QUIET)
+set(EJIT_VERSION_HEADER "${CMAKE_CURRENT_BINARY_DIR}/EJitVersion.h")
+add_custom_target(ejit_version_header
+  COMMAND ${CMAKE_COMMAND}
+    -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+    -DSOURCE_DIR=${LLVM_MAIN_SRC_DIR}
+    -DOUT_FILE=${EJIT_VERSION_HEADER}
+    -P "${CMAKE_CURRENT_SOURCE_DIR}/GenerateEJitVersion.cmake"
+  BYPRODUCTS "${EJIT_VERSION_HEADER}"
+  COMMENT "Refreshing EJIT build-version header (git commit/branch)"
+  VERBATIM)
+add_dependencies(LLVMEJIT ejit_version_header)
+# EJitRuntime.cpp #includes "EJitVersion.h"; put the build dir on the path.
+target_include_directories(LLVMEJIT PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 #===-- Minimal embedded runtime target -----------------------------------===#
 # Builds a single combined static library (libejit_minimal.a) that bundles
 # EJIT + all transitive LLVM dependencies. Designed for ARM embedded targets

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -2,6 +2,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/ExecutionEngine/EJIT/EJit.h"
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
@@ -11,6 +12,9 @@
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+// Build-time-generated: EJIT_GIT_COMMIT / EJIT_GIT_BRANCH (git HEAD of the
+// llvm-project source tree). Lives in the LLVMEJIT build directory.
+#include "EJitVersion.h"
 #ifdef EJIT_SRE_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h"
 #endif
@@ -20,6 +24,11 @@
 #ifndef EJIT_FREESTANDING
 #include <chrono>
 #endif
+// ejit_print_version() falls back to std::printf when not routing through the
+// SRE platform sink. Mirrors the EJIT_DIAG <cstdio> include (non-SRE path).
+#ifndef EJIT_SRE_DIAG
+#include <cstdio>
+#endif
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -28,6 +37,15 @@ static EJit *gEJIT = nullptr;
 
 #ifdef EJIT_FREESTANDING
 extern "C" uint64_t SRE_CycleCountGet64(void);
+#endif
+
+// ejit_print_version() prints unconditionally (not via EJIT_DIAG), so on SRE
+// builds it calls SRE_printf directly. EJitDiag.h only declares SRE_printf
+// under EJIT_DIAG_ENABLE; declare it here for the SRE-but-diagnostics-off case
+// so the function links. When EJIT_DIAG_ENABLE is also on, EJitDiag.h already
+// provides the identical declaration and this guard skips a redundant one.
+#if defined(EJIT_SRE_DIAG) && !defined(EJIT_DIAG_ENABLE)
+extern "C" int SRE_printf(const char *fmt, ...);
 #endif
 
 #ifndef EJIT_WRAPPER_TIMING_REPORT_EVERY
@@ -1203,6 +1221,24 @@ void ejit_print_active(void) {
     return;
   }
   gEJIT->printActive();
+}
+
+void ejit_print_version(void) {
+  // LLVM release version (major.minor.patch) comes from llvm/Config/llvm-config.h
+  // (LLVM_VERSION_STRING); the git commit + branch come from the build-time
+  // generated EJitVersion.h. Printed unconditionally - not through EJIT_DIAG and
+  // not gated on EJIT_DIAG_ENABLE or gEJitDiagLevel - so the build identity is
+  // always recoverable, even on a build with diagnostics compiled out and before
+  // ejit_init(). Routes through the same platform sink as EJIT_DIAG: SRE_printf
+  // on SRE/bare-metal builds (declared at file scope above / by EJitDiag.h),
+  // std::printf otherwise.
+#ifdef EJIT_SRE_DIAG
+  SRE_printf("[EJIT] LLVM version %s, branch %s, commit %s\n",
+             LLVM_VERSION_STRING, EJIT_GIT_BRANCH, EJIT_GIT_COMMIT);
+#else
+  std::printf("[EJIT] LLVM version %s, branch %s, commit %s\n",
+              LLVM_VERSION_STRING, EJIT_GIT_BRANCH, EJIT_GIT_COMMIT);
+#endif
 }
 
 } // extern "C"

--- a/llvm/lib/ExecutionEngine/EJIT/GenerateEJitVersion.cmake
+++ b/llvm/lib/ExecutionEngine/EJIT/GenerateEJitVersion.cmake
@@ -1,0 +1,93 @@
+#===-- GenerateEJitVersion.cmake - bake git commit into EJitVersion.h ------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===----------------------------------------------------------------------===//
+#
+# CMake -P script invoked by a custom target on every build (see CMakeLists.txt
+# in this directory). It queries the llvm-project git repository for the current
+# HEAD commit and branch, then writes EJitVersion.h with copy_if_different so
+# the header's mtime (and therefore EJitRuntime.cpp) only changes when the
+# commit actually changes. This keeps ejit_print_version() fresh across
+# rebuilds without forcing a full CMake reconfigure.
+#
+# Inputs:
+#   GIT_EXECUTABLE - path to git (may be empty if git was not found)
+#   SOURCE_DIR     - a directory inside the llvm-project tree (git walks up)
+#   OUT_FILE       - absolute path to the generated EJitVersion.h
+#
+# When git is unavailable or the source tree is not a checkout, the macros fall
+# back to "unknown" so the runtime still builds and ejit_print_version() still
+# reports the LLVM release version (from llvm/Config/llvm-config.h).
+#
+#===----------------------------------------------------------------------===//
+
+set(_commit "")
+set(_branch "")
+
+if(GIT_EXECUTABLE)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+    WORKING_DIRECTORY "${SOURCE_DIR}"
+    OUTPUT_VARIABLE _commit
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE _rc)
+  if(NOT _rc EQUAL 0)
+    set(_commit "")
+  endif()
+
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY "${SOURCE_DIR}"
+    OUTPUT_VARIABLE _branch
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE _rc)
+  if(NOT _rc EQUAL 0)
+    set(_branch "")
+  endif()
+endif()
+
+if(NOT _commit)
+  set(_commit "unknown")
+endif()
+if(NOT _branch)
+  set(_branch "unknown")
+endif()
+
+# Escape backslashes/quotes so the values survive being placed in a string
+# literal. Commit hashes and branch names are otherwise plain ASCII.
+string(REPLACE "\\" "\\\\" _commit_esc "${_commit}")
+string(REPLACE "\"" "\\\"" _commit_esc "${_commit_esc}")
+string(REPLACE "\\" "\\\\" _branch_esc "${_branch}")
+string(REPLACE "\"" "\\\"" _branch_esc "${_branch_esc}")
+
+file(WRITE "${OUT_FILE}.tmp"
+"//===-- EJitVersion.h - EmbeddedJIT build version (generated) ------------===//
+//
+// Generated at build time by llvm/lib/ExecutionEngine/EJIT/GenerateEJitVersion.cmake.
+// Do not edit by hand; this header is regenerated on every build and overwritten.
+//
+// EJIT_GIT_COMMIT is the full hash of the llvm-project source tree HEAD at the
+// time the runtime was built; EJIT_GIT_BRANCH is its checked-out branch (or
+// \"unknown\" when git is unavailable or the source is not a checkout). The LLVM
+// release version is intentionally NOT duplicated here: it lives in
+// llvm/Config/llvm-config.h (LLVM_VERSION_STRING) and is consumed directly.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EJIT_EJITVERSION_H
+#define LLVM_EJIT_EJITVERSION_H
+
+#define EJIT_GIT_COMMIT \"${_commit_esc}\"
+#define EJIT_GIT_BRANCH \"${_branch_esc}\"
+
+#endif // LLVM_EJIT_EJITVERSION_H
+")
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+  "${OUT_FILE}.tmp" "${OUT_FILE}")
+file(REMOVE "${OUT_FILE}.tmp")

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -688,6 +688,7 @@ extern void ejit_print_func_meta(const char *funcName);
 extern int ejit_get_code_pool_stats(void *out);
 extern void ejit_print_code_pool_stats(void);
 extern void ejit_print_active(void);
+extern void ejit_print_version(void);
 }
 
 // The "runtime-dynamic cellIdx" C-API tests below exercise the LEGACY model:
@@ -3076,4 +3077,13 @@ TEST(EJitDiagnostics, PrintCodePoolStatsNoCrash) {
 
 TEST(EJitDiagnostics, PrintActiveNoCrash) {
   ejit_print_active(); // uninitialized: prints a notice
+}
+
+// ejit_print_version() prints the LLVM release version + source git commit
+// through the platform sink (SRE_printf on SRE builds, std::printf here). It
+// is unconditional - not gated on EJIT_DIAG_ENABLE and needs no initialized
+// runtime - so the build identity is always recoverable. The test only
+// asserts it does not crash; the version/commit are baked in at compile time.
+TEST(EJitDiagnostics, PrintVersionNoCrash) {
+  ejit_print_version();
 }


### PR DESCRIPTION
Add a version interface to the EJIT runtime that prints the build identity (the LLVM release version plus the llvm-project git commit and branch) through the platform log, for correlating a bare-metal device's behavior with the exact source it was compiled from.

* CMake (new GenerateEJitVersion.cmake + CMakeLists.txt): a build-time custom target runs the generator on every build to write EJitVersion.h with the current HEAD commit + branch. It uses copy_if_different, so EJitRuntime.cpp (the only includer) only rebuilds when the commit actually changes - fresh across rebuilds (a rebuild after `git commit` picks up the new hash) without a full CMake reconfigure, and no recompile on no-op builds. The LLVM release version is read from llvm/Config/llvm-config.h (LLVM_VERSION_STRING), not duplicated.
* EJitRuntime: ejit_print_version() is unconditional - not gated on EJIT_DIAG_ENABLE or gEJitDiagLevel, needs no initialized runtime - so the build identity is always recoverable, even with diagnostics compiled out and before ejit_init(). Routes through SRE_printf on SRE builds, std::printf otherwise (mirroring EJIT_DIAG's sink selection).
* lipo.py: add ejit_print_version to the always-retained GC-root API list so it survives --gc-sections in the lipo-trimmed bare-metal archive (it is called from user app code, never from AOT).
* Unit test: PrintVersionNoCrash mirrors the existing ejit_print_* no-crash tests.

Verified: cmake configure + ninja build of LLVMEJIT (custom target fires, header generated, EJitRuntime.cpp compiles) in all four diag/SRE configs; a minimal driver calling ejit_print_version() prints "[EJIT] LLVM version 21.1.8, branch <branch>, commit <full-hash>".