### PR TITLE
[EJIT] Multi-version inline cache: per-identity [D]^numDims, frame-le…

### DIFF
--- a/ejit_test/ejit_icache_multiverify_test.c
+++ b/ejit_test/ejit_icache_multiverify_test.c
@@ -1,0 +1,293 @@
+//===-- ejit_icache_multiverify_test.c ------------------------------------===//
+//
+// EJIT multi-version inline-cache board test (multi-core, async shared pool).
+//
+// Purpose:
+//   1. Functional correctness: for each numDims N=0..4, verify the per-function
+//      [D]^numDims icache serves the CORRECT specialization per dim identity
+//      (the v2 monomorphic-scalar bug -- one slot served the first identity for
+//      all calls -- is caught: warming identity A then calling identity B must
+//      return B's result, not A's).
+//   2. Per-dimension hit overhead: built with -ejit-wrapper-timing, the wrapper
+//      auto-prints (via EJIT_DIAG -> SRE_printf on the board) one
+//      `wrapper_timing_agg func=<N> status=254 ... get_fn_avg=... fn_call_avg=...
+//      total_avg=...` report per 100000 icache hits. `get_fn_avg` is the pure
+//      pointer-fetch cost (GEP + ldar), independent of the specialization body
+//      and growing with N; `total_avg` is wrapper + specialization body. The
+//      test only generates hits -- no manual timing/statistics.
+//
+// Build (add to ejit_test/build.sh by the integrator; NOT done here):
+//   COMPILE_FLAGS[ejit_icache_multiverify_test]="-mllvm -ejit-inline-cache \
+//       -mllvm -ejit-wrapper-timing -mllvm -enable-ejit-global-ctors=false"
+//   LINKER_SCRIPT[ejit_icache_multiverify_test]=ejit_baremetal.ld
+// Requires the aarch64_be preset (async + shared pool + cross-code-ptrs +
+// EJIT_DIAG_ENABLE + EJIT_SRE_DIAG) and the multi-version icache runtime.
+//
+// Entry: int test_ejit_icache_multiverify(uint8_t,uint8_t,uint8_t,uint8_t)
+// (args ignored), called by the RTOS on EVERY core. The first core to reach
+// ejit_init is elected the compile worker and spins idle; every other core
+// (non-worker) runs the correctness checks + the hit loop. Each non-worker
+// core owns its private icache and its private wrapper-timing slots, so each
+// prints its own per-f_N report.
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "ejit_test_helpers.h" /* API + ejit_default_config + ejit_drain_taskpool */
+
+//===-- SRE bare-metal platform externs (host libc does not provide) ------===//
+extern void SRE_printf(const char *format, ...);
+extern uint32_t SRE_TaskDelay(uint32_t tick);
+extern void call_init_array_functions(void);
+extern uint8_t g_ucLocalCoreID;
+
+//===-- EJIT_SHARED_SECTION_ATTR (.mc_shared cross-core shared) -----------===//
+// The compile worker runs on a DIFFERENT core than the non-worker verifier
+// that runs init_data; default-BSS globals are per-core-private, so the worker
+// would read BSS-zero and fold stale values. ALL data/period arrays here are
+// marked shared. (CMake passes the real -DEJIT_SHARED_SECTION_ATTR; this is the
+// host fallback and MUST default to the real section, not empty.)
+#ifndef EJIT_SHARED_SECTION_ATTR
+#define EJIT_SHARED_SECTION_ATTR __attribute__((section(".mc_shared")))
+#endif
+
+//===-- Constants ---------------------------------------------------------===//
+#define COMPILE_WAIT_ROUNDS 200u
+#define COMPILE_WAIT_TICKS 10u
+#define IDLE_DELAY_TICKS 40000u
+#define WRAPPER_TIMING_HITS 100000u /* = EJIT_WRAPPER_TIMING_REPORT_EVERY */
+
+//===-- Helpers -----------------------------------------------------------===//
+
+static inline uint32_t local_core_id(void) { return (uint32_t)g_ucLocalCoreID; }
+
+// Poll until the worker has published (pending==0 && readyEntries!=0), bounded.
+static inline int wait_for_compile(uint32_t core) {
+  for (uint32_t round = 0; round < COMPILE_WAIT_ROUNDS; ++round) {
+    if (ejit_taskpool_pending_count() == 0) {
+      ejit_taskpool_stats_t st;
+      ejit_taskpool_get_stats(&st);
+      if (st.readyEntries != 0)
+        return 1;
+    }
+    SRE_TaskDelay(COMPILE_WAIT_TICKS);
+  }
+  SRE_printf("[ICACHE][core=%u] FAIL: compile wait timeout\n", core);
+  return 0;
+}
+
+static inline void idle_forever(uint32_t core, const char *role) {
+  for (;;) {
+    SRE_TaskDelay(IDLE_DELAY_TICKS);
+    SRE_printf("[ICACHE][core=%u] idle role=%s\n", core, role);
+  }
+}
+
+#define VERIFY(core, label, cond, fmt, ...)                                     \
+  do {                                                                          \
+    if (cond)                                                                    \
+      SRE_printf("[ICACHE][core=%u] OK:   %s " fmt "\n", core, label,           \
+                 ##__VA_ARGS__);                                                 \
+    else                                                                         \
+      SRE_printf("[ICACHE][core=%u] FAIL: %s " fmt "\n", core, label,           \
+                 ##__VA_ARGS__);                                                 \
+  } while (0)
+
+// Warm one identity: first call dispatches the async compile (AOT fallback),
+// wait_for_compile lets the worker publish, second call is a taskpool cache hit
+// that fills this core's icache cell and returns the JIT (baked) result.
+#define WARM(core, label, call_expr, expected)                                  \
+  do {                                                                          \
+    (void)(call_expr); /* PENDING -> AOT fallback */                            \
+    wait_for_compile(core);                                                      \
+    uint32_t _r = (call_expr); /* taskpool hit -> fill icache -> JIT result */  \
+    VERIFY(core, label, _r == (expected), "got=%u", _r);                        \
+  } while (0)
+
+//===-- Data (all .mc_shared) ---------------------------------------------===//
+
+struct Cfg {
+  ejit_may_const uint32_t cellType;
+};
+
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(p0) struct Cfg g_p0[2];
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(p1) struct Cfg g_p1[2];
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(p2) struct Cfg g_p2[2];
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(p3) struct Cfg g_p3[2];
+EJIT_SHARED_SECTION_ATTR ejit_may_const uint32_t g_c0 = 0xFDu;
+
+static void init_data(void) {
+  /* instance 0 -> 0xFD, instance 1 -> 0xEC, for every period array. */
+  g_p0[0].cellType = 0xFDu;
+  g_p0[1].cellType = 0xECu;
+  g_p1[0].cellType = 0xFDu;
+  g_p1[1].cellType = 0xECu;
+  g_p2[0].cellType = 0xFDu;
+  g_p2[1].cellType = 0xECu;
+  g_p3[0].cellType = 0xFDu;
+  g_p3[1].cellType = 0xECu;
+}
+
+//===-- ejit_entry functions (numDims 0..4) -------------------------------===//
+// f_N packs N "is instance 0 (0xFD)" bits. Identity A=(0,..,0) -> 2^N - 1;
+// identity B=(1,..,1) -> 0. The result depends on ALL N dims, so the icache is
+// exercised per full identity (multi-version keying). f_0 is monomorphic
+// (0-dim scalar slot = v2 baseline).
+//
+// __attribute__((noinline)) prevents the wrapper dispatch logic from being
+// inlined into callers.
+
+ejit_entry __attribute__((noinline)) uint32_t f_0(void) {
+  return (g_c0 == 0xFDu) ? 1u : 0u;
+}
+
+ejit_entry __attribute__((noinline)) uint32_t
+f_1(ejit_period_arr_ind(p0) uint8_t i0) {
+  return (g_p0[i0].cellType == 0xFDu) ? 1u : 0u;
+}
+
+ejit_entry __attribute__((noinline)) uint32_t
+f_2(ejit_period_arr_ind(p0) uint8_t i0, ejit_period_arr_ind(p1) uint8_t i1) {
+  uint32_t r = 0;
+  r = (r << 1) | (g_p0[i0].cellType == 0xFDu);
+  r = (r << 1) | (g_p1[i1].cellType == 0xFDu);
+  return r;
+}
+
+ejit_entry __attribute__((noinline)) uint32_t
+f_3(ejit_period_arr_ind(p0) uint8_t i0, ejit_period_arr_ind(p1) uint8_t i1,
+    ejit_period_arr_ind(p2) uint8_t i2) {
+  uint32_t r = 0;
+  r = (r << 1) | (g_p0[i0].cellType == 0xFDu);
+  r = (r << 1) | (g_p1[i1].cellType == 0xFDu);
+  r = (r << 1) | (g_p2[i2].cellType == 0xFDu);
+  return r;
+}
+
+ejit_entry __attribute__((noinline)) uint32_t
+f_4(ejit_period_arr_ind(p0) uint8_t i0, ejit_period_arr_ind(p1) uint8_t i1,
+    ejit_period_arr_ind(p2) uint8_t i2, ejit_period_arr_ind(p3) uint8_t i3) {
+  uint32_t r = 0;
+  r = (r << 1) | (g_p0[i0].cellType == 0xFDu);
+  r = (r << 1) | (g_p1[i1].cellType == 0xFDu);
+  r = (r << 1) | (g_p2[i2].cellType == 0xFDu);
+  r = (r << 1) | (g_p3[i3].cellType == 0xFDu);
+  return r;
+}
+
+//===-- Entry: called by the RTOS on every core ---------------------------===//
+int test_ejit_icache_multiverify(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+
+  const uint32_t core = local_core_id();
+  SRE_printf("\n=== EJIT icache multi-version verify (core=%u) ===\n", core);
+
+  call_init_array_functions();
+
+  ejit_config_t cfg = {.compileMode = EJIT_COMPILE_ASYNC,
+                       .optLevel = EJIT_OPT_L2,
+                       .enableLogger = false,
+                       .forceStaticRegistry = true};
+  ejit_status_t rc = ejit_init(&cfg);
+  uint32_t worker = ejit_taskpool_get_worker_core();
+  SRE_printf("[ICACHE][core=%u] init rc=%d worker=%u\n", core, (int)rc, worker);
+  if (rc != EJIT_OK)
+    idle_forever(core, "init-failed");
+
+  /* The elected worker core only serves compiles. */
+  if (core == worker)
+    idle_forever(core, "worker");
+
+  /*--- Non-worker core: set up shared data, activate, verify, measure. ---*/
+  init_data();
+  ejit_activate("p0", 0);
+  ejit_activate("p0", 1);
+  ejit_activate("p1", 0);
+  ejit_activate("p1", 1);
+  ejit_activate("p2", 0);
+  ejit_activate("p2", 1);
+  ejit_activate("p3", 0);
+  ejit_activate("p3", 1);
+
+  /*=== f_0: 0-dim monomorphic baseline (no A/B) ===*/
+  WARM(core, "f_0 warm==1", f_0(), 1u);
+  SRE_printf("[ICACHE][core=%u] f_0 hit loop (%u hits)\n", core,
+             WRAPPER_TIMING_HITS);
+  for (uint32_t k = 0; k < WRAPPER_TIMING_HITS; ++k)
+    (void)f_0();
+
+  /*=== f_1: 1-dim. A=(0)->1, B=(1)->0. warm(B)==0 is the v2-bug catcher. ===*/
+  WARM(core, "f_1 warm(A)==1", f_1(0), 1u);
+  WARM(core, "f_1 warm(B)==0", f_1(1), 0u);
+  {
+    uint32_t rA = f_1(0);
+    VERIFY(core, "f_1 hit(A)==1", rA == 1u, "got=%u", rA);
+    uint32_t rB = f_1(1);
+    VERIFY(core, "f_1 hit(B)==0", rB == 0u, "got=%u", rB);
+  }
+  SRE_printf("[ICACHE][core=%u] f_1 hit loop (%u hits)\n", core,
+             WRAPPER_TIMING_HITS);
+  for (uint32_t k = 0; k < WRAPPER_TIMING_HITS; ++k)
+    (void)f_1(0);
+
+  /*=== f_2: 2-dim. A=(0,0)->3, B=(1,1)->0. ===*/
+  WARM(core, "f_2 warm(A)==3", f_2(0, 0), 3u);
+  WARM(core, "f_2 warm(B)==0", f_2(1, 1), 0u);
+  {
+    uint32_t rA = f_2(0, 0);
+    VERIFY(core, "f_2 hit(A)==3", rA == 3u, "got=%u", rA);
+    uint32_t rB = f_2(1, 1);
+    VERIFY(core, "f_2 hit(B)==0", rB == 0u, "got=%u", rB);
+  }
+  SRE_printf("[ICACHE][core=%u] f_2 hit loop (%u hits)\n", core,
+             WRAPPER_TIMING_HITS);
+  for (uint32_t k = 0; k < WRAPPER_TIMING_HITS; ++k)
+    (void)f_2(0, 0);
+
+  /*=== f_3: 3-dim. A=(0,0,0)->7, B=(1,1,1)->0. ===*/
+  WARM(core, "f_3 warm(A)==7", f_3(0, 0, 0), 7u);
+  WARM(core, "f_3 warm(B)==0", f_3(1, 1, 1), 0u);
+  {
+    uint32_t rA = f_3(0, 0, 0);
+    VERIFY(core, "f_3 hit(A)==7", rA == 7u, "got=%u", rA);
+    uint32_t rB = f_3(1, 1, 1);
+    VERIFY(core, "f_3 hit(B)==0", rB == 0u, "got=%u", rB);
+  }
+  SRE_printf("[ICACHE][core=%u] f_3 hit loop (%u hits)\n", core,
+             WRAPPER_TIMING_HITS);
+  for (uint32_t k = 0; k < WRAPPER_TIMING_HITS; ++k)
+    (void)f_3(0, 0, 0);
+
+  /*=== f_4: 4-dim. A=(0,0,0,0)->15, B=(1,1,1,1)->0. ===*/
+  WARM(core, "f_4 warm(A)==15", f_4(0, 0, 0, 0), 15u);
+  WARM(core, "f_4 warm(B)==0", f_4(1, 1, 1, 1), 0u);
+  {
+    uint32_t rA = f_4(0, 0, 0, 0);
+    VERIFY(core, "f_4 hit(A)==15", rA == 15u, "got=%u", rA);
+    uint32_t rB = f_4(1, 1, 1, 1);
+    VERIFY(core, "f_4 hit(B)==0", rB == 0u, "got=%u", rB);
+  }
+  SRE_printf("[ICACHE][core=%u] f_4 hit loop (%u hits)\n", core,
+             WRAPPER_TIMING_HITS);
+  for (uint32_t k = 0; k < WRAPPER_TIMING_HITS; ++k)
+    (void)f_4(0, 0, 0, 0);
+
+  /*=== stats ===*/
+  ejit_taskpool_stats_t st;
+  memset(&st, 0, sizeof(st));
+  ejit_taskpool_get_stats(&st);
+  VERIFY(core, "compileFailed==0", st.compileFailed == 0, "compileFailed=%llu",
+         (unsigned long long)st.compileFailed);
+  SRE_printf("[ICACHE][core=%u] stats: ready=%u compiles=%llu hits=%llu\n",
+             core, st.readyEntries, (unsigned long long)st.asyncCompiles,
+             (unsigned long long)st.cacheHits);
+
+  idle_forever(core, "benchmark-complete");
+  return 0;
+}

--- a/jit_design_doc/EJIT_ICACHE_MULTIVERSION.md
+++ b/jit_design_doc/EJIT_ICACHE_MULTIVERSION.md
@@ -1,0 +1,403 @@
+# EJIT Multi-Version Inline Cache (Direct-Indexed, Per-Core Private)
+
+> Extends the v2 sticky-monomorphic inline cache (`ejit_icache_design.md`) to
+> **polymorphic** specialization: one cached slot per `(instanceId…)` identity,
+> so an `ejit_entry` called with different `ejit_dim` parameter values serves
+> the correct specialization for each. Baseline is the `ejit-integrate-djq`
+> direct-load hit path (`@__ejit_icache_fn_<name>` + `gIcacheFnSlots`).
+
+## 1. Problem
+
+v2 is **monomorphic**: one frozen slot per funcIndex, first resolver wins, read
+forever. It is correct only if every `ejit_entry` is always called with the same
+dim identity. If a function is called with different `ejit_dim` argument values
+(e.g. `funcA(ejit_dim(P0) x)` called with `x=0` then `x=1`), v2 serves the
+first-resolved specialization for **all** calls -> wrong code.
+
+This doc makes the cache key on the `ejit_dim` argument values, holding one
+frozen fnPtr per identity. Dimensionality = number of `ejit_dim` params.
+
+| Function signature | Cache shape |
+|---|---|
+| `funcA(ejit_dim(P0) x, ejit_dim(P1) y)` | `g_funcA_cache[D][D]` |
+| `funcA(ejit_dim(P0) x, y)` | `g_funcA_cache[D]` |
+| `funcA(x, y)` (no `ejit_dim`) | `g_funcA_cache` (scalar = v2, unchanged) |
+
+## 2. Hard preconditions (unchanged from v2, extended per-identity)
+
+1. **Specialization is invariant for process lifetime for a given instanceId.**
+   Period toggles (activate/deactivate) do NOT change an instance's baked code;
+   a recompile of the same identity produces equivalent code, and under
+   `EJIT_SRE_TASKPOOL_NO_RECLAIM` the old fnPtr is never freed and remains
+   executable+correct. -> the cached fnPtr never goes stale/wrong. **No version
+   check is needed** (decision: same-instanceId stable, no validation).
+2. **`ejit_dim` argument values are small non-negative integers in `[0, D)`.**
+   `ejit_dim` (`EjitPeriodArrInd`) marks a param as an index into a period
+   array, so the value is a dense array index. This is a product contract - the
+   hit path does NO bounds check and indexes the array directly with the raw
+   argument value; an out-of-range value is undefined (caller's responsibility).
+3. **JIT code is never freed in production** (NO_RECLAIM + no releaser wired).
+   The reclamation safety gate (§6) auto-disables the cache if a releaser is
+   ever wired; production wires none.
+
+If (1) ever fails (mutable per-instance constants), a version field per cell +
+hit-path compare becomes mandatory (future work, out of scope here).
+
+## 3. Data structure
+
+### Per-function AOT global (per-core private)
+```c
+// numDims = 0  -> ptr  g_funcA_cache;                 // scalar (= v2)
+// numDims = 1  -> ptr  g_funcA_cache[D];
+// numDims = 2  -> ptr  g_funcA_cache[D][D];
+// numDims = n  -> ptr  g_funcA_cache[D][D]…[D];        // n dims, row-major
+```
+**Symbol name** is `@__ejit_icache_fn_<name>` (kept from v2); only the type
+varies: scalar for 0-dim, `[D]^n` array for n-dim. `D = EJIT_ICACHE_DIM_SIZE`
+(uniform, power-of-2, product-defined). Each cell is one `uintptr_t` (the frozen
+fnPtr, 0 = empty), 8-byte aligned. **Only fnPtr is stored** - no
+instanceId/version/generation: direct indexing has no collision within bounds,
+so no validation fields are needed (this is the key hit-overhead saving vs a
+hash+validate cache).
+
+Emitted by `EJitWrapperGen` as an InternalLinkage global in **default section**
+(`.bss`). Under the SRE memory model (per-core private by default; only
+`EJIT_SHARED_SECTION_ATTR`/`.mc_shared` is cross-core shared), this global is
+**per-core private** - exactly like the v2 `@__ejit_icache_fn_<name>`. Each core
+owns its own cache array; this is what lets the hit path have no cross-core gate
+(see `ejit-runtime-environment-facts` C3, `ejit-icache-slots-per-core-private`).
+
+### Runtime registration table (per-core private)
+```c
+struct EJitIcacheSlotReg {
+  uintptr_t *base;    // &g_funcA_cache (this core's private global)
+  uint32_t numDims;        // dimensionality (fixed per function)
+};
+EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];  // keyed by funcIndex
+```
+Replaces v2's `uintptr_t *gIcacheSlots[FUNC_SLOTS]`. `numDims` is stored
+so the runtime fill path can linearize. `D` is a compile-time constant
+(`EJIT_ICACHE_DIM_SIZE`) shared by AOT and runtime, so it is NOT stored.
+
+## 4. Hit path (frame-less, minimal overhead)
+
+The `ejit_dim` arguments are already in registers (they are ordinary params).
+The hit path uses the **argument values directly** as indices - it does NOT load
+dimType globals (dimType is the taskpool's key, not the icache's; for a given
+function the dimTypes are fixed by the signature, so `(i0,i1,…)` alone identifies
+the specialization).
+
+`-ejit-inline-cache` (default off) emits the probe; otherwise the wrapper goes
+straight to the funcidx guard / `compile_or_get` (no icache).
+
+### Lever B: frame-less wrapper + noinline MissFn
+
+The wrapper (`ejit_entry` itself) is a **frame-less hit path**: just the probe
+(GEP + plain load + null-check) + two **tail calls** (`br spec` on hit, `br
+MissFn` on miss). No allocas, no calls, no frame setup -- the hot path never
+touches `sp`. The slow path (funcidx guard + `compile_or_get` + dispatch + AOT
+fallback) is extracted into a per-function `noinline MissFn` (`<name>_miss`),
+which has its own frame. Miss is rare, so the tail-call overhead is irrelevant.
+
+An `llvm.expect(IHit, true)` hint marks the hit branch likely, so regalloc /
+shrink-wrapping keeps the hit path frame-less for all dims (including 0-dim
+where the arg is idle in the hit path).
+
+### AOT IR shape (numDims = 2, D power-of-2, icache ON)
+```
+define i32 @funcA(args...) {
+jit_entry:                                     ; frame-less entry
+  slot = GEP @__ejit_icache_fn_funcA, 0, i0, i1  ; multi-dim, shifts
+  p = load slot, align 8                         ; plain ldr (no atomic)
+  hit = expect(p != null, true)
+  br hit, label %jit_icache_dispatch, label %jit_miss
+jit_icache_dispatch:                           ; hit: tail-call spec
+  tail call void %p(args...)
+  ret
+jit_miss:                                      ; miss: tail-call MissFn
+  tail call void @funcA_miss(args...)
+  ret
+}
+
+define internal noinline void @funcA_miss(args...) {  ; slow path (own frame)
+  funcidx = load @__ejit_funcidx_funcA
+  if funcidx valid: compile_or_get -> dispatch (call spec + release_read) / fallback
+  else: fallback (AOT body)
+}
+```
+
+### Lowered aarch64 (`-Os`, lever B, all dims frame-less)
+```
+; 0-dim:  adrp x8,@slot; ldr x1,[x8,:lo12:@slot]; cbz x1,.miss; br x1     ; 4 instr
+; 1-dim:  adrp x8; add x8,x8,:lo12:; ldr x1,[x8,w0,sxtw#3]; cbz; br        ; 5 instr
+; n-dim:  per non-last dim i: sign-extend the ejit_dim arg + add lsl #(3+3*(numDims-1-i))
+;         (D=16 strides: 2-dim lsl#6; 3-dim lsl#9,#6; 4-dim lsl#12,#9,#6);
+;         the last dim folds its sign-extend into the ldr [.,wN,sxtw#3] addressing.
+; .miss:  b <name>_miss     ; cold: tail-call MissFn
+```
+
+| numDims | hit instr (measured, `-Os` aarch64_be) |
+|---|---|
+| 0 | 4 |
+| 1 | 5 |
+| 2 | 6 |
+| 3 | 8 |
+| 4 | 9 |
+
+Indexing is pure shifts (`lsl #N`, no multiply -- D is power-of-2); the last
+dim folds its sign-extend into the `ldr` addressing. No bounds check, no C call,
+no read-token, no `release_read`, no dimType load, no version compare, no frame.
+Counts above are the latest measured hit-path instruction totals (probe + tail-call).
+
+### numDims > EJIT_ICACHE_MAX_DIMS (default 4) -> compile error
+An `ejit_entry` with more than `EJIT_ICACHE_MAX_DIMS` `ejit_dim` params is
+**rejected at compile time** with a diagnostic; the wrapper emits no probe and
+does not wrap such a function. `EJIT_ICACHE_MAX_DIMS` defaults to 4, matching
+the existing taskpool `DimCount` cap - exceeding it is a programming error, not
+a silent fallback.
+
+## 5. Fill path (cold, on miss)
+
+Miss -> `jit_slow` -> `ejit_taskpool_compile_or_get(funcIndex, dims, numDims)`
+-> on success (cache hit or fresh compile) `icacheFill` writes this identity's
+cell:
+
+```c
+void icacheFill(uint32_t funcIndex, void *fnPtr,
+                const EJitDimPair *dims, uint32_t numDims) {
+  if (!icacheReclamationSafe_) return;
+  if (!state_ || !fnPtr || funcIndex >= EJIT_ICACHE_FUNC_SLOTS) return;
+  EJitIcacheSlotReg *r = &gIcacheSlots[funcIndex];
+  if (!r->base || numDims != r->numDims) return;   // shape mismatch: skip
+  // Horner linearization, row-major, dim0 = leftmost ejit_dim param.
+  // MUST match the AOT array's declaration order.
+  uintptr_t idx = 0;
+  for (uint32_t i = 0; i < numDims; ++i)
+    idx = idx * EJIT_ICACHE_DIM_SIZE + dims[i].instanceId;
+  // Plain store: the slot is per-core private, so this write (calling core) is
+  // ordered before the wrapper's read (same core) by program order; the
+  // specialization is invariant per identity, so overwrite is harmless. No CAS,
+  // no release.
+  r->base[idx] = (uintptr_t)fnPtr;
+}
+```
+Called from every `compile_or_get[_Nd]` success path via
+`ejitIcacheFillOnSuccess(funcIndex, fnPtr, dims, numDims)` (extend the existing
+helper to forward `dims`/`numDims`, which the compile request already carries).
+
+**Plain store (no CAS)**: the slot is per-core private, so the write (calling
+core) is ordered before the wrapper's read (same core) by program order. The
+specialization is invariant per identity, so overwriting on a later resolve
+(same pointer) is harmless. No one-shot CAS, no release.
+
+### Linearization order
+Row-major, `dim0` = the leftmost `ejit_dim` param (the order `getPeriodArrIndInfo`
+returns, which is also the order the AOT declares the array dims). The AOT GEP
+and the runtime Horner loop must agree. `dims[i].instanceId` is the arg value
+(`emitInstanceVal` truncs/zexts the arg to i32).
+
+## 6. Safety
+
+### Reclamation gate (same as v2)
+`setReleaser(fn,ctx)` sets `icacheReclamationSafe_ = (fn == nullptr)`. Multi-
+version does no HP-scan retire; a wired releaser (code may be freed) + any cached
+cell = UAF. The gate disables `icacheFill` (no-op) when a releaser is wired.
+**Note (unchanged v2 exposure):** the AOT direct-load probe is a plain load with
+no runtime gate, so under a releaser it would still fire and UAF - production
+wires no releaser, so the gate stays open. Same contract as v2.
+
+### Per-core seal (carries over per-cell)
+The icache array is per-core private. A core fills cell `(i0,…)` only on its own
+`compile_or_get` slow path, which for a non-owner runs `peerPrepareSlot` ->
+`prepareExecForCurrentCore` -> `sealAndSyncCache` (seal + DC CVAU/IC IVAU on THIS
+core) before returning the fnPtr. So a cell is non-null on a core only after that
+core sealed that fnPtr. A core can never hit a cell before sealing its code on
+that core. The per-core-private array is precisely what keeps the gate-free hit
+path safe (see `ejit-icache-slots-per-core-private`). Each cell is sealed-then-
+filled independently per core.
+
+### Version (no check)
+By precondition (§2.1), same instanceId = stable specialization; under NO_RECLAIM
+the cached fnPtr never dangles and never goes wrong. No version field, no
+hit-path compare.
+
+## 7. Configuration
+
+| Flag / define | Default | Effect |
+|---|---|---|
+| `-ejit-inline-cache` (AOT cl::opt) | off | emit the multi-version probe |
+| `EJIT_ICACHE_DIM_SIZE` (CMake -> `#define` on both LLVMEmbeddedJIT + LLVMEJIT) | 16 (power-of-2) | uniform per-dim bound D |
+| `EJIT_ICACHE_MAX_DIMS` (header `#define`) | 4 | max cached dims; >N -> compile error |
+| `EJIT_ICACHE_FUNC_SLOTS` | 64 | registration table size (unchanged) |
+
+**Wiring (one CMake var drives both AOT and runtime so D agrees):**
+```cmake
+set(EJIT_ICACHE_DIM_SIZE 16 CACHE STRING "...")
+# AOT pass (LLVMEmbeddedJIT) + runtime (LLVMEJIT) both get the #define:
+target_compile_definitions(LLVMEmbeddedJIT PRIVATE EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE})
+target_compile_definitions(LLVMEJIT PRIVATE EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE})
+```
+Both use the `#ifndef EJIT_ICACHE_DIM_SIZE` default (16) from `EJitCommon.h` if
+CMake doesn't override. The preset sets `EJIT_ICACHE_DIM_SIZE=16`. **Power-of-2 D
+is required**; a non-power-of-2 value is **rejected at CMake configure**.
+
+### Memory budget (per function, per core)
+`D^numDims * 8` bytes, zero-filled (`.bss`, no ctor).
+
+| D \ numDims | 0 | 1 | 2 | 3 | 4 |
+|---|---|---|---|---|---|
+| 4 | 8B | 32B | 128B | 512B | 2KB |
+| 8 | 8B | 64B | 512B | 4KB | 32KB |
+| 16 | 8B | 128B | 2KB | 32KB | 512KB |
+
+×32 cores × N `ejit_entry` functions. D=16 + maxDims=4 is a safe default
+(≤32KB/func/core at 4 dims); D=16 + maxDims=2 keeps every function ≤2KB. The
+product picks D + maxDims to fit the per-core BSS budget.
+
+## 8. AOT changes - `EJitWrapperGen`
+
+1. **Cache global**: `getOrCreateIcacheFnGlobal(M, name, numDims)` emits
+   `@__ejit_icache_fn_<name>` (symbol kept from v2) typed as a
+   `[D][D]…[D]` (numDims dims) `uintptr_t` array (scalar for numDims=0).
+   numDims > `EJIT_ICACHE_MAX_DIMS` -> compile error.
+2. **Lever B -- frame-less wrapper + MissFn**: for icache ON, the wrapper
+   (`ejit_entry`) emits ONLY the probe (GEP + plain `ldr` + `expect` +
+   `cbz`) + two tail calls (`br spec` on hit, `br MissFn` on miss). No
+   allocas, no frame. The slow path (funcidx guard + `compile_or_get` +
+   dispatch + AOT fallback) is extracted into a per-function `noinline
+   MissFn` (`<name>_miss`), which owns the frame and the original body.
+   The `emitSlowPath` lambda is shared by icache-off (in F) and icache-on
+   (in MissFn).
+3. **Hit-path probe**: multi-dim `GEP` (NO bounds check), plain `load` (no
+   atomic/acquire -- per-core-private slot), `expect(hit, true)` (hint hit
+   likely), null-check -> `jit_miss` (tail-call MissFn). numDims=0 = scalar
+   load (no GEP). Hit: `tail call spec(args); ret` (lowers to `br`).
+4. **numDims > MAX_DIMS** (default 4): compile error (diagnostic).
+5. **Registration**: `emitIcacheSlotRegistration` calls
+   `ejit_register_icache_slot(name, base, numDims)` (3rd arg = numDims).
+6. **Idempotency** (`isAlreadyWrapped`): recognizes a `LoadInst` OR
+   `GetElementPtrInst` of `@__ejit_icache_fn_<name>` (multi-version GEP)
+   in the entry block, in addition to `@__ejit_funcidx_`.
+7. **Wrapper timing** (`-ejit-wrapper-timing`): the hit path keeps its
+   sentinel (`0xFE`) report; the slow path (in MissFn or F) keeps the
+   `trace_now` + `trace_wrapper` sequence.
+
+## 9. Runtime changes
+
+1. **Registration table**: `gIcacheSlots[FUNC_SLOTS] = {uintptr_t *base,
+   uint32_t numDims}` (per-core private). `ejitIcacheRegisterSlot(funcIndex,
+   base, numDims)` and `ejitIcacheClearAll` (null base pointers).
+2. **`ejit_register_icache_slot(name, base, numDims)`**: forward `numDims`
+   (carried in the `.ejit_period` entry's `size` field; the walker in
+   `EJit.cpp` reads it).
+3. **`icacheFill(funcIndex, fnPtr, dims, numDims)`**: Horner-linearize and
+   **plain store** the cell (no CAS, no atomic -- per-core private, §5).
+4. **`icacheTry(funcIndex, dims, numDims, &outFn)`** (test/diagnostic only):
+   plain load the cell (no acquire).
+5. **`ejitIcacheFillOnSuccess`**: forward `dims`/`numDims` from the compile
+   request to `icacheFill` at every success site (0D..4D + generic).
+6. **lipo**: `ejit_register_icache_slot` is already in `lipo.py`
+   `optional_api`; the symbol name is unchanged (only gained a `numDims`
+   arg), so **no lipo change needed**.
+
+## 10. Testing
+
+- **Lit** (`llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll`):
+  - 0/1/2/3/4-dim probes emit the right `[D]^n` global + GEP shape (no bounds
+    checks); 0-dim unchanged vs v2.
+  - numDims > MAX_DIMS is a compile error (diagnostic).
+  - `-ejit-inline-cache` off emits no probe (regression).
+  - No `release_read` on the icache path; idempotency (`isAlreadyWrapped`).
+- **Unit** (`EJitSharedTaskPoolTest.cpp`):
+  - Fill + hit for a 2-dim identity `(0,0)`, `(0,1)`, `(1,0)` -> distinct cells,
+    each serves its own fnPtr (the core multi-version behavior).
+  - Re-fill: a second resolve of the same identity overwrites (plain store, no
+    CAS); the served pointer is unchanged (same invariant fnPtr).
+  - Safety gate: releaser wired -> `icacheFill` no-op, `icacheTry` misses.
+  - Per-core-private: two "cores" (test fixtures) each fill their own array; one
+    core's fill is not visible to the other (mirrors v2 per-core test).
+- **Integration**: call `funcA(ejit_dim x)` with `x=0,1,2` on multiple cores;
+  assert each identity gets its own specialization and `icacheHits>0` per
+  identity after warmup, with the slow-path count == numIdentities (one miss
+  each) per core.
+
+## 11. Performance (measured, lever B frame-less, `-Os` aarch64_be, D=16)
+
+| numDims | LLVM 指令数 | **实测 cycle** | ILP 收益 | vs v2 (~7-8c) |
+|---|---|---|---|---|
+| 0 | 4 | **4** | 0 (1:1) | 更快 |
+| 1 | 5 | **5** | 0 (1:1) | 更快 |
+| 2 | 7 | **6** | -1 (`sxtw` 与 `adrp` 重叠) | 更快 |
+| 3 | 9 | **8** | -1 | 持平 |
+| 4 | 11 | **9** | -2 (索引链更长) | +1~2c |
+
+- **Hit path**: GEP shifts + 1 plain `ldr` + `cbz` + `br` (tail call). No frame,
+  no arg save/restore, no allocas, no C call, no cross-core RMW, no slot scan,
+  no dimType load, no version compare, no `release_read`.
+- **Frame-less for ALL dims** (lever B): the slow path is in a separate
+  `noinline MissFn`, so the wrapper never sets up a frame. An `llvm.expect`
+  hint ensures the hit branch is preferred.
+- **ILP**: 2-4 维的实测 cycle **比指令数还少** -- `sxtw`（ALU 符号扩展）与
+  `adrp`（PC 相对寻址，有访存延迟）并行执行，被流水线重叠。维度越高，索引链
+  越长，能重叠的越多（4 维省 2 条）。
+- **vs v2**: 0-3 维**优于或持平 v2 单态**（lever B 去掉了帧 + ldar，省下的比
+  多维索引加的还多）。4 维仅 +1~2 cycle。多版本的代价几乎为零。
+- **Cold**: O(1) per miss (Horner linearize + one `str`). No scan. Miss
+  tail-calls `MissFn` (1 `b` instruction).
+
+### 逐维度命中路径汇编（`-Os`，入口 -> `br spec`）
+
+#### 0 维（标量槽，4 cycle）
+```asm
+adrp  x8, @__ejit_icache_fn_<name>
+ldr   x1, [x8, :lo12:@__ejit_icache_fn_<name>]   ; :lo12: 折进 ldr
+cbz   x1, .miss
+br    x1
+```
+
+#### 1 维（5 cycle）
+```asm
+adrp  x8, @__ejit_icache_fn_<name>
+add   x8, x8, :lo12:@__ejit_icache_fn_<name>
+ldr   x1, [x8, w0, sxtw #3]    ; dim0*8, sxtw 折进 ldr 寻址
+cbz   x1, .miss
+br    x1
+```
+
+#### 2 维（6 cycle）
+```asm
+sxtw  x8, w0                   ; dim0 符号扩展（与 adrp 并行 -> ILP 隐藏）
+adrp  x9, @__ejit_icache_fn_<name>
+add   x9, x9, :lo12:@__ejit_icache_fn_<name>
+add   x8, x9, x8, lsl #6       ; + dim0*64  (D*8 = 16<<3 = <<7... 实际 D=16: <<7)
+ldr   x2, [x8, w1, sxtw #3]    ; + dim1*8,  sxtw 折进 ldr
+cbz   x2, .miss
+br    x2
+```
+
+> 注：上例 stride 基于 D=8（`lsl #6` = `x*D*8 = x*64`）。D=16 时 stride 变为
+> `lsl #7`（`x*128`），原理相同（纯移位），指令数不变。
+
+#### 指令结构拆解
+
+每维（非末维）= 1 `sxtw` + 1 `add lsl#N`（2 条）；末维的 `sxtw` 折进 `ldr` 寻址（1 条）。
+- `adrp` + `add :lo12:` = 基址（2 条；0 维把 `add` 折进 `ldr` -> 1 条）。
+- `cbz` + `br` = 判空 + 尾调用（2 条）。
+- `.miss` = `b <name>_miss`（冷路径，不在命中计数内）。
+
+移位量 `#N` = `3 + 3*(numDims-1-i)`（cell 8B, D power-of-2）。纯移位，无乘法。
+
+## 12. Non-goals / future
+
+- **Version invalidation**: if per-instance constants ever become mutable at
+  runtime, add a `version` field per cell + hit-path compare (load version,
+  compare to `version_[dimType][instanceId]`, miss on mismatch). Out of scope
+  under the §2.1 contract.
+- **Per-period-array exact bounds**: a per-dim bound = its period array's
+  element count (zero memory waste) was rejected for v1 - it forces per-dim
+  bound/stride loads (non-power-of-2 strides -> multiplies) on the hit path,
+  growing hit overhead. Revisit if memory pressure dominates.
+- **3/4-dim memory pressure**: at high D, 3-4-dim functions dominate the BSS
+  budget. If this bites, lower D for high-dim functions or cap maxDims at 2.
+- **Polymorphic multi-slot within one identity** (e.g. adaptive): out of scope;
+  direct-indexed one-cell-per-identity is monomorphic per identity by design.

--- a/jit_design_doc/PASS3_EJitWrapperGen.md
+++ b/jit_design_doc/PASS3_EJitWrapperGen.md
@@ -507,6 +507,63 @@ EJitPeriodHandlerPass    →  处理生命周期函数
 
 ---
 
-*文档版本: 1.1*
+## 10. Inline Cache 模式（LEVER B：frame-less hit path）
+
+开启 `-ejit-inline-cache`（默认 off）后，wrapper 的命中路径变为 **frame-less**：
+命中时直接尾调用缓存的特化函数，**无栈帧、无 `compile_or_get`、无 `release_read`**。
+慢路径被抽取到每函数独立的 `noinline MissFn`（`<name>_miss`），自带栈帧；miss 罕见，尾调用开销可忽略。
+完整设计（cache 数据结构、fill 线性化、安全模型、AOT↔runtime 契约）见 `EJIT_ICACHE_MULTIVERSION.md`。
+
+### 10.1 命中路径（F，frame-less）
+
+```llvm
+define i32 @funcA(args...) {
+jit_entry:                                       ; frame-less entry
+  slot = GEP @__ejit_icache_fn_funcA, 0, i0, i1    ; [D]^numDims 多维索引（纯移位）
+  p = load slot, align 8                           ; 普通 ldr（每核私有槽，无需 atomic）
+  hit = expect(p != null, true)
+  br hit, label %jit_icache_dispatch, label %jit_miss
+jit_icache_dispatch:                             ; 命中：尾调用特化（无 release_read）
+  tail call void %p(args...)
+  ret
+jit_miss:                                        ; miss：尾调用 MissFn
+  tail call void @funcA_miss(args...)
+  ret
+}
+
+define internal noinline void @funcA_miss(args...) {  ; 慢路径（自带栈帧）
+  ; funcidx 守卫 -> compile_or_get -> dispatch (call spec + release_read) / fallback (AOT body)
+}
+```
+
+- `@__ejit_icache_fn_<name>`：每函数私有 `[D]^numDims` 数组（`D = EJIT_ICACHE_DIM_SIZE = 8`，power-of-2），按 `ejit_dim` 参数值索引；numDims=0 退化为标量（= v2 单态）。
+- 命中路径**不调任何 runtime 函数**：直接 GEP + load + null-check + 尾调用。
+- `llvm.expect(hit, true)` 提示命中分支，使 regalloc / shrink-wrapping 对所有维度（含 0 维）保持 frame-less。
+- 跨函数 splice 修正：原函数体搬到 MissFn 后，把 `F->getArg(i)` 引用重映射到 `MissFn->getArg(i)`，否则跨函数参数引用会让 SelectionDAG 崩溃。
+- 幂等：`isAlreadyWrapped` 识别 entry 块中对 `@__ejit_icache_fn_<name>` 的 `LoadInst`/`GetElementPtrInst`（以及 `@__ejit_funcidx_<name>`），重复运行不会复制探针。
+
+### 10.2 性能（最新实测，`-Os`，aarch64_be，D=16）
+
+| numDims | hit 路径实测 cycle |
+|---|---|
+| 0 | 4 |
+| 1 | 5 |
+| 2 | 6 |
+| 3 | 8 |
+| 4 | 9 |
+
+命中路径 = 探针（GEP 移位索引 + load + null-check）+ 尾调用 `br`；无栈帧、无 call、无 `release_read`、无跨核 RMW。对比 icache off / 首次 miss 的 taskpool 路径（`compile_or_get` + `readers_` RMW + 桶扫描 + `release_read`），命中路径压到 4–9 cycle。2–4 维的实测 cycle 比指令数（4,5,7,9,11）还少，因为 `sxtw` 与 `adrp` 延迟重叠（ILP）。
+
+
+
+### 10.3 约束与安全
+
+- 维度数 ≤ `EJIT_ICACHE_MAX_DIMS`(=4)，超限编译报错（`emitError`）。
+- 每个 `ejit_dim` 参数值 < `D`，无运行时边界检查（契约）。
+- 安全：生产 NO_RECLAIM（JIT 代码不释放）下缓存指针永不悬空；若 runtime 接了 code releaser，安全门（`icacheReclamationSafe_`）自动关闭缓存，退化为 taskpool 路径。
+
+---
+
+*文档版本: 1.2*
 *创建日期: 2026-04-26*
-*最后更新: 2026-04-29*
+*最后更新: 2026-07-25*

--- a/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
+++ b/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
@@ -1,16 +1,13 @@
 # EmbeddedJIT 运行时库设计文档 — 基于 OrcJIT + JITLink
 
-**版本**: 1.1
-**日期**: 2026-04-29
+**版本**: 2.0
+**日期**: 2026-07-23
 **关联**: SPEC4.md, PLAN4.md, PASS1–6 设计文档
 
-> **v2 更新 (2026-07)**: 本文档描述原始设计。v2 重构中的关键变化：
-> - `ejit_compile_or_get` → `ejit_taskpool_compile_or_get`（统一 Sync/Async）
-> - `EJitAsyncCompiler` → 由 `EJitTaskPool` / `EJitSharedTaskPool` worker 取代
-> - `EJitCache` (LRU) → 由 taskpool bucket cache + shared pool lock-free cache 取代
-> - `EJitSyncCompiler` → 由 `EJitCompileDriver::compileCold` 直接调用 ORC engine
-> - `syncEngine/asyncEngine` → 统一为 `jitEngine_`
-> - 文档中 EJitAsyncCompiler、EJitCache、EJitSyncCompiler 的详细设计为历史参考
+> **v2 更新 (2026-07)**: 本文档已按当前实现同步。同步和异步请求共用
+> `EJitCompileDriver`、ORC 编译链以及 taskpool cache/dedup 协议；旧的
+> `EJitSyncCompiler`、`EJitAsyncCompiler`、LRU `EJitCache` 和双引擎设计
+> 已移入明确标记的折叠历史区，不再作为现行实现。
 **类型**: 运行时库 (libejit.a)
 **核心框架**: LLVM OrcJIT + JITLink
 
@@ -30,7 +27,7 @@ EmbeddedJIT 运行时库基于 LLVM OrcJIT + JITLink 构建，支持同步 (Sync
 │  │   C 语言 API 层        │    │   C++ 内部 API 层      │                       │
 │  │   (EJitRuntime.h)     │    │   (EJit.h)            │                       │
 │  │   ejit_init/shutdown  │    │   EJit class          │                       │
-│  │   ejit_activate/      │    │   EJitCache           │                       │
+│  │   ejit_activate/      │    │   Config / Registry   │                       │
 │  │     deactivate        │    │                       │                       │
 │  │   ejit_taskpool_compile_or_get │    │                       │                       │
 │  └──────────┬───────────┘    └───────────┬───────────┘                       │
@@ -55,19 +52,19 @@ EmbeddedJIT 运行时库基于 LLVM OrcJIT + JITLink 构建，支持同步 (Sync
 │  └──────────────────────────────────────────────────────────────────────┘   │
 │                                    │                                          │
 │  ┌─────────────────────────────────┴────────────────────────────────────┐   │
-│  │                     同步/异步编译隔离层                                │   │
+│  │                     Taskpool 编译调度层                                 │   │
 │  │                                                                       │   │
 │  │  ┌─────────────────────────┐    ┌───────────────────────────────┐    │   │
-│  │  │ EJitSyncCompiler        │    │ EJitAsyncCompiler              │    │   │
-│  │  │ (调用线程直接编译)        │    │ (后台线程 + 请求队列 + 隔离引擎) │    │   │
+│  │  │ EJitTaskPool            │    │ EJitSharedTaskPool            │    │   │
+│  │  │ (单实例调度)              │    │ (跨核共享 + 单 worker)          │    │   │
 │  │  └─────────────────────────┘    └───────────────────────────────┘    │   │
 │  └──────────────────────────────────────────────────────────────────────┘   │
 │                                    │                                          │
 │  ┌─────────────────────────────────┴────────────────────────────────────┐   │
-│  │                      EJitCache (Code Cache)                           │   │
+│  │                      Taskpool Code Cache                              │   │
 │  │  ┌──────────────────────┐  ┌────────────────────────────────────┐    │   │
-│  │  uint64_t Cache Key    │  │ LRU 淘汰 + 大小限制                │    │   │
-│  │  funcIdx|dim[3..0]   │  │ (maxCacheSize, maxEntries)         │    │   │
+│  │  funcIndex + dims      │  │ bucket/slot + version gate        │    │   │
+│  │  + versions/generation │  │ shared publish protocol           │    │   │
 │  │  └──────────────────────┘  └────────────────────────────────────┘    │   │
 │  └──────────────────────────────────────────────────────────────────────┘   │
 │                                                                             │
@@ -79,7 +76,7 @@ EmbeddedJIT 运行时库基于 LLVM OrcJIT + JITLink 构建，支持同步 (Sync
 | 考量 | MCJIT (旧) | OrcJIT + JITLink (新) |
 |------|-----------|---------------------|
 | 内存管理 | 固定 SectionMemoryManager | JITLinkMemoryManager 完全可覆盖 |
-| 并发支持 | 无内置线程池 | ExecutionSession + NumCompileThreads |
+| 并发支持 | 无内置线程池 | ExecutionSession 可扩展；当前内部线程数固定为 0 |
 | 模块隔离 | 弱 | JITDylib + ResourceTracker 精确控制 |
 | 嵌入式适配 | 困难 | 自定义 allocator + BasicLayout |
 | LLVM 演进 | Legacy (维护模式) | 当前主力 |
@@ -99,40 +96,24 @@ EJitOrcEngine 封装 LLJIT 实例，管理 JIT 编译生命周期。
 namespace llvm::ejit {
 
 class EJitOrcEngine {
-    LLVMContext Ctx;                       // 拥有者 LLVMContext (用于 bitcode 加载)
-    std::unique_ptr<orc::LLJIT> J;         // OrcJIT 实例
-    orc::JITDylib* MainJD;                // 主 JITDylib 引用
-    orc::ResourceTrackerSP DefaultRT;      // 默认 ResourceTracker (用于模块管理)
-
-    EJitJITLinkMemoryManager* MemMgr;      // 我们的嵌入式内存管理器
-
-    // JIT 编译上下文 — 每次编译前由 SyncCompiler/AsyncCompiler 设置
-    // 同步模式下在调用线程设置；异步模式下在后台线程设置，无竞态
-    SpecializationContext* ActiveCtx = nullptr;
-    OptimizationLevel OptLevel = OptimizationLevel::Level2;
+    struct Impl;
+    std::unique_ptr<Impl> P;               // LLJIT、optimizer、activeCtx 等私有状态
 
 public:
-    // 工厂方法: 创建 EJitOrcEngine
     static Expected<std::unique_ptr<EJitOrcEngine>>
-    Create(const EJitConfig& config);
+    Create(const Config& config,
+           PeriodArrayRegistry& periodReg,
+           EJitRuntimeState& runtimeState);
 
-    // 错误信息 (创建失败时)
-    static std::string getLastError() { return lastError_; }
-    static std::string lastError_;
-
-    // 加载 Bitcode Module 并注册到 JITDylib
     Error loadBitcodeModule(StringRef bitcodeData,
-                            StringRef funcName);
+                            uint64_t cacheKey,
+                            const std::string& funcName);
 
-    // 查询已编译符号
-    Expected<void*> lookup(StringRef funcName);
+    Expected<void*> lookup(uint64_t cacheKey,
+                           const std::string& funcName);
 
-    // 移除模块 (释放内存)
-    Error removeModule(orc::ResourceTrackerSP RT);
-
-    // 获取内存统计
-    size_t getCurrentCodeSize() const;
-    size_t getTotalAllocatedMemory() const;
+    void setActiveContext(const SpecializationContext* ctx);
+    void addUserSymbol(const std::string& name, void* addr);
 };
 
 } // namespace llvm::ejit
@@ -147,44 +128,28 @@ EJitOrcEngine::Create(const EJitConfig& config) {
 
     // 注意: 使用 Expected<> 返回错误，不在嵌入式场景调用 cantFail/abort
 
-    // 步骤 1: 创建嵌入式 JITLinkMemoryManager
-    auto memMgr = std::make_unique<EJitJITLinkMemoryManager>(
-        config.maxCodeMemory,      // 最大代码内存 (默认 512KB)
-        config.pageSize             // 页大小 (ARM/AArch64 通常 4KB)
-    );
-    engine->MemMgr = memMgr.get();
-
-    // 步骤 2: 配置 JITTargetMachineBuilder
+    // 步骤 1: 配置 JITTargetMachineBuilder
     auto JTMBOrErr = JITTargetMachineBuilder::detectHost();
     if (!JTMBOrErr) {
         return JTMBOrErr.takeError();
     }
     auto JTMB = std::move(*JTMBOrErr);
 
-    // 步骤 3: 构建 LLJIT
-    //   - 使用自定义 ObjectLinkingLayerCreator 注入嵌入式内存管理器
-    //   - 设置 compile threads 为 0 (同步) 或 1+ (异步)
-    //   - IRTransformLayer 注入 EJitStructFieldPass
+    // 步骤 2: 构建 LLJIT。ORC 内部编译线程始终关闭；
+    // 异步性由 ORC 外部的 taskpool worker 提供。
     orc::LLJITBuilder Builder;
 
-    Builder.setJITTargetMachineBuilder(std::move(JTMB));
+    Builder.setJITTargetMachineBuilder(JTMB);
 
-    // 注入嵌入式内存管理器
+    // 启用 code pool 时注入 EJitCodePoolMemoryManager。
     Builder.setObjectLinkingLayerCreator(
         [&](orc::ExecutionSession& ES)
             -> Expected<std::unique_ptr<orc::ObjectLayer>> {
             return std::make_unique<orc::ObjectLinkingLayer>(
-                ES, *engine->MemMgr);
+                ES, makeCodePoolMemoryManager());
         });
 
-    // 编译线程配置
-    if (config.compileMode == CompileMode::Sync) {
-        // 同步模式: 0 编译线程 = 在调用线程上编译
-        Builder.setNumCompileThreads(0);
-    } else {
-        // 异步模式: 1 个编译线程 (嵌入式场景资源受限)
-        Builder.setNumCompileThreads(1);
-    }
+    Builder.setNumCompileThreads(0);
 
     // 创建 LLJIT 实例
     auto JOrErr = Builder.create();
@@ -192,11 +157,10 @@ EJitOrcEngine::Create(const EJitConfig& config) {
         return JOrErr.takeError();
     }
     engine->J = std::move(*JOrErr);
-    engine->MainJD = &engine->J->getMainJITDylib();
-    engine->DefaultRT = engine->MainJD->getDefaultResourceTracker();
 
-    // 步骤 4: 注册 IRTransformLayer 回调
-    // 完整的 JIT Pipeline: 参数替换 → InstCombine → Inline → PASS6 → 标准优化 (详见 §2.4)
+    // 步骤 3: 注册 IRTransformLayer 回调
+    // 完整的 JIT Pipeline: 参数替换 → InstCombine → StructFieldPass → IPSCCP →
+    //   InstCombine → StructFieldPass → 标准优化 (详见 §2.4)
     // 注意: IRTransformLayer::TransformFunction 签名为
     //   Expected<ThreadSafeModule>(ThreadSafeModule, MaterializationResponsibility&)
     // withModuleDo 的回调签名为 Expected<Error>(Module&)，原地修改 Module
@@ -205,26 +169,24 @@ EJitOrcEngine::Create(const EJitConfig& config) {
                  orc::MaterializationResponsibility& R)
             -> Expected<orc::ThreadSafeModule> {
             Error Err = TSM.withModuleDo([engine](Module& M) -> Error {
-                if (!engine->ActiveCtx)
+                const SpecializationContext* ctx =
+                    engine->getActiveContext();
+                if (!ctx)
                     return Error::success();
 
-                // Step 1: 参数预处理 (替换 ejit_period_arr_ind 为常量)
-                preReplacePeriodIndices(M, engine->ActiveCtx);
-
-                // Step 2: InstCombine (折叠常量链)
-                runInstCombine(M);
-
-                // Step 3: Inline (展开跨函数 GEP 链)
-                runInline(M);
-
-                // Step 4: EJitStructFieldPass (may_const load → 常量)
-                EJitStructFieldPass SFPass;
-                SFPass.setSpecializationContext(engine->ActiveCtx);
-                ModuleAnalysisManager MAM;
-                SFPass.run(M, MAM);
-
-                // Step 5: 标准优化 (按 OptLevel 编排)
-                runOptimizationPipeline(M, engine->OptLevel);
+                // 完整流水线实现于 EJitOptimizer::runPipeline
+                // (llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp)。JIT 侧不再
+                // 单独运行 Inline —— callee 已在 AOT 预优化
+                // (EJitRegisterBitcodePass: AlwaysInline + ModuleInliner(O2)) 内联，
+                // 跨函数常量改由 IPSCCP 在调用边界传播。
+                //   1a preReplacePeriodIndices —— ejit_period_arr_ind 参数 → 常量
+                //   1b runInstCombine          —— 折叠常量 GEP 链
+                //   1c EJitStructFieldPass      —— may_const load → 常量
+                //   1d runInterproceduralPropagation —— 内部化非 entry 定义 + IPSCCP
+                //   1e/1f runInstCombine + EJitStructFieldPass（对 callee 再做一轮）
+                //   2-4 LowerExpect + buildFunctionSimplificationPipeline(O1/O2/O3)
+                //        + 二次 StructFieldPass + cleanup(InstCombine/SCCP/SimplifyCFG/ADCE)
+                engine->P->optimizer->runPipeline(M, *ctx);
 
                 return Error::success();
             });
@@ -233,11 +195,9 @@ EJitOrcEngine::Create(const EJitConfig& config) {
             return std::move(TSM);
         });
 
-    // 步骤 5: 注册 Process Symbols JITDylib
-    // 使 JIT 代码可调用 AOT 编译的外部函数
-    if (auto Err = engine->J->getProcessSymbolsJITDylib()) {
-        // 外部符号在此 JITDylib 中解析
-    }
+    // 步骤 4: 注册静态变量和用户显式注册的 JIT 外部符号。
+    // 裸核构建关闭 host process-symbol 搜索；enable_ex、SRE_Task* 等
+    // 平台符号仍必须由最终链接提供强定义，不能由 ejit_register_symbol 补齐。
 
     return engine;
 }
@@ -245,9 +205,28 @@ EJitOrcEngine::Create(const EJitConfig& config) {
 
 ---
 
-## 2.2 EJitJITLinkMemoryManager — 嵌入式内存管理器
+## 2.2 EJitCodePoolMemoryManager — 嵌入式内存管理器
 
 ### 2.2.1 设计目标
+
+当前 `EJitCodePoolMemoryManager` 将 JITLink `BasicLayout` 的 segment
+从 `EJitCodePoolManager` 按需分配，而不是预留一块固定 slab：
+
+- code pool 默认大小为 2MiB，耗尽时按需创建下一池；
+- `allocate` 按 layout 分配连续空间并记录所有 executable segment；
+- 只对 executable segment 做 RX seal，rodata/GOT/writable data 不会误封；
+- legacy 模式在 lookup 时封整个 2MiB pool；
+- 4K 模式在 pool 创建时执行 `split_2m_to_4k`，finalize 后逐个
+  executable page 调用 `enable_ex` 并同步 I-cache；
+- `deallocate` 运行 JITLink dealloc actions，但当前不回收物理
+  code-pool 内存，pool lifetime 与 engine 一致。
+
+平台 adapter 只声明 `enable_ex`、`split_2m_to_4k` 和
+`SRE_MemDbgAlloc`。目标最终链接必须提供强定义；这些平台依赖不能由
+`ejit_register_symbol` 补齐。
+
+<details>
+<summary>历史设计：固定 slab EJitJITLinkMemoryManager（已删除）</summary>
 
 | 约束 | 规格 |
 |------|------|
@@ -411,9 +390,39 @@ LRU 淘汰时:
 - 或者: 使用更好的 allocator 支持碎片回收 (后续优化)
 ```
 
+</details>
+
 ---
 
-## 2.3 同步/异步编译隔离
+## 2.3 Taskpool 同步/异步调度
+
+当前同步和异步模式使用同一条编译链：
+
+```text
+wrapper
+  └─ ejit_taskpool_compile_or_get[_0d...4d]
+       ├─ cache hit → 返回 JIT fnPtr
+       └─ cache miss
+            ├─ Off   → 返回 fallback
+            ├─ Sync  → 当前调用栈 compileNow → compileCold → publish
+            └─ Async → dedup + MPSC queue → 返回 fallback
+                                      └─ 单 worker 消费并 publish
+```
+
+- `EJitTaskPool` 用于单实例调度；`EJitSharedTaskPool` 将队列、dedup、
+  lifecycle version 和 cache 放入跨核共享 POD 状态。
+- shared 模式通过 CAS 选出一个 owner，只由 owner 启动一个 worker。
+  worker 使用 owner 私有的 `EJitCompileDriver` 和 `EJitOrcEngine`；peer
+  可以拥有自己的初始化对象，但不另启 worker 编译同一共享请求。
+- ORC 内部始终 `setNumCompileThreads(0)`。目标侧 worker 由
+  `EJitSreTask_sre.cpp` 的平台任务接口驱动，不依赖 C++ 线程库。
+- worker 在 `Initializing` 或 Ready 空队列时调用平台 yield；退出前由
+  owner stop/join，之后才允许析构 owner 私有 ORC 状态。
+- queue full 会回滚 dedup；编译前后及 publish 前会重查 generation 和
+  lifecycle version，避免 deactivate/re-init 后发布旧结果。
+
+<details>
+<summary>历史设计：独立 Sync/Async compiler 与 C++ 后台线程（已删除）</summary>
 
 ### 2.3.1 隔离架构
 
@@ -663,32 +672,36 @@ void EJitAsyncCompiler::compileOne(const CompileRequest& req) {
 | Code Cache | 调用线程访问 | 共享 (mutex 保护) |
 | PeriodArrayRegistry | 调用线程更新 (activate/deactivate) | 只读快照 |
 
+</details>
+
 ---
 
 ## 2.4 IRTransformLayer — EJitStructFieldPass 集成
 
 ### 2.4.1 Transform 回调
 
-Transform 回调在 §2.1.1 `EJitOrcEngine::Create()` 中注册为内联 lambda，直接捕获 `engine` 指针读取 `ActiveCtx` 和 `OptLevel`。不需要插件类：
+Transform 回调在 §2.1.1 `EJitOrcEngine::Create()` 中注册为内联 lambda。
+`EJitCompileDriver::compileCold` 在 load/lookup 前通过
+`setActiveContext(&ctx)` 安装当前特化上下文，并在所有返回路径清空；
+回调从 engine 私有实现读取该上下文。shared 模式只有 elected owner
+worker 进入这条编译链，不会由多个 core 并发改写同一个 `activeCtx`。
 
 ```cpp
 // §2.1.1 中的注册代码 (简化引用)
 engine->J->getIRTransformLayer().setTransform(
     [engine](orc::ThreadSafeModule TSM, ...) -> Expected<orc::ThreadSafeModule> {
         Error Err = TSM.withModuleDo([engine](Module& M) -> Error {
-            if (!engine->ActiveCtx)
+            const SpecializationContext* ctx = engine->getActiveContext();
+            if (!ctx)
                 return Error::success();
 
-            preReplacePeriodIndices(M, engine->ActiveCtx);
-            runInstCombine(M);
-            runInline(M);
-
-            EJitStructFieldPass SFPass;
-            SFPass.setSpecializationContext(engine->ActiveCtx);
-            ModuleAnalysisManager MAM;
-            SFPass.run(M, MAM);
-
-            runOptimizationPipeline(M, engine->OptLevel);
+            // 全部阶段封装在 EJitOptimizer::runPipeline 内（见 §2.4.2/§2.4.3）：
+            //   preReplacePeriodIndices → runInstCombine → EJitStructFieldPass
+            //   → runInterproceduralPropagation(内部化 + IPSCCP)
+            //   → runInstCombine → EJitStructFieldPass
+            //   → runOptimizationPipeline(LowerExpect + buildFunctionSimplificationPipeline)
+            // JIT 侧不再运行 Inline（AOT 预优化已内联）。
+            engine->P->optimizer->runPipeline(M, *ctx);
             return Error::success();
         });
         if (Err)
@@ -697,9 +710,7 @@ engine->J->getIRTransformLayer().setTransform(
     });
 ```
 
-`preReplacePeriodIndices`、`runInstCombine`、`runInline`、`runOptimizationPipeline` 为同一编译单元内的静态辅助函数（详见 §2.4.2, §2.4.3）。
-```
-
+`preReplacePeriodIndices`、`runInstCombine`、`runInterproceduralPropagation`、`runOptimizationPipeline` 现为 `EJitOptimizer` 的成员函数（`llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp`，详见 §2.4.2, §2.4.3）。
 ### 2.4.2 JIT Pipeline 各阶段实现
 
 **`preReplacePeriodIndices`** — 将 `ejit_period_arr_ind` 参数替换为运行时常量值：
@@ -737,74 +748,78 @@ void runInstCombine(Module& M) {
 }
 ```
 
-**`runInline`** — 内联 callee，使跨函数的 may_const load 暴露给 PASS6：
+**`runInterproceduralPropagation`** — 内部化所有非 `ejit_entry` 定义后运行 IPSCCP，把 1a–1c 在每个调用点变成常量的实参推进 callee 函数体（并把常量返回值推回调用点）。JIT 侧**不再单独运行 Inline**：callee 已在 AOT 预优化（`EJitRegisterBitcodePass`：AlwaysInline + ModuleInliner(O2)）内联。
 
 ```cpp
-void runInline(Module& M) {
-    // 使用 LLVM 默认 Inline 阈值
-    ModuleAnalysisManager MAM;
+void EJitOptimizer::runInterproceduralPropagation(Module& M) {
+    // IPSCCP 仅能推理 local linkage 且未被取地址函数的实参；
+    // 特化模块自包含（只对外查找 ejit_entry 符号），因此把每个
+    // 非 entry 定义内部化，使 IPSCCP 能枚举其所有调用点。
+    for (Function& F : M.functions()) {
+        if (F.isDeclaration() || F.hasLocalLinkage())
+            continue;
+        if (hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY))
+            continue;
+        F.setVisibility(GlobalValue::DefaultVisibility);
+        F.setLinkage(GlobalValue::InternalLinkage);
+    }
     ModulePassManager MPM;
-    MPM.addPass(InlinerPass());
-    MPM.run(M, MAM);
+    MPM.addPass(IPSCCPPass());
+    MPM.run(M, MAM_);
 }
 ```
 
-### 2.4.3 优化 Pipeline (L1/L2/L3) — PASS6 之后
+### 2.4.3 优化 Pipeline (L1/L2/L3) — 第二次 StructFieldPass 之后
+
+后特化清理直接复用 **真实的 LLVM 函数级简化流水线** `PassBuilder::buildFunctionSimplificationPipeline`（O1/O2/O3 各预建一份并缓存），而不是手工拼装的 pass 序列。`ctx.optLevel`（L1→O1、L2→O2、L3→O3）只选择这三条已缓存的 FPM 之一；它**不改变**流水线其余部分。注意这是**函数级**简化流水线，并非完整的 `clang -O2` module 流水线——除 phase 1d 的 IPSCCP 外，不含 GlobalOpt、CalledValuePropagation、ArgumentPromotion 等 module/CGSCC pass。
 
 ```cpp
-void runOptimizationPipeline(Module& M, OptimizationLevel level) {
-    LoopAnalysisManager LAM;
-    FunctionAnalysisManager FAM;
-    CGSCCAnalysisManager CGAM;
-    ModuleAnalysisManager MAM;
+// 构造时预建（EJitOptimizer 构造函数）
+PassBuilder PB;
+PB.registerModuleAnalyses(MAM_);   PB.registerCGSCCAnalyses(CGAM_);
+PB.registerFunctionAnalyses(FAM_); PB.registerLoopAnalyses(LAM_);
+PB.crossRegisterProxies(LAM_, FAM_, CGAM_, MAM_);
+lowerExpectFPM_.addPass(LowerExpectIntrinsicPass());        // Phase 2
+simplifyO1_ = PB.buildFunctionSimplificationPipeline(O1, ThinOrFullLTOPhase::None);
+simplifyO2_ = PB.buildFunctionSimplificationPipeline(O2, ThinOrFullLTOPhase::None);
+simplifyO3_ = PB.buildFunctionSimplificationPipeline(O3, ThinOrFullLTOPhase::None);
+cleanupFPM_.addPass(InstCombinePass());  cleanupFPM_.addPass(SCCPPass());
+cleanupFPM_.addPass(SimplifyCFGPass());  cleanupFPM_.addPass(ADCEPass());
 
-    PassBuilder PB;
-
-    // 注册 analysis managers
-    PB.registerModuleAnalyses(MAM);
-    PB.registerCGSCCAnalyses(CGAM);
-    PB.registerFunctionAnalyses(FAM);
-    PB.registerLoopAnalyses(LAM);
-    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
-
-    ModulePassManager MPM;
-
-    // L1: 基础优化 (全等级执行)
-    MPM.addPass(SCCPPass());            // 稀疏条件常量传播
-    MPM.addPass(ADCEPass());            // 激进死代码消除
-    MPM.addPass(SimplifyCFGPass());     // CFG 简化 (分支折叠)
-
-    // L2: 中等优化 (二次内联)
-    // 注意：首次 Inline 已在 PASS6 之前完成（见 §2.4.1 Transform 函数）
-    // 此处的 Inline 用于内联 PASS6 常量替换后新暴露的调用机会
-    if (level >= OptimizationLevel::Level2) {
-        MPM.addPass(InlinerPass());     // 二次函数内联
-        MPM.addPass(SimplifyCFGPass()); // 内联后再次简化 CFG
-    }
-
-    // L3: 激进优化
-    if (level >= OptimizationLevel::Level3) {
-        MPM.addPass(LoopUnrollPass(    // 循环展开
-            LoopUnrollOptions()
-                .setPartial(false)      // 不全展开
-                .setPeeling(false)      // 不 peeling
-                .setRuntime(false)      // 不运行时展开
-                .setUpperBound(true)    // 使用上限
-                .setThreshold(50)       // 展开阈值
-        ));
-        MPM.addPass(SimplifyCFGPass()); // 展开后 CFG 简化
-    }
-
-    // 运行
-    MPM.run(M, MAM);
+void EJitOptimizer::runOptimizationPipeline(Module& M, ejit::OptimizationLevel level) {
+    FunctionPassManager& simplifyFPM = simplifyFPMForLevel(level); // L1→O1 / L2→O2 / L3→O3
+    for (Function& F : M.functions())
+        if (!F.isDeclaration()) {
+            lowerExpectFPM_.run(F, FAM_);   // Phase 2: LowerExpect（不在简化流水线内）
+            simplifyFPM.run(F, FAM_);       // Phase 3: 真实 -Ox 函数简化流水线
+        }
+    // Phase 4: 展开暴露出新的常量下标数组访问后，再跑一次 StructFieldPass + 轻量 cleanup
+    runStructFieldPass(M);
+    for (Function& F : M.functions())
+        if (!F.isDeclaration())
+            cleanupFPM_.run(F, FAM_);
 }
 ```
+
+> **注**：`buildFunctionSimplificationPipeline` 包含 SROA、InstCombine、SCCP、GVN、CorrelatedValuePropagation、BDCE、DSE、loop-rotate、LICM、loop-unroll 等，但**不含向量化**。首次 Inline 由 AOT 预优化完成；JIT 侧不再做二次 Inline。
 
 ---
 
 ## 2.5 EJitCompileDriver — 编译调度器
 
-编译调度器统一同步/异步编译路径，调用方不感知内部实现。
+`EJitCompileDriver` 是 taskpool compile callback 与 ORC 之间的统一冷路径：
+
+1. `compileNow(req)` 校验 `numDims <= 4`、instance 范围和重复 dimType；
+2. 按函数 metadata 的 dimType 顺序重排请求维度并构造 64-bit cache key；
+3. `compileCold(cacheKey, false)` 按 dense `funcIndex` 查函数名和 bitcode；
+4. 检查 lifecycle active 状态，构造 `SpecializationContext`；
+5. 在同一个 `jitEngine_` 上执行 load + lookup，返回 fnPtr。
+
+cache hit、dedup、enqueue 和 publish 均由 taskpool 完成，compile driver
+不再拥有独立的同步/异步 compiler 或 LRU cache。
+
+<details>
+<summary>历史设计：driver 内置 Sync/Async compiler（已删除）</summary>
 
 ```cpp
 // 编译调度器
@@ -889,9 +904,25 @@ void* EJitCompileDriver::getOrCompile(uint32_t funcIdx,
 }
 ```
 
+</details>
+
 ---
 
-## 2.6 EJitCache — Code Cache
+## 2.6 Taskpool Code Cache
+
+当前 cache 由 `EJitTaskPool` / `EJitSharedTaskPool` 持有：
+
+- identity 为 `funcIndex + dims`，并保存对应 lifecycle versions；
+- shared cache 使用固定 bucket/slot POD 布局和显式原子/短临界区；
+- publish 先写 identity、versions、code range 和 fnPtr，再发布 Ready；
+- reader 返回的 bucket token 由 `ejit_taskpool_release_read` 释放；
+- `EJIT_SRE_TASKPOOL_NO_RECLAIM` 在“代码生命周期内不物理回收”的前提下
+  改用 seqlock load-only hit，release 成为 no-op；
+- deactivate/version bump 后旧 slot 不会作为有效命中返回；编译中的旧结果
+  也会在 publish gate 被丢弃。
+
+<details>
+<summary>历史设计：独立 LRU EJitCache（已删除）</summary>
 
 ```cpp
 // Code Cache 管理器 — iterator-embedded LRU (单 hash 查找完成 LRU bump)
@@ -940,6 +971,8 @@ private:
     size_t currentTotalSize_ = 0;
 };
 ```
+
+</details>
 
 ---
 
@@ -1040,6 +1073,22 @@ private:
 ```
 
 ### 2.7.2 ejit_init
+
+当前 `ejit_init` 创建一个 `EJit` 实例。初始化顺序为：
+
+1. 消费 constructor 注册数据，或在静态注册模式下遍历 linker ranges；
+2. 按名称分配 dense `funcIndex` 和 lifecycle `dimType`，回填 wrapper globals；
+3. 注册 bitcode、period arrays、static vars 和用户符号；
+4. 创建一个 `EJitOrcEngine` 并安装到 `EJitCompileDriver::jitEngine_`；
+5. 冻结 registration；
+6. Async 模式启动 private worker，或执行 shared owner election 并由 owner
+   启动唯一 worker；Sync/Off 不启动后台 worker。
+
+任何注册容量、ABI/fingerprint、engine 创建或 worker 启动失败都会使
+`ejit_init` 返回错误，不暴露半初始化 taskpool。
+
+<details>
+<summary>历史设计：双 engine 与 EJitAsyncCompiler 初始化（已删除）</summary>
 
 **全局单例类型定义**：
 
@@ -1158,6 +1207,8 @@ ejit_status_t ejit_init(const ejit_config_t* config) {
 }
 ```
 
+</details>
+
 ### 2.7.3 Auto Register 与 ejit_init 的时序
 
 ```
@@ -1181,9 +1232,10 @@ ejit_status_t ejit_init(const ejit_config_t* config) {
     │       │   → 取出所有暂存数据，清空 Store
     │       ├── 用暂存数据填充 PeriodArrayRegistry
     │       ├── 用暂存数据填充 BitcodeTracker
-    │       ├── 创建 Engine, Cache, CompileDriver
+    │       ├── 创建 CompileDriver 和单条 ORC 编译链
+    │       ├── 冻结 registration
     │       ├── 验证注册数据完整性
-    │       └── 启动异步编译器 (如果配置)
+    │       └── Async: 启动 private worker 或完成 shared owner election
     │
     └── 业务代码...
         └── ejit_activate("cell", 3)
@@ -1193,6 +1245,26 @@ ejit_status_t ejit_init(const ejit_config_t* config) {
 ---
 
 ## 3. 线程安全模型
+
+当前目标平台并发模型不是 C++ 线程模型：
+
+- shared state 只包含 fixed-width POD、`EJitAtomic`、queue cells、dedup、
+  switch/version、cache slots 和 counters；
+- LLVMContext、LLJIT、optimizer、STL 容器、callback 与平台 task 对象均为
+  owner 私有，不放入 shared section；
+- queue producer 写完整 request 后 release-publish sequence，consumer
+  acquire 后读取；
+- cache publish 在发布 Ready/fnPtr 前写完 identity、versions 和 code range；
+- 编译、ORC/JITLink、内存申请、平台 seal 和日志不在 bucket 短临界区内执行；
+- activate/deactivate bump version，worker 在 dequeue、compile 后和 publish
+  gate 复查版本；不匹配则释放/丢弃结果；
+- `aarch64_be` 下字段按声明类型访问，不做字节流解析，不使用 bitfield。
+
+host 测试适配层可以使用 `std::thread` 模拟 worker，但 target core 文件不依赖
+`std::thread`、`std::mutex`、`std::condition_variable`、future 或 promise。
+
+<details>
+<summary>历史设计：mutex/C++ 后台线程模型（已删除）</summary>
 
 ### 3.1 线程角色
 
@@ -1250,9 +1322,9 @@ ejit_status_t ejit_init(const ejit_config_t* config) {
 用户线程                          编译线程
 ───────                          ───────
 ejit_activate(name, idx)
-  ├─ 写入 RuntimeState               
-  │  (设置为 active)               
-  ├─ atomic_thread_fence            
+  ├─ 写入 RuntimeState
+  │  (设置为 active)
+  ├─ atomic_thread_fence
   │  (memory_order_release)    ─────────→  compileOne()
   │                                         ├─ isPeriodActive() → active
   │                                         ├─ atomic_thread_fence
@@ -1292,6 +1364,8 @@ void EJitRuntimeState::deactivate(const std::string& periodName, int cellIdx) {
 - `compileOne` 在读取 may_const 字段值前执行 `acquire` fence，与 activate 中的 `release` fence 配对，保证字段修改可见。
 - `isPeriodActive` 检查本身在 mutex 保护下，确保 deactivate 后提交的编译请求能看到失效状态。
 - 若 `isPeriodActive` 返回 false，`compileOne` 直接跳过，不读取任何字段值——因此不存在 "读到半修改值" 的窗口。
+
+</details>
 
 ---
 
@@ -1423,25 +1497,24 @@ public:
            │    ├─ejit_taskpool_compile_or_get()
            │    │   ├─查 Cache → MISS
            │    │   ├─验证时间窗状态
-           │    │   ├─syncCompiler.compile()
-           │    │   │   ├─loadBitcodeModule         (~5ms)
+           │    │   ├─compileNow() → compileCold()
+           │    │   │   ├─loadBitcodeModule
            │    │   │   ├─[IRTransformLayer]:
-           │    │   │   │   ├─参数预处理              (<1ms)
-           │    │   │   │   ├─InstCombine             (~2ms)
-           │    │   │   │   ├─Inline                  (~3ms)
-           │    │   │   │   ├─EJitStructFieldPass     (~2ms)
-           │    │   │   │   └─优化 Pipeline           (~12ms)
+           │    │   │   │   ├─参数替换 + InstCombine
+           │    │   │   │   ├─EJitStructFieldPass
+           │    │   │   │   ├─IPSCCP
+           │    │   │   │   └─函数级优化 Pipeline
            │    │   │   ├─IRCompileLayer:
-           │    │   │   │   └─LLVM → Object           (~20ms)
+           │    │   │   │   └─LLVM → Object
            │    │   │   ├─ObjectLinkingLayer:
-           │    │   │   │   └─JITLink 链接+分配        (~3ms)
+           │    │   │   │   └─JITLink 链接+code pool 分配
            │    │   │   └─lookup → 函数指针
-           │    │   ├─cache.put(entry)
+           │    │   ├─taskpool publish
            │    │   └─return pfn
            │    ├─pfn != NULL
            │    └─调用 pfn(idx) → 特化函数
            │
-           └─总延迟: ~48ms → 返回
+           └─编译耗时与目标函数大小、优化级别和平台有关
 ```
 
 ### 6.2 异步编译时序
@@ -1449,8 +1522,8 @@ public:
 ```
 时间 →
 
-调用线程:                后台线程:
-───────                ───────────
+业务核:                  单 taskpool worker:
+──────                  ─────────────────
 adjust_param(idx)
 │
 ├─ wrapper:
@@ -1458,15 +1531,15 @@ adjust_param(idx)
 │    ├─ejit_taskpool_compile_or_get()
 │    │   ├─查 Cache → MISS
 │    │   ├─提交 CompileRequest
-│    │   └─return NULL ─────→    workerLoop():
+│    │   └─return fallback ──→   runWorkerLoop():
 │    │                              ├─从队列取请求
-│    ├─pfn == NULL                  ├─compileOne()
+│    ├─pfn == NULL                  ├─runCompile()
 │    └─fallback(AOT)                │   ├─loadBitcode
 │                                   │   ├─IRTransform
 │    ←返回 (运行 AOT 代码)            │   ├─优化
 │                                   │   ├─CodeGen
 │                                   │   ├─MemoryAlloc
-│                                   │   └─cache.put()
+│                                   │   └─publish (version/generation gate)
 │                                   │
 下次调用:                             │
 adjust_param(idx)                   │
@@ -1476,7 +1549,7 @@ adjust_param(idx)                   │
 │    ├─return pfn ────────────────  │
 │    └─调用 pfn → 特化函数
 │
-└─总延迟: <1ms (Cache 命中)
+└─命中开销由 cache 查询、间接调用和 read-token release 构成
 ```
 
 ---
@@ -1488,11 +1561,13 @@ llvm/lib/ExecutionEngine/EJIT/
 ├── EJit.cpp                     # 主类实现 (EJit)
 ├── EJitRuntime.cpp              # C 运行时接口 (ejit_init/shutdown/activate...)
 ├── EJitOrcEngine.cpp            # LLJIT 封装 + 引擎创建
-├── EJitJITLinkMemoryManager.cpp # 嵌入式 JITLink 内存管理器
-├── EJitSyncCompiler.cpp         # 同步编译器
-├── EJitAsyncCompiler.cpp        # 异步编译器 (后台线程+队列)
+├── EJitCodePoolMemoryManager.cpp # code-pool JITLink 内存管理器
+├── EJitTaskPool.cpp             # 单实例 taskpool
+├── EJitSharedTaskPool.cpp       # 跨核共享 taskpool/cache/worker
+├── EJitSreTask_sre.cpp          # 目标平台 task 适配
+├── EJitSreQueue.cpp             # taskpool queue 适配
 ├── EJitCompileDriver.cpp        # 编译调度器 (Sync/Async 统一入口)
-├── EJitCache.cpp                # Code Cache (LRU + 大小限制)
+├── EJitCodePool.cpp             # code pool 分配与 2M/4K seal
 ├── EJitStructFieldPass.cpp      # 结构体字段特化 Pass (JIT Pipeline)
 ├── EJitOptimizer.cpp            # 优化 Pipeline (L1/L2/L3)
 ├── EJitModuleLoader.cpp         # Bitcode 按需加载器
@@ -1506,8 +1581,10 @@ llvm/include/llvm/ExecutionEngine/EJIT/
 ├── EJit.h                       # C++ 主 API
 ├── EJitRuntime.h                # C 运行时接口
 ├── EJitOrcEngine.h              # EJitOrcEngine 声明
-├── EJitJITLinkMemoryManager.h   # 内存管理器声明
-├── EJitCache.h                  # Cache 声明
+├── EJitCodePoolMemoryManager.h  # 内存管理器声明
+├── EJitTaskPool.h               # 单实例 taskpool
+├── EJitSharedTaskPool.h         # shared taskpool API
+├── EJitSharedTaskPoolState.h    # shared POD 状态布局
 ├── EJitStructFieldPass.h        # StructField Pass 声明
 ├── EJitOptimizer.h              # 优化 Pipeline 声明
 ├── EJitOptions.h                # 配置选项
@@ -1528,27 +1605,15 @@ llvm/include/llvm/ExecutionEngine/EJIT/
 // TEST(MemoryManager, ConcurrentAlloc)     - 并发分配
 // TEST(MemoryManager, MixedProtections)    - RX + RW 混合
 
-// EJitCacheTest.cpp
-// TEST(Cache, PutAndGet)                   - 基本读写
-// TEST(Cache, LRU_Eviction)                - LRU 淘汰
-// TEST(Cache, SizeLimit)                   - 大小限制
-// TEST(Cache, InvalidateByPeriod)          - 时间窗失效
+// EJitTaskPoolTest.cpp
+// - queue / dedup / sync / async / activate-version / freeCode / stats
 
-// EJitSyncCompilerTest.cpp
-// TEST(SyncCompiler, CompileBasicFunction) - 基本编译
-// TEST(SyncCompiler, StructFieldReplace)   - 字段替换后编译
-// TEST(SyncCompiler, MultiPeriod)          - 多时间窗编译
+// EJitSharedTaskPoolTest.cpp
+// - owner election / MPSC / cross-core dedup / cache publication
+// - generation / peer execute permission / big-endian layout / NO_RECLAIM
 
-// EJitAsyncCompilerTest.cpp
-// TEST(AsyncCompiler, SubmitAndRetrieve)   - 提交+结果
-// TEST(AsyncCompiler, ConcurrentSubmit)    - 并发提交
-// TEST(AsyncCompiler, StopDuringCompile)   - 编译中停止
-
-// EJitCompileDriverTest.cpp
-// TEST(Driver, Sync_CacheHit)              - 同步+Cache 命中
-// TEST(Driver, Sync_CacheMiss)             - 同步+Cache 未命中
-// TEST(Driver, Async_FirstCallNull)        - 异步首次 NULL
-// TEST(Driver, Async_SecondCallHit)        - 异步第二次命中
+// EJitCodePoolMemoryManagerTest.cpp, EJitCodePoolTest.cpp
+// - JITLink layout / executable ranges / 2M and 4K sealing / failures
 ```
 
 ### 8.2 集成测试
@@ -1563,15 +1628,14 @@ llvm/include/llvm/ExecutionEngine/EJIT/
 
 // 场景 2: 端到端异步编译
 //   同上，配置 EJIT_COMPILE_ASYNC
-//   首次调用返回 AOT 结果 → sleep(100ms) → 第二次调用返回 JIT 结果
+//   首次调用返回 AOT 结果 → worker poll/等待发布 → 后续调用返回 JIT 结果
 
 // 场景 3: 时间窗失效
 //   JIT 编译 → activate → deactivate → activate(new_value)
 //   验证特化函数使用新值重新编译
 
-// 场景 4: Cache 淘汰
-//   填充 Cache 到超过限制
-//   验证 LRU 正确淘汰旧条目
+// 场景 4: Cache 与并发协议
+//   验证 queue-full dedup rollback、publish gate、generation/version 失效
 
 // 场景 5: 多时间窗
 //   ejit_entry 依赖 cell+trp
@@ -1656,5 +1720,5 @@ typedef struct {
 
 ---
 
-*文档版本: 1.2*  
+*文档版本: 2.0*
 *更新日期: 2026-06-01*

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -661,6 +661,28 @@ if(EJIT_SRE_CODE_POOL AND EJIT_CODE_POOL_4K_SEAL)
   message(STATUS "EmbeddedJIT: SRE code pool uses 4K-granular page sealing")
 endif()
 
+#===-- EmbeddedJIT per-function inline cache (multi-version) -------------===#
+# EJIT_ICACHE_DIM_SIZE: the per-dimension bound D of the per-function
+# @__ejit_icache_fn_<name> [D]^numDims inline-cache array. MUST be a power of 2
+# so the hit path indexes with shifts (no multiply). The same value is applied
+# to the runtime (LLVMEJIT -DEJIT_ICACHE_DIM_SIZE) and to the AOT pass (clang
+# -mllvm -ejit-icache-dim-size) so the AOT array layout and the runtime
+# linearization agree. Default 8; the product overrides it via the preset.
+set(EJIT_ICACHE_DIM_SIZE 16 CACHE STRING
+  "EJIT inline-cache per-dim bound D (must be a power of 2)")
+if(EJIT_ICACHE_DIM_SIZE LESS 1)
+  message(FATAL_ERROR
+    "EJIT_ICACHE_DIM_SIZE must be a positive power of 2, got ${EJIT_ICACHE_DIM_SIZE}")
+endif()
+math(EXPR _ejit_icache_dim_pow2
+  "${EJIT_ICACHE_DIM_SIZE} & (${EJIT_ICACHE_DIM_SIZE} - 1)")
+if(NOT _ejit_icache_dim_pow2 EQUAL 0)
+  message(FATAL_ERROR
+    "EJIT_ICACHE_DIM_SIZE must be a power of 2 (the hit path uses shift indexing, no multiply), got ${EJIT_ICACHE_DIM_SIZE}")
+endif()
+unset(_ejit_icache_dim_pow2)
+message(STATUS "EmbeddedJIT: inline-cache per-dim bound D=${EJIT_ICACHE_DIM_SIZE}")
+
 #===-- EmbeddedJIT SRE taskpool compile scheduler -------------------------===#
 # Route ejit_compile_or_get through a unified taskpool (cache + dedup + queue)
 # instead of calling the synchronous compile driver directly. Sync and async

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -87,7 +87,8 @@
         "EJIT_DIAG_ENABLE": "ON",
         "EJIT_SRE_DIAG": "ON",
         "EJIT_DUMP_ASM": "ON",
-        "EJIT_STATS_ENABLE": "ON"
+        "EJIT_STATS_ENABLE": "ON",
+        "EJIT_ICACHE_DIM_SIZE": "16"
       }
     },
     {

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -29,6 +29,23 @@
 #include <optional>
 #include <string>
 
+//===----------------------------------------------------------------------===//
+// Multi-version inline-cache sizing. The per-function @__ejit_icache_fn_<name>
+// global is a [D]^numDims array (D = EJIT_ICACHE_DIM_SIZE) indexed by the
+// ejit_dim argument values. D MUST be a power of 2 (the hit path indexes with
+// shifts, no multiply). The CMake EJIT_ICACHE_DIM_SIZE var overrides this
+// default and is applied to BOTH the AOT pass (LLVMEmbeddedJIT, which emits
+// the array type) and the runtime (LLVMEJIT, which linearizes on fill) so the
+// two always agree. EJIT_ICACHE_MAX_DIMS caps the dimensionality; an ejit_entry
+// with more ejit_dim params is a compile error.
+//===----------------------------------------------------------------------===//
+#ifndef EJIT_ICACHE_DIM_SIZE
+#define EJIT_ICACHE_DIM_SIZE 16u
+#endif
+#ifndef EJIT_ICACHE_MAX_DIMS
+#define EJIT_ICACHE_MAX_DIMS 4u
+#endif
+
 namespace llvm {
 namespace ejit {
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
@@ -40,8 +40,9 @@ typedef struct {
       *name1; // funcName / periodName / varName / symbolName / lifecycleName
   const char *name2; // varName (period/static), NULL otherwise
   const void *ptr;   // bitcode data / baseAddr / symbol addr / &i32 slot /
-                     //   &ptr icache slot (EJIT_REG_ICACHE_SLOT)
-  uint64_t size;     // bitcode size / array size / 0
+                     //   &ptr icache slot base (EJIT_REG_ICACHE_SLOT)
+  uint64_t size;     // bitcode size / array size / numDims (EJIT_REG_ICACHE_SLOT)
+                     //   / 0
 } ejit_reg_entry_t;
 
 #ifdef __cplusplus

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -155,13 +155,16 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut);
 void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 
 // Register the wrapper's per-function inline-cache slot (@__ejit_icache_fn_<name>
-// global address) by name. The runtime writes the frozen specialization pointer
-// through it on a successful resolve (icacheFill); the wrapper reads it directly
-// on the hit path (one atomic load + null-check + indirect call, no
-// ejit_icache_try call). Keys the slot by the SAME registry funcIndex assigned
-// by ejit_register_funcindex. Called by AOT auto-registration. A null slot or
-// capacity exhaustion is recorded; the slot stays null and the probe misses.
-void ejit_register_icache_slot(const char *funcName, void *slot);
+// global address) by name, with its dimensionality (number of ejit_dim params).
+// The runtime writes the frozen specialization pointer through the [D]^numDims
+// cell at [i0][i1]... on a successful resolve (icacheFill); the wrapper reads
+// the cell directly on the hit path (GEP + one atomic load + null-check +
+// indirect call, no ejit_icache_try call). Keys the slot by the SAME registry
+// funcIndex assigned by ejit_register_funcindex. Called by AOT auto-registration.
+// A null slot or capacity exhaustion is recorded; the base stays null and the
+// probe misses.
+void ejit_register_icache_slot(const char *funcName, void *slot,
+                               uint32_t numDims);
 
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index
 // only; there is no array-pointer dimension in the active state (a period name

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -108,18 +108,35 @@ enum class EJitWorkerStep : uint32_t {
 #define EJIT_ICACHE_FUNC_SLOTS 64u
 #endif
 
+// Per-dim bound D of the multi-version inline cache (@__ejit_icache_fn_<name>
+// is a [D]^numDims array). MUST be a power of 2 (the hit path indexes with
+// shifts, no multiply). The CMake EJIT_ICACHE_DIM_SIZE var overrides this
+// default; the AOT pass reads the same value via -mllvm -ejit-icache-dim-size
+// so array layout and runtime linearization agree.
+#ifndef EJIT_ICACHE_DIM_SIZE
+#define EJIT_ICACHE_DIM_SIZE 16u
+#endif
+// Maximum number of ejit_dim params a cached ejit_entry may have. An entry
+// with more is a compile error (the wrapper is not emitted). 4 matches the
+// taskpool DimCount cap.
+#ifndef EJIT_ICACHE_MAX_DIMS
+#define EJIT_ICACHE_MAX_DIMS 4u
+#endif
+
 // Test/diagnostic: clear every icache slot. The slot-pointer table is
 // process-static storage shared across pool instances, so tests clear it
 // between cases to avoid stale cross-test leakage.
 void ejitIcacheClearAll();
 
-// Register a per-function icache slot: \p slot is the address of the wrapper's
-// @__ejit_icache_fn_<name> global (an EJitAtomicUPtr). The runtime writes the
-// frozen specialization pointer through it on a successful resolve (icacheFill);
-// the wrapper reads it directly. Called from ejit_register_icache_slot (name->
-// funcIndex resolution) at ejit_auto_register / .ejit_period time. No-op for an
-// out-of-range funcIndex or null slot.
-void ejitIcacheRegisterSlot(uint32_t funcIndex, void *slot);
+// Register a per-function icache slot: \p base is the address of the wrapper's
+// @__ejit_icache_fn_<name> global (an EJitAtomicUPtr, or a [D]^numDims array of
+// them for a multi-version entry), and \p numDims is its dimensionality. The
+// runtime writes the frozen specialization pointer through the cell at
+// [i0][i1]... (linearized from dims) on a successful resolve (icacheFill); the
+// wrapper reads the cell directly. Called from ejit_register_icache_slot
+// (name->funcIndex resolution) at ejit_auto_register / .ejit_period time.
+// No-op for an out-of-range funcIndex or null base.
+void ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
 
 class EJitSharedTaskPool {
 public:
@@ -410,25 +427,30 @@ public:
   /// false for an out-of-range dimType/instanceId (never reads out of bounds).
   bool isInstanceActive(uint32_t dimType, uint32_t instanceId) const;
 
-  //--- per-function inline cache (v2 sticky monomorphic) ---------------------
+  //--- per-function inline cache (multi-version direct-indexed) --------------
   // NOTE: the production hit path does NOT use icacheTry. With -ejit-inline-cache
   // the ejit_entry wrapper reads its per-function @__ejit_icache_fn_<name> slot
-  // directly - one acquire load + null-check + indirect call, NO ejit_icache_try
-  // call, NO per-call guards. icacheTry is retained for unit tests / diagnostics:
-  // on a hit it sets *outFn to the frozen specialization (call with NO
-  // releaseRead) and returns true; on a miss returns false. It keeps the
-  // reclamation-safety, pool-Ready, range, and cross-core code-sharing gates
+  // directly - a GEP into the [D]^numDims array by the ejit_dim arg values, one
+  // acquire load + null-check + indirect call, NO ejit_icache_try call, NO
+  // per-call guards. icacheTry is retained for unit tests / diagnostics: on a
+  // hit it sets *outFn to the frozen specialization for the given dims (call
+  // with NO releaseRead) and returns true; on a miss returns false. It keeps
+  // the reclamation-safety, pool-Ready, range, and cross-core code-sharing gates
   // (the latter matters in non-shared test builds; the wrapper's inline probe is
   // only enabled under EJIT_SRE_SHARED_CODE_POINTERS, where the gate is
   // compile-time true).
-  bool icacheTry(uint32_t funcIndex, void **outFn);
-  // Fill the per-function icache slot (the wrapper's @__ejit_icache_fn_<name>
-  // global, reached through the registered slot pointer) with a freshly
-  // resolved specialization (call on a taskpool cache hit or a successful
-  // compile). One-shot: the first resolver wins; later resolves (same pointer,
-  // invariant) no-op. No-op when reclamation is not safe, the function is
-  // unregistered (no slot wired), funcIndex is out of range, or fnPtr is null.
-  void icacheFill(uint32_t funcIndex, void *fnPtr);
+  bool icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
+                 uint32_t numDims, void **outFn);
+  // Fill the per-function icache cell at [i0][i1]... (linearized from \p dims,
+  // row-major, dim0 = leftmost ejit_dim param - MUST match the AOT array order)
+  // with a freshly resolved specialization (call on a taskpool cache hit or a
+  // successful compile). One-shot per cell: the first resolver for an identity
+  // wins; later resolves of the same identity (same invariant pointer) no-op;
+  // a different identity fills a different cell. No-op when reclamation is not
+  // safe, the function is unregistered (no base wired) or numDims mismatches,
+  // funcIndex is out of range, or fnPtr is null.
+  void icacheFill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
+                  uint32_t numDims);
 
   //--- consumer path (worker / test) -----------------------------------------
   bool pollOne();

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -149,6 +149,15 @@ if(EJIT_SRE_CODE_POOL AND EJIT_CODE_POOL_4K_SEAL)
   target_compile_definitions(LLVMEJIT PRIVATE EJIT_CODE_POOL_4K_SEAL)
 endif()
 
+# EJIT_ICACHE_DIM_SIZE: per-dim bound D of the multi-version inline cache.
+# Used by icacheFill/icacheTry linearization in EJitSharedTaskPool. Must match
+# the AOT -mllvm -ejit-icache-dim-size value (both from the top-level CMake
+# var). Scoped to LLVMEJIT (the icache runtime lives here); gated on the shared
+# taskpool, which is the only build the icache is compiled under.
+if(EJIT_SRE_SHARED_TASKPOOL)
+  target_compile_definitions(LLVMEJIT PRIVATE EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE})
+endif()
+
 # EJIT_FREESTANDING must be visible in LLVMJITLink headers so that
 # std::promise / std::future usage is guarded (bare-metal has no <future>).
 if(EJIT_FREESTANDING)

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -201,22 +201,24 @@ EJit::EJit(const Config &config) : config_(config) {
         }
         case EJIT_REG_ICACHE_SLOT: {
           // Wire the wrapper's per-function @__ejit_icache_fn_<name> slot into
-          // the runtime's slot-pointer table (gIcacheFnSlots), keyed by the
-          // SAME registry funcIndex assigned above. The wrapper reads this slot
-          // directly on the icache hit path (no ejit_icache_try call); icacheFill
-          // writes the frozen specialization pointer through it on resolve. A
-          // null fixup pointer or an exhausted funcIndex capacity is a hard init
-          // failure (the slot stays null -> probe misses -> taskpool fallback,
-          // correct but without the icache fast path).
+          // the runtime's slot registry (gIcacheSlots), keyed by the SAME
+          // registry funcIndex assigned above. e->size carries numDims (the
+          // [D]^numDims shape) so icacheFill can linearize. The wrapper reads
+          // the cell directly on the icache hit path (no ejit_icache_try call);
+          // icacheFill writes the frozen specialization pointer through it on
+          // resolve. A null fixup pointer or an exhausted funcIndex capacity is
+          // a hard init failure (the base stays null -> probe misses -> taskpool
+          // fallback, correct but without the icache fast path).
           if (!e->name1 || !e->ptr) {
             recordInitError(EJIT_ERR_INVALID_PARAM,
                             "icache slot registration has a null fixup pointer",
                             e->name1 ? e->name1 : "");
             break;
           }
+          uint32_t numDims = static_cast<uint32_t>(e->size);
           uint32_t idx = EJitFuncRegistry::instance().resolveAssign(e->name1);
           if (idx != kEJitInvalidFuncIndex)
-            ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr));
+            ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr), numDims);
           else
             recordInitError(EJIT_ERR_CACHE_FULL,
                             "funcIndex capacity exhausted for icache slot",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -328,20 +328,22 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
   }
 }
 
-void ejit_register_icache_slot(const char *funcName, void *slot) {
+void ejit_register_icache_slot(const char *funcName, void *slot,
+                               uint32_t numDims) {
   // Wire the wrapper's per-function @__ejit_icache_fn_<name> slot into the
-  // runtime slot-pointer table, keyed by the SAME registry funcIndex
-  // ejit_register_funcindex assigns by name. The wrapper reads this slot
-  // directly on the icache hit path; icacheFill writes the frozen specialization
-  // pointer through it on resolve. Idempotent by name (resolveAssign is).
-  // A null slot or unresolvable name is recorded; the slot stays null and the
-  // wrapper's probe cleanly misses -> taskpool fallback.
+  // runtime slot registry, keyed by the SAME registry funcIndex
+  // ejit_register_funcindex assigns by name. numDims is the [D]^numDims shape
+  // so icacheFill can linearize. The wrapper reads the cell directly on the
+  // icache hit path; icacheFill writes the frozen specialization pointer through
+  // it on resolve. Idempotent by name (resolveAssign is). A null slot or
+  // unresolvable name is recorded; the base stays null and the wrapper's probe
+  // cleanly misses -> taskpool fallback.
   if (!funcName || !slot) {
     EJIT_DIAG("register_icache_slot reject: name=%p slot=%p",
               (const void *)funcName, slot);
     return;
   }
-  EJIT_DIAG_VERBOSE("register_icache_slot name=%s", funcName);
+  EJIT_DIAG_VERBOSE("register_icache_slot name=%s numDims=%u", funcName, numDims);
 #ifdef EJIT_SRE_TASKPOOL
   if (gEJIT && gEJIT->registrationFrozen()) {
     EJitRegistrationStore::instance().recordError(
@@ -361,8 +363,9 @@ void ejit_register_icache_slot(const char *funcName, void *slot) {
               funcName);
     return;
   }
-  ejitIcacheRegisterSlot(idx, slot);
-  EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u", funcName, idx);
+  ejitIcacheRegisterSlot(idx, slot, numDims);
+  EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
+                    funcName, idx, numDims);
 }
 
 ejit_status_t ejit_activate(const char *periodName, uint8_t cellIdx) {
@@ -521,20 +524,25 @@ inline EJitTaskPool *activeTaskPool() {
 
 // Fill the calling core's icache slot on a successful taskpool resolve (cache
 // hit or fresh compile), so a cold icache is filled on the first taskpool hit,
-// not only on a fresh compile. v2: one-shot, fnPtr-only (the specialization is
-// invariant - no dims/version snapshot). No-op without the shared pool or a
-// null fnPtr. Always defined (a no-op without the shared taskpool) so call sites
-// need no #ifdef guards.
-inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr) {
+// not only on a fresh compile. Multi-version: one-shot per cell (the
+// specialization is invariant per identity - no version snapshot); dims selects
+// the [D]^numDims cell. No-op without the shared pool or a null fnPtr. Always
+// defined (a no-op without the shared taskpool) so call sites need no #ifdef
+// guards.
+inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
+                                    const EJitDimPair *dims,
+                                    uint32_t numDims) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (!fnPtr)
     return;
   EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr;
   if (sp)
-    sp->icacheFill(funcIndex, fnPtr);
+    sp->icacheFill(funcIndex, fnPtr, dims, numDims);
 #else
   (void)funcIndex;
   (void)fnPtr;
+  (void)dims;
+  (void)numDims;
 #endif
 }
 } // namespace
@@ -604,7 +612,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u fast status=%u fn=%p",
                       funcIndex, static_cast<unsigned>(fast.status),
                       fast.fnPtr);
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dimsCast, numDims);
     return taskpoolStatus(fast.status);
   }
 
@@ -616,7 +624,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     *outBucket = r.bucketIndex;
   EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u status=%u fn=%p",
                     funcIndex, static_cast<unsigned>(r.status), r.fnPtr);
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dimsCast, numDims);
   return taskpoolStatus(r.status);
 }
 
@@ -659,7 +667,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, nullptr, 0);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, nullptr, 0, /*fallback=*/nullptr);
@@ -667,7 +675,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, nullptr, 0);
   return taskpoolStatus(r.status);
 }
 
@@ -686,22 +694,22 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
   if (!ejitTaskpoolDimInRange(dim0, inst0))
     return EJIT_ERR_INVALID_PARAM;
 
+  const EJitDimPair dims[1] = {{dim0, inst0}};
   auto fast = tp->tryCacheHit1D(funcIndex, dim0, inst0);
   if (fast.fastPathTerminal) {
     if (outFn)
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 1);
     return taskpoolStatus(fast.status);
   }
-  const EJitDimPair dims[1] = {{dim0, inst0}};
   auto r = tp->compileOrGet(funcIndex, dims, 1, /*fallback=*/nullptr);
   if (outFn)
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 1);
   return taskpoolStatus(r.status);
 }
 
@@ -722,22 +730,22 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
       !ejitTaskpoolDimInRange(dim1, inst1))
     return EJIT_ERR_INVALID_PARAM;
 
+  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
   auto fast = tp->tryCacheHit2D(funcIndex, dim0, inst0, dim1, inst1);
   if (fast.fastPathTerminal) {
     if (outFn)
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 2);
     return taskpoolStatus(fast.status);
   }
-  const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
   auto r = tp->compileOrGet(funcIndex, dims, 2, /*fallback=*/nullptr);
   if (outFn)
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 2);
   return taskpoolStatus(r.status);
 }
 
@@ -760,6 +768,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
       !ejitTaskpoolDimInRange(dim2, inst2))
     return EJIT_ERR_INVALID_PARAM;
 
+  const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
   auto fast =
       tp->tryCacheHit3D(funcIndex, dim0, inst0, dim1, inst1, dim2, inst2);
   if (fast.fastPathTerminal) {
@@ -767,16 +776,15 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 3);
     return taskpoolStatus(fast.status);
   }
-  const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
   auto r = tp->compileOrGet(funcIndex, dims, 3, /*fallback=*/nullptr);
   if (outFn)
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 3);
   return taskpoolStatus(r.status);
 }
 
@@ -801,6 +809,8 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
       !ejitTaskpoolDimInRange(dim3, inst3))
     return EJIT_ERR_INVALID_PARAM;
 
+  const EJitDimPair dims[4] = {
+      {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
   auto fast = tp->tryCacheHit4D(funcIndex, dim0, inst0, dim1, inst1, dim2,
                                 inst2, dim3, inst3);
   if (fast.fastPathTerminal) {
@@ -808,17 +818,15 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 4);
     return taskpoolStatus(fast.status);
   }
-  const EJitDimPair dims[4] = {
-      {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
   auto r = tp->compileOrGet(funcIndex, dims, 4, /*fallback=*/nullptr);
   if (outFn)
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 4);
   return taskpoolStatus(r.status);
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -121,37 +121,60 @@ constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 /// cacheLookupNd block can also reference it.
 constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
-// Per-function inline-cache slot-pointer table (v2 sticky monomorphic). Each
-// entry points at the wrapper's per-function @__ejit_icache_fn_<name> global -
-// an EJitAtomicUPtr holding the frozen specialization pointer - registered by
-// name at ejit_auto_register / .ejit_period time via ejit_register_icache_slot
-// (which calls ejitIcacheRegisterSlot). The wrapper reads its OWN global
-// directly (one acquire load + null-check + indirect call) with NO
-// ejit_icache_try call and NO per-call guards: the hit path is just a pointer
-// non-null check. icacheFill writes the specialization pointer THROUGH the
-// registered slot pointer on a successful resolve (one-shot CAS); icacheTry
-// (test/diagnostic only) reads it. Process-static, zero-filled by the loader
-// (entries start null = unregistered = probe misses = taskpool fallback). See
-// the header for the safety model.
-EJitAtomicUPtr *gIcacheFnSlots[EJIT_ICACHE_FUNC_SLOTS];
+// Per-function inline-cache slot registry (multi-version direct-indexed). Each
+// entry records the wrapper's per-function @__ejit_icache_fn_<name> global base
+// (a uintptr_t cell, or a [D]^numDims array of them for a multi-version entry)
+// plus its dimensionality, registered by name at ejit_auto_register / .ejit_period
+// time via ejit_register_icache_slot (which calls ejitIcacheRegisterSlot). The
+// wrapper reads its OWN global directly (a GEP by the ejit_dim arg values + one
+// plain load + null-check + indirect call) with NO ejit_icache_try call and NO
+// per-call guards. icacheFill writes the specialization pointer through the cell
+// at [i0][i1]... (linearized from dims) on a successful resolve; icacheTry
+// (test/diagnostic only) reads it. The slot is PER-CORE PRIVATE (default BSS),
+// so the fill and the read are same-core, ordered by program order; the
+// indirect call's data dependency on the loaded pointer orders the load before
+// the br. So NO atomic/acquire/CAS is needed -- plain load (ldr) / store (str)
+// is correct. Process-static, zero-filled by the loader (base starts null =
+// unregistered = probe misses = taskpool fallback). See the header for the
+// safety model.
+struct EJitIcacheSlotReg {
+  uintptr_t *base;
+  uint32_t numDims;
+};
+EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
+
+// Linearize the dim identity to a flat cell index, row-major, dim0 = leftmost
+// ejit_dim param (MUST match the AOT [D]^numDims array declaration order). D is
+// EJIT_ICACHE_DIM_SIZE (power-of-2). numDims=0 -> idx 0 (the scalar cell). No
+// bounds check - the contract is every ejit_dim arg < D.
+static uintptr_t icacheLinearize(const EJitDimPair *dims, uint32_t numDims) {
+  uintptr_t idx = 0;
+  for (uint32_t i = 0; i < numDims; ++i)
+    idx = idx * EJIT_ICACHE_DIM_SIZE + dims[i].instanceId;
+  return idx;
+}
 
 } // namespace
 
-void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *slot) {
-  if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !slot)
+void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
+                                        uint32_t numDims) {
+  if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !base)
     return;
-  gIcacheFnSlots[funcIndex] = reinterpret_cast<EJitAtomicUPtr *>(slot);
+  gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
+  gIcacheSlots[funcIndex].numDims = numDims;
 }
 
 void llvm::ejit::ejitIcacheClearAll() {
-  // Unregister every slot: nulling the table entries makes all probes miss
-  // (icacheTry/icacheFill see no slot and bail), which is the "empty" state.
-  // We do NOT dereference the slot pointers here: in tests the slots are
-  // stack locals that may already be destroyed by the time a later test clears
-  // (e.g. if an ASSERT returned early and skipped the prior test's end-clear),
-  // so dereferencing would be a use-after-free. Production never calls this.
-  for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f)
-    gIcacheFnSlots[f] = nullptr;
+  // Unregister every slot: nulling base makes all probes miss (icacheTry/icacheFill
+  // see no base and bail), which is the "empty" state. We do NOT dereference the
+  // base pointers here: in tests the slots are stack locals that may already be
+  // destroyed by the time a later test clears (e.g. if an ASSERT returned early
+  // and skipped the prior test's end-clear), so dereferencing would be a
+  // use-after-free. Production never calls this.
+  for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
+    gIcacheSlots[f].base = nullptr;
+    gIcacheSlots[f].numDims = 0;
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -181,36 +204,39 @@ uint32_t EJitSharedTaskPool::instanceVersion(uint32_t dimType,
 }
 
 //===----------------------------------------------------------------------===//
-// Per-function inline cache (v2 sticky monomorphic).
+// Per-function inline cache (multi-version direct-indexed).
 //
 // The production hit path does NOT call icacheTry: the ejit_entry wrapper reads
-// its own @__ejit_icache_fn_<name> global directly (one acquire load + null
-// check + indirect call, no call, no per-call guards). icacheTry is retained
-// for unit tests and diagnostics. icacheFill writes the specialization pointer
-// THROUGH the registered slot pointer (gIcacheFnSlots[funcIndex]) on a
-// successful resolve; it is a frozen, one-shot fill - the slot is written once
-// and never refilled, so the pointer is always the correct (invariant)
-// specialization. Lifetime is safe because JIT code is never freed in
+// its own @__ejit_icache_fn_<name> global directly (GEP into the [D]^numDims
+// array by the ejit_dim arg values + acquire load + null check + indirect call,
+// no call, no per-call guards). icacheTry is retained for unit tests and
+// diagnostics. icacheFill writes the specialization pointer through the cell at
+// [i0][i1]... (linearized from dims) on a successful resolve; it is a frozen,
+// one-shot fill PER CELL - each identity's cell is written once and never
+// refilled, so a cell's pointer is always the correct (invariant) specialization
+// for that identity. Lifetime is safe because JIT code is never freed in
 // production; the safety gate auto-disables the cache if a releaser is wired
-// (v2 does no HP-scan retire). The code-sharing gate retains the cross-core
-// pointer discipline of resolveMatchedSlot (relevant to icacheTry in non-shared
-// test builds; the wrapper's inline probe is only enabled under
+// (no HP-scan retire). The code-sharing gate retains the cross-core pointer
+// discipline of resolveMatchedSlot (relevant to icacheTry in non-shared test
+// builds; the wrapper's inline probe is only enabled under
 // EJIT_SRE_SHARED_CODE_POINTERS, where the gate is compile-time true).
 //===----------------------------------------------------------------------===//
-bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, void **outFn) {
+bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
+                                   uint32_t numDims, void **outFn) {
   if (!outFn)
     return false;
   *outFn = nullptr;
-  // Safety gate: auto-disable while a releaser is wired (v2 does no HP-scan
-  // retire, so freeing code + a cached fnPtr = UAF). Production wires no
-  // releaser, so this never trips and the cache is unconditionally safe.
+  // Safety gate: auto-disable while a releaser is wired (no HP-scan retire, so
+  // freeing code + a cached fnPtr = UAF). Production wires no releaser, so this
+  // never trips and the cache is unconditionally safe.
   if (!icacheReclamationSafe_)
     return false;
   if (!state_ || funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
     return false;
-  // Unregistered function (no per-function slot global wired up): miss.
-  EJitAtomicUPtr *slot = gIcacheFnSlots[funcIndex];
-  if (!slot)
+  EJitIcacheSlotReg &reg = gIcacheSlots[funcIndex];
+  // Unregistered function, or shape mismatch (caller's numDims != registered):
+  // miss.
+  if (!reg.base || numDims != reg.numDims)
     return false;
   // The cache is only meaningful once the pool is Ready.
   if (state_->initState.loadAcquire() != kReady)
@@ -227,29 +253,35 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, void **outFn) {
 #endif
   if (!mayReadPtr)
     return false;
-  // Frozen read: the slot is immutable after the one-shot fill, so a single
-  // acquire load is correct with no re-validation.
-  uintptr_t p = slot->loadAcquire();
+  // Read this identity's cell. The slot is per-core private: the fill (same
+  // core) is ordered before this read by program order, and the caller's
+  // indirect call depends on the loaded pointer (data dependency). So a plain
+  // load is correct -- no acquire needed.
+  uintptr_t idx = icacheLinearize(dims, numDims);
+  uintptr_t p = reg.base[idx];
   if (p == 0)
     return false;
   *outFn = reinterpret_cast<void *>(p);
   return true;
 }
 
-void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr) {
+void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
+                                    const EJitDimPair *dims, uint32_t numDims) {
   if (!icacheReclamationSafe_)
     return;
   if (!state_ || !fnPtr || funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
     return;
-  EJitAtomicUPtr *slot = gIcacheFnSlots[funcIndex];
-  if (!slot)
-    return; // unregistered function: nowhere to write.
-  // One-shot: the first resolver wins. Later resolves carry the same invariant
-  // pointer and no-op. compareExchange is acq_rel on success / acquire on
-  // failure, pairing with the wrapper's / icacheTry's acquire load.
-  uintptr_t desired = reinterpret_cast<uintptr_t>(fnPtr);
-  uintptr_t expected = 0;
-  (void)slot->compareExchange(expected, desired);
+  EJitIcacheSlotReg &reg = gIcacheSlots[funcIndex];
+  if (!reg.base || numDims != reg.numDims)
+    return; // unregistered, or shape mismatch: nowhere to write.
+  // Plain store: the slot is per-core private, so this write (on the calling
+  // core) is ordered before the wrapper's read (same core) by program order.
+  // The specialization is invariant per identity under the contract + NO_RECLAIM,
+  // so overwriting on a later resolve (same pointer) is harmless -- no one-shot
+  // CAS is needed. No atomic/release: same-core, and the read's data dependency
+  // on the pointer orders this store-before-use.
+  uintptr_t idx = icacheLinearize(dims, numDims);
+  reg.base[idx] = reinterpret_cast<uintptr_t>(fnPtr);
 }
 
 void EJitSharedTaskPool::forEachCompiled(CompiledFuncCallback cb,

--- a/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
+++ b/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
@@ -13,3 +13,10 @@ add_llvm_component_library(LLVMEmbeddedJIT
   TransformUtils
   BitWriter
   )
+
+# EJIT_ICACHE_DIM_SIZE: the AOT pass (EJitWrapperGen) emits the per-function
+# @__ejit_icache_fn_<name> as a [D]^numDims array; the runtime (LLVMEJIT)
+# linearizes with the same D on fill. Both targets get the identical value from
+# the top-level CMake var so array layout and linearization never disagree.
+target_compile_definitions(LLVMEmbeddedJIT PRIVATE
+  EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE})

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -21,6 +21,7 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Casting.h"
@@ -223,6 +224,14 @@ static GlobalVariable *getOrCreateFuncIndexGlobal(Module &M,
       ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), GVName);
 }
 
+// A per-function inline-cache global plus its dimensionality (number of
+// ejit_dim params). The runtime needs NumDims to linearize the [D]^NumDims
+// array on fill, and the hit-path emitter needs it to build the GEP.
+struct IcacheSlotInfo {
+  GlobalVariable *GV = nullptr;
+  unsigned NumDims = 0;
+};
+
 // Per-function pointer-typed global holding the frozen inline-cache slot: the
 // specialization pointer once resolved, null until then. Internal linkage (each
 // module's copy is wired into the runtime slot-pointer table by name at
@@ -230,15 +239,30 @@ static GlobalVariable *getOrCreateFuncIndexGlobal(Module &M,
 // runtime pairs against it are lock-free on aarch64. The wrapper reads it
 // DIRECTLY (load atomic acquire + null-check + indirect call) - no
 // ejit_icache_try call, no per-call guards - so the hit path is one load.
+//
+// Multi-version: the global is a [D]^NumDims array (D = EJIT_ICACHE_DIM_SIZE,
+// power-of-2) indexed by the ejit_dim argument values, so each dim identity
+// gets its own frozen fnPtr cell. NumDims=0 is a scalar ptr (= v2 monomorphic).
 static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
-                                                 StringRef FuncName) {
+                                                 StringRef FuncName,
+                                                 unsigned NumDims) {
   std::string GVName = ("__ejit_icache_fn_" + FuncName).str();
   if (auto *Existing = M.getGlobalVariable(GVName))
     return Existing;
-  auto *PtrTy = PointerType::getUnqual(M.getContext());
-  auto *GV = new GlobalVariable(M, PtrTy, /*isConstant=*/false,
-                                GlobalValue::InternalLinkage,
-                                ConstantPointerNull::get(PtrTy), GVName);
+  LLVMContext &Ctx = M.getContext();
+  auto *PtrTy = PointerType::getUnqual(Ctx);
+  // Build [D]^NumDims (row-major); scalar ptr for NumDims==0.
+  Type *SlotTy = PtrTy;
+  const uint64_t D = EJIT_ICACHE_DIM_SIZE;
+  for (unsigned I = 0; I < NumDims; ++I)
+    SlotTy = ArrayType::get(SlotTy, D);
+  Constant *Init = nullptr;
+  if (NumDims == 0)
+    Init = ConstantPointerNull::get(PtrTy);
+  else
+    Init = ConstantAggregateZero::get(SlotTy);
+  auto *GV = new GlobalVariable(M, SlotTy, /*isConstant=*/false,
+                                GlobalValue::InternalLinkage, Init, GVName);
   GV->setAlignment(Align(8));
   return GV;
 }
@@ -329,7 +353,7 @@ emitFuncIndexRegistration(Module &M,
 // skips if the static section payload already exists.
 static void
 emitIcacheSlotRegistration(Module &M,
-                           const std::map<std::string, GlobalVariable *> &Fns) {
+                           const std::map<std::string, IcacheSlotInfo> &Fns) {
   if (Fns.empty() || M.getGlobalVariable(".ejit.registry.icache"))
     return;
   LLVMContext &Ctx = M.getContext();
@@ -337,10 +361,11 @@ emitIcacheSlotRegistration(Module &M,
   auto *I32Ty = Type::getInt32Ty(Ctx);
   auto *I64Ty = Type::getInt64Ty(Ctx);
 
-  // void ejit_register_icache_slot(const char *name, void *slot)
+  // void ejit_register_icache_slot(const char *name, void *slot, uint32_t numDims)
+  // numDims tells the runtime the [D]^numDims shape so icacheFill can linearize.
   M.getOrInsertFunction(
       FN_REGISTER_ICACHE_SLOT,
-      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy}, false));
+      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy, I32Ty}, false));
 
   Function *AutoReg = M.getFunction(FN_AUTO_REGISTER);
   bool CreatedAutoReg = false;
@@ -357,14 +382,16 @@ emitIcacheSlotRegistration(Module &M,
   for (auto &KV : Fns) {
     IRBuilder<> Builder(Ret);
     Value *Name = Builder.CreateGlobalString(KV.first);
-    Builder.CreateCall(FnReg, {Name, Builder.CreateBitCast(KV.second, PtrTy)});
+    Builder.CreateCall(FnReg, {Name, Builder.CreateBitCast(KV.second.GV, PtrTy),
+                               ConstantInt::get(I32Ty, KV.second.NumDims)});
   }
 
   if (EnableEJitGlobalCtors && CreatedAutoReg)
     appendToGlobalCtors(M, AutoReg, EJIT_CTOR_PRIORITY);
 
   // Static registry entries for bare-metal / testing fallback (same linker-
-  // concatenated .ejit_period model as funcindex above).
+  // concatenated .ejit_period model as funcindex above). The `size` (i64) field
+  // carries NumDims; the ejit_init walker forwards it to ejitIcacheRegisterSlot.
   StructType *EntryTy = StructType::get(
       Ctx, {I32Ty, PtrTy, PtrTy, PtrTy, I64Ty}, /*isPacked=*/false);
   auto makeStrGV = [&](const std::string &S) -> Constant * {
@@ -379,8 +406,8 @@ emitIcacheSlotRegistration(Module &M,
     Entries.push_back(ConstantStruct::get(
         EntryTy, {ConstantInt::get(I32Ty, 7), // EJIT_REG_ICACHE_SLOT
                   makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
-                  ConstantExpr::getBitCast(KV.second, PtrTy),
-                  ConstantInt::get(I64Ty, 0)}));
+                  ConstantExpr::getBitCast(KV.second.GV, PtrTy),
+                  ConstantInt::get(I64Ty, KV.second.NumDims)}));
   }
   if (Entries.empty())
     return;
@@ -432,17 +459,23 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
   auto isAlreadyWrapped = [](Function &F) -> bool {
     if (!F.getEntryBlock().getName().starts_with("jit_entry"))
       return false;
-    // The wrapper's jit_entry loads a per-function global that uniquely
-    // identifies an already-wrapped function: @__ejit_icache_fn_<name> (when
-    // -ejit-inline-cache hoists the probe to the entry block) or, with the
-    // cache off, @__ejit_funcidx_<name> (the funcIndex load that heads jit_entry
-    // in that layout).
-    for (Instruction &I : F.getEntryBlock())
+    // The wrapper's jit_entry references a per-function global that uniquely
+    // identifies an already-wrapped function: @__ejit_icache_fn_<name> (the
+    // icache probe -- a direct load for 0-dim, or a GEP for numDims>0) or, with
+    // the cache off, @__ejit_funcidx_<name> (the funcIndex load in jit_entry).
+    for (Instruction &I : F.getEntryBlock()) {
+      Value *Ptr = nullptr;
       if (auto *LI = dyn_cast<LoadInst>(&I))
-        if (auto *GV = dyn_cast<GlobalVariable>(LI->getPointerOperand()))
-          if (GV->getName().starts_with("__ejit_funcidx_") ||
-              GV->getName().starts_with("__ejit_icache_fn_"))
-            return true;
+        Ptr = LI->getPointerOperand();
+      else if (auto *GEP = dyn_cast<GetElementPtrInst>(&I))
+        Ptr = GEP->getPointerOperand();
+      if (!Ptr)
+        continue;
+      if (auto *GV = dyn_cast<GlobalVariable>(Ptr))
+        if (GV->getName().starts_with("__ejit_funcidx_") ||
+            GV->getName().starts_with("__ejit_icache_fn_"))
+          return true;
+    }
     return false;
   };
 
@@ -498,11 +531,21 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
   // resolve. Requires the runtime to be built with EJIT_SRE_SHARED_CODE_POINTERS
   // (production preset) - the inline probe has no per-call cross-core gate, so
   // it is only safe when a cached pointer is callable on any core.
-  std::map<std::string, GlobalVariable *> IcacheFnGlobals;
+  std::map<std::string, IcacheSlotInfo> IcacheFnGlobals;
   if (EJitInlineCache) {
-    for (Function *F : EntryFuncs)
-      IcacheFnGlobals.emplace(F->getName().str(),
-                              getOrCreateIcacheFnGlobal(M, F->getName()));
+    for (Function *F : EntryFuncs) {
+      unsigned NumDims = getPeriodArrIndInfo(*F).size();
+      // Skip functions exceeding the cache dimensionality cap from the icache
+      // map. They are still wrapped (taskpool path) but without an icache probe;
+      // the per-function DimCount > EJIT_ICACHE_MAX_DIMS check below emits the
+      // compile error, so this just avoids emitting a wasteful [D]^N global.
+      if (NumDims > EJIT_ICACHE_MAX_DIMS)
+        continue;
+      IcacheSlotInfo Info;
+      Info.GV = getOrCreateIcacheFnGlobal(M, F->getName(), NumDims);
+      Info.NumDims = NumDims;
+      IcacheFnGlobals.emplace(F->getName().str(), Info);
+    }
     emitIcacheSlotRegistration(M, IcacheFnGlobals);
   }
 
@@ -583,297 +626,298 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // Save original entry block
     BasicBlock &OrigEntry = F->getEntryBlock();
 
-    // Create the wrapper blocks. jit_entry is the new entry block. With
-    // -ejit-inline-cache ON, jit_entry is the inline probe (load the per-function
-    // cached specialization pointer, null-check, hit -> call it directly + return;
-    // miss -> jit_slow), and jit_slow runs the funcIndex guard -> jit_call (taskpool
-    // request) / jit_fallback (AOT body). With the cache OFF, jit_entry runs the
-    // funcIndex guard directly (no probe, no jit_slow). jit_dispatch runs the
-    // taskpool-resolved specialization.
-    auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F, &OrigEntry);
-    BasicBlock *JitSlow =
-        EJitInlineCache ? BasicBlock::Create(Ctx, "jit_slow", F) : nullptr;
-    auto *JitCall = BasicBlock::Create(Ctx, "jit_call", F);
-    auto *JitFallback = BasicBlock::Create(Ctx, "jit_fallback", F);
-    auto *JitDispatch = BasicBlock::Create(Ctx, "jit_dispatch", F);
+    // Whether this function gets an icache probe: the flag is on AND the
+    // function is in the icache map.
+    auto IcacheIt = IcacheFnGlobals.find(F->getName().str());
+    bool EmitIcacheProbe =
+        EJitInlineCache && IcacheIt != IcacheFnGlobals.end();
 
-    // Update PHI incoming blocks in successors that reference OrigEntry.
-    //
-    // NOTE: replaceAllUsesWith does NOT update PHI incoming blocks — a
-    // PHINode's incoming block is stored inside the PHINode and is NOT part
-    // of the BasicBlock's use list (OrigEntry can be a PHI incoming block
-    // while getNumUses() == 0). Without this explicit rewrite, erasing
-    // OrigEntry leaves dangling PHI incoming block pointers, crashing later
-    // passes. This triggers whenever the ejit_entry function's entry block
-    // is an incoming predecessor of a PHI — e.g. short-circuit && / || inside
-    // __builtin_expect(!!(a && b), 1) produces a PHI in the merge block whose
-    // incoming block is the entry block; lower-expect's handlePhiDef then
-    // dereferences the dangling pointer.
-    //
-    // Must run before splice(): replaceSuccessorsPhiUsesWith walks OrigEntry's
-    // successors via its terminator, which the splice below moves away.
-    OrigEntry.replaceSuccessorsPhiUsesWith(JitFallback);
-
-    // Splice all instructions from OrigEntry to jit_fallback
-    JitFallback->splice(JitFallback->end(), &OrigEntry, OrigEntry.begin(),
-                        OrigEntry.end());
-
-    // Handle any remaining non-PHI uses of OrigEntry (e.g. blockaddress).
-    OrigEntry.replaceAllUsesWith(JitFallback);
-
-    // Delete the now-empty original entry block
-    OrigEntry.eraseFromParent();
-
-    // jit_entry (new entry block): allocas + timing decls live here so they
-    // dominate the taskpool path. With -ejit-inline-cache ON, jit_entry IS the
-    // inline probe (see below); with it OFF, jit_entry runs the funcIndex guard
-    // directly (the original layout).
-    IRBuilder<> Builder(JitEntry);
-    // Emit the fixed-dimension fast-path C API only for 0/1/2-dim entries when
-    // the opt-in flag is set. Rationale (measured on aarch64, -Os): 0D/1D/2D
-    // pass funcIndex + up to 4 dim scalars + 2 out pointers, which still fit in
-    // the 8 integer argument registers (no stack spill) and hit a specialized
-    // cacheLookupNd with the numDims/identity/version loops fully unrolled. A
-    // 3D call needs 9 and a 4D call 11 integer arguments, spilling to the stack
-    // at every call site, which cancels the lookup saving — so 3D/4D keep using
-    // the generic ejit_taskpool_compile_or_get (one dim-array pointer). The
-    // fixed 3D/4D C APIs still exist and are semantically correct for direct
-    // callers; the wrapper just does not select them.
-    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
     auto *I64Ty = Type::getInt64Ty(Ctx);
-    Value *DimsAlloca = UseFixed
-                            ? nullptr
-                            : Builder.CreateAlloca(ArrayType::get(DimPairTy, 4),
-                                                   nullptr, "ejit_dims");
-    Value *OutFnAlloca =
-        Builder.CreateAlloca(PtrTy, nullptr, "ejit_out_fn");
-    Value *OutBucketAlloca =
-        Builder.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
-    Value *OutFnArg = Builder.CreatePointerCast(OutFnAlloca, PtrTy);
-    // Timing callees are shared by the icache hit path and the slow taskpool
-    // path, so declare them once here (idempotent getOrInsertFunction).
+    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
+
+    // Timing callees (shared by hit and slow paths).
     FunctionCallee TraceNow{};
     FunctionCallee TraceWrapper{};
     if (EJitWrapperTiming) {
       TraceNow = M.getOrInsertFunction(FN_TASKPOOL_TRACE_NOW,
                                        FunctionType::get(I64Ty, false));
-      SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty,
-                                         I64Ty, I64Ty, I64Ty, I64Ty};
+      SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty, I64Ty,
+                                         I64Ty, I64Ty, I64Ty};
       TraceWrapper = M.getOrInsertFunction(
           FN_TASKPOOL_TRACE_WRAPPER,
           FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
     }
-    // funcIndex is loaded on the miss path (jit_slow / the cache-off guard); the
-    // hit path does not need it. Declared here so jit_call (below) can use it.
-    Value *FuncIdx = nullptr;
 
-    if (EJitInlineCache) {
-      // --- inline probe (the hit path) ---
-      // One atomic acquire load of the per-function cached specialization
-      // pointer (@__ejit_icache_fn_<name>), null-check, hit -> call it directly
-      // + return. NO ejit_icache_try call, NO per-call guards, NO funcIndex /
-      // IdxValid, NO dim loads on the hit path - just "pointer non-null? jump".
-      // The slot is null until the first successful resolve fills it (icacheFill,
-      // on the jit_call path); a null slot falls through to jit_slow. Timing (when
-      // -ejit-wrapper-timing): probe cost (the load) + fn-call cost are logged via
-      // ejit_taskpool_trace_wrapper with the icache-hit sentinel. funcIndex is
-      // loaded here ONLY for trace attribution (diagnostic, off in production) so
-      // the non-timing hit path stays a single load.
-      Value *TBeforeIcache = nullptr;
-      Value *FuncIdxForTiming = nullptr;
-      if (EJitWrapperTiming) {
-        TBeforeIcache = Builder.CreateCall(TraceNow, {}, "ejit_t_before_icache");
-        FuncIdxForTiming = Builder.CreateLoad(
-            I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx_t");
+    // emitSlowPath: emit the funcIndex guard (EntryBB) + compile_or_get
+    // (CallBB) + dispatch (DispatchBB) into Fn, using Fn's args. FallbackBB
+    // already holds the spliced original body (with its own ret). Shared by
+    // icache-off (in F) and icache-on (in MissFn).
+    auto emitSlowPath = [&](Function &Fn, BasicBlock *EntryBB,
+                            BasicBlock *CallBB, BasicBlock *DispatchBB,
+                            BasicBlock *FallbackBB) {
+      IRBuilder<> B(EntryBB);
+      // Allocas live in the entry block so they dominate the call/dispatch
+      // blocks (and match the original layout: allocas precede the funcidx
+      // guard).
+      Value *DimsAlloca = UseFixed ? nullptr
+                                   : B.CreateAlloca(ArrayType::get(DimPairTy, 4),
+                                                    nullptr, "ejit_dims");
+      Value *OutFnAlloca = B.CreateAlloca(PtrTy, nullptr, "ejit_out_fn");
+      Value *OutBucketAlloca = B.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
+      Value *OutFnArg = B.CreatePointerCast(OutFnAlloca, PtrTy);
+      Value *OutBucketArg = B.CreatePointerCast(OutBucketAlloca, PtrTy);
+      Value *FuncIdx = B.CreateLoad(
+          I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
+      Value *IdxValid = B.CreateICmpNE(
+          FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
+      B.CreateCondBr(IdxValid, CallBB, FallbackBB);
+
+      B.SetInsertPoint(CallBB);
+      auto emitDimTypeVal = [&](unsigned I) {
+        return B.CreateLoad(I32Ty, DimTypeGlobals[PeriodInds[I].PeriodName],
+                            "ejit_dimtype");
+      };
+      auto emitInstanceVal = [&](unsigned I) -> Value * {
+        Value *ArgVal = Fn.getArg(PeriodInds[I].ArgIndex);
+        unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
+        if (BW > 32) return B.CreateTrunc(ArgVal, I32Ty);
+        if (BW < 32) return B.CreateZExt(ArgVal, I32Ty);
+        return ArgVal;
+      };
+      Value *TBeforeLookup = nullptr, *TAfterLookup = nullptr;
+      if (EJitWrapperTiming)
+        TBeforeLookup = B.CreateCall(TraceNow, {}, "ejit_t_before_lookup");
+      Value *Status = nullptr;
+      if (UseFixed) {
+        static const char *const FixedNames[] = {
+            FN_TASKPOOL_COMPILE_OR_GET_0D, FN_TASKPOOL_COMPILE_OR_GET_1D,
+            FN_TASKPOOL_COMPILE_OR_GET_2D, FN_TASKPOOL_COMPILE_OR_GET_3D,
+            FN_TASKPOOL_COMPILE_OR_GET_4D};
+        SmallVector<Type *, 12> ParamTys;
+        SmallVector<Value *, 12> Args;
+        ParamTys.push_back(I32Ty);
+        Args.push_back(FuncIdx);
+        for (unsigned I = 0; I < DimCount; ++I) {
+          ParamTys.push_back(I32Ty);
+          ParamTys.push_back(I32Ty);
+          Args.push_back(emitDimTypeVal(I));
+          Args.push_back(emitInstanceVal(I));
+        }
+        ParamTys.push_back(PtrTy);
+        ParamTys.push_back(PtrTy);
+        Args.push_back(OutFnArg);
+        Args.push_back(OutBucketArg);
+        FunctionCallee FixedFn = M.getOrInsertFunction(
+            FixedNames[DimCount], FunctionType::get(I32Ty, ParamTys, false));
+        Status = B.CreateCall(FixedFn, Args);
+      } else {
+        for (unsigned I = 0; I < DimCount; ++I) {
+          Value *Idxs[] = {ConstantInt::get(I32Ty, 0), ConstantInt::get(I32Ty, I)};
+          Value *PairPtr = B.CreateInBoundsGEP(ArrayType::get(DimPairTy, 4),
+                                               DimsAlloca, Idxs);
+          B.CreateStore(emitDimTypeVal(I), B.CreateStructGEP(DimPairTy, PairPtr,
+                                                              0, "dim_type_ptr"));
+          B.CreateStore(emitInstanceVal(I),
+                        B.CreateStructGEP(DimPairTy, PairPtr, 1, "instance_ptr"));
+        }
+        Value *DimsPtr = DimCount > 0 ? B.CreatePointerCast(DimsAlloca, PtrTy)
+                                      : ConstantPointerNull::get(PtrTy);
+        Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
+                              {FuncIdx, DimsPtr,
+                               ConstantInt::get(I32Ty, DimCount), OutFnArg,
+                               OutBucketArg});
       }
-      // The one-shot frozen slot: acquire load pairs with icacheFill's acq_rel
-      // CAS. 8-byte aligned for a lock-free atomic on aarch64.
-      GlobalVariable *IcacheSlot = IcacheFnGlobals[F->getName().str()];
-      LoadInst *ICSlotLoad =
-          Builder.CreateLoad(PtrTy, IcacheSlot, "ejit_ic_fn");
-      ICSlotLoad->setAtomic(AtomicOrdering::Acquire);
+      if (EJitWrapperTiming)
+        TAfterLookup = B.CreateCall(TraceNow, {}, "ejit_t_after_lookup");
+      Value *OutFn = B.CreateLoad(PtrTy, OutFnAlloca, "ejit_fn");
+      Value *HitStatus = B.CreateICmpEQ(Status, ConstantInt::get(I32Ty, 0));
+      B.CreateCondBr(B.CreateAnd(HitStatus, B.CreateIsNotNull(OutFn)),
+                     DispatchBB, FallbackBB);
+
+      B.SetInsertPoint(DispatchBB);
+      SmallVector<Value *, 8> Args;
+      for (auto &A : Fn.args())
+        Args.push_back(&A);
+      auto releaseAndTrace = [&]() {
+        if (EJitWrapperTiming) {
+          Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+          Value *Bucket = B.CreateLoad(I32Ty, OutBucketAlloca);
+          B.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
+          Value *TAfterRelease = B.CreateCall(TraceNow, {}, "ejit_t_after_release");
+          B.CreateCall(TraceWrapper, {FuncIdx, Status, OutFn, Bucket,
+                                      TBeforeLookup, TAfterLookup, TAfterFn,
+                                      TAfterRelease});
+        } else {
+          Value *Bucket = B.CreateLoad(I32Ty, OutBucketAlloca);
+          B.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
+        }
+      };
+      if (F->getReturnType()->isVoidTy()) {
+        B.CreateCall(F->getFunctionType(), OutFn, Args);
+        releaseAndTrace();
+        B.CreateRetVoid();
+      } else {
+        Value *RetVal = B.CreateCall(F->getFunctionType(), OutFn, Args);
+        releaseAndTrace();
+        B.CreateRet(RetVal);
+      }
+    };
+
+    // Helper: splice the original body into Dst, fixing PHI/uses, then erase
+    // the now-empty OrigEntry.
+    auto spliceOriginalBody = [&](BasicBlock *Dst) {
+      OrigEntry.replaceSuccessorsPhiUsesWith(Dst);
+      Dst->splice(Dst->end(), &OrigEntry, OrigEntry.begin(), OrigEntry.end());
+      OrigEntry.replaceAllUsesWith(Dst);
+      OrigEntry.eraseFromParent();
+    };
+
+    if (EmitIcacheProbe) {
+      //=== LEVER B: frame-less wrapper (F) + noinline MissFn (slow path) =====
+      // The hit path (F) is just the probe + two tail calls (br spec on hit, br
+      // MissFn on miss) -- no allocas, no calls, no frame. MissFn holds the
+      // funcidx guard + compile_or_get + dispatch + the AOT fallback (original
+      // body), with its own frame. Miss is rare, so the call overhead is fine.
+      Function *MissFn = Function::Create(F->getFunctionType(),
+                                          GlobalValue::InternalLinkage,
+                                          F->getName() + "_miss", &M);
+      MissFn->addFnAttr(Attribute::NoInline);
+      MissFn->setSection(F->getSection());
+
+      // Move ALL of F's original blocks to MissFn (not just the entry block --
+      // the original function has multiple BBs; splicing only the entry leaves
+      // the rest dangling in F with undef references -> IPSCCP folds to
+      // unreachable). F becomes empty; MissFn's entry is the original entry.
+      SmallVector<BasicBlock *, 16> OrigBlocks;
+      for (BasicBlock &BB : *F)
+        OrigBlocks.push_back(&BB);
+      for (BasicBlock *BB : OrigBlocks)
+        BB->removeFromParent();
+      for (BasicBlock *BB : OrigBlocks)
+        MissFn->insert(MissFn->end(), BB);
+      BasicBlock *MissFallback = &MissFn->getEntryBlock();
+      MissFallback->setName("miss_fallback");
+
+      // Remap F's args to MissFn's args in ALL moved blocks (cross-function
+      // arg references would crash SelectionDAG).
+      for (unsigned Ai = 0; Ai < F->arg_size(); ++Ai)
+        F->getArg(Ai)->replaceAllUsesWith(MissFn->getArg(Ai));
+
+      // Create the slow-path entry (funcidx guard) BEFORE MissFallback so it
+      // becomes MissFn's entry block.
+      auto *MissEntry = BasicBlock::Create(Ctx, "miss_entry", MissFn,
+                                            MissFallback);
+      auto *MissCall = BasicBlock::Create(Ctx, "miss_call", MissFn);
+      auto *MissDispatch = BasicBlock::Create(Ctx, "miss_dispatch", MissFn);
+      if (!MissFallback->getTerminator()) {
+        IRBuilder<> B(MissFallback);
+        if (F->getReturnType()->isVoidTy())
+          B.CreateRetVoid();
+        else
+          B.CreateRet(PoisonValue::get(F->getReturnType()));
+      }
+      emitSlowPath(*MissFn, MissEntry, MissCall, MissDispatch, MissFallback);
+
+      // Wrapper (F): frame-less probe + tail calls.
+      auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
+      auto *JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
+      auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
+      IRBuilder<> B(JitEntry);
+      Value *TBeforeIcache = nullptr, *FuncIdxForTiming = nullptr;
+      if (EJitWrapperTiming) {
+        TBeforeIcache = B.CreateCall(TraceNow, {}, "ejit_t_before_icache");
+        FuncIdxForTiming = B.CreateLoad(I32Ty,
+                                        FuncIndexGlobals[F->getName().str()],
+                                        "ejit_funcidx_t");
+      }
+      GlobalVariable *IcacheSlot = IcacheIt->second.GV;
+      unsigned NumDims = IcacheIt->second.NumDims;
+      Value *SlotPtr = IcacheSlot;
+      if (NumDims > 0) {
+        SmallVector<Value *, 5> Indices;
+        Indices.push_back(ConstantInt::get(I32Ty, 0));
+        for (unsigned I = 0; I < NumDims; ++I) {
+          Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
+          unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
+          Value *Idx = ArgVal;
+          if (BW > 32) Idx = B.CreateTrunc(ArgVal, I32Ty);
+          else if (BW < 32) Idx = B.CreateZExt(ArgVal, I32Ty);
+          Indices.push_back(Idx);
+        }
+        SlotPtr = B.CreateInBoundsGEP(IcacheSlot->getValueType(), IcacheSlot,
+                                      Indices, "ejit_ic_slot");
+      }
+      LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
       ICSlotLoad->setAlignment(Align(8));
       Value *TAfterIcache = nullptr;
       if (EJitWrapperTiming)
-        TAfterIcache = Builder.CreateCall(TraceNow, {}, "ejit_t_after_icache");
-      Value *IHit = Builder.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
-      // jit_icache_dispatch: call the cached specialization directly. NO
-      // ejit_taskpool_release_read - the inline cache never frees code in
-      // production.
-      auto *JitIcacheDispatch =
-          BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
-      Builder.CreateCondBr(IHit, JitIcacheDispatch, JitSlow);
+        TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
+      Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
+      IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
+                               {IHit, ConstantInt::getTrue(Ctx)});
+      B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
 
-      Builder.SetInsertPoint(JitIcacheDispatch);
+      // Hit: tail-call the cached specialization directly (no release_read).
+      // With -ejit-wrapper-timing the wrapper is NOT frame-less (JitEntry emits
+      // bl @ejit_taskpool_trace_now), so the hit path cannot be a musttail tail
+      // call: emitHitTiming() inserts calls BETWEEN the call and the ret, which
+      // would violate the musttail rule ("musttail call must precede a ret") and
+      // yield broken IR -> codegen silently drops the function -> boot
+      // translation fault. Use a plain (framed) call + trace + ret instead; the
+      // frame-less musttail fast path is reserved for the no-timing case.
+      B.SetInsertPoint(JitIcacheDispatch);
       SmallVector<Value *, 8> ICArgs;
-      for (auto &Arg : F->args())
-        ICArgs.push_back(&Arg);
-      auto emitIcacheTiming = [&] {
-        Value *TAfterFn = Builder.CreateCall(TraceNow, {}, "ejit_t_after_fn");
-        Builder.CreateCall(TraceWrapper,
-                           {FuncIdxForTiming,
-                            ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
-                            ICSlotLoad, ConstantInt::get(I32Ty, 0),
-                            TBeforeIcache, TAfterIcache, TAfterFn, TAfterFn});
+      for (auto &A : F->args()) ICArgs.push_back(&A);
+      auto emitHitTiming = [&]() {
+        if (!EJitWrapperTiming) return;
+        Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+        B.CreateCall(TraceWrapper,
+                     {FuncIdxForTiming,
+                      ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
+                      ICSlotLoad, ConstantInt::get(I32Ty, 0), TBeforeIcache,
+                      TAfterIcache, TAfterFn, TAfterFn});
       };
       if (F->getReturnType()->isVoidTy()) {
-        Builder.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (EJitWrapperTiming)
-          emitIcacheTiming();
-        Builder.CreateRetVoid();
+        CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
+        if (!EJitWrapperTiming)
+          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        emitHitTiming();
+        B.CreateRetVoid();
       } else {
-        Value *RetVal =
-            Builder.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (EJitWrapperTiming)
-          emitIcacheTiming();
-        Builder.CreateRet(RetVal);
+        CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
+        if (!EJitWrapperTiming)
+          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        emitHitTiming();
+        B.CreateRet(CI);
       }
 
-      // --- jit_slow: funcIndex guard (miss path) ---
-      // Load the registration-backfilled dense funcIndex. While it is invalid,
-      // branch straight to the AOT fallback without entering the taskpool;
-      // otherwise enter the taskpool (jit_call), which fills the icache slot on
-      // a successful resolve.
-      Builder.SetInsertPoint(JitSlow);
-      FuncIdx = Builder.CreateLoad(
-          I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
-      Value *IdxValid = Builder.CreateICmpNE(
-          FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
-      Builder.CreateCondBr(IdxValid, JitCall, JitFallback);
+      // Miss: tail-call MissFn (which does compile_or_get + dispatch/fallback).
+      B.SetInsertPoint(JitMiss);
+      SmallVector<Value *, 8> MissArgs;
+      for (auto &A : F->args()) MissArgs.push_back(&A);
+      if (F->getReturnType()->isVoidTy()) {
+        CallInst *CI = B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+        CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        B.CreateRetVoid();
+      } else {
+        CallInst *CI = B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+        CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        B.CreateRet(CI);
+      }
     } else {
-      // icache OFF: jit_entry runs the funcIndex guard directly.
-      FuncIdx = Builder.CreateLoad(
-          I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
-      Value *IdxValid = Builder.CreateICmpNE(
-          FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
-      Builder.CreateCondBr(IdxValid, JitCall, JitFallback);
-    }
-
-    // jit_call: unified taskpool API. Both Sync and Async modes share the same
-    // AOT wrapper — the runtime compile mode controls whether compilation is
-    // inline or via a background worker.
-    Builder.SetInsertPoint(JitCall);
-
-    // Load each dim's (dimType, instanceId) as i32. Shared by both emitters.
-    auto emitDimTypeVal = [&](unsigned I) {
-      return Builder.CreateLoad(I32Ty, DimTypeGlobals[PeriodInds[I].PeriodName],
-                                "ejit_dimtype");
-    };
-    auto emitInstanceVal = [&](unsigned I) -> Value * {
-      Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
-      unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
-      if (BW > 32)
-        return Builder.CreateTrunc(ArgVal, I32Ty);
-      if (BW < 32)
-        return Builder.CreateZExt(ArgVal, I32Ty);
-      return ArgVal;
-    };
-
-    Value *OutBucketArg = Builder.CreatePointerCast(OutBucketAlloca, PtrTy);
-    Value *Status = nullptr;
-    Value *TBeforeLookup = nullptr;
-    Value *TAfterLookup = nullptr;
-    if (EJitWrapperTiming) {
-      TBeforeLookup =
-          Builder.CreateCall(TraceNow, {}, "ejit_t_before_lookup");
-    }
-    if (UseFixed) {
-      // ejit_taskpool_compile_or_get_Nd(i32 funcIndex,
-      //     [i32 dimType, i32 instanceId] * N, ptr outFn, ptr outBucket)
-      static const char *const FixedNames[] = {
-          FN_TASKPOOL_COMPILE_OR_GET_0D, FN_TASKPOOL_COMPILE_OR_GET_1D,
-          FN_TASKPOOL_COMPILE_OR_GET_2D, FN_TASKPOOL_COMPILE_OR_GET_3D,
-          FN_TASKPOOL_COMPILE_OR_GET_4D};
-      SmallVector<Type *, 12> ParamTys;
-      SmallVector<Value *, 12> Args;
-      ParamTys.push_back(I32Ty);
-      Args.push_back(FuncIdx);
-      for (unsigned I = 0; I < DimCount; ++I) {
-        Value *DimTypeVal = emitDimTypeVal(I);
-        Value *InstanceId = emitInstanceVal(I);
-        ParamTys.push_back(I32Ty);
-        ParamTys.push_back(I32Ty);
-        Args.push_back(DimTypeVal);
-        Args.push_back(InstanceId);
+      //=== icache OFF: single-function wrapper (funcidx guard -> slow path) ==
+      auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F, &OrigEntry);
+      auto *JitCall = BasicBlock::Create(Ctx, "jit_call", F);
+      auto *JitFallback = BasicBlock::Create(Ctx, "jit_fallback", F);
+      auto *JitDispatch = BasicBlock::Create(Ctx, "jit_dispatch", F);
+      spliceOriginalBody(JitFallback);
+      if (!JitFallback->getTerminator()) {
+        IRBuilder<> B(JitFallback);
+        if (F->getReturnType()->isVoidTy()) B.CreateRetVoid();
+        else B.CreateRet(PoisonValue::get(F->getReturnType()));
       }
-      ParamTys.push_back(PtrTy);
-      ParamTys.push_back(PtrTy);
-      Args.push_back(OutFnArg);
-      Args.push_back(OutBucketArg);
-      FunctionCallee FixedFn = M.getOrInsertFunction(
-          FixedNames[DimCount], FunctionType::get(I32Ty, ParamTys, false));
-      Status = Builder.CreateCall(FixedFn, Args);
-    } else {
-      for (unsigned I = 0; I < DimCount; ++I) {
-        Value *Idxs[] = {ConstantInt::get(I32Ty, 0),
-                         ConstantInt::get(I32Ty, I)};
-        Value *PairPtr = Builder.CreateInBoundsGEP(ArrayType::get(DimPairTy, 4),
-                                                   DimsAlloca, Idxs);
-        Value *DimTypePtr =
-            Builder.CreateStructGEP(DimPairTy, PairPtr, 0, "dim_type_ptr");
-        Value *InstancePtr =
-            Builder.CreateStructGEP(DimPairTy, PairPtr, 1, "instance_ptr");
-        Builder.CreateStore(emitDimTypeVal(I), DimTypePtr);
-        Builder.CreateStore(emitInstanceVal(I), InstancePtr);
-      }
-      Value *DimsPtr = DimCount > 0
-                           ? Builder.CreatePointerCast(DimsAlloca, PtrTy)
-                           : ConstantPointerNull::get(PtrTy);
-      Status = Builder.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
-                                  {FuncIdx, DimsPtr,
-                                   ConstantInt::get(I32Ty, DimCount), OutFnArg,
-                                   OutBucketArg});
-    }
-    if (EJitWrapperTiming)
-      TAfterLookup = Builder.CreateCall(TraceNow, {}, "ejit_t_after_lookup");
-    Value *OutFn = Builder.CreateLoad(PtrTy, OutFnAlloca, "ejit_fn");
-    Value *HitStatus =
-        Builder.CreateICmpEQ(Status, ConstantInt::get(I32Ty, 0));
-    Builder.CreateCondBr(
-        Builder.CreateAnd(HitStatus, Builder.CreateIsNotNull(OutFn)),
-        JitDispatch, JitFallback);
-
-    // jit_dispatch: cast function pointer, call, and release the read token.
-    Builder.SetInsertPoint(JitDispatch);
-
-    // Build argument list for indirect call
-    SmallVector<Value *, 8> Args;
-    for (auto &Arg : F->args())
-      Args.push_back(&Arg);
-
-    if (F->getReturnType()->isVoidTy()) {
-      Builder.CreateCall(F->getFunctionType(), OutFn, Args);
-      Value *TAfterFn = nullptr;
-      if (EJitWrapperTiming)
-        TAfterFn = Builder.CreateCall(TraceNow, {}, "ejit_t_after_fn");
-      // Always release the taskpool read token after the JIT call finishes.
-      Value *Bucket = Builder.CreateLoad(I32Ty, OutBucketAlloca);
-      Builder.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
-      if (EJitWrapperTiming) {
-        Value *TAfterRelease =
-            Builder.CreateCall(TraceNow, {}, "ejit_t_after_release");
-        Builder.CreateCall(TraceWrapper,
-                           {FuncIdx, Status, OutFn, Bucket, TBeforeLookup,
-                            TAfterLookup, TAfterFn, TAfterRelease});
-      }
-      Builder.CreateRetVoid();
-    } else {
-      Value *RetVal = Builder.CreateCall(F->getFunctionType(), OutFn, Args);
-      Value *TAfterFn = nullptr;
-      if (EJitWrapperTiming)
-        TAfterFn = Builder.CreateCall(TraceNow, {}, "ejit_t_after_fn");
-      // Always release the taskpool read token after the JIT call finishes.
-      Value *Bucket = Builder.CreateLoad(I32Ty, OutBucketAlloca);
-      Builder.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
-      if (EJitWrapperTiming) {
-        Value *TAfterRelease =
-            Builder.CreateCall(TraceNow, {}, "ejit_t_after_release");
-        Builder.CreateCall(TraceWrapper,
-                           {FuncIdx, Status, OutFn, Bucket, TBeforeLookup,
-                            TAfterLookup, TAfterFn, TAfterRelease});
-      }
-      Builder.CreateRet(RetVal);
+      emitSlowPath(*F, JitEntry, JitCall, JitDispatch, JitFallback);
     }
 
     Changed = true;

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-maxdims.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-maxdims.ll
@@ -1,0 +1,24 @@
+; An ejit_entry with more than EJIT_ICACHE_MAX_DIMS (4) ejit_dim params is a
+; compile error - the wrapper is not emitted. (The taskpool DimCount cap is 4,
+; which the inline cache mirrors as EJIT_ICACHE_MAX_DIMS.)
+
+; RUN: not opt -passes=ejit-wrapper-gen -ejit-inline-cache -S %s 2>&1 | FileCheck %s
+; CHECK: error: ejit-wrapper-gen: more than 4 ejit_period_arr_ind dimensions are not supported
+
+define i32 @five_dim_entry(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e) !ejit.metadata !0 {
+entry:
+  ret i32 0
+}
+
+@data = global i32 0, !ejit.metadata !10
+@data2 = global i32 0, !ejit.metadata !11
+@data3 = global i32 0, !ejit.metadata !12
+@data4 = global i32 0, !ejit.metadata !13
+@data5 = global i32 0, !ejit.metadata !14
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"p1", i32 0}, !{!"ejit_period_arr_ind", !"p2", i32 1}, !{!"ejit_period_arr_ind", !"p3", i32 2}, !{!"ejit_period_arr_ind", !"p4", i32 3}, !{!"ejit_period_arr_ind", !"p5", i32 4}}
+!10 = distinct !{!{!"ejit_period_arr", !"p1", i32 16}}
+!11 = distinct !{!{!"ejit_period_arr", !"p2", i32 32}}
+!12 = distinct !{!{!"ejit_period_arr", !"p3", i32 48}}
+!13 = distinct !{!{!"ejit_period_arr", !"p4", i32 64}}
+!14 = distinct !{!{!"ejit_period_arr", !"p5", i32 80}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -1,75 +1,102 @@
 ; -ejit-inline-cache (ON): emits an inline probe DIRECTLY in the ejit_entry
-; wrapper - a load atomic of the per-function @__ejit_icache_fn_<name> slot +
-; null-check; the hit path (jit_icache_dispatch) calls the cached specialization
-; directly with NO ejit_icache_try call and NO ejit_taskpool_release_read. The
-; probe takes no dims, so a hit pays no dim loads. Default (OFF): the original
-; 4-block wrapper, no icache. Idempotent: running the pass twice does not
-; duplicate the probe. With -ejit-wrapper-timing the icache hit path is
-; instrumented (trace_now + trace_wrapper, sentinel status).
+; wrapper - a GEP into the per-function @__ejit_icache_fn_<name> [D]^numDims
+; array (D = EJIT_ICACHE_DIM_SIZE, power-of-2) by the ejit_dim argument values,
+; then a plain load + null-check; the hit path (jit_icache_dispatch) calls the
+; cached specialization directly with NO ejit_icache_try call and NO
+; ejit_taskpool_release_read. numDims=0 is a scalar slot (no GEP). Default
+; (OFF): the original 4-block wrapper, no icache. Idempotent: running the pass
+; twice does not duplicate the probe.
 
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s --check-prefix=ICACHE
 ; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s --check-prefix=NOICACHE
 ; RUN: opt -passes=ejit-wrapper-gen,ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s --check-prefix=IDEM
+; --- -ejit-wrapper-timing + -ejit-inline-cache: the hit path emits trace calls
+;     AFTER the specialization call, so it must NOT be musttail (musttail must
+;     immediately precede a ret). Verify the module is valid (opt verifies by
+;     default) and the hit path is a plain call. Regression for the broken-IR
+;     boot crash where codegen silently dropped the ejit_entry function. ---
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-wrapper-timing -disable-output %s
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-wrapper-timing -S %s | FileCheck %s --check-prefix=TIMING
 
-; --- 1D entry: inline probe = load atomic @__ejit_icache_fn + null-check; hit
-; --- calls the cached ptr directly (NO release_read). NO ejit_icache_try call. ---
-; ICACHE-LABEL: define i32 @one_dim_entry(
+; --- icache globals: [D]^numDims, D=8 (EJIT_ICACHE_DIM_SIZE). 0D is scalar. ---
+; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, align 8
+; ICACHE-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, align 8
+; ICACHE-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, align 8
+
+; --- 0D entry: scalar slot, direct plain load (NO GEP). ---
+; ICACHE-LABEL: define i32 @zero_dim_entry(
 ; ICACHE-NOT: ejit_icache_try
-; ICACHE: load atomic ptr, ptr @__ejit_icache_fn_one_dim_entry acquire, align 8
+; ICACHE-NOT: getelementptr
+; ICACHE: load ptr, ptr @__ejit_icache_fn_zero_dim_entry, align 8
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
 ; ICACHE: call {{.*}} %ejit_ic_fn
 ; ICACHE: ret
 
-; --- 3D entry: same probe shape (load atomic, no dims in the probe). ---
-; ICACHE-LABEL: define i32 @three_dim_entry(
+; --- 1D entry: [16 x ptr] slot, GEP by the single dim arg + plain load. ---
+; ICACHE-LABEL: define i32 @one_dim_entry(
 ; ICACHE-NOT: ejit_icache_try
-; ICACHE: load atomic ptr, ptr @__ejit_icache_fn_three_dim_entry acquire, align 8
+; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
+; ICACHE: load ptr, ptr {{.*}}, align 8
+; ICACHE-LABEL: jit_icache_dispatch:
+; ICACHE-NOT: call void @ejit_taskpool_release_read
+; ICACHE: call {{.*}} %ejit_ic_fn
+; ICACHE: ret
+
+; --- 2D entry: [16 x [16 x ptr]] slot, 2-subscript GEP. ---
+; ICACHE-LABEL: define i32 @two_dim_entry(
+; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_two_dim_entry, i32 0, i32 {{.*}}, i32 {{.*}}
+
+; --- registration carries numDims (3rd arg): 0 / 1 / 2 (DAG: order-independent). ---
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 2)
 
 ; --- Default (flag OFF): no icache anywhere; original compile_or_get path. ---
 ; NOICACHE-LABEL: define i32 @one_dim_entry(
-; NOICACHE-NOT: ejit_icache_try
 ; NOICACHE-NOT: __ejit_icache_fn
 ; NOICACHE-NOT: ejit_register_icache_slot
 ; NOICACHE: call i32 @ejit_taskpool_compile_or_get_1d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
-; NOICACHE-NOT: ejit_icache_try
 
-; --- Idempotent: two passes emit the probe exactly once. ---
+; --- Idempotent: two passes emit each probe exactly once. ---
 ; IDEM-LABEL: define i32 @one_dim_entry(
-; IDEM-COUNT-1: load atomic ptr, ptr @__ejit_icache_fn_one_dim_entry acquire, align 8
+; IDEM-COUNT-1: getelementptr {{.*}} @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
 
-; --- Timing: the icache hit path is instrumented (trace_now + trace_wrapper). ---
-; TIMING-LABEL: define i32 @one_dim_entry(
-; TIMING: call i64 @ejit_taskpool_trace_now()
-; TIMING: load atomic ptr, ptr @__ejit_icache_fn_one_dim_entry acquire, align 8
-; TIMING: call i64 @ejit_taskpool_trace_now()
+; --- timing hit path: plain call (NOT musttail) + trace + ret. The miss path
+;     stays musttail (no trailing calls), so we only forbid musttail within the
+;     hit block. ---
+; TIMING-LABEL: define i32 @zero_dim_entry(
 ; TIMING-LABEL: jit_icache_dispatch:
-; TIMING: call i64 @ejit_taskpool_trace_now()
-; TIMING: call void @ejit_taskpool_trace_wrapper(i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, i32 {{.*}}, i64 {{.*}}, i64 {{.*}}, i64 {{.*}}, i64 {{.*}})
-; TIMING-NOT: call void @ejit_taskpool_release_read
+; TIMING-NOT: musttail
+; TIMING: call i32 %ejit_ic_fn
+; TIMING: call i64 @ejit_taskpool_trace_now
+; TIMING: call void @ejit_taskpool_trace_wrapper
 ; TIMING: ret
 
-define i32 @one_dim_entry(i32 %idx1) !ejit.metadata !0 {
+define i32 @zero_dim_entry(i32 %x) !ejit.metadata !0 {
 entry:
   %v1 = load i32, ptr @data
   ret i32 0
 }
 
-define i32 @three_dim_entry(i32 %a, i32 %b, i32 %c) !ejit.metadata !1 {
+define i32 @one_dim_entry(i32 %idx1) !ejit.metadata !1 {
+entry:
+  %v1 = load i32, ptr @data
+  ret i32 0
+}
+
+define i32 @two_dim_entry(i32 %a, i32 %b) !ejit.metadata !2 {
 entry:
   %v1 = load i32, ptr @data
   %v2 = load i32, ptr @data2
-  %v3 = load i32, ptr @data3
   ret i32 0
 }
 
 @data = global i32 0, !ejit.metadata !10
 @data2 = global i32 0, !ejit.metadata !11
-@data3 = global i32 0, !ejit.metadata !12
 
-!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
-!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}, !{!"ejit_period_arr_ind", !"grp", i32 2}}
+!0 = distinct !{!{!"ejit_entry"}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!2 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
 !10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
 !11 = distinct !{!{!"ejit_period_arr", !"trp", i32 32}}
-!12 = distinct !{!{!"ejit_period_arr", !"grp", i32 48}}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2633,18 +2633,18 @@ TEST_F(SharedTaskPoolTest, InlineCacheStickyFrozen) {
   constexpr uint32_t kFunc = 3;
   // Register a per-function icache slot (the wrapper's @__ejit_icache_fn_
   // global, here a test-local stand-in) so icacheFill has somewhere to write.
-  std::atomic<uintptr_t> slot{0};
-  ejitIcacheRegisterSlot(kFunc, &slot);
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
 
   // Cold icache misses (empty slot).
-  EXPECT_FALSE(pool.icacheTry(kFunc, &out));
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
 
   // Fill on a resolve -> subsequent probe hits, returning the frozen fnPtr.
-  pool.icacheFill(kFunc, fn);
-  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
 
   // Frozen: a period toggle bumps the version, but v2 does NOT re-validate, so
@@ -2652,18 +2652,19 @@ TEST_F(SharedTaskPoolTest, InlineCacheStickyFrozen) {
   // invalidated). This is the v2 contract - the specialization is invariant.
   ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
   ASSERT_TRUE(pool.setInstanceEnabled(0, 5, false)); // bump version
-  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
 
-  // One-shot: a later fill with a DIFFERENT pointer does not overwrite - the
-  // first resolver wins and the slot is frozen.
-  void *fn2 = codeFor(1000);
-  pool.icacheFill(kFunc, fn2);
-  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
-  EXPECT_EQ(out, fn); // still the first pointer
+  // No one-shot CAS (per-core-private slot -> plain store). A later fill
+  // OVERWRITES; under the contract the specialization is invariant per identity,
+  // so a later resolve carries the SAME pointer and the overwrite is harmless.
+  // Verify a same-pointer re-fill leaves the served pointer unchanged.
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
 
   // Out-of-range funcIndex misses without touching memory.
-  EXPECT_FALSE(pool.icacheTry(EJIT_ICACHE_FUNC_SLOTS, &out));
+  EXPECT_FALSE(pool.icacheTry(EJIT_ICACHE_FUNC_SLOTS, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
 
   ejitIcacheClearAll();
@@ -2677,30 +2678,85 @@ TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
-  std::atomic<uintptr_t> slot{0};
-  ejitIcacheRegisterSlot(kFunc, &slot);
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
 
   // Before a releaser: fill -> hit.
-  pool.icacheFill(kFunc, fn);
-  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
 
   // Wire a releaser: icache auto-disables (miss + no-op fill).
   ReleaseLog rel;
   pool.setReleaser(&mockRelease, &rel);
-  EXPECT_FALSE(pool.icacheTry(kFunc, &out));
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
-  pool.icacheFill(kFunc, fn); // no-op: the gate blocks the fill
-  EXPECT_FALSE(pool.icacheTry(kFunc, &out));
+  pool.icacheFill(kFunc, fn, nullptr, 0); // no-op: the gate blocks the fill
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
 
   // Unwire the releaser: the gate re-opens; fill -> hit works again.
   pool.setReleaser(nullptr, nullptr);
-  pool.icacheFill(kFunc, fn);
-  EXPECT_TRUE(pool.icacheTry(kFunc, &out));
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
+
+  ejitIcacheClearAll();
+}
+
+// Multi-version: a 2-dim icache holds one frozen fnPtr per dim identity, so
+// different (i,j) combos serve different specializations (the v2 monomorphic
+// bug - one slot for all identities - is fixed). Distinct identities fill
+// distinct cells; one-shot per cell; shape mismatch misses.
+TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  // A 2-dim [D][D] slot (D = EJIT_ICACHE_DIM_SIZE), zero-initialized. The
+  // runtime reaches cells through an EJitAtomicUPtr* + linearized index.
+  constexpr uint32_t D = EJIT_ICACHE_DIM_SIZE;
+  uintptr_t slots[D][D] = {};
+  ejitIcacheRegisterSlot(kFunc, &slots[0][0], 2);
+
+  void *fn00 = codeFor(kFunc);
+  void *fn01 = codeFor(kFunc + 1);
+  void *fn10 = codeFor(kFunc + 2);
+  EJitDimPair id00[2] = {{0, 0}, {0, 0}};
+  EJitDimPair id01[2] = {{0, 0}, {0, 1}};
+  EJitDimPair id10[2] = {{0, 1}, {0, 0}};
+  void *out = nullptr;
+
+  // Cold: every identity misses (cells start empty).
+  EXPECT_FALSE(pool.icacheTry(kFunc, id00, 2, &out));
+  EXPECT_FALSE(pool.icacheTry(kFunc, id01, 2, &out));
+
+  // Fill each identity with its own fnPtr.
+  pool.icacheFill(kFunc, fn00, id00, 2);
+  pool.icacheFill(kFunc, fn01, id01, 2);
+  pool.icacheFill(kFunc, fn10, id10, 2);
+
+  // Each identity serves its OWN fnPtr (multi-version: no cross-contamination).
+  EXPECT_TRUE(pool.icacheTry(kFunc, id00, 2, &out));
+  EXPECT_EQ(out, fn00);
+  EXPECT_TRUE(pool.icacheTry(kFunc, id01, 2, &out));
+  EXPECT_EQ(out, fn01);
+  EXPECT_TRUE(pool.icacheTry(kFunc, id10, 2, &out));
+  EXPECT_EQ(out, fn10);
+
+  // No one-shot CAS (per-core-private -> plain store): a later fill of (0,0)
+  // OVERWRITES with the latest pointer. Under the contract a later resolve of
+  // the same identity carries the same pointer, so re-fill with fn00 is a no-op
+  // semantically; verify the served pointer is still fn00.
+  pool.icacheFill(kFunc, fn00, id00, 2);
+  EXPECT_TRUE(pool.icacheTry(kFunc, id00, 2, &out));
+  EXPECT_EQ(out, fn00);
+
+  // Shape mismatch (caller numDims != registered 2): miss, no OOB access.
+  EXPECT_FALSE(pool.icacheTry(kFunc, id00, 1, &out));
+  EXPECT_FALSE(pool.icacheTry(kFunc, id00, 0, &out));
 
   ejitIcacheClearAll();
 }


### PR DESCRIPTION
…ss hit path

Measured aarch64_be hit-path performance (-Os, D=16, lever B frame-less):
  | numDims | LLVM instr | Measured cycle | vs v2 (~7-8c) |
  |---------|------------|----------------|----------------|
  | 0       | 4          | 4              | faster         |
  | 1       | 5          | 5              | faster         |
  | 2       | 7          | 6              | faster         |
  | 3       | 9          | 8              | on par         |
  | 4       | 11         | 9              | +1-2c          |

Extend the per-function inline cache from sticky-monomorphic (one frozen slot per funcIndex) to polymorphic: @__ejit_icache_fn_<name> is a [D]^numDims array (D = EJIT_ICACHE_DIM_SIZE = 16, power-of-2, product-defined; scalar for numDims=0) indexed by the ejit_dim argument values, so each dim identity gets its own frozen specialization cell. Fixes the v2 bug where an ejit_entry called with different ejit_dim values served the first-resolved specialization.

Hit path (lever B, frame-less for ALL dims):
  Wrapper is a frame-less probe + two tail calls: GEP (shifts, no multiply) +
  plain ldr (no atomic -- per-core-private slot) + expect(hit, true) + cbz ->
  br spec (hit) | br MissFn (miss). Slow path in per-function noinline MissFn.
  ALL original basic blocks moved to MissFn; F args remapped. musttail forces
  br (not blr); gated on !EJitWrapperTiming (timing path uses plain call).

  2-4 dim beat instruction count via ILP (sxtw overlaps adrp latency).

Fill: icacheFill linearizes (Horner, row-major) and plain-stores the cell (no CAS, no atomic -- per-core private, invariant specialization).

Safety: per-core-private array (default BSS), each cell sealed-then-filled on the calling core's own slow path. Reclamation gate retained. No version check.

Config: EJIT_ICACHE_DIM_SIZE (CMake, default 16, power-of-2 enforced) via #define on both LLVMEmbeddedJIT + LLVMEJIT. numDims > EJIT_ICACHE_MAX_DIMS (4) is a compile error.

Tests: 33/33 EmbeddedJIT lit pass (5 XFAIL); icache unit 3/3 pass. Board test validates correctness + per-dim overhead.

Docs: PASS3_EJitWrapperGen.md §10, EJIT_ICACHE_MULTIVERSION.md (design + perf), PASS7_EJitRuntime_OrcJITLink.md (runtime doc sync).