### PR TITLE
[EJIT] Add JIT-local cross-TU helper mode

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1685,6 +1685,10 @@ def fejit_cross_inline : Flag<["-"], "fejit-cross-inline">,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Enable cross-TU inlining for EJIT entry functions (defers bitcode "
            "extraction to link time)">;
+def fejit_cross_jit_helpers : Flag<["-"], "fejit-cross-jit-helpers">,
+  Visibility<[ClangOption]>,
+  HelpText<"Keep ordinary cross-TU helpers as JIT-local functions instead of "
+           "inlining them into EJIT entry functions">;
 defm gnu_inline_asm : BoolFOption<"gnu-inline-asm",
   LangOpts<"GNUAsm">, DefaultTrue,
   NegFlag<SetFalse, [], [ClangOption, CC1Option],

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5311,11 +5311,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.getLastArg(options::OPT_save_temps_EQ))
     Args.AddLastArg(CmdArgs, options::OPT_save_temps_EQ);
 
-  // EJIT cross-TU inlining: defer bitcode extraction to link time.
-  if (Args.hasArg(options::OPT_fejit_cross_inline)) {
+  // Both EJIT cross-TU policies defer bitcode extraction to link time.
+  if (Args.hasArg(options::OPT_fejit_cross_inline,
+                  options::OPT_fejit_cross_jit_helpers)) {
+    const char *ModeFlag = Args.hasArg(options::OPT_fejit_cross_jit_helpers)
+                               ? "-fejit-cross-jit-helpers"
+                               : "-fejit-cross-inline";
     if (IsUsingLTO) {
-      D.Diag(diag::err_drv_argument_not_allowed_with)
-          << "-fejit-cross-inline" << "-flto";
+      D.Diag(diag::err_drv_argument_not_allowed_with) << ModeFlag << "-flto";
     }
     CmdArgs.push_back("-mllvm");
     CmdArgs.push_back("-ejit-cross-inline");

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -462,20 +462,23 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   bool NeedsXRayDeps = addXRayRuntime(ToolChain, Args, CmdArgs);
   addLinkerCompressDebugSectionsOption(ToolChain, Args, CmdArgs);
 
-  // EJIT cross-TU inlining. ld.lld is the single owner of the merge; the clang
-  // driver never performs it. When -fejit-cross-inline is requested we require
-  // ld.lld and forward the request via --ejit-cross-inline. Any other linker
-  // cannot consume the .ejit_cross sections, so we emit a hard error rather
-  // than produce an output that still carries the (large) .ejit_cross data and
-  // no registry -- which would silently fall back to per-TU AOT bitcode.
-  if (Args.hasArg(options::OPT_fejit_cross_inline)) {
+  // ld.lld is the single owner of both cross-TU helper policies. JIT-helper
+  // mode consumes the same sections but preserves ordinary helper definitions.
+  bool CrossInline = Args.hasArg(options::OPT_fejit_cross_inline);
+  bool JitHelpers = Args.hasArg(options::OPT_fejit_cross_jit_helpers);
+  if (CrossInline || JitHelpers) {
+    const char *ModeFlag =
+        JitHelpers ? "-fejit-cross-jit-helpers" : "-fejit-cross-inline";
     bool LinkerIsLLD = false;
     (void)ToolChain.GetLinkerPath(&LinkerIsLLD);
     if (!LinkerIsLLD)
       ToolChain.getDriver().Diag(diag::err_drv_argument_only_allowed_with)
-          << "-fejit-cross-inline" << "-fuse-ld=lld";
-    else
+          << ModeFlag << "-fuse-ld=lld";
+    else {
       CmdArgs.push_back("--ejit-cross-inline");
+      if (JitHelpers)
+        CmdArgs.push_back("--ejit-cross-jit-helpers");
+    }
   }
 
   AddLinkerInputs(ToolChain, Inputs, Args, CmdArgs, JA);

--- a/clang/test/Driver/ejit-cross-inline.c
+++ b/clang/test/Driver/ejit-cross-inline.c
@@ -13,15 +13,37 @@
 // LLD: "-ejit-cross-inline"
 // LLD: "--ejit-cross-inline"
 
+// JIT-local helper mode emits the same cc1 section-production flag, then asks
+// ld.lld to preserve ordinary helper definitions instead of cost-model
+// inlining them.
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fuse-ld=lld \
+// RUN:     -fejit-cross-jit-helpers %s 2>&1 | \
+// RUN:     FileCheck %s --check-prefix=JITHELPERS
+// JITHELPERS: "-cc1"
+// JITHELPERS: "-ejit-cross-inline"
+// JITHELPERS: "--ejit-cross-inline"
+// JITHELPERS: "--ejit-cross-jit-helpers"
+
 // With a non-lld linker: hard error, no silent .bc / leftover .ejit_cross.
 // RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fuse-ld=gold \
 // RUN:     -fejit-cross-inline %s 2>&1 | FileCheck %s --check-prefix=NOLLD
 // NOLLD: invalid argument '-fejit-cross-inline' only allowed with '-fuse-ld=lld'
 
+// The helper-preserving mode has the same ld.lld requirement.
+// RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fuse-ld=gold \
+// RUN:     -fejit-cross-jit-helpers %s 2>&1 | \
+// RUN:     FileCheck %s --check-prefix=HELPER-NOLLD
+// HELPER-NOLLD: invalid argument '-fejit-cross-jit-helpers' only allowed with '-fuse-ld=lld'
+
 // Conflicts with -flto at compile time.
 // RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fuse-ld=lld -flto \
 // RUN:     -fejit-cross-inline %s 2>&1 | FileCheck %s --check-prefix=LTO
 // LTO: invalid argument '-fejit-cross-inline' not allowed with '-flto'
+
+// RUN: not %clang -### --target=x86_64-unknown-linux-gnu -fuse-ld=lld -flto \
+// RUN:     -fejit-cross-jit-helpers %s 2>&1 | \
+// RUN:     FileCheck %s --check-prefix=HELPER-LTO
+// HELPER-LTO: invalid argument '-fejit-cross-jit-helpers' not allowed with '-flto'
 
 // Default (no -fejit-cross-inline): neither the cc1 flag nor the linker flag
 // appears, so behaviour is unchanged.
@@ -29,5 +51,6 @@
 // RUN:     %s 2>&1 | FileCheck %s --check-prefix=OFF
 // OFF-NOT: "-ejit-cross-inline"
 // OFF-NOT: "--ejit-cross-inline"
+// OFF-NOT: "--ejit-cross-jit-helpers"
 
 int main(void) { return 0; }

--- a/ejit_test/ejit_jit_local_helpers_sre_helper.c
+++ b/ejit_test/ejit_jit_local_helpers_sre_helper.c
@@ -1,0 +1,19 @@
+// Ordinary cross-TU helpers retained by -fejit-cross-jit-helpers.
+
+#include <stdint.h>
+
+struct LocalHelperCfg {
+  uint32_t mode;
+  uint32_t bias;
+  uint32_t runtimeCounter;
+};
+
+extern struct LocalHelperCfg g_localHelperCfg[];
+
+uint32_t jit_local_helper_c(uint8_t cell) {
+  return g_localHelperCfg[cell].mode * 10u + g_localHelperCfg[cell].bias;
+}
+
+uint32_t jit_local_helper_b(uint8_t cell) {
+  return jit_local_helper_c(cell) + (uint32_t)cell + 7u;
+}

--- a/ejit_test/ejit_jit_local_helpers_sre_test.c
+++ b/ejit_test/ejit_jit_local_helpers_sre_test.c
@@ -1,0 +1,177 @@
+//===-- ejit_jit_local_helpers_sre_test.c ---------------------------------===//
+//
+// SRE functional demo for -fejit-cross-jit-helpers:
+//
+//   jit_local_entry -> jit_local_helper_b -> jit_local_helper_c
+//
+// Start test_ejit_period on the intended worker core first, then start it on a
+// business core. The first call enqueues an async compile and runs AOT
+// fallback; the second call verifies the JIT result. The worker then prints
+// optimized IR/ASM. Both ordinary helpers must remain as specialized
+// definitions and the calls should be direct code-pool-local branches.
+//
+// Compile BOTH this file and ejit_jit_local_helpers_sre_helper.c with:
+//   -O2 -fejit-cross-jit-helpers
+// Link/merge with:
+//   clang -fuse-ld=lld -fejit-cross-jit-helpers -r main.o helper.o -o test.o
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "ejit_test_helpers.h"
+
+extern void SRE_printf(const char *format, ...);
+extern uint32_t SRE_TaskDelay(uint32_t tick);
+extern void call_init_array_functions(void);
+extern uint8_t g_ucLocalCoreID;
+
+#ifndef EJIT_SHARED_SECTION_ATTR
+#define EJIT_SHARED_SECTION_ATTR __attribute__((section(".mc_shared")))
+#endif
+
+#define TEST_CELL 1u
+#define EXPECTED_RESULT 247u
+#define WAIT_ROUNDS 400u
+#define WAIT_TICKS 10u
+#define IDLE_TICKS 40000u
+
+enum { PHASE_IDLE, PHASE_ARMED, PHASE_VERIFIED, PHASE_PRINTED };
+
+struct LocalHelperCfg {
+  ejit_may_const uint32_t mode;
+  ejit_may_const uint32_t bias;
+  uint32_t runtimeCounter;
+};
+
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(cell)
+struct LocalHelperCfg g_localHelperCfg[2];
+EJIT_SHARED_SECTION_ATTR static uint32_t g_testPhase;
+EJIT_SHARED_SECTION_ATTR static uint32_t g_businessClaim;
+
+extern uint32_t jit_local_helper_b(uint8_t cell);
+
+ejit_entry __attribute__((noinline)) uint32_t
+jit_local_entry(ejit_period_arr_ind(cell) uint8_t cell) {
+  return jit_local_helper_b(cell) * 2u + 1u;
+}
+
+static uint32_t core_id(void) { return (uint32_t)g_ucLocalCoreID; }
+
+static uint32_t load_phase(void) {
+  return __atomic_load_n(&g_testPhase, __ATOMIC_ACQUIRE);
+}
+
+static void store_phase(uint32_t phase) {
+  __atomic_store_n(&g_testPhase, phase, __ATOMIC_RELEASE);
+}
+
+static void idle_forever(uint32_t core, const char *role) {
+  for (;;) {
+    SRE_TaskDelay(IDLE_TICKS);
+    SRE_printf("[JITHELPER][core=%u] idle role=%s phase=%u\n", core, role,
+               load_phase());
+  }
+}
+
+static bool wait_for_compile(void) {
+  for (uint32_t i = 0; i < WAIT_ROUNDS; ++i) {
+    ejit_taskpool_stats_t stats;
+    ejit_taskpool_get_stats(&stats);
+    if (ejit_taskpool_pending_count() == 0 && stats.readyEntries != 0)
+      return true;
+    SRE_TaskDelay(WAIT_TICKS);
+  }
+  return false;
+}
+
+static void run_worker(uint32_t core) {
+  while (load_phase() < PHASE_VERIFIED)
+    SRE_TaskDelay(WAIT_TICKS);
+
+  SRE_printf("[JITHELPER][core=%u] printing optimized IR/ASM\n", core);
+  ejit_print_dumped("jit_local_entry");
+  store_phase(PHASE_PRINTED);
+  idle_forever(core, "worker-complete");
+}
+
+static void run_business(uint32_t core) {
+  uint32_t unclaimed = 0;
+  if (!__atomic_compare_exchange_n(&g_businessClaim, &unclaimed, core + 1u,
+                                   false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+    idle_forever(core, "non-owner-business");
+
+  const struct LocalHelperCfg initial = {
+      .mode = 11u, .bias = 5u, .runtimeCounter = 0u};
+  g_localHelperCfg[TEST_CELL] = initial;
+
+  ejit_status_t activateRc = ejit_activate("cell", TEST_CELL);
+  SRE_printf("[JITHELPER][core=%u] activate rc=%d\n", core, (int)activateRc);
+
+  ejit_dump_func("jit_local_entry");
+  store_phase(PHASE_ARMED);
+
+  uint32_t first = jit_local_entry(TEST_CELL);
+  SRE_printf("[JITHELPER][core=%u] first(AOT)=%u expected=%u\n", core, first,
+             EXPECTED_RESULT);
+  if (first != EXPECTED_RESULT)
+    idle_forever(core, "aot-mismatch");
+
+  if (!wait_for_compile()) {
+    SRE_printf("[JITHELPER][core=%u] FAIL: compile timeout\n", core);
+    ejit_taskpool_print_stats();
+    idle_forever(core, "compile-timeout");
+  }
+
+  uint32_t second = jit_local_entry(TEST_CELL);
+  SRE_printf("[JITHELPER][core=%u] second(JIT)=%u expected=%u\n", core, second,
+             EXPECTED_RESULT);
+  if (second != EXPECTED_RESULT)
+    idle_forever(core, "jit-mismatch");
+
+  SRE_printf("[JITHELPER][core=%u] PASS: nested JIT-local helpers\n", core);
+  ejit_taskpool_print_compiled();
+  ejit_taskpool_print_stats();
+  store_phase(PHASE_VERIFIED);
+
+  for (uint32_t i = 0; i < WAIT_ROUNDS; ++i) {
+    if (load_phase() >= PHASE_PRINTED)
+      idle_forever(core, "test-complete");
+    SRE_TaskDelay(WAIT_TICKS);
+  }
+  idle_forever(core, "dump-timeout");
+}
+
+int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+
+  uint32_t core = core_id();
+  call_init_array_functions();
+
+  ejit_config_t cfg;
+  ejit_default_config(&cfg);
+  cfg.compileMode = EJIT_COMPILE_ASYNC;
+  cfg.optLevel = EJIT_OPT_L2;
+  cfg.enableLogger = false;
+  cfg.forceStaticRegistry = true;
+
+  ejit_status_t initRc = ejit_init(&cfg);
+  uint32_t worker = ejit_taskpool_get_worker_core();
+  SRE_printf("[JITHELPER][core=%u] init rc=%d worker=%u\n", core, (int)initRc,
+             worker);
+  if (initRc != EJIT_OK)
+    idle_forever(core, "init-failed");
+
+  if (core == worker) {
+    __atomic_store_n(&g_businessClaim, 0u, __ATOMIC_RELEASE);
+    store_phase(PHASE_IDLE);
+    run_worker(core);
+  }
+
+  run_business(core);
+  return 0;
+}

--- a/jit_design_doc/EJIT_BITCODE_REPOSITORY_SCC.md
+++ b/jit_design_doc/EJIT_BITCODE_REPOSITORY_SCC.md
@@ -1,0 +1,189 @@
+# EJIT Bitcode Repository and SCC Manifest
+
+**Status:** experimental  
+**Version:** 1  
+**Applies to:** `-fejit-cross-jit-helpers`
+
+## 1. Problem
+
+The original cross-TU helper mode emits one self-contained bitcode module for
+every `ejit_entry`. If several entries reach the same large helper closure, the
+final image stores that closure once per entry:
+
+```text
+entry_a payload = entry_a + helper_b + helper_c
+entry_d payload = entry_d + helper_b + helper_c
+```
+
+Forcing all helpers to inline does not solve the storage problem. It duplicates
+the helper instructions at each call site and can make both bitcode and
+generated code larger.
+
+The repository format separates template storage from specialization:
+
+* the linked image stores every reachable helper definition once;
+* each runtime compilation gets an independent transient module;
+* IPSCCP may therefore produce different helper versions for different entry
+  dimension values without duplicating the original bitcode payload.
+
+## 2. Linked-image format
+
+`ld.lld --ejit-cross-jit-helpers` merges the `.ejit_cross` inputs, keeps the
+union of all entry closures, and serializes that module once as:
+
+```text
+@__ejit_bitcode_repository
+```
+
+Every `EJIT_REG_BITCODE` record still has the existing ABI:
+
+```text
+{ type, entryName, reserved, data, size }
+```
+
+The records for all entries point to the same repository `data` and `size`.
+There is no runtime registry ABI change and legacy per-entry payloads remain
+valid.
+
+The repository module contains three named metadata records:
+
+```llvm
+!ejit.repository.version = !{!0}
+!ejit.repository.sccs = !{!1, !2, ...}
+!ejit.repository.entries = !{!10, !11, ...}
+
+!0 = !{i32 1}
+!1 = !{i32 0, !"helper_b", !"helper_c"}
+!10 = !{!"entry_a", i32 0, i32 3}
+```
+
+`ejit.repository.sccs` records the function call-graph SCCs. An SCC is the
+smallest unit that must remain together for recursion. An entry record contains
+the sorted SCC IDs in its transitive closure.
+
+Global initializers, aliases, ifunc resolvers, constant expressions and
+function-pointer tables participate in reference collection. Runtime-supplied
+indirect targets cannot be inferred and remain external runtime dependencies.
+
+## 3. Link-time algorithm
+
+1. Merge selected `.ejit_cross` modules.
+2. Find every `ejit_entry`.
+3. Compute the conservative union closure and remove unrelated definitions.
+4. Apply `AlwaysInlinerPass`; ordinary helpers remain as functions.
+5. Build direct function-reference edges, including references reached through
+   kept global initializers.
+6. Run Tarjan SCC decomposition.
+7. Compute each entry's transitive closure and encode its sorted SCC IDs.
+8. Externalize mutable process globals exactly as the legacy extractor does.
+9. Serialize the repository once.
+10. Emit one normal bitcode registry record per entry, all referring to that
+    repository payload.
+
+The normal `-fejit-cross-inline` policy is unchanged and continues to emit
+independent per-entry payloads.
+
+## 4. Runtime selection
+
+`EJitOrcEngine::loadBitcodeModule` parses the registered payload and calls
+`prepareRepositoryForEntry` before symbol collection or optimization.
+
+For a repository module:
+
+1. Validate the format version and the requested entry record.
+2. Validate all referenced SCC IDs and unique function membership.
+3. Keep the requested entry externally visible.
+4. Internalize every other definition, including other entries and helpers.
+5. Run `GlobalDCE`; the requested entry becomes the sole root and reconstructs
+   its function/global closure.
+6. Verify every surviving function belongs to an SCC listed by the entry
+   manifest.
+7. Run the unchanged EJIT specialization pipeline:
+   period-index substitution, may-const folding, IPSCCP and the selected
+   function simplification pipeline.
+
+Consequently, `entry_a(x=1)` and `entry_a(x=2)` parse the same repository
+template but optimize independent transient helper copies. Symbols cannot mix
+because every specialization retains the existing isolated JITDylib.
+
+Legacy modules without `!ejit.repository.version` bypass repository selection
+unchanged.
+
+## 5. Size and cost model
+
+Let `E` be the entry count, `H` the shared helper bitcode size and `A_i` each
+entry's unique bitcode:
+
+```text
+per-entry closure:  sum(A_i) + E * H
+repository:         sum(A_i) + H + manifest
+```
+
+The saving grows with the number of entries sharing a large closure. The
+trade-off is worker-side parsing and `GlobalDCE` over the union repository for
+each new specialization. Compilation is asynchronous, so this design
+deliberately trades worker CPU and temporary memory for linked-image size.
+
+The first implementation stores one repository. If parsing a very large union
+becomes expensive, the compatible next step is one repository payload per
+connected group of SCCs, while preserving the same metadata format.
+
+## 6. Correctness invariants
+
+* Repository metadata is versioned and malformed manifests fail compilation.
+* The manifest is not trusted as a deletion instruction: `GlobalDCE` derives
+  liveness from the selected entry; the manifest validates the result.
+* Mutable globals remain owned by the AOT image.
+* Helper definitions become local before IPSCCP, so constants can propagate
+  through all statically known call sites.
+* The selected entry remains externally visible for ORC lookup.
+* Existing registry ABI, funcIndex assignment, cache keys, taskpool state and
+  code-pool publication are unchanged.
+
+## 7. Limitations
+
+* Different specialization values may still require different helper machine
+  code. This design deduplicates bitcode templates, not inherently distinct
+  generated code.
+* The whole repository is parsed for each cache miss. SCC-sharded physical
+  payloads are a future optimization.
+* Truly dynamic indirect callees cannot be added to a static closure unless a
+  module-owned function table exposes their candidates.
+* Repository mode currently follows the JIT-local-helper option. It is
+  experimental until linked-image size and worker compilation latency are
+  measured on the production SRE image.
+
+## 8. Required verification
+
+* Link two entries sharing a nested or recursive helper closure.
+* Confirm one `__ejit_bitcode_repository` symbol and one helper definition in
+  saved repository IR.
+* Confirm both registry entries use the shared payload.
+* Select each entry independently and confirm the unrelated closure is removed.
+* Confirm different dimension values specialize the same helper template
+  independently.
+* Compare `.ejit_bitcode`/ELF size and worker compile time against per-entry
+  JIT-helper payloads on representative production inputs.
+
+## 9. Prototype result
+
+The initial AArch64 test links two entries that share an ordinary nested helper
+chain. Both versions use the same input objects:
+
+```text
+legacy per-entry payloads: 4732 bytes total
+repository payload:        2996 bytes
+reduction:                  36.7%
+```
+
+The final ELF contains one `__ejit_bitcode_repository` symbol. Its saved IR
+contains both entries, one copy of each helper, and all three repository
+metadata records. Runtime tests select each entry independently, remove the
+other closure, retain a recursive helper SCC, reject an unknown SCC, and
+specialize the same helper template to two different constant results (`10`
+and `20`).
+
+This small result demonstrates structural deduplication, not a production size
+forecast. Production benefit depends on how much helper closure is shared
+between entries. Worker compile latency still includes parsing the whole
+repository and must be measured on the SRE workload.

--- a/jit_design_doc/EJIT_CROSS_TU_INLINE.md
+++ b/jit_design_doc/EJIT_CROSS_TU_INLINE.md
@@ -1,6 +1,6 @@
 # EJIT Cross-TU Inlining 设计文档
 
-**版本**: 1.1
+**版本**: 1.2
 **日期**: 2026-07-30
 **关联**: SPEC4.md, PLAN4.md, PASS1_EJitRegisterBitcode.md
 
@@ -16,7 +16,11 @@
 
 ### 1.2 目标
 
-通过新选项 `-fejit-cross-inline`，让**只有** `__ejit_bitcode` 获得跨 TU 内联优化，AOT 代码走普通编译流程。
+提供两种只作用于 `__ejit_bitcode` 的跨 TU 优化策略，AOT 代码仍走普通编译流程：
+
+- `-fejit-cross-inline`：按 LLVM 成本模型内联普通 helper；
+- `-fejit-cross-jit-helpers`：仅展开 `always_inline`，普通 helper 的传递
+  闭包随 entry 进入 JIT module，在 code pool 内生成特化版本。
 
 ### 1.3 核心思路
 
@@ -31,7 +35,7 @@
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  编译期 (-fejit-cross-inline -c)                                │
+│  编译期 (-fejit-cross-inline / -fejit-cross-jit-helpers -c)     │
 │                                                                 │
 │  clang → IR → PASS1(cross-inline 模式)                         │
 │                  │                                              │
@@ -56,8 +60,9 @@
 │    2. parseBitcodeFile → 每个 section 解析为一个 Module          │
 │    3. llvm::Linker::linkInModule() → 合并所有 Module            │
 │    4. 找 ejit_entry → computeTransitiveClosure (保守引用收集)    │
-│    5. AlwaysInliner + ModuleInlinerWrapperPass → 真实内联跨 TU  │
-│       普通函数 (成本模型驱动, 非仅 always_inline)               │
+│    5. helper 策略:                                               │
+│       cross-inline: AlwaysInliner + 成本模型 ModuleInliner       │
+│       jit-helpers: 仅 AlwaysInliner, 普通 helper 保留为定义      │
 │    6. reAnnotateMayConst (复用 EJitCommon.h canonical resolver)  │
 │    7. 对每个 ejit_entry 单独:                                   │
 │       CloneModule → computeTransitiveClosure → trim             │
@@ -83,6 +88,41 @@ clang -fejit-cross-inline combined.o tu_c.o -o app
   → 读取 tu_c.o 的 .ejit_cross + combined.o 的 @__ejit_bitcode
   → 合并处理 → 生成新的 @__ejit_bitcode
 ```
+
+### 2.2 JIT-local helper 模式
+
+```
+clang -fejit-cross-jit-helpers -c entry.c -o entry.o
+clang -fejit-cross-jit-helpers -c helper.c -o helper.o
+clang -fuse-ld=lld -fejit-cross-jit-helpers entry.o helper.o -o app
+```
+
+clang cc1 仍使用内部 `-ejit-cross-inline` 生成同一种 `.ejit_cross` 输入；
+driver 额外向 lld 传递 `--ejit-cross-jit-helpers`。因此两种策略可以使用同一批
+对象文件，区别只发生在 lld 合并后的 helper policy。
+
+对 `A -> B -> C`：
+
+1. 保守闭包收集将 B、C 的定义都放入 A 的 per-entry bitcode；
+2. runtime 将非 entry 定义 internalize；
+3. IPSCCP 把 entry 已固定的维度参数逐层传播到 B、C；
+4. 第二轮 InstCombine + StructFieldPass 折叠 helper 内的 may_const；
+5. A、B、C 一起 codegen/JITLink，内部调用生成 code-pool 内的直接 `BL`。
+
+该模式不提供跨 entry 的 helper 机器码共享：每个 specialization 拥有自己的
+helper 副本。这样无需新增 helper cache、失效协议、跨核发布或回收依赖，语义
+与现有 per-entry JITDylib 生命周期一致。
+
+限制：
+
+- helper 若通过运行时不可推断的函数指针调用，闭包只能保留静态可见候选，
+  IPSCCP 也不能假定参数恒定；
+- helper 被多个 entry 使用时，各 entry specialization 仍各自生成一份；
+- helper 与 entry 同属一个 JITLink graph/code allocation，现有 2 MiB pool 下
+  可使用 AArch64 直接 `BL`；若未来单个 graph 超过 `BL` 范围，需要重新引入
+  range extension thunk；
+- fully folded 的纯 helper 调用可能被后续 DCE 完全消除，这比保留 `BL` 更优，
+  不应视为模式失效。
 
 ---
 
@@ -342,8 +382,9 @@ add_llvm_component_library(LLVMEmbeddedJIT
 
 ### 5.2 clangDriver
 
-clang driver 只负责校验选中的 linker 并转发 `--ejit-cross-inline`；不再链接
-BitReader/Object/Linker 等 cross-link 实现依赖。
+clang driver 只负责校验选中的 linker 并转发 `--ejit-cross-inline`；helper
+模式再追加 `--ejit-cross-jit-helpers`。driver 不再链接 BitReader/Object/Linker
+等 cross-link 实现依赖。
 
 ---
 
@@ -353,9 +394,9 @@ BitReader/Object/Linker 等 cross-link 实现依赖。
 |---|---|
 | **PASS3 (WrapperGen)** | 不受影响 — wrapper 仍正常生成 |
 | **PASS2 (RegisterPeriod)** | 不受影响 |
-| **运行时 (libLLVMEJIT)** | 不受影响 — `ejit_init` 仍通过 `ejit_register_bitcode` 加载 `@__ejit_bitcode` |
-| **JIT 编译** | 受益 — bitcode 中跨 TU 子函数已内联，PASS6 可以追到 may_const load |
-| **默认编译路径** | 不受影响 — 不传 `-fejit-cross-inline` 时行为完全不变 |
+| **运行时 (libLLVMEJIT)** | ABI 不变；helper 模式复用 internalize + IPSCCP |
+| **JIT 编译** | inline 模式展开 helper；helper 模式生成同 module 特化 helper |
+| **默认编译路径** | 不受影响 — 不传两个 EJIT cross-TU flag 时行为完全不变 |
 
 ---
 
@@ -371,7 +412,7 @@ BitReader/Object/Linker 等 cross-link 实现依赖。
 |---|---|
 | 无 .ejit_cross section 的链接 | 返回空结果，正常链接（默认行为不变） |
 | 普通非对象参数或不含该 section 的输入 | 跳过，非错误 |
-| **archive 成员含 .ejit_cross** | **硬报错**（明确诊断：暂不支持 archive 成员，请直接链接 .o） |
+| **显式 archive 成员含 .ejit_cross** | 扫描并合并选中的 archive 成员 |
 | **bitcode 解析失败 / section 读取失败** | **链接失败**（带文件名+阶段+Error） |
 | **`Linker::linkInModule` 合并冲突** | **链接失败**（检查返回值） |
 | 合并后无 ejit_entry | **链接失败**（已承诺有 .ejit_cross，却无可注册入口） |
@@ -404,10 +445,11 @@ Cross-link 返回精确的 `consumedFiles`，Driver 写入
 `ctx.ejitCrossConsumedFiles`。`InputFiles.cpp` 只有在当前 input identifier 命中该
 集合且 section 名为 `.ejit_cross` 时才设为 `InputSection::discarded`：
 - 已处理的原始 `.o` section 不进入输出，`-r` 和最终链接都生效；
-- archive、`-l` 或 linker script 后续引入的未处理 section 不会被全局状态误删，
-  而是在 parse 后得到明确的 unsupported 诊断。
+- 显式输入的 archive 会扫描并消费选中成员；
+- `-l` 或 linker script 后续引入的未处理 section 不会被全局状态误删，而是在
+  parse 后得到明确的 unsupported 诊断。
 
-### 7.4 被调用的 TU 也需要 `-fejit-cross-inline`
+### 7.4 被调用的 TU 也需要相同 cross-TU 编译模式
 
 只有 `ejit_entry` 所在 TU 用该 flag 是不够的——`child_func()` 定义的 TU 也必须用，否则链接期看不到它的 IR。
 
@@ -416,19 +458,22 @@ clang -fejit-cross-inline -c tu_a.c -o tu_a.o   # ejit_entry 在此
 clang -fejit-cross-inline -c tu_b.c -o tu_b.o   # child_func 在此, 必须
 ```
 
+使用 JIT-local helper 模式时，将两条命令中的 flag 都替换为
+`-fejit-cross-jit-helpers`。
+
 ---
 
 ## 8. 与 ThinLTO/FullLTO 方案对比
 
-| 维度 | ThinLTO/FullLTO | `-fejit-cross-inline` |
-|---|---|---|
-| AOT 代码影响 | 全局跨模块优化 | 无影响 |
-| 编译时间 | 增加 (summary + 多阶段) | 仅编译期多一次序列化 |
-| 链接时间 | 增加 (LTO backend) | 增加 (合并 + 内联) |
-| JIT bitcode 质量 | 跨模块内联 ✓ | 跨模块内联 ✓ |
-| `!ejit.may_const` | 需要 noinline 保护 | 天然保留 (完整 Module) |
-| 构建系统改动 | clang flag | 同 |
-| `-r` 兼容性 | 复杂 | 简单 (标准 ELF section) |
+| 维度 | ThinLTO/FullLTO | `-fejit-cross-inline` | `-fejit-cross-jit-helpers` |
+|---|---|---|---|
+| AOT 代码影响 | 全局跨模块优化 | 无影响 | 无影响 |
+| 编译时间 | 增加 (summary + 多阶段) | 多一次序列化 | 多一次序列化 |
+| 链接时间 | 增加 (LTO backend) | 合并 + 内联 | 合并 + mandatory inline |
+| JIT bitcode | helper 展开 | 成本模型展开 | 传递 helper 闭包 |
+| 代码尺寸倾向 | 视 LTO 决策 | entry 可能膨胀 | helper 每 specialization 一份 |
+| 内部调用 | 可能消失 | 多数消失 | code pool 内直接 `BL` |
+| `-r` 兼容性 | 复杂 | 标准 ELF section | 标准 ELF section |
 
 ---
 
@@ -438,22 +483,24 @@ PR #102 hardening 后（ld.lld 为唯一 owner）：
 
 | 文件 | 改动 |
 |---|---|
-| `clang/include/clang/Driver/Options.td` | `-fejit-cross-inline` |
-| `clang/lib/Driver/ToolChains/Clang.cpp` | 编译选项传递 + `-flto` 冲突检测（不变） |
-| `clang/lib/Driver/ToolChains/Gnu.cpp` | link 阶段：检测非 lld → 报错；lld → 追加 `--ejit-cross-inline`（不再自行合并） |
+| `clang/include/clang/Driver/Options.td` | 两种 cross-TU 策略 flag |
+| `clang/lib/Driver/ToolChains/Clang.cpp` | 两种模式生成相同 `.ejit_cross` + `-flto` 冲突检测 |
+| `clang/lib/Driver/ToolChains/Gnu.cpp` | 校验 lld，转发 cross-link 与 helper policy |
 | ~~`clang/lib/Driver/EJitCrossLink.cpp` / `.h`~~ | **已删除**（去重：实现只剩 lld 一份） |
 | `clang/lib/Driver/CMakeLists.txt` | 移除 `EJitCrossLink.cpp` 及其专用 LINK_COMPONENTS |
-| `lld/ELF/EJitCrossLink.cpp` | 链接期处理核心（唯一实现）：`Expected<EJitCrossLinkResult>`、保守闭包、真实 inliner、TmpM 内 registry + `verifyModule`、错误传播、临时文件清理 |
+| `lld/ELF/EJitCrossLink.cpp` | 保守闭包、inline/JIT-helper policy、registry、错误传播 |
 | `lld/ELF/EJitCrossLink.h` | API 声明（`Expected<EJitCrossLinkResult>`） |
-| `lld/ELF/Options.td` | `--ejit-cross-inline`（gate，默认关闭时零扫描） |
-| `lld/ELF/Config.h` | `Config::ejitCrossInline`（arg）+ `Ctx::ejitCrossConsumedFiles`（精确消费集合） |
+| `lld/ELF/Options.td` | cross-link gate + JIT-helper policy |
+| `lld/ELF/Config.h` | 两种模式状态 + 精确消费集合 |
 | `lld/ELF/Driver.cpp` | 解析 flag；gated 调用 + `Expected`/`Error` 处理；临时文件清理（`+Signals.h`） |
 | `lld/ELF/InputFiles.cpp` | 仅丢弃精确匹配已消费输入的 `.ejit_cross` |
 | `lld/ELF/CMakeLists.txt` | 新增源（不变） |
 | `llvm/lib/Passes/PassBuilderPipelines.cpp` | flag + 构造函数传参（不变） |
 | `llvm/include/.../EJitPasses.h` | CrossInline 成员（不变） |
 | `llvm/.../EJitRegisterBitcode.cpp` | 分支 + embedBitcodeInSection（不变） |
-| `lld/test/ELF/ejit-cross-inline.ll` | **新建**：生产路径测试（exactly-once / discard / registry / external / malformed→fail / 默认不变） |
+| `lld/test/ELF/ejit-cross-inline.ll` | 两种 policy、嵌套闭包、AArch64 direct `BL` |
+| `llvm/unittests/.../EJitRuntimeTest.cpp` | IPSCCP 穿透 A→B→C noinline helper |
+| `ejit_test/ejit_jit_local_helpers_sre_*.c` | SRE worker-first 双 TU 功能 demo |
 
 ### 9.1 闭包支持的引用形态（Area 4）
 

--- a/jit_design_doc/EJIT_CROSS_TU_INLINE.md
+++ b/jit_design_doc/EJIT_CROSS_TU_INLINE.md
@@ -103,15 +103,18 @@ driver 额外向 lld 传递 `--ejit-cross-jit-helpers`。因此两种策略可�
 
 对 `A -> B -> C`：
 
-1. 保守闭包收集将 B、C 的定义都放入 A 的 per-entry bitcode；
-2. runtime 将非 entry 定义 internalize；
-3. IPSCCP 把 entry 已固定的维度参数逐层传播到 B、C；
-4. 第二轮 InstCombine + StructFieldPass 折叠 helper 内的 may_const；
-5. A、B、C 一起 codegen/JITLink，内部调用生成 code-pool 内的直接 `BL`。
+1. 链接器将全部 entry 的闭包存入一份 repository bitcode，B、C 模板只保存
+   一次；
+2. SCC manifest 记录每个 entry 依赖的函数强连通分量；
+3. runtime 以目标 entry 为唯一 root，通过 GlobalDCE 重建其临时闭包；
+4. IPSCCP 把 entry 已固定的维度参数逐层传播到 B、C；
+5. 第二轮 InstCombine + StructFieldPass 折叠 helper 内的 may_const；
+6. A、B、C 一起 codegen/JITLink，内部调用生成 code-pool 内的直接 `BL`。
 
-该模式不提供跨 entry 的 helper 机器码共享：每个 specialization 拥有自己的
-helper 副本。这样无需新增 helper cache、失效协议、跨核发布或回收依赖，语义
-与现有 per-entry JITDylib 生命周期一致。
+repository 复用的是最终镜像中的 helper bitcode 模板。每个 specialization
+仍拥有独立的临时 IR、机器码和 JITDylib，因此不同常量可以生成不同的 B/C
+版本且不会串号。详细格式与校验协议见
+`EJIT_BITCODE_REPOSITORY_SCC.md`。
 
 限制：
 

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -219,7 +219,7 @@ struct Config {
   // EJIT: opt-in cross-TU inline processing at link time. Set by clang for
   // -fejit-cross-inline links that use ld.lld; ld.lld is the single owner.
   bool ejitCrossInline = false;
-  // Preserve ordinary helper definitions in each per-entry JIT module.
+  // Preserve ordinary helpers in one shared repository bitcode template.
   bool ejitCrossJitHelpers = false;
   uint32_t andFeatures = 0;
   llvm::CachePruningPolicy thinLTOCachePolicy;

--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -219,6 +219,8 @@ struct Config {
   // EJIT: opt-in cross-TU inline processing at link time. Set by clang for
   // -fejit-cross-inline links that use ld.lld; ld.lld is the single owner.
   bool ejitCrossInline = false;
+  // Preserve ordinary helper definitions in each per-entry JIT module.
+  bool ejitCrossJitHelpers = false;
   uint32_t andFeatures = 0;
   llvm::CachePruningPolicy thinLTOCachePolicy;
   llvm::SetVector<llvm::CachedHashString> dependencyFiles; // for --dependency-file

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1484,7 +1484,9 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
       args.hasFlag(OPT_mmap_output_file, OPT_no_mmap_output_file, false);
   ctx.arg.nmagic = args.hasFlag(OPT_nmagic, OPT_no_nmagic, false);
   ctx.arg.noinhibitExec = args.hasArg(OPT_noinhibit_exec);
-  ctx.arg.ejitCrossInline = args.hasArg(OPT_ejit_cross_inline);
+  ctx.arg.ejitCrossJitHelpers = args.hasArg(OPT_ejit_cross_jit_helpers);
+  ctx.arg.ejitCrossInline =
+      args.hasArg(OPT_ejit_cross_inline) || ctx.arg.ejitCrossJitHelpers;
   ctx.arg.nostdlib = args.hasArg(OPT_nostdlib);
   ctx.arg.oFormatBinary = isOutputFormatBinary(ctx, args);
   ctx.arg.omagic = args.hasFlag(OPT_omagic, OPT_no_omagic, false);
@@ -3160,7 +3162,8 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
     StringRef SaveTempsPrefix =
         args.hasArg(OPT_save_temps) ? ctx.arg.outputFile : StringRef();
     Expected<EJitCrossLinkResult> CrossResult =
-        runEJitCrossLink(InputPaths, /*TargetTriple=*/"", SaveTempsPrefix);
+        runEJitCrossLink(InputPaths, /*TargetTriple=*/"",
+                         ctx.arg.ejitCrossJitHelpers, SaveTempsPrefix);
     if (!CrossResult) {
       ErrAlways(ctx) << toString(CrossResult.takeError());
       return;

--- a/lld/ELF/EJitCrossLink.cpp
+++ b/lld/ELF/EJitCrossLink.cpp
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// ld.lld is the single owner of EJIT cross-TU inline processing. It runs at
-// most once per link, and only when --ejit-cross-inline is passed (clang emits
-// that flag exactly for -fejit-cross-inline links that use ld.lld). The clang
-// driver never performs the merge itself; when the selected linker is not lld
-// it emits a hard error instead of silently leaving a huge .ejit_cross section
-// in the output. See jit_design_doc/EJIT_CROSS_TU_INLINE.md.
+// ld.lld is the single owner of EJIT cross-TU processing. It runs at most once
+// per link when --ejit-cross-inline or its --ejit-cross-jit-helpers policy is
+// selected. The clang driver never performs the merge itself; when the
+// selected linker is not lld it emits a hard error instead of silently leaving
+// a huge .ejit_cross section in the output. See
+// jit_design_doc/EJIT_CROSS_TU_INLINE.md.
 //
 // Every stage that can fail after a .ejit_cross section has been observed
 // reports an llvm::Error carrying the input file name, the failing stage and
@@ -306,12 +306,10 @@ static void reAnnotateMayConst(Module &M) {
   }
 }
 
-/// Real, cost-model-driven inliner (Area 2): mandatory always-inline first,
-/// then the production module inliner (the same CGSCC inliner + inline cost
-/// model buildPerModuleDefaultPipeline uses), then a light cleanup. Ordinary
-/// (non always_inline) helpers are inlined when the cost model allows; large
-/// functions are not force-inlined.
-static void runRealInliner(Module &M) {
+/// Apply the selected cross-TU helper policy, then perform light cleanup.
+/// JIT-helper mode keeps ordinary functions in the transitive closure so the
+/// runtime can specialize and emit them beside the entry.
+static void runCrossTUInliner(Module &M, bool PreserveJitHelpers) {
   LoopAnalysisManager LAM;
   FunctionAnalysisManager FAM;
   CGSCCAnalysisManager CGAM;
@@ -325,7 +323,8 @@ static void runRealInliner(Module &M) {
 
   ModulePassManager MPM;
   MPM.addPass(AlwaysInlinerPass());
-  MPM.addPass(ModuleInlinerWrapperPass());
+  if (!PreserveJitHelpers)
+    MPM.addPass(ModuleInlinerWrapperPass());
   FunctionPassManager FPM;
   FPM.addPass(PromotePass());
   FPM.addPass(InstCombinePass());
@@ -491,6 +490,7 @@ namespace elf {
 
 Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
                                                StringRef TargetTriple,
+                                               bool PreserveJitHelpers,
                                                StringRef SaveTempsPrefix) {
   // ---- Phase 1: detect .ejit_cross. Distinguish "no section" (normal skip)
   // from "corrupt input" (Area 5). Non-object inputs (scripts, shared libs)
@@ -672,7 +672,7 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
   for (Function &F : *Composite)
     if (!F.isDeclaration())
       F.setDSOLocal(true);
-  runRealInliner(*Composite);
+  runCrossTUInliner(*Composite, PreserveJitHelpers);
   reAnnotateMayConst(*Composite);
 
   // ---- Phase 5: per-entry bitcode + one registry, all owned by TmpM.

--- a/lld/ELF/EJitCrossLink.cpp
+++ b/lld/ELF/EJitCrossLink.cpp
@@ -22,6 +22,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "EJitCrossLink.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -219,6 +221,143 @@ computeTransitiveClosure(ArrayRef<Function *> EntryFuncs,
     drainGlobals();
   }
   drainGlobals();
+}
+
+static void
+collectDirectFunctionReferences(Function &F,
+                                SmallVectorImpl<Function *> &References) {
+  SmallPtrSet<const Constant *, 32> Visited;
+  SetVector<GlobalVariable *> Globals;
+  collectReferences(F, References, Globals, Visited);
+  for (unsigned I = 0; I < Globals.size(); ++I) {
+    GlobalVariable *GV = Globals[I];
+    if (GV->hasInitializer())
+      collectFromConstant(GV->getInitializer(), References, Globals, Visited);
+  }
+}
+
+struct RepositoryManifest {
+  SmallVector<SmallVector<Function *, 4>, 16> SCCs;
+  DenseMap<Function *, uint32_t> FunctionSCC;
+  SmallVector<SmallVector<uint32_t, 4>, 8> EntrySCCs;
+};
+
+class RepositorySCCBuilder {
+public:
+  RepositorySCCBuilder(Module &M, ArrayRef<Function *> Entries)
+      : Entries(Entries) {
+    for (Function &F : M)
+      if (!F.isDeclaration())
+        Nodes.push_back(&F);
+    for (Function *F : Nodes) {
+      SmallVector<Function *, 8> Refs;
+      collectDirectFunctionReferences(*F, Refs);
+      SmallPtrSet<Function *, 8> Seen;
+      for (Function *Ref : Refs)
+        if (!Ref->isDeclaration() && Seen.insert(Ref).second)
+          Edges[F].push_back(Ref);
+    }
+  }
+
+  RepositoryManifest build() {
+    for (Function *F : Nodes)
+      if (!Index.count(F))
+        visit(F);
+
+    RepositoryManifest Result;
+    Result.SCCs = std::move(SCCs);
+    for (uint32_t I = 0; I < Result.SCCs.size(); ++I)
+      for (Function *F : Result.SCCs[I])
+        Result.FunctionSCC[F] = I;
+
+    for (Function *Entry : Entries) {
+      SetVector<Function *> Funcs;
+      SetVector<GlobalVariable *> Globals;
+      SmallVector<Function *, 1> Roots{Entry};
+      computeTransitiveClosure(Roots, Funcs, Globals);
+      SmallDenseSet<uint32_t, 8> Seen;
+      SmallVector<uint32_t, 4> IDs;
+      for (Function *F : Funcs) {
+        auto It = Result.FunctionSCC.find(F);
+        if (It != Result.FunctionSCC.end() && Seen.insert(It->second).second)
+          IDs.push_back(It->second);
+      }
+      llvm::sort(IDs);
+      Result.EntrySCCs.push_back(std::move(IDs));
+    }
+    return Result;
+  }
+
+private:
+  void visit(Function *F) {
+    uint32_t I = NextIndex++;
+    Index[F] = I;
+    LowLink[F] = I;
+    Stack.push_back(F);
+    OnStack.insert(F);
+
+    for (Function *To : Edges[F]) {
+      if (!Index.count(To)) {
+        visit(To);
+        LowLink[F] = std::min(LowLink[F], LowLink[To]);
+      } else if (OnStack.contains(To)) {
+        LowLink[F] = std::min(LowLink[F], Index[To]);
+      }
+    }
+
+    if (LowLink[F] != Index[F])
+      return;
+    SmallVector<Function *, 4> Component;
+    while (true) {
+      Function *Top = Stack.pop_back_val();
+      OnStack.erase(Top);
+      Component.push_back(Top);
+      if (Top == F)
+        break;
+    }
+    llvm::sort(Component, [](const Function *L, const Function *R) {
+      return L->getName() < R->getName();
+    });
+    SCCs.push_back(std::move(Component));
+  }
+
+  ArrayRef<Function *> Entries;
+  SmallVector<Function *, 32> Nodes;
+  DenseMap<Function *, SmallVector<Function *, 4>> Edges;
+  DenseMap<Function *, uint32_t> Index;
+  DenseMap<Function *, uint32_t> LowLink;
+  SmallVector<Function *, 32> Stack;
+  SmallPtrSet<Function *, 32> OnStack;
+  SmallVector<SmallVector<Function *, 4>, 16> SCCs;
+  uint32_t NextIndex = 0;
+};
+
+static void addRepositoryManifest(Module &M, ArrayRef<Function *> Entries,
+                                  const RepositoryManifest &Manifest) {
+  LLVMContext &Ctx = M.getContext();
+  auto mdInt = [&](uint32_t V) -> Metadata * {
+    return ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(Ctx), V));
+  };
+
+  M.getOrInsertNamedMetadata(MD_EJIT_REPOSITORY_VERSION)
+      ->addOperand(MDNode::get(Ctx, mdInt(EJIT_REPOSITORY_VERSION)));
+
+  NamedMDNode *SCCs = M.getOrInsertNamedMetadata(MD_EJIT_REPOSITORY_SCCS);
+  for (uint32_t I = 0; I < Manifest.SCCs.size(); ++I) {
+    SmallVector<Metadata *, 8> Ops{mdInt(I)};
+    for (Function *F : Manifest.SCCs[I])
+      Ops.push_back(MDString::get(Ctx, F->getName()));
+    SCCs->addOperand(MDNode::get(Ctx, Ops));
+  }
+
+  NamedMDNode *EntryMap =
+      M.getOrInsertNamedMetadata(MD_EJIT_REPOSITORY_ENTRIES);
+  for (size_t I = 0; I < Entries.size(); ++I) {
+    SmallVector<Metadata *, 8> Ops{MDString::get(Ctx, Entries[I]->getName())};
+    for (uint32_t ID : Manifest.EntrySCCs[I])
+      Ops.push_back(mdInt(ID));
+    EntryMap->addOperand(MDNode::get(Ctx, Ops));
+  }
 }
 
 /// Delete every defined function/global not in the closure, without leaving a
@@ -562,8 +701,8 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
   SmallVector<std::string, 4> ConsumedFiles;
 
   // Helper to process a single bitcode buffer into the composite.
-  auto mergeBitcodeIntoComposite =
-      [&](MemoryBufferRef BCBuf, StringRef DisplayName) -> Error {
+  auto mergeBitcodeIntoComposite = [&](MemoryBufferRef BCBuf,
+                                       StringRef DisplayName) -> Error {
     auto M = parseBitcodeFile(BCBuf, *Ctx);
     if (!M)
       return crossError("parse bitcode", DisplayName, M.takeError());
@@ -687,47 +826,96 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
   SetVector<Function *> ExternalFuncs;
   SetVector<GlobalVariable *> ExternalGlobals;
 
-  for (Function *F : EntryFuncs) {
-    auto PerFunc = CloneModule(*Composite);
-    Function *ClonedF = PerFunc->getFunction(F->getName());
-    if (!ClonedF)
-      return crossError("clone", F->getName(),
-                        "entry function vanished after cloning the composite");
+  if (PreserveJitHelpers) {
+    // Store one template repository for every entry. At runtime the selected
+    // entry is the sole externally-visible root, GlobalDCE reconstructs its
+    // closure, and the SCC manifest verifies that the result matches the
+    // link-time dependency graph. Helper bodies therefore occupy the final
+    // image once while each specialization still receives an independent
+    // transient copy for IPSCCP.
+    RepositoryManifest Manifest =
+        RepositorySCCBuilder(*Composite, EntryFuncs).build();
+    addRepositoryManifest(*Composite, EntryFuncs, Manifest);
 
-    SetVector<Function *> PerFuncs;
-    SetVector<GlobalVariable *> PerGlobals;
-    SmallVector<Function *, 1> Single{ClonedF};
-    computeTransitiveClosure(Single, PerFuncs, PerGlobals);
-    trimToClosure(*PerFunc, PerFuncs, PerGlobals);
+    SetVector<Function *> RepositoryFuncs;
+    SetVector<GlobalVariable *> RepositoryGlobals;
+    computeTransitiveClosure(EntryFuncs, RepositoryFuncs, RepositoryGlobals);
 
-    // Externalise non-const global definitions so JITLink resolves them from
-    // the host image, mirroring the single-TU extractor.
-    for (GlobalVariable &GV : PerFunc->globals())
+    for (GlobalVariable &GV : Composite->globals())
       if (!GV.isDeclaration() && !GV.isConstant()) {
         GV.setInitializer(nullptr);
         GV.setLinkage(GlobalValue::ExternalLinkage);
       }
 
-    if (Error E = collectExternalSymbols(PerFuncs, PerGlobals, *TmpM,
-                                         ExternalFuncs, ExternalGlobals))
-      return crossError("collect external symbols", F->getName(), std::move(E));
+    if (Error E = collectExternalSymbols(RepositoryFuncs, RepositoryGlobals,
+                                         *TmpM, ExternalFuncs, ExternalGlobals))
+      return crossError("collect repository external symbols", "<repository>",
+                        std::move(E));
 
-    if (verifyModule(*PerFunc, &errs()))
-      return crossError("verify per-entry module", F->getName(),
-                        "cloned/trimmed module failed verification");
+    if (verifyModule(*Composite, &errs()))
+      return crossError("verify repository module", "<repository>",
+                        "repository module failed verification");
 
     if (!SaveTempsPrefix.empty()) {
-      std::string Path = saveTempEntryPath(SaveTempsPrefix, F->getName());
-      if (Error E = writeModuleBitcode(*PerFunc, Path))
-        return crossError("save per-entry bitcode", Path, std::move(E));
+      std::string Path = saveTempEntryPath(SaveTempsPrefix, "repository");
+      if (Error E = writeModuleBitcode(*Composite, Path))
+        return crossError("save repository bitcode", Path, std::move(E));
     }
 
     std::string BC;
     raw_string_ostream OS(BC);
-    WriteBitcodeToFile(*PerFunc, OS);
+    WriteBitcodeToFile(*Composite, OS);
     OS.flush();
-    BitcodeGVs.push_back(embedBitcode(*TmpM, BC, F->getName()));
-    ValidEntryFuncs.push_back(F);
+    GlobalVariable *RepositoryGV = embedBitcode(*TmpM, BC, "repository");
+    for (Function *Entry : EntryFuncs) {
+      ValidEntryFuncs.push_back(Entry);
+      BitcodeGVs.push_back(RepositoryGV);
+    }
+  } else {
+    for (Function *F : EntryFuncs) {
+      auto PerFunc = CloneModule(*Composite);
+      Function *ClonedF = PerFunc->getFunction(F->getName());
+      if (!ClonedF)
+        return crossError(
+            "clone", F->getName(),
+            "entry function vanished after cloning the composite");
+
+      SetVector<Function *> PerFuncs;
+      SetVector<GlobalVariable *> PerGlobals;
+      SmallVector<Function *, 1> Single{ClonedF};
+      computeTransitiveClosure(Single, PerFuncs, PerGlobals);
+      trimToClosure(*PerFunc, PerFuncs, PerGlobals);
+
+      // Externalise non-const global definitions so JITLink resolves them from
+      // the host image, mirroring the single-TU extractor.
+      for (GlobalVariable &GV : PerFunc->globals())
+        if (!GV.isDeclaration() && !GV.isConstant()) {
+          GV.setInitializer(nullptr);
+          GV.setLinkage(GlobalValue::ExternalLinkage);
+        }
+
+      if (Error E = collectExternalSymbols(PerFuncs, PerGlobals, *TmpM,
+                                           ExternalFuncs, ExternalGlobals))
+        return crossError("collect external symbols", F->getName(),
+                          std::move(E));
+
+      if (verifyModule(*PerFunc, &errs()))
+        return crossError("verify per-entry module", F->getName(),
+                          "cloned/trimmed module failed verification");
+
+      if (!SaveTempsPrefix.empty()) {
+        std::string Path = saveTempEntryPath(SaveTempsPrefix, F->getName());
+        if (Error E = writeModuleBitcode(*PerFunc, Path))
+          return crossError("save per-entry bitcode", Path, std::move(E));
+      }
+
+      std::string BC;
+      raw_string_ostream OS(BC);
+      WriteBitcodeToFile(*PerFunc, OS);
+      OS.flush();
+      BitcodeGVs.push_back(embedBitcode(*TmpM, BC, F->getName()));
+      ValidEntryFuncs.push_back(F);
+    }
   }
 
   generateRegistryTable(*TmpM, ValidEntryFuncs, BitcodeGVs, ExternalFuncs,

--- a/lld/ELF/EJitCrossLink.h
+++ b/lld/ELF/EJitCrossLink.h
@@ -17,9 +17,11 @@ struct EJitCrossLinkResult {
   llvm::SmallVector<std::string, 4> consumedFiles;
 };
 
-/// Merge the .ejit_cross bitcode sections of \p InputFiles, inline cross-TU
-/// callees into each ejit_entry, and write a single registry bitcode module to
-/// a temporary file whose path is returned.
+/// Merge the .ejit_cross bitcode sections of \p InputFiles, apply the selected
+/// helper policy to each ejit_entry, and write a single registry bitcode module
+/// to a temporary file whose path is returned.
+/// With \p PreserveJitHelpers, only mandatory always_inline calls are expanded;
+/// ordinary transitive helper definitions remain in each per-entry module.
 ///
 /// Three-state result:
 ///   * an Error         - a .ejit_cross section was found but processing failed
@@ -31,7 +33,7 @@ struct EJitCrossLinkResult {
 ///                          cleanup of the temporary file.
 llvm::Expected<EJitCrossLinkResult>
 runEJitCrossLink(llvm::ArrayRef<std::string> InputFiles,
-                 llvm::StringRef TargetTriple,
+                 llvm::StringRef TargetTriple, bool PreserveJitHelpers = false,
                  llvm::StringRef SaveTempsPrefix = {});
 
 } // namespace elf

--- a/lld/ELF/EJitCrossLink.h
+++ b/lld/ELF/EJitCrossLink.h
@@ -21,7 +21,8 @@ struct EJitCrossLinkResult {
 /// helper policy to each ejit_entry, and write a single registry bitcode module
 /// to a temporary file whose path is returned.
 /// With \p PreserveJitHelpers, only mandatory always_inline calls are expanded;
-/// ordinary transitive helper definitions remain in each per-entry module.
+/// ordinary helpers remain in one repository bitcode template shared by all
+/// registry entries. An SCC manifest identifies each entry's runtime closure.
 ///
 /// Three-state result:
 ///   * an Error         - a .ejit_cross section was found but processing failed

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -42,6 +42,10 @@ def ejit_cross_inline: F<"ejit-cross-inline">,
   HelpText<"(EJIT) Merge .ejit_cross bitcode sections from the inputs, inline "
            "cross-TU callees into each ejit_entry, and add the resulting "
            "registry bitcode to the link. Emitted by clang -fejit-cross-inline.">;
+def ejit_cross_jit_helpers: F<"ejit-cross-jit-helpers">,
+  HelpText<"(EJIT) Preserve ordinary cross-TU callees as JIT-local helper "
+           "definitions; implies --ejit-cross-inline. Emitted by clang "
+           "-fejit-cross-jit-helpers.">;
 
 def Bno_symbolic: F<"Bno-symbolic">, HelpText<"Don't bind default visibility defined symbols locally for -shared (default)">;
 

--- a/lld/test/ELF/ejit-cross-inline.ll
+++ b/lld/test/ELF/ejit-cross-inline.ll
@@ -60,41 +60,44 @@
 # RUN: llvm-dis %t/out.so.ejit-cross.ejit_entry_two.bc -o - | \
 # RUN:   FileCheck %s --check-prefix=SECOND
 # SECOND-LABEL: define{{.*}} i32 @ejit_entry_two()
-# SECOND: call i32 @some_extern_fn(i32 5)
+# SECOND-NOT: call i32 @helper
+# SECOND: call i32 @some_extern_fn
 # SECOND: load i32, ptr @extern_global
 
-## JIT-local helper mode consumes the same cross sections but expands only
-## mandatory always_inline calls. The ordinary A -> B -> C chain remains in
-## the per-entry bitcode so runtime specialization can optimize every body and
-## codegen can place all three functions in one JIT allocation.
+## JIT-local helper mode consumes the same cross sections but stores one
+## repository payload shared by every entry. The repository contains each
+## helper definition once plus an entry-to-SCC manifest; runtime selection
+## trims it back to one entry closure before specialization.
 # RUN: ld.lld --ejit-cross-jit-helpers --save-temps -shared \
 # RUN:   --unresolved-symbols=ignore-all \
 # RUN:   %t/entry.o %t/helper.o -o %t/helpers.so
 # RUN: llvm-readelf -S %t/helpers.so | FileCheck %s --check-prefix=LINKED
-# RUN: llvm-dis %t/helpers.so.ejit-cross.ejit_entry_fn.bc -o - | \
+# RUN: llvm-nm %t/helpers.so | FileCheck %s --check-prefix=REPOSITORY-SYMBOL
+# REPOSITORY-SYMBOL-COUNT-1: __ejit_bitcode_repository
+# RUN: llvm-dis %t/helpers.so.ejit-cross.repository.bc -o - | \
 # RUN:   FileCheck %s --check-prefix=JITHELPERS
 # JITHELPERS-LABEL: define{{.*}} i32 @ejit_entry_fn()
 # JITHELPERS-NOT: call i32 @mandatory_helper()
 # JITHELPERS-COUNT-2: call i32 @helper()
+# JITHELPERS-LABEL: define{{.*}} i32 @ejit_entry_two()
+# JITHELPERS: call i32 @helper()
 # JITHELPERS-LABEL: define{{.*}} i32 @helper()
 # JITHELPERS: call i32 @helper_leaf()
 # JITHELPERS-LABEL: define{{.*}} i32 @helper_leaf()
 # JITHELPERS-NOT: define{{.*}} i32 @unused_helper()
-
-## The second entry does not reach the helper chain, so per-entry closure
-## trimming must not copy those definitions into its bitcode.
-# RUN: llvm-dis %t/helpers.so.ejit-cross.ejit_entry_two.bc -o - | \
-# RUN:   FileCheck %s --check-prefix=JITHELPERS-SECOND
-# JITHELPERS-SECOND-LABEL: define{{.*}} i32 @ejit_entry_two()
-# JITHELPERS-SECOND-NOT: define{{.*}} i32 @helper
+# JITHELPERS: !ejit.repository.version = !{![[VERSION:[0-9]+]]}
+# JITHELPERS: !ejit.repository.sccs = !{
+# JITHELPERS: !ejit.repository.entries = !{
+# JITHELPERS-DAG: !{!"ejit_entry_fn", i32
+# JITHELPERS-DAG: !{!"ejit_entry_two", i32
 
 ## AArch64 codegen sees definitions, not declarations, and therefore emits
 ## direct intra-module branches rather than an external GOT/PLT call.
 # RUN: llc -mtriple=aarch64-unknown-linux-gnu -O2 \
-# RUN:   %t/helpers.so.ejit-cross.ejit_entry_fn.bc -o - | \
+# RUN:   %t/helpers.so.ejit-cross.repository.bc -o - | \
 # RUN:   FileCheck %s --check-prefix=AARCH64
 # AARCH64-LABEL: ejit_entry_fn:
-# AARCH64-COUNT-2: bl helper
+# AARCH64-COUNT-3: bl helper
 # AARCH64-LABEL: helper:
 # AARCH64: bl helper_leaf
 
@@ -160,7 +163,8 @@ define i32 @ejit_entry_fn() !ejit.metadata !0 {
 }
 
 define i32 @ejit_entry_two() !ejit.metadata !0 {
-  %e = call i32 @some_extern_fn(i32 5)
+  %h = call i32 @helper()
+  %e = call i32 @some_extern_fn(i32 %h)
   %g = load i32, ptr @extern_global
   %r = add i32 %e, %g
   ret i32 %r

--- a/lld/test/ELF/ejit-cross-inline.ll
+++ b/lld/test/ELF/ejit-cross-inline.ll
@@ -1,4 +1,4 @@
-# REQUIRES: x86
+# REQUIRES: x86, aarch64
 ## ld.lld is the single owner of EJIT cross-TU inline processing (PR #102
 ## hardening). This exercises the real production path end to end:
 ##   * the merge/inline/registry runs only with --ejit-cross-inline (default
@@ -63,6 +63,41 @@
 # SECOND: call i32 @some_extern_fn(i32 5)
 # SECOND: load i32, ptr @extern_global
 
+## JIT-local helper mode consumes the same cross sections but expands only
+## mandatory always_inline calls. The ordinary A -> B -> C chain remains in
+## the per-entry bitcode so runtime specialization can optimize every body and
+## codegen can place all three functions in one JIT allocation.
+# RUN: ld.lld --ejit-cross-jit-helpers --save-temps -shared \
+# RUN:   --unresolved-symbols=ignore-all \
+# RUN:   %t/entry.o %t/helper.o -o %t/helpers.so
+# RUN: llvm-readelf -S %t/helpers.so | FileCheck %s --check-prefix=LINKED
+# RUN: llvm-dis %t/helpers.so.ejit-cross.ejit_entry_fn.bc -o - | \
+# RUN:   FileCheck %s --check-prefix=JITHELPERS
+# JITHELPERS-LABEL: define{{.*}} i32 @ejit_entry_fn()
+# JITHELPERS-NOT: call i32 @mandatory_helper()
+# JITHELPERS-COUNT-2: call i32 @helper()
+# JITHELPERS-LABEL: define{{.*}} i32 @helper()
+# JITHELPERS: call i32 @helper_leaf()
+# JITHELPERS-LABEL: define{{.*}} i32 @helper_leaf()
+# JITHELPERS-NOT: define{{.*}} i32 @unused_helper()
+
+## The second entry does not reach the helper chain, so per-entry closure
+## trimming must not copy those definitions into its bitcode.
+# RUN: llvm-dis %t/helpers.so.ejit-cross.ejit_entry_two.bc -o - | \
+# RUN:   FileCheck %s --check-prefix=JITHELPERS-SECOND
+# JITHELPERS-SECOND-LABEL: define{{.*}} i32 @ejit_entry_two()
+# JITHELPERS-SECOND-NOT: define{{.*}} i32 @helper
+
+## AArch64 codegen sees definitions, not declarations, and therefore emits
+## direct intra-module branches rather than an external GOT/PLT call.
+# RUN: llc -mtriple=aarch64-unknown-linux-gnu -O2 \
+# RUN:   %t/helpers.so.ejit-cross.ejit_entry_fn.bc -o - | \
+# RUN:   FileCheck %s --check-prefix=AARCH64
+# AARCH64-LABEL: ejit_entry_fn:
+# AARCH64-COUNT-2: bl helper
+# AARCH64-LABEL: helper:
+# AARCH64: bl helper_leaf
+
 ## Default (no flag): behaviour is unchanged. The .ejit_cross sections are left
 ## untouched and no registry is synthesised.
 # RUN: ld.lld -shared --unresolved-symbols=ignore-all \
@@ -103,16 +138,21 @@ target triple = "x86_64-unknown-linux-gnu"
 ; always_inline) that the real inliner must fold away. @some_extern_fn and
 ; @extern_global stay external and must be registered.
 declare i32 @helper()
+declare i32 @mandatory_helper()
 declare i32 @some_extern_fn(i32)
 @extern_global = external global i32
 @helper_table = external constant [1 x ptr]
 
 define i32 @ejit_entry_fn() !ejit.metadata !0 {
+  %m = call i32 @mandatory_helper()
   %h = call i32 @helper()
+  %h2 = call i32 @helper()
   %fp.addr = getelementptr [1 x ptr], ptr @helper_table, i64 0, i64 0
   %fp = load ptr, ptr %fp.addr
   %t = call i32 %fp()
-  %arg = add i32 %h, %t
+  %hh = add i32 %h, %h2
+  %hm = add i32 %hh, %m
+  %arg = add i32 %hm, %t
   %e = call i32 @some_extern_fn(i32 %arg)
   %g = load i32, ptr @extern_global
   %r = add i32 %e, %g
@@ -134,9 +174,14 @@ target triple = "x86_64-unknown-linux-gnu"
 
 @helper_table = constant [1 x ptr] [ptr @table_target]
 
+define i32 @mandatory_helper() #0 {
+  ret i32 3
+}
+
 define i32 @helper() {
   %v = call i32 @helper_leaf()
-  ret i32 %v
+  %r = add i32 %v, 1
+  ret i32 %r
 }
 
 define i32 @helper_leaf() {
@@ -146,6 +191,12 @@ define i32 @helper_leaf() {
 define i32 @table_target() {
   ret i32 7
 }
+
+define i32 @unused_helper() {
+  ret i32 999
+}
+
+attributes #0 = { alwaysinline }
 
 #--- bad.s
 .section .ejit_cross,"a",@progbits

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -54,6 +54,10 @@ namespace ejit {
 //===----------------------------------------------------------------------===//
 constexpr const char *MD_EJIT_METADATA = "ejit.metadata";
 constexpr const char *MD_EJIT_MAY_CONST = "ejit.may_const";
+constexpr const char *MD_EJIT_REPOSITORY_VERSION = "ejit.repository.version";
+constexpr const char *MD_EJIT_REPOSITORY_SCCS = "ejit.repository.sccs";
+constexpr const char *MD_EJIT_REPOSITORY_ENTRIES = "ejit.repository.entries";
+constexpr uint32_t EJIT_REPOSITORY_VERSION = 1;
 
 //===----------------------------------------------------------------------===//
 // Metadata entry tags (first operand of sub-nodes in !ejit.metadata)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -9,17 +9,24 @@
 #ifndef LLVM_EXECUTIONENGINE_EJIT_EJITOPTIMIZER_H
 #define LLVM_EXECUTIONENGINE_EJIT_EJITOPTIMIZER_H
 
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
-#include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
-#include "llvm/Analysis/CGSCCPassManager.h"
-#include "llvm/Analysis/LoopAnalysisManager.h"
-#include "llvm/IR/Module.h"
 #include "llvm/ExecutionEngine/EJIT/EJitPassBuilder.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Error.h"
 
 namespace llvm {
 namespace ejit {
+
+/// If M is a shared EJIT bitcode repository, make EntryName its sole public
+/// root, remove unreachable entry/helper definitions, and validate the result
+/// against the link-time SCC manifest. Legacy per-entry modules are unchanged.
+Error prepareRepositoryForEntry(Module &M, StringRef EntryName);
 
 /// JIT optimization pipeline. Runs on the extracted bitcode module during
 /// JIT compilation to specialize the code for the current time-window values.
@@ -32,8 +39,8 @@ public:
   /// Run the full JIT specialization pipeline:
   ///   1. Parameter substitution (ejit_period_arr_ind → constants)
   ///   2. InstCombine (fold GEP chains from substituted params)
-  ///   3. Inline (L2+: expand callee bodies so may_const GEPs are traceable)
-  ///   4. StructFieldPass (may_const loads → runtime constants)
+  ///   3. StructFieldPass (may_const loads → runtime constants)
+  ///   4. IPSCCP (propagate constants through JIT-local helpers)
   ///   5. Core optimization pipeline (L1/L2/L3)
   void runPipeline(Module &M, const SpecializationContext &ctx);
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -96,10 +96,10 @@ void EJitOptimizer::runPipeline(Module &M,
   //       compute the byte offset of each may_const field access.
   runInstCombine(M);
   EJIT_DIAG_DEBUG("pipeline phase1b done: InstCombine");
-  // Inlining is intentionally not run here: the AOT pre-optimization
-  // (EJitRegisterBitcodePass: AlwaysInline + ModuleInliner(O2)) already expanded
-  // callee bodies in the embedded bitcode, so their may_const GEP chains are
-  // already traceable to the global.
+  // Inlining is intentionally not run here. The cross-inline mode has already
+  // expanded profitable callees, while JIT-local-helper mode deliberately
+  // preserves them. The interprocedural phase below propagates specialization
+  // constants through calls without inflating the entry body.
   //   (c) Replace the may_const loads with their runtime constant values.
   runStructFieldPass(M);
   EJIT_DIAG_DEBUG("pipeline phase1c done: StructFieldPass");
@@ -244,4 +244,3 @@ void EJitOptimizer::runOptimizationPipeline(Module &M,
     if (!F.isDeclaration())
       cleanupFPM_.run(F, FAM_);
 }
-

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -1,19 +1,25 @@
 //===-- EJitOptimizer.cpp - JIT Optimization Pipeline ---------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/GlobalAlias.h"
+#include "llvm/IR/GlobalIFunc.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Debug.h"
 // The post-specialization cleanup is the real LLVM -O2 function-simplification
 // pipeline (PassBuilder::buildFunctionSimplificationPipeline); only the light
 // cleanupFPM_ and the LowerExpect prefix are hand-added below.
-#include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/IPO/GlobalDCE.h"
 #include "llvm/Transforms/IPO/SCCP.h"
+#include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar/ADCE.h"
 #include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
@@ -23,6 +29,169 @@ using namespace llvm;
 using namespace llvm::ejit;
 
 #define DEBUG_TYPE "ejit-optimizer"
+
+static Expected<uint32_t> repositoryMDInt(const MDNode &N, unsigned Index,
+                                          StringRef Context) {
+  if (Index >= N.getNumOperands())
+    return createStringError(inconvertibleErrorCode(),
+                             "EJIT repository %s: missing integer operand %u",
+                             Context.str().c_str(), Index);
+  auto *CI = mdconst::dyn_extract<ConstantInt>(N.getOperand(Index));
+  if (!CI || CI->getBitWidth() != 32)
+    return createStringError(inconvertibleErrorCode(),
+                             "EJIT repository %s: operand %u is not i32",
+                             Context.str().c_str(), Index);
+  return static_cast<uint32_t>(CI->getZExtValue());
+}
+
+Error llvm::ejit::prepareRepositoryForEntry(Module &M, StringRef EntryName) {
+  NamedMDNode *VersionMD = M.getNamedMetadata(MD_EJIT_REPOSITORY_VERSION);
+  if (!VersionMD)
+    return Error::success();
+
+  if (VersionMD->getNumOperands() != 1)
+    return createStringError(inconvertibleErrorCode(),
+                             "EJIT repository has invalid version metadata");
+  Expected<uint32_t> Version =
+      repositoryMDInt(*VersionMD->getOperand(0), 0, "version");
+  if (!Version)
+    return Version.takeError();
+  if (*Version != EJIT_REPOSITORY_VERSION)
+    return createStringError(
+        inconvertibleErrorCode(),
+        "EJIT repository version mismatch: got %u, expected %u", *Version,
+        EJIT_REPOSITORY_VERSION);
+
+  NamedMDNode *SCCMD = M.getNamedMetadata(MD_EJIT_REPOSITORY_SCCS);
+  NamedMDNode *EntryMD = M.getNamedMetadata(MD_EJIT_REPOSITORY_ENTRIES);
+  if (!SCCMD || !EntryMD)
+    return createStringError(inconvertibleErrorCode(),
+                             "EJIT repository manifest is incomplete");
+
+  SmallDenseSet<uint32_t, 16> SelectedSCCs;
+  bool FoundEntry = false;
+  for (MDNode *N : EntryMD->operands()) {
+    if (N->getNumOperands() == 0)
+      return createStringError(inconvertibleErrorCode(),
+                               "EJIT repository has empty entry manifest");
+    auto *Name = dyn_cast<MDString>(N->getOperand(0));
+    if (!Name)
+      return createStringError(inconvertibleErrorCode(),
+                               "EJIT repository entry name is not a string");
+    if (Name->getString() != EntryName)
+      continue;
+    if (FoundEntry)
+      return createStringError(inconvertibleErrorCode(),
+                               "EJIT repository has duplicate entry '%s'",
+                               EntryName.str().c_str());
+    FoundEntry = true;
+    for (unsigned I = 1; I < N->getNumOperands(); ++I) {
+      Expected<uint32_t> ID = repositoryMDInt(*N, I, "entry");
+      if (!ID)
+        return ID.takeError();
+      SelectedSCCs.insert(*ID);
+    }
+  }
+  if (!FoundEntry)
+    return createStringError(inconvertibleErrorCode(),
+                             "EJIT repository has no manifest for entry '%s'",
+                             EntryName.str().c_str());
+
+  StringMap<uint32_t> FunctionSCC;
+  SmallDenseSet<uint32_t, 16> KnownSCCs;
+  for (MDNode *N : SCCMD->operands()) {
+    Expected<uint32_t> ID = repositoryMDInt(*N, 0, "SCC");
+    if (!ID)
+      return ID.takeError();
+    if (!KnownSCCs.insert(*ID).second)
+      return createStringError(inconvertibleErrorCode(),
+                               "EJIT repository has duplicate SCC %u", *ID);
+    for (unsigned I = 1; I < N->getNumOperands(); ++I) {
+      auto *Name = dyn_cast<MDString>(N->getOperand(I));
+      if (!Name)
+        return createStringError(
+            inconvertibleErrorCode(),
+            "EJIT repository SCC %u has a non-string member", *ID);
+      if (!FunctionSCC.try_emplace(Name->getString(), *ID).second)
+        return createStringError(
+            inconvertibleErrorCode(),
+            "EJIT repository function '%s' belongs to multiple SCCs",
+            Name->getString().str().c_str());
+    }
+  }
+  for (uint32_t ID : SelectedSCCs)
+    if (!KnownSCCs.contains(ID))
+      return createStringError(
+          inconvertibleErrorCode(),
+          "EJIT repository entry '%s' references unknown SCC %u",
+          EntryName.str().c_str(), ID);
+
+  Function *Entry = M.getFunction(EntryName);
+  if (!Entry || Entry->isDeclaration())
+    return createStringError(inconvertibleErrorCode(),
+                             "EJIT repository entry '%s' has no definition",
+                             EntryName.str().c_str());
+
+  // The selected entry is the only externally-visible root. All helper and
+  // non-selected entry definitions become local, then GlobalDCE reconstructs
+  // exactly the selected call/global-initializer closure.
+  for (Function &F : M.functions()) {
+    if (F.isDeclaration())
+      continue;
+    F.setVisibility(GlobalValue::DefaultVisibility);
+    F.setLinkage(&F == Entry ? GlobalValue::ExternalLinkage
+                             : GlobalValue::InternalLinkage);
+    if (&F != Entry)
+      F.setComdat(nullptr);
+  }
+  for (GlobalVariable &GV : M.globals())
+    if (!GV.isDeclaration() && GV.isConstant()) {
+      GV.setVisibility(GlobalValue::DefaultVisibility);
+      GV.setLinkage(GlobalValue::InternalLinkage);
+      GV.setComdat(nullptr);
+    }
+  for (GlobalAlias &GA : M.aliases()) {
+    GA.setVisibility(GlobalValue::DefaultVisibility);
+    GA.setLinkage(GlobalValue::InternalLinkage);
+  }
+  for (GlobalIFunc &GI : M.ifuncs()) {
+    GI.setVisibility(GlobalValue::DefaultVisibility);
+    GI.setLinkage(GlobalValue::InternalLinkage);
+  }
+
+  ModuleAnalysisManager MAM;
+  PassBuilder PB;
+  PB.registerModuleAnalyses(MAM);
+  ModulePassManager MPM;
+  MPM.addPass(GlobalDCEPass());
+  MPM.run(M, MAM);
+
+  if (verifyModule(M, nullptr))
+    return createStringError(
+        inconvertibleErrorCode(),
+        "EJIT repository entry '%s' produced an invalid selected module",
+        EntryName.str().c_str());
+
+  for (Function &F : M.functions()) {
+    if (F.isDeclaration() || F.isIntrinsic())
+      continue;
+    auto It = FunctionSCC.find(F.getName());
+    if (It == FunctionSCC.end())
+      return createStringError(
+          inconvertibleErrorCode(),
+          "EJIT repository live function '%s' is absent from the SCC manifest",
+          F.getName().str().c_str());
+    if (!SelectedSCCs.contains(It->second))
+      return createStringError(
+          inconvertibleErrorCode(),
+          "EJIT repository live function '%s' is outside entry '%s' closure",
+          F.getName().str().c_str(), EntryName.str().c_str());
+  }
+
+  EJIT_DIAG_DEBUG("repository select entry=%s sccs=%u", EntryName.str().c_str(),
+                  static_cast<unsigned>(SelectedSCCs.size()));
+  return Error::success();
+}
 
 EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
     : registry_(reg) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -763,6 +763,12 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     return ModuleOrErr.takeError();
   }
 
+  if (Error E = prepareRepositoryForEntry(**ModuleOrErr, origFnName)) {
+    EJIT_DIAG("loadBitcode FAIL key=0x%016lx func=%s: repository select error",
+              cacheKey, origFnName.c_str());
+    return E;
+  }
+
   Triple TT((*ModuleOrErr)->getTargetTriple());
   if (TT.isAArch64() && TT.isOSBinFormatELF()) {
     // External-symbol access from JIT specializations. The JIT slab is

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -2494,9 +2494,8 @@ TEST(EJitEndToEnd, PipelineFoldsMayConstBranchAtAllLevels) {
 // callee folds to a constant return like the entry does.
 namespace {
 
-/// Entry (has ejit_entry metadata) calls a callee with a constant cell index
-/// — the shape phase 1a leaves behind. The callee loads field 1 of
-/// g_ipcfg[cell] (may_const) and branches on it.
+/// Entry calls a two-level helper chain with a constant cell index.
+/// The leaf loads field 1 of g_ipcfg[cell] (may_const) and branches on it.
 std::unique_ptr<Module> parseInterprocModule(LLVMContext &Ctx) {
   SMDiagnostic Err;
   auto M = parseAssemblyString(R"(
@@ -2516,8 +2515,14 @@ std::unique_ptr<Module> parseInterprocModule(LLVMContext &Ctx) {
       ret i32 200
     }
 
+    define i32 @ip_mid(i8 noundef %cell) {
+      %r = call i32 @ip_callee(i8 noundef %cell)
+      %adjusted = add i32 %r, 1
+      ret i32 %adjusted
+    }
+
     define i32 @ip_entry() !ejit.metadata !3 {
-      %r = call i32 @ip_callee(i8 noundef 2)
+      %r = call i32 @ip_mid(i8 noundef 2)
       ret i32 %r
     }
 
@@ -2527,7 +2532,7 @@ std::unique_ptr<Module> parseInterprocModule(LLVMContext &Ctx) {
     !3 = !{!4}
     !4 = !{!"ejit_entry"}
   )",
-                              Err, Ctx);
+                               Err, Ctx);
   if (!M)
     Err.print("parseInterprocModule", errs());
   return M;
@@ -2576,7 +2581,7 @@ TEST(EJitInterprocedural, ConstantsStopAtCallEdgeWithoutIPSCCP) {
 // re-fold), the constant argument crosses the edge, the callee's may_const
 // load folds against cell 2's runtime value, and the guard collapses: the
 // callee body becomes `ret i32 100`.
-TEST(EJitInterprocedural, IPSCCPPropagatesDimsIntoCallee) {
+TEST(EJitInterprocedural, IPSCCPPropagatesDimsThroughNestedHelpers) {
   LLVMContext Ctx;
   auto M = parseInterprocModule(Ctx);
   ASSERT_NE(M, nullptr);
@@ -2596,13 +2601,16 @@ TEST(EJitInterprocedural, IPSCCPPropagatesDimsIntoCallee) {
   opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
 
   Function *Callee = M->getFunction("ip_callee");
+  Function *Mid = M->getFunction("ip_mid");
   Function *Entry = M->getFunction("ip_entry");
   ASSERT_NE(Callee, nullptr);
+  ASSERT_NE(Mid, nullptr);
   ASSERT_NE(Entry, nullptr);
 
   // The callee was internalized so IPSCCP could trust its call-site set; the
   // entry must stay externally visible — it is the symbol the JIT looks up.
   EXPECT_TRUE(Callee->hasLocalLinkage());
+  EXPECT_TRUE(Mid->hasLocalLinkage());
   EXPECT_FALSE(Entry->hasLocalLinkage());
 
   // The callee's period load and guard folded to the constant return.

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -266,6 +266,25 @@ TEST(EJitModuleLoader, SameNameSamePayloadIdempotent) {
   EXPECT_EQ(r->size(), 2u);
 }
 
+TEST(EJitModuleLoader, DifferentNamesMayShareRepositoryPayload) {
+  EJitModuleLoader loader;
+  const uint8_t repository[] = {0x42, 0x43, 0xc0, 0xde};
+  EXPECT_TRUE(
+      loader.registerBitcode("repo_entry_a", repository, sizeof(repository)));
+  EXPECT_TRUE(
+      loader.registerBitcode("repo_entry_b", repository, sizeof(repository)));
+
+  uint32_t A = EJitFuncRegistry::instance().lookup("repo_entry_a");
+  uint32_t B = EJitFuncRegistry::instance().lookup("repo_entry_b");
+  ASSERT_NE(A, B);
+  auto APayload = loader.getBitcodeByFuncIdx(A);
+  auto BPayload = loader.getBitcodeByFuncIdx(B);
+  ASSERT_TRUE(static_cast<bool>(APayload));
+  ASSERT_TRUE(static_cast<bool>(BPayload));
+  EXPECT_EQ(APayload->data(), BPayload->data());
+  EXPECT_EQ(APayload->size(), BPayload->size());
+}
+
 TEST(EJitModuleLoader, SameNameDifferentPayloadRejectedKeepsOriginal) {
   EJitModuleLoader loader;
   const uint8_t d1[] = {0x10};
@@ -2621,6 +2640,180 @@ TEST(EJitInterprocedural, IPSCCPPropagatesDimsThroughNestedHelpers) {
   auto *RetVal = dyn_cast<ConstantInt>(Ret->getReturnValue());
   ASSERT_NE(RetVal, nullptr) << "callee return did not fold";
   EXPECT_EQ(RetVal->getSExtValue(), 100); // mock[2].b == 7 → then-branch
+}
+
+TEST(EJitRepository, SelectsOneEntrySCCClosure) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    define i32 @entry_a(i32 %x) {
+      %v = call i32 @helper_b(i32 %x)
+      ret i32 %v
+    }
+    define i32 @entry_other(i32 %x) {
+      %v = call i32 @helper_other(i32 %x)
+      ret i32 %v
+    }
+    define i32 @helper_b(i32 %x) {
+      %v = call i32 @helper_c(i32 %x)
+      ret i32 %v
+    }
+    define i32 @helper_c(i32 %x) {
+      %done = icmp eq i32 %x, 0
+      br i1 %done, label %exit, label %again
+    again:
+      %next = sub i32 %x, 1
+      %v = call i32 @helper_b(i32 %next)
+      ret i32 %v
+    exit:
+      ret i32 7
+    }
+    define i32 @helper_other(i32 %x) {
+      %v = add i32 %x, 99
+      ret i32 %v
+    }
+
+    !ejit.repository.version = !{!0}
+    !ejit.repository.sccs = !{!1, !2, !3, !4}
+    !ejit.repository.entries = !{!5, !6}
+    !0 = !{i32 1}
+    !1 = !{i32 0, !"helper_b", !"helper_c"}
+    !2 = !{i32 1, !"entry_a"}
+    !3 = !{i32 2, !"helper_other"}
+    !4 = !{i32 3, !"entry_other"}
+    !5 = !{!"entry_a", i32 0, i32 1}
+    !6 = !{!"entry_other", i32 2, i32 3}
+  )",
+                               Err, Ctx);
+  ASSERT_NE(M, nullptr);
+
+  Error E = prepareRepositoryForEntry(*M, "entry_a");
+  if (E)
+    FAIL() << toString(std::move(E));
+
+  Function *Entry = M->getFunction("entry_a");
+  ASSERT_NE(Entry, nullptr);
+  EXPECT_FALSE(Entry->isDeclaration());
+  EXPECT_FALSE(Entry->hasLocalLinkage());
+  ASSERT_NE(M->getFunction("helper_b"), nullptr);
+  ASSERT_NE(M->getFunction("helper_c"), nullptr);
+  EXPECT_TRUE(M->getFunction("helper_b")->hasLocalLinkage());
+  EXPECT_TRUE(M->getFunction("helper_c")->hasLocalLinkage());
+  EXPECT_EQ(M->getFunction("entry_other"), nullptr);
+  EXPECT_EQ(M->getFunction("helper_other"), nullptr);
+}
+
+TEST(EJitRepository, SharedTemplateSpecializesIndependently) {
+  auto parseRepository = [](LLVMContext &Ctx) {
+    SMDiagnostic Err;
+    return parseAssemblyString(R"(
+      define i32 @entry_one() !ejit.metadata !6 {
+        %v = call i32 @shared_helper(i32 1)
+        ret i32 %v
+      }
+      define i32 @entry_two() !ejit.metadata !6 {
+        %v = call i32 @shared_helper(i32 2)
+        ret i32 %v
+      }
+      define i32 @shared_helper(i32 %x) {
+        %v = mul i32 %x, 10
+        ret i32 %v
+      }
+      !ejit.repository.version = !{!0}
+      !ejit.repository.sccs = !{!1, !2, !3}
+      !ejit.repository.entries = !{!4, !5}
+      !0 = !{i32 1}
+      !1 = !{i32 0, !"shared_helper"}
+      !2 = !{i32 1, !"entry_one"}
+      !3 = !{i32 2, !"entry_two"}
+      !4 = !{!"entry_one", i32 0, i32 1}
+      !5 = !{!"entry_two", i32 0, i32 2}
+      !6 = !{!7}
+      !7 = !{!"ejit_entry"}
+    )",
+                               Err, Ctx);
+  };
+
+  auto specialize = [&](StringRef EntryName) {
+    LLVMContext Ctx;
+    auto M = parseRepository(Ctx);
+    if (!M)
+      return int64_t{-1};
+    if (Error E = prepareRepositoryForEntry(*M, EntryName)) {
+      consumeError(std::move(E));
+      return int64_t{-2};
+    }
+
+    PeriodArrayRegistry Reg;
+    EJitOptimizer Opt(Reg);
+    SpecializationContext SC;
+    SC.fnName = EntryName.str();
+    SC.optLevel = llvm::ejit::OptimizationLevel::L2;
+    Opt.runPipeline(*M, SC);
+
+    Function *ResultFn = M->getFunction(EntryName);
+    if (!ResultFn || ResultFn->empty())
+      return int64_t{-3};
+    auto *Ret = dyn_cast<ReturnInst>(ResultFn->getEntryBlock().getTerminator());
+    auto *Value =
+        Ret ? dyn_cast_or_null<ConstantInt>(Ret->getReturnValue()) : nullptr;
+    if (!Value) {
+      ResultFn = M->getFunction("shared_helper");
+      if (!ResultFn || ResultFn->empty())
+        return int64_t{-3};
+      Ret = dyn_cast<ReturnInst>(ResultFn->getEntryBlock().getTerminator());
+      Value =
+          Ret ? dyn_cast_or_null<ConstantInt>(Ret->getReturnValue()) : nullptr;
+    }
+    return Value ? Value->getSExtValue() : int64_t{-4};
+  };
+
+  EXPECT_EQ(specialize("entry_one"), 10);
+  EXPECT_EQ(specialize("entry_two"), 20);
+}
+
+TEST(EJitRepository, LegacyPerEntryModuleIsUnchanged) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    define i32 @entry() {
+      ret i32 1
+    }
+    define i32 @unrelated() {
+      ret i32 2
+    }
+  )",
+                               Err, Ctx);
+  ASSERT_NE(M, nullptr);
+
+  Error E = prepareRepositoryForEntry(*M, "entry");
+  if (E)
+    FAIL() << toString(std::move(E));
+  EXPECT_NE(M->getFunction("entry"), nullptr);
+  EXPECT_NE(M->getFunction("unrelated"), nullptr);
+}
+
+TEST(EJitRepository, RejectsUnknownSCC) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    define i32 @entry() {
+      ret i32 1
+    }
+    !ejit.repository.version = !{!0}
+    !ejit.repository.sccs = !{!1}
+    !ejit.repository.entries = !{!2}
+    !0 = !{i32 1}
+    !1 = !{i32 0, !"entry"}
+    !2 = !{!"entry", i32 7}
+  )",
+                               Err, Ctx);
+  ASSERT_NE(M, nullptr);
+
+  Error E = prepareRepositoryForEntry(*M, "entry");
+  if (!E)
+    FAIL() << "unknown repository SCC was accepted";
+  EXPECT_NE(toString(std::move(E)).find("unknown SCC 7"), std::string::npos);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## 中文

### 背景

现有 `-fejit-cross-inline` 会在链接期按成本模型把跨 TU helper 展开进 `ejit_entry`。这能消除调用，但大型或多层 helper 可能显著放大 entry bitcode。此 PR 增加一个独立、显式的研究模式，在不改变默认路径和现有 inline 模式的前提下，让 helper 跟随 entry 进入 JIT。

### 改动

- 新增 clang 选项 `-fejit-cross-jit-helpers`。
- clang 仍生成 `.ejit_cross`，并向 ld.lld 转发 `--ejit-cross-jit-helpers`；非 lld 与 LTO 组合会明确报错。
- ld.lld 只展开 `always_inline`，保留普通跨 TU helper 的传递闭包。
- 每个 entry 的 bitcode 可保留 `A -> B -> C`；运行时沿用 internalize + IPSCCP，把已固定的维度常量传播到嵌套 helper，再由 JITLink 将它们放入同一 code allocation。
- 不新增 helper cache、共享状态、回收协议或运行时 ABI；v1 不跨 entry 共享 helper 机器码。
- 新增 SRE worker-first 双 TU 功能 demo，可验证首次 AOT fallback、异步编译、第二次 JIT hit，并打印优化后的 IR/ASM。

### 已验证

- clang driver lit：通过。
- lld ELF production-path lit：通过，覆盖 nested closure、always_inline、dead helper trimming 和默认路径不变。
- AArch64 codegen：确认 `entry -> helper_b -> helper_c` 为同模块直接 `bl`。
- 运行时 IPSCCP 单测：确认常量穿透两层普通 helper，2/2 通过。
- 真实双 TU demo host 交叉编译/`-r` 链接：通过；helper 模式 bitcode 保留 A/B/C，原 inline 模式删除 helper 调用与定义。
- `clang`、`lld`、`LLVMEJIT` 构建成功；`git diff --check` clean。

### 风险与限制

- helper 在多个 entry 中使用时，每个 specialization 会生成自己的副本，可能增加 code-pool 占用。
- 间接调用只能保留静态可见的闭包，运行时未知函数指针不能获得同等跨调用传播。
- 尚需在 SRE 板上确认真实业务的 code size、compile latency 和 direct-BL 性能收益。

## English

This draft adds an opt-in `-fejit-cross-jit-helpers` policy alongside the existing cross-TU inlining mode. Ordinary transitive helpers remain in each per-entry JIT module, while mandatory `always_inline` calls are still expanded. Runtime internalization and IPSCCP specialize nested `A -> B -> C` helpers, and JITLink emits their internal calls as direct code-pool-local `BL` instructions.

The default path and existing `-fejit-cross-inline` behavior are unchanged. No runtime ABI, helper cache, shared-state, or reclamation protocol is added. The main tradeoff is per-specialization helper duplication; board validation is still required for real code size and performance.