### PR TITLE
[EJIT] Optimize cross-TU per-entry extraction

### DIFF
--- a/jit_design_doc/EJIT_CROSS_TU_INLINE.md
+++ b/jit_design_doc/EJIT_CROSS_TU_INLINE.md
@@ -177,59 +177,64 @@ if (Args.hasArg(options::OPT_fejit_cross_inline)) {
 
 ```cpp
 /// 链接期跨 TU 内联处理。
-/// 从所有输入 .o 中提取 .ejit_cross section，合并、内联、生成 @__ejit_bitcode，
-/// 写入临时 .bc，并返回路径及被精确消费的输入集合。
+/// 从 lld 实际选中的目标文件（ctx.objectFiles）中提取 .ejit_cross section，
+/// 合并、内联、生成 registry，写入临时 .bc，并返回路径及被精确消费的输入集合。
+/// SelectedObjects 的每个 MemoryBufferRef 标识必须是 canonical ObjFile::getName()。
 /// 无 .ejit_cross 时返回空结果；检测后的任何失败返回 Error。
 Expected<EJitCrossLinkResult>
-runEJitCrossLink(ArrayRef<std::string> InputFiles, StringRef TargetTriple,
-                 StringRef SaveTempsPrefix = {});
+runEJitCrossLink(ArrayRef<MemoryBufferRef> SelectedObjects,
+                 StringRef TargetTriple, StringRef SaveTempsPrefix = {});
 ```
+
+> **调用时机（archive member selection）**：`runEJitCrossLink` 在 lld 完成符号解析
+> **之后**运行（`addWrappedSymbols` 之后、`initSectionsAndLocalSyms` 之前），此时
+> `ctx.objectFiles` 恰好是被链接选中的目标文件集合——包含被实际拉入链接的 archive
+> member、`-l` 输入与 linker-script 输入。因此只处理被选中的 member，不重新实现一套
+> ELF 符号选择，未被选中的 member 既不进入 composite 也不进入 registry。早期版本在
+> `parseFiles` 之前无条件合并 archive 内所有带 `.ejit_cross` 的 member，语义错误且会
+> 拖慢链接，已被移除。
+
 
 ### 4.2 处理流程
 
 ```
-runEJitCrossLink(InputFiles, TargetTriple):
+runEJitCrossLink(SelectedObjects, TargetTriple):
 
-  1. 快速扫描: 检查是否有任何输入包含 .ejit_cross section
-     └─ 无 → return EJitCrossLinkResult{}
-
-  2. 提取并解析:
-     for each input file:
+  1. 扫描 + 提取 + 合并（合并为一次遍历）:
+     for each MemoryBufferRef in SelectedObjects:   // 只遍历被选中的目标文件
        ObjectFile::createObjectFile()
-       for each section:
-         if name == ".ejit_cross":
-           parseBitcodeFile(section contents) → Module
+       找到 .ejit_cross section:
+         parseBitcodeFile(section contents) → Module
+         Composite 为空 → std::move；否则 Linker::linkInModule
+       consumedFiles += buffer identifier            // == ObjFile::getName()
+     无 .ejit_cross → return EJitCrossLinkResult{}
 
-  3. 合并:
-     Composite = std::move(FirstModule)
-     for each remaining Module:
-       Linker::linkInModule(module, None)  // 全部链接，确保所有 ejit_entry 都在
-
-  4. 闭包计算:
+  2. 闭包计算 (union):
      collectEntryFunctions(Composite) → EntryFuncs
-     computeTransitiveClosure(EntryFuncs) → ClosureFuncs + ClosureGlobals
+     computeTransitiveClosure(EntryFuncs) → ClosureFuncs + ClosureGlobals + ClosureIndirect
      扫描 operand、常量表达式/聚合、alias/ifunc、全局 initializer
      deleteBody/setInitializer(nullptr) + GlobalDCE 安全裁剪
 
-  5. 内联跨 TU 子函数:
+  3. 内联跨 TU 子函数:
      将 JIT-only composite definitions 标记 dso_local
      AlwaysInlinerPass + ModuleInlinerWrapperPass (成本模型)
 
-  6. 轻量 cleanup + metadata 恢复:
+  4. 轻量 cleanup + metadata 恢复:
      Promote → InstCombine → SimplifyCFG
      reAnnotateMayConst(Composite)
 
-  7. 对每个 ejit_entry 单独提取闭包 + 序列化:
+  5. 对每个 ejit_entry 单独提取闭包 + 序列化 (closure-only clone，见 4.6):
      for each EntryFunc:
-       PerFuncModule = CloneModule(Composite)
-       computeTransitiveClosure({EntryFunc}, Closure, Globals)
-       安全裁剪 PerFuncModule 中非闭包函数/全局变量
+       computeTransitiveClosure({EntryFunc}) → SrcFuncs/SrcGlobals/SrcIndirect  // 在 Composite 上
+       PerFuncModule = CloneModule(Composite, VMap, ShouldClone=闭包成员)        // 只克隆闭包定义
+       擦除闭包外的 ifunc（CloneModule 对 ifunc 不遵守 ShouldClone 回调）
+       trimToClosure → GlobalDCE 清理残留声明
        externalize mutable globals
        collectExternalSymbols → 在 TmpModule 中建立稳定 declaration
        verifyModule(*PerFuncModule)
        serializeToBitcode(*PerFuncModule) → BC
 
-  8. 生成临时 Module (含 N 个 @__ejit_bitcode_<name> + 单一 registry):
+  6. 生成临时 Module (含 N 个 @__ejit_bitcode_<name> + 单一 registry):
      TmpModule = new Module("ejit_cross_link", Ctx)
      复制 DataLayout + TargetTriple
      for each EntryFunc + its BC:
@@ -237,12 +242,20 @@ runEJitCrossLink(InputFiles, TargetTriple):
      generateRegistryTable(TmpModule, entries, external symbols)
      verifyModule(TmpModule)
 
-  9. 写入临时 .bc:
+  7. 写入临时 .bc:
      WriteBitcodeToFile(TmpModule) → 临时 .bc 文件
-     lld 原生支持 .bc 输入，无需编译为 .o
 
-  10. return {tmpfile path, consumed input files}
+  8. return {tmpfile path, consumed input files}
 ```
+
+> 每个阶段都包裹在 `llvm::TimeTraceScope("EJitCross:*")` 中（`DetectScan`、
+> `ParseBitcode`、`MergeModule`、`EntryScan`、`UnionClosure`、`Inliner`、
+> `PerEntryExtraction`、`PerEntryClosure`、`PerEntryClone`、`PerEntryTrim`、
+> `PerEntryVerify`、`PerEntrySerialize`、`RegistryGen`）。这些 scope 只在
+> `ld.lld --time-trace` 初始化 profiler 时才产生记录；关闭 time trace 时每个 scope
+> 仅多一次 TimeTraceScope 的 inactive-profiler 分支，不产生任何记录或输出（并非
+> 编译期完全消除）。使用方法见 4.7。
+
 
 ### 4.3 与 PASS1 共享的语义
 
@@ -263,17 +276,32 @@ driver 自身**不再**执行任何合并。协议如下：
      只允许配合 `-fuse-ld=lld`）。绝不生成 GNU ld 无法消费的 `.bc`，也绝不把巨大的
      `.ejit_cross` 静默留在最终产物。
    - 若是 lld → 仅向链接命令行追加 `--ejit-cross-inline`，把处理交给 lld。
-2. **ld.lld**: `lld/ELF/Driver.cpp` — `LinkerDriver::link()` 中，`parseFiles` 之前，
-   **仅当 `--ejit-cross-inline` 存在**（`ctx.arg.ejitCrossInline`）时扫描 OPT_INPUT，
-   调用 `runEJitCrossLink`：
+2. **ld.lld**: `lld/ELF/Driver.cpp` — `LinkerDriver::link()` 中，**仅当
+   `--ejit-cross-inline` 存在**（`ctx.arg.ejitCrossInline`）时调用
+   `runEJitCrossLink`。调用点在**符号解析完成之后**（`addWrappedSymbols` 之后、
+   `initSectionsAndLocalSyms` 之前），传入 `ctx.objectFiles`（被选中的目标文件）
+   的 `MemoryBufferRef`：
    - 返回 `Expected<EJitCrossLinkResult>`：`Error` → `ErrAlways(ctx)` 令链接失败；
      空 `tempPath` → 无 `.ejit_cross`（正常跳过，默认行为完全不变）；非空 →
      临时 `.bc` 路径和被精确消费的输入文件集合。
-   - 生成的 `.bc` 通过 `addFile` 加入链接；`InputFiles.cpp` 只丢弃
-     `consumedFiles` 中输入的 `.ejit_cross` section，不能用全局布尔值误删后续由
-     `-l`、archive 或 linker script 引入但未处理的 section。
-   - 临时 `.bc` 在 `parseFiles` 读入内存后由 Driver 立即 `sys::fs::remove` 删除，
-     并在创建时 `RemoveFileOnSignal` 注册，保证不会在 `/tmp` 永久遗留。
+   - `consumedFiles` 用 `ObjFile::getName()`（即 buffer identifier）标识，`InputFiles.cpp`
+     只丢弃 `ctx.ejitCrossConsumedFiles` 中列出的输入的 `.ejit_cross` section。因为
+     只有被选中的目标文件被处理并消费，任何仍带未处理 `.ejit_cross` 的**被选中**
+     输入都会被 `rejectUnprocessedEJitCross` 硬报错，绝不静默丢弃。
+   - 生成的 registry 是 bitcode：用 `addFile` 加入 `files` 后立即
+     `parseFile(ctx, ...)` 解析，使其进入 `ctx.bitcodeFiles`，随后由既有的 LTO
+     步骤（`compileBitcodeFiles`）编译为携带 `.ejit_bitcode` 的目标文件。它对 AOT
+     符号的引用绑定到已选中的定义；由于在符号解析之后加入，绝不会再拉入新的 member。
+   - 临时 `.bc` 被 `parseFile` 读入内存后立即 `sys::fs::remove` 删除。
+
+> **旧实现的问题（本轮修复）**：早期 `runEJitCrossLink` 在 `parseFiles` 之前扫描
+> `OPT_INPUT` 路径，用一个**全局** `HasCross` 布尔在 archive member 循环里 `break`。
+> 只要更早的普通目标文件已把 `HasCross` 置真，后续 archive 就只检查第一个 member，
+> 后面 member 里的 ejit_entry 会被漏掉，链接以 "no ejit_entry" 失败。同时它无条件
+> 合并 archive 内**所有**带 `.ejit_cross` 的 member（含未被链接选中的），既污染
+> registry 又拖慢链接。改为符号解析后遍历 `ctx.objectFiles` 后，这两个问题都从
+> 结构上消除，`-l` / linker-script 输入也自然被支持。
+
 
 > clang 复制版 `clang/lib/Driver/EJitCrossLink.cpp` 已删除，因此实现只剩 lld 一份，
 > 不存在两份实现漂移（Area 6）。`.ejit_cross` 里的 may_const 语义直接复用
@@ -316,7 +344,106 @@ struct BitcodeEntry {
 };
 ```
 
+### 4.6 每函数闭包提取的复杂度与 closure-only clone
+
+**原始实现（`entry × Composite` 克隆）**：每个 ejit_entry 都
+`CloneModule(*Composite)` 复制**整个** composite，再删除闭包以外的 ~99% 内容。
+per-entry 代价 ∝ composite 大小，总代价 ∝ `entry 数 × composite 大小`。当每个
+entry 只依赖自身的小闭包、而 composite 包含所有 entry 的闭包时，这呈**二次**增长
+（benchmark 中 entry 数翻倍 → 墙钟约 4 倍）。
+
+**closure-only clone（本轮）**：先在 composite 上算出该 entry 的传递闭包，再用
+`CloneModule(M, VMap, ShouldCloneDefinition)` 的**选择性回调**只克隆闭包内的函数/
+全局的**定义**，其余一律克隆为**声明**（无函数体/无 initializer，代价低），最后
+`trimToClosure` 的 `GlobalDCE` 清除残留声明。这与 `llvm-extract` 采用的抽取方式
+相同，复用 LLVM 结构化 clone API，不手写不完整 clone。
+
+关键语义处理：
+
+- **alias / ifunc 纳入闭包跟踪**：`computeTransitiveClosure` 额外产出
+  `ClosureIndirect`（被引用的 `GlobalAlias`/`GlobalIFunc`）。回调对 alias/ifunc
+  按闭包成员判定，而非一律返回 `true`。原因：`GlobalDCE` **不会**删除
+  externally-visible 的未引用 alias/ifunc，若一律克隆会把死符号泄漏进每个 per-entry
+  模块。被闭包引用的 alias 仍以 alias 定义保留（JIT 解析到 aliasee），未引用的则退化
+  为声明并被 `GlobalDCE` 删除。
+- **ifunc 的特殊处理**：`CloneModule` 对 `GlobalIFunc` **不**咨询 `ShouldCloneDefinition`
+  回调，总是把 ifunc 物化为定义并指向其 resolver。若某 entry 不引用该 ifunc，其
+  resolver 只会被克隆为声明，导致 "ifunc resolver must be a definition" 的非法模块。
+  因此 clone 之后显式擦除闭包外的 ifunc（通过 `VMap` 定位），只保留被引用的合法 ifunc。
+- **闭包引用形态**：`call`/`invoke`/`callbr`（均为 `CallBase`，callee 是 operand）、
+  `bitcast`/ConstantExpr callee、常量聚合中的函数地址、函数指针表（global initializer）、
+  `GlobalAlias`/`GlobalIFunc`、personality、comdat、metadata；mutable global externalize、
+  const global 保留、external func/global 注册、`may_const`/`ejit.metadata` 均保留。
+  见 `lld/test/ELF/ejit-cross-inline-refs.ll`。
+
+**输出等价性**：closure-only clone 的 per-entry bitcode 与旧的 full-clone+trim 路径
+**大小逐字节一致、反汇编 IR 一致**（语义相同），但**原始 bitcode 字节并非 bit-identical**
+——full-clone-then-trim 与 closure-only-clone 会留下不同的内部 value ordering，序列化
+为不同字节。因此正确的说法是「size + 反汇编 IR 一致」，而非「byte-for-byte identical」。
+`lld/utils/ejit-cross-link-bench.py --mode=compare` 会同时报告原始字节 hash（不等）与
+归一化 IR hash（相等）。
+
+**尚存限制**：`CloneModule` 仍会为整个 composite 的每个 GlobalValue 创建一个声明
+骨架（`PerEntryClone`），且 per-entry `GlobalDCE`（`PerEntryTrim`）会遍历整份克隆。
+两者仍是 `O(entry 数 × composite 符号数)`，在 256 entry 的 trace 中合计占
+`PerEntryExtraction` 的绝大部分。要做到真正 `O(闭包)`，需要一个**真正的 closure-only
+module builder**（用 `IRMover`/`CloneFunctionInto` 直接把闭包搬进新模块），但那会
+偏离 `llvm-extract` 惯用法，且需自行正确处理 module flags、named metadata、comdat、
+alias/ifunc 等，风险较高，故本轮不实现，列为后续工作。
+
+### 4.7 time-trace 使用方法
+
+```
+# 采集各阶段耗时（关闭 granularity 阈值以捕获亚毫秒阶段）
+ld.lld --ejit-cross-inline --time-trace=trace.json --time-trace-granularity=0 \
+       -shared a.o b.o -o out.so
+# 用 Chrome about:tracing 或脚本聚合 "EJitCross:*" 事件
+```
+
+不带 `--time-trace` 时不产生任何 trace 文件，也无控制台输出（见
+`lld/test/ELF/ejit-cross-inline-time-trace.ll`）。scope 名称是固定短字符串，
+per-entry 的函数名放在 TimeTraceScope 的 detail 参数里，不会把不受控超长字符串
+放进 scope 名。
+
+### 4.8 production benchmark 方法与 before/after 数据
+
+`lld/utils/ejit-cross-link-bench.py` 生成可复现输入（每个 entry 一条 `noinline`
+helper 链 + 私有全局；composite 含所有 entry 的闭包），并分三种**互不污染**的模式：
+
+- `--mode=production`：不开 `--save-temps`、不开 `--time-trace`，测量墙钟与 peak RSS。
+- `--mode=trace`：只开 `--time-trace`，给出阶段占比（其墙钟**不**作为生产结果）。
+- `--mode=compare`：只开 `--save-temps`，比较 per-entry bitcode 大小与 hash。
+
+复现命令（baseline = `dong/ejit_dev_spec4` 基线 full-clone 的 `ld.lld`）：
+
+```
+lld/utils/ejit-cross-link-bench.py --mode=all \
+  --baseline-bin /path/to/baseline/bin \
+  --optimized-bin build_release_x86/bin \
+  --entries 1,8,32,64,128,256
+```
+
+**production 墙钟 / peak RSS（helpers=20，globals=6，best-of-3，x86 Release+asserts）**：
+
+| entries | baseline wall | optimized wall | speedup | baseline RSS | optimized RSS |
+|--------:|--------------:|---------------:|--------:|-------------:|--------------:|
+| 1       | 0.017 s       | 0.017 s        | ~1.0×   | 54.3 MB      | 54.5 MB       |
+| 8       | 0.030 s       | 0.026 s        | 1.17×   | 55.3 MB      | 55.6 MB       |
+| 32      | 0.151 s       | 0.071 s        | 2.12×   | 58.9 MB      | 59.9 MB       |
+| 64      | 0.509 s       | 0.176 s        | 2.89×   | 65.4 MB      | 65.7 MB       |
+| 128     | 1.967 s       | 0.536 s        | 3.67×   | 76.6 MB      | 77.4 MB       |
+| 256     | 8.323 s       | 1.961 s        | 4.24×   | 99.8 MB      | 100.4 MB      |
+
+peak RSS 基本持平（优化不以内存换时间）。
+
+**compare（输出保持）**：所有规模下 per-entry bitcode **大小逐条一致**，原始字节
+hash 不等（内部 value ordering 差异），归一化 IR hash 相等 → 语义/文本一致。
+
+**trace（256 entry 阶段占比）**：`PerEntryClone` ≈ 1105 ms、`PerEntryTrim` ≈ 565 ms
+合计占 `PerEntryExtraction`（≈ 1813 ms）的绝大部分，与 4.6 的尚存限制一致。
+
 ---
+
 
 ## 5. 构建依赖
 
@@ -371,7 +498,7 @@ BitReader/Object/Linker 等 cross-link 实现依赖。
 |---|---|
 | 无 .ejit_cross section 的链接 | 返回空结果，正常链接（默认行为不变） |
 | 普通非对象参数或不含该 section 的输入 | 跳过，非错误 |
-| **archive 成员含 .ejit_cross** | **硬报错**（明确诊断：暂不支持 archive 成员，请直接链接 .o） |
+| **被选中的 archive 成员 / `-l` / linker-script 输入含 .ejit_cross** | 正常处理（在符号解析后遍历 `ctx.objectFiles`）；未被选中的成员不处理 |
 | **bitcode 解析失败 / section 读取失败** | **链接失败**（带文件名+阶段+Error） |
 | **`Linker::linkInModule` 合并冲突** | **链接失败**（检查返回值） |
 | 合并后无 ejit_entry | **链接失败**（已承诺有 .ejit_cross，却无可注册入口） |
@@ -404,8 +531,10 @@ Cross-link 返回精确的 `consumedFiles`，Driver 写入
 `ctx.ejitCrossConsumedFiles`。`InputFiles.cpp` 只有在当前 input identifier 命中该
 集合且 section 名为 `.ejit_cross` 时才设为 `InputSection::discarded`：
 - 已处理的原始 `.o` section 不进入输出，`-r` 和最终链接都生效；
-- archive、`-l` 或 linker script 后续引入的未处理 section 不会被全局状态误删，
-  而是在 parse 后得到明确的 unsupported 诊断。
+- archive、`-l` 或 linker script 引入的 member 仍由 lld 原生符号解析选择；
+- provisional registry 若引用新的 lazy archive symbol，Driver 会提取对应 member，
+  重新扩展 composite，直到 `ctx.objectFiles` 不再增长；只有 fixed point 的最终
+  registry 会进入 LTO，因此不会遗留未处理的 `.ejit_cross` 或重复 registry。
 
 ### 7.4 被调用的 TU 也需要 `-fejit-cross-inline`
 
@@ -443,17 +572,18 @@ PR #102 hardening 后（ld.lld 为唯一 owner）：
 | `clang/lib/Driver/ToolChains/Gnu.cpp` | link 阶段：检测非 lld → 报错；lld → 追加 `--ejit-cross-inline`（不再自行合并） |
 | ~~`clang/lib/Driver/EJitCrossLink.cpp` / `.h`~~ | **已删除**（去重：实现只剩 lld 一份） |
 | `clang/lib/Driver/CMakeLists.txt` | 移除 `EJitCrossLink.cpp` 及其专用 LINK_COMPONENTS |
-| `lld/ELF/EJitCrossLink.cpp` | 链接期处理核心（唯一实现）：`Expected<EJitCrossLinkResult>`、保守闭包、真实 inliner、TmpM 内 registry + `verifyModule`、错误传播、临时文件清理 |
-| `lld/ELF/EJitCrossLink.h` | API 声明（`Expected<EJitCrossLinkResult>`） |
+| `lld/ELF/EJitCrossLink.cpp` | 链接期处理核心（唯一实现）：`Expected<EJitCrossLinkResult>`、保守闭包、真实 inliner、TmpM 内 registry + `verifyModule`、错误传播、临时文件清理。**本轮**：改为遍历选中的 `MemoryBufferRef`；closure-only 选择性 `CloneModule` + alias/ifunc 闭包跟踪 + 擦除闭包外 ifunc；返回 registry 强引用的 external symbol；每阶段 `TimeTraceScope` |
+| `lld/ELF/EJitCrossLink.h` | API 声明改为 `runEJitCrossLink(ArrayRef<MemoryBufferRef> SelectedObjects, ...)`，结果附带 `requiredSymbols` |
 | `lld/ELF/Options.td` | `--ejit-cross-inline`（gate，默认关闭时零扫描） |
 | `lld/ELF/Config.h` | `Config::ejitCrossInline`（arg）+ `Ctx::ejitCrossConsumedFiles`（精确消费集合） |
-| `lld/ELF/Driver.cpp` | 解析 flag；gated 调用 + `Expected`/`Error` 处理；临时文件清理（`+Signals.h`） |
-| `lld/ELF/InputFiles.cpp` | 仅丢弃精确匹配已消费输入的 `.ejit_cross` |
-| `lld/ELF/CMakeLists.txt` | 新增源（不变） |
-| `llvm/lib/Passes/PassBuilderPipelines.cpp` | flag + 构造函数传参（不变） |
-| `llvm/include/.../EJitPasses.h` | CrossInline 成员（不变） |
-| `llvm/.../EJitRegisterBitcode.cpp` | 分支 + embedBitcodeInSection（不变） |
-| `lld/test/ELF/ejit-cross-inline.ll` | **新建**：生产路径测试（exactly-once / discard / registry / external / malformed→fail / 默认不变） |
+| `lld/ELF/Driver.cpp` | 解析 flag；**本轮**：调用点移到符号解析之后、遍历 `ctx.objectFiles`；根据 provisional registry 的 `requiredSymbols` 迭代提取 lazy archive member 至 fixed point，最后一份 registry 经 `addFile`+`parseFile` 进入 LTO |
+| `lld/ELF/InputFiles.cpp` | 仅丢弃精确匹配已消费输入的 `.ejit_cross`（不变） |
+| `lld/test/ELF/ejit-cross-inline.ll` | 生产路径测试；**本轮**更新 archive/`-l` 用例为需显式选中 member |
+| `lld/test/ELF/ejit-cross-inline-time-trace.ll` | **新建**：`--time-trace` 下所有阶段 scope 存在；不传时不产生 trace 文件 |
+| `lld/test/ELF/ejit-cross-inline-archive-select.ll` | **新建**：archive member selection（HasCross 顺序 bug；只处理选中 member；冲突符号；顺序无关；registry 引发 late extraction 的 fixed-point 回归） |
+| `lld/test/ELF/ejit-cross-inline-refs.ll` | **新建**：引用形态覆盖（call/invoke/personality/fptr 表/常量聚合/bitcast/alias(live+dead)/ifunc/shared+dead helper/mutable+const global/external 注册） |
+| `lld/utils/ejit-cross-link-bench.py` | **新建**：production/trace/compare 三模式 benchmark，支持 baseline/optimized before/after |
+| `jit_design_doc/EJIT_CROSS_TU_INLINE.md` | 本文档：复杂度、closure-only 算法、archive 选择语义、time-trace、benchmark 与 before/after 数据、尚存限制 |
 
 ### 9.1 闭包支持的引用形态（Area 4）
 
@@ -465,15 +595,20 @@ bitcast 后的 callee 也覆盖。运行时传入的真正间接目标无法静�
 module-owned 函数表目标由 initializer 扫描覆盖。trim 先 `deleteBody`，再由 `GlobalDCE`
 安全回收，Debug/Release 都不会断言或留下 dangling reference。
 
+**本轮补充**：`computeTransitiveClosure` 额外产出 `ClosureIndirect`（被引用的
+alias/ifunc），供 closure-only clone 判定是否保留 alias/ifunc 定义（见 4.6）。
+
 ---
 
 ## 10. 未来扩展
 
-- 支持从 archive (.a) 中提取 `.ejit_cross`
+- ~~支持从 archive (.a) 中提取 `.ejit_cross`~~ **已实现**（符号解析后遍历选中 member）
+- 真正的 closure-only module builder（`IRMover`/`CloneFunctionInto`），把 per-entry
+  `PerEntryClone`/`PerEntryTrim` 从 `O(entry×composite符号)` 降到 `O(闭包)`（见 4.6 风险）
 - 增量链接：缓存已处理的跨 TU bitcode 避免重复合并
 - `-fejit-cross-inline=thin` 变体：利用 ThinLTO summary 实现按需导入
 
 ---
 
-*文档版本: 1.0*
+*文档版本: 2.0（cross-TU per-entry extraction 优化 + archive member selection）*
 *创建日期: 2026-07-29*

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -3147,41 +3147,7 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
   for (StringRef name : ctx.arg.undefined)
     ctx.symtab->addUnusedUndefined(name)->referenced = true;
 
-  // EJIT cross-TU inlining. ld.lld is the single owner of this processing and
-  // runs it at most once per link, only when --ejit-cross-inline is present
-  // (clang emits that flag for -fejit-cross-inline links that use ld.lld). On
-  // any failure after a .ejit_cross section is observed the link fails rather
-  // than silently dropping back to the per-TU AOT bitcode.
-  SmallVector<std::string, 1> ejitCrossTemps;
-  if (ctx.arg.ejitCrossInline) {
-    std::vector<std::string> InputPaths;
-    for (auto *arg : args.filtered(OPT_INPUT))
-      InputPaths.push_back(arg->getValue());
-    StringRef SaveTempsPrefix =
-        args.hasArg(OPT_save_temps) ? ctx.arg.outputFile : StringRef();
-    Expected<EJitCrossLinkResult> CrossResult =
-        runEJitCrossLink(InputPaths, /*TargetTriple=*/"", SaveTempsPrefix);
-    if (!CrossResult) {
-      ErrAlways(ctx) << toString(CrossResult.takeError());
-      return;
-    }
-    for (const std::string &path : CrossResult->consumedFiles)
-      ctx.ejitCrossConsumedFiles.insert(path);
-    if (!CrossResult->tempPath.empty()) {
-      llvm::sys::RemoveFileOnSignal(CrossResult->tempPath);
-      ejitCrossTemps.push_back(CrossResult->tempPath);
-      addFile(ctx.saver.save(CrossResult->tempPath), /*withLOption=*/false);
-    }
-  }
-
   parseFiles(ctx, files);
-
-  // The cross-inline temp bitcode is now resident in memory (parseFiles read
-  // it into an owned buffer), so reclaim the on-disk temp file immediately.
-  for (const std::string &p : ejitCrossTemps) {
-    llvm::sys::fs::remove(p);
-    llvm::sys::DontRemoveFileOnSignal(p);
-  }
 
   auto rejectUnprocessedEJitCross = [&]() {
     if (!ctx.arg.ejitCrossInline)
@@ -3193,9 +3159,8 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
           ErrAlways(ctx) << "ejit-cross-inline: selected input '"
                          << file->getName()
                          << "' contains an unprocessed .ejit_cross section "
-                            "(archive members, -l inputs, and linker-script "
-                            "inputs are not yet supported; link the object "
-                            "file directly)";
+                            "after archive dependency selection reached a "
+                            "fixed point";
           return true;
         }
       }
@@ -3263,6 +3228,75 @@ template <class ELFT> void LinkerDriver::link(opt::InputArgList &args) {
 
   // Archive members defining __wrap symbols may be extracted.
   std::vector<WrappedSymbol> wrapped = addWrappedSymbols(ctx, args);
+
+  // EJIT cross-TU inlining. ld.lld is the single owner of this processing and
+  // runs it at most once per link, only when --ejit-cross-inline is present
+  // (clang emits that flag for -fejit-cross-inline links that use ld.lld).
+  //
+  // It runs here after ordinary symbol resolution, so ctx.objectFiles starts as
+  // exactly the set of object files
+  // (including the archive members, -l inputs and linker-script inputs that
+  // were actually pulled into the link) that make up the AOT image. Feeding
+  // that set to runEJitCrossLink is what gives correct archive-member selection
+  // without re-implementing ELF symbol resolution: an unselected member is
+  // never merged or registered. On any failure after a .ejit_cross section is
+  // observed the link fails rather than silently dropping to per-TU AOT.
+  //
+  // A generated registry can itself reference an external symbol whose archive
+  // member was not needed by the optimized AOT object. Since .ejit_cross holds
+  // the pre-optimization module, that dependency difference is legitimate.
+  // Iterate to a fixed point: let lld extract lazy definitions required by each
+  // provisional registry, then rebuild from the expanded selected-object set.
+  // Only the final registry is added to the link.
+  if (ctx.arg.ejitCrossInline) {
+    StringRef saveTempsPrefix =
+        args.hasArg(OPT_save_temps) ? ctx.arg.outputFile : StringRef();
+    std::optional<EJitCrossLinkResult> finalResult;
+    while (true) {
+      SmallVector<MemoryBufferRef, 0> selectedObjects;
+      selectedObjects.reserve(ctx.objectFiles.size());
+      for (ELFFileBase *file : ctx.objectFiles)
+        selectedObjects.push_back(file->mb);
+
+      Expected<EJitCrossLinkResult> crossResult = runEJitCrossLink(
+          selectedObjects, /*TargetTriple=*/"", saveTempsPrefix);
+      if (!crossResult) {
+        ErrAlways(ctx) << toString(crossResult.takeError());
+        return;
+      }
+      if (!crossResult->tempPath.empty())
+        llvm::sys::RemoveFileOnSignal(crossResult->tempPath);
+
+      size_t objectCount = ctx.objectFiles.size();
+      for (const std::string &name : crossResult->requiredSymbols)
+        if (Symbol *sym = ctx.symtab->find(name))
+          handleUndefined(ctx, sym, "--ejit-cross-inline");
+
+      if (ctx.objectFiles.size() == objectCount) {
+        finalResult = std::move(*crossResult);
+        break;
+      }
+
+      // A provisional registry is never added to lld. Remove its temporary
+      // file before rebuilding from the newly selected archive members.
+      if (!crossResult->tempPath.empty()) {
+        llvm::sys::fs::remove(crossResult->tempPath);
+        llvm::sys::DontRemoveFileOnSignal(crossResult->tempPath);
+      }
+    }
+
+    for (const std::string &path : finalResult->consumedFiles)
+      ctx.ejitCrossConsumedFiles.insert(path);
+    if (!finalResult->tempPath.empty()) {
+      size_t firstNew = files.size();
+      addFile(ctx.saver.save(finalResult->tempPath), /*withLOption=*/false);
+      for (size_t i = firstNew; i < files.size(); ++i)
+        parseFile(ctx, files[i].get());
+      // The temp bitcode is now resident in memory; reclaim the on-disk file.
+      llvm::sys::fs::remove(finalResult->tempPath);
+      llvm::sys::DontRemoveFileOnSignal(finalResult->tempPath);
+    }
+  }
 
   // No more lazy bitcode can be extracted at this point. Do post parse work
   // like checking duplicate symbols.

--- a/lld/ELF/EJitCrossLink.cpp
+++ b/lld/ELF/EJitCrossLink.cpp
@@ -48,13 +48,13 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Linker/Linker.h"
-#include "llvm/Object/Archive.h"
 #include "llvm/Object/Binary.h"
 #include "llvm/Object/ObjectFile.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
@@ -150,6 +150,7 @@ static void collectEntryFunctions(Module &M,
 static void collectFromConstant(const Constant *C,
                                 SmallVectorImpl<Function *> &FuncWL,
                                 SetVector<GlobalVariable *> &Globals,
+                                SetVector<GlobalValue *> &Indirect,
                                 SmallPtrSetImpl<const Constant *> &Visited) {
   if (!C || !Visited.insert(C).second)
     return;
@@ -162,37 +163,47 @@ static void collectFromConstant(const Constant *C,
     return;
   }
   if (auto *GA = dyn_cast<GlobalAlias>(C)) {
-    collectFromConstant(GA->getAliasee(), FuncWL, Globals, Visited);
+    // Record the alias itself (so the closure-only clone keeps its definition)
+    // and follow the aliasee (so the target stays alive too).
+    Indirect.insert(const_cast<GlobalAlias *>(GA));
+    collectFromConstant(GA->getAliasee(), FuncWL, Globals, Indirect, Visited);
     return;
   }
   if (auto *GI = dyn_cast<GlobalIFunc>(C)) {
-    collectFromConstant(GI->getResolver(), FuncWL, Globals, Visited);
+    Indirect.insert(const_cast<GlobalIFunc *>(GI));
+    collectFromConstant(GI->getResolver(), FuncWL, Globals, Indirect, Visited);
     return;
   }
   // ConstantExpr (bitcast/gep/...), ConstantAggregate (array/struct/vector):
   // recurse through operands to reach any embedded function/global.
   for (const Use &U : C->operands())
     if (auto *OpC = dyn_cast<Constant>(U.get()))
-      collectFromConstant(OpC, FuncWL, Globals, Visited);
+      collectFromConstant(OpC, FuncWL, Globals, Indirect, Visited);
 }
 
 static void collectReferences(Function &F, SmallVectorImpl<Function *> &FuncWL,
                               SetVector<GlobalVariable *> &Globals,
+                              SetVector<GlobalValue *> &Indirect,
                               SmallPtrSetImpl<const Constant *> &Visited) {
   for (BasicBlock &BB : F)
     for (Instruction &I : BB)
       for (Value *Op : I.operands())
         if (auto *C = dyn_cast<Constant>(Op))
-          collectFromConstant(C, FuncWL, Globals, Visited);
+          collectFromConstant(C, FuncWL, Globals, Indirect, Visited);
 }
 
 /// Compute the transitive closure of functions and globals reachable from the
 /// entry set. Global initializers are scanned so function-pointer tables keep
-/// their targets alive.
+/// their targets alive. Referenced aliases and ifuncs are recorded in
+/// \p ClosureIndirect so the closure-only clone keeps exactly those definitions
+/// (GlobalDCE would otherwise retain any *externally visible* alias/ifunc even
+/// when the entry never references it, leaking dead symbols into the per-entry
+/// bitcode).
 static void
 computeTransitiveClosure(ArrayRef<Function *> EntryFuncs,
                          SetVector<Function *> &ClosureFuncs,
-                         SetVector<GlobalVariable *> &ClosureGlobals) {
+                         SetVector<GlobalVariable *> &ClosureGlobals,
+                         SetVector<GlobalValue *> &ClosureIndirect) {
   SmallPtrSet<const Constant *, 32> Visited;
   SmallVector<Function *, 16> FuncWL(EntryFuncs.begin(), EntryFuncs.end());
   SetVector<GlobalVariable *> PendingGlobals;
@@ -205,7 +216,7 @@ computeTransitiveClosure(ArrayRef<Function *> EntryFuncs,
         continue;
       if (GV->hasInitializer())
         collectFromConstant(GV->getInitializer(), FuncWL, PendingGlobals,
-                            Visited);
+                            ClosureIndirect, Visited);
     }
   };
 
@@ -215,7 +226,7 @@ computeTransitiveClosure(ArrayRef<Function *> EntryFuncs,
       continue;
     if (F->isDeclaration())
       continue; // declarations are handled by the symbol registry
-    collectReferences(*F, FuncWL, PendingGlobals, Visited);
+    collectReferences(*F, FuncWL, PendingGlobals, ClosureIndirect, Visited);
     drainGlobals();
   }
   drainGlobals();
@@ -489,82 +500,28 @@ collectExternalSymbols(const SetVector<Function *> &ClosureFuncs,
 namespace lld {
 namespace elf {
 
-Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
-                                               StringRef TargetTriple,
-                                               StringRef SaveTempsPrefix) {
-  // ---- Phase 1: detect .ejit_cross. Distinguish "no section" (normal skip)
-  // from "corrupt input" (Area 5). Non-object inputs (scripts, shared libs)
-  // are skipped; archive members with .ejit_cross are collected for Phase 2.
-  bool HasCross = false;
-  StringSet<> CrossArchives; // archive paths whose members carry .ejit_cross
-  for (StringRef F : InputFiles) {
-    auto Buf = MemoryBuffer::getFile(F);
-    if (!Buf)
-      continue; // not a readable regular file (e.g. -l resolved elsewhere)
-    file_magic Magic = identify_magic(Buf->get()->getBuffer());
-    if (Magic == file_magic::archive) {
-      auto ArOrErr = object::Archive::create(Buf->get()->getMemBufferRef());
-      if (!ArOrErr)
-        return crossError("read archive", F, ArOrErr.takeError());
-      Error Err = Error::success();
-      for (const auto &Child : (*ArOrErr)->children(Err)) {
-        auto ChildBuf = Child.getMemoryBufferRef();
-        if (!ChildBuf)
-          return crossError("read archive member", F, ChildBuf.takeError());
-        auto Obj = object::ObjectFile::createObjectFile(*ChildBuf);
-        if (!Obj) {
-          consumeError(Obj.takeError());
-          continue;
-        }
-        for (const object::SectionRef &Sec : (*Obj)->sections()) {
-          Expected<StringRef> N = Sec.getName();
-          if (N && *N == kCrossSection) {
-            HasCross = true;
-            CrossArchives.insert(F);
-            break;
-          }
-          if (!N)
-            consumeError(N.takeError());
-        }
-        if (HasCross)
-          break;
-      }
-      if (Err)
-        return crossError("iterate archive", F, std::move(Err));
-      continue;
-    }
-    auto Obj =
-        object::ObjectFile::createObjectFile(Buf->get()->getMemBufferRef());
-    if (!Obj) {
-      consumeError(Obj.takeError());
-      continue; // not a relocatable object we understand; skip
-    }
-    for (const object::SectionRef &Sec : (*Obj)->sections()) {
-      Expected<StringRef> N = Sec.getName();
-      if (!N) {
-        consumeError(N.takeError());
-        continue;
-      }
-      if (*N == kCrossSection) {
-        HasCross = true;
-        break;
-      }
-    }
-  }
-  if (!HasCross)
-    return EJitCrossLinkResult{}; // nothing to do: normal AOT path is preserved
+Expected<EJitCrossLinkResult>
+runEJitCrossLink(ArrayRef<MemoryBufferRef> SelectedObjects,
+                 StringRef TargetTriple, StringRef SaveTempsPrefix) {
+  // When time tracing is disabled, each TimeTraceScope below adds only the
+  // standard TimeTraceScope inactive-profiler branch and emits no
+  // records/output; the profiler is initialised by Driver.cpp solely for
+  // --time-trace.
+  TimeTraceScope crossScope("EJitCrossLink");
 
-  // ---- Phase 2: parse and merge every .ejit_cross module into a composite.
-  // From here on, any failure aborts the link (a .ejit_cross was promised).
+  // The composite that every .ejit_cross module is merged into.
   auto Ctx = std::make_unique<LLVMContext>();
   std::unique_ptr<Module> Composite;
   StringSet<> ConsumedFileSet;
   SmallVector<std::string, 4> ConsumedFiles;
 
-  // Helper to process a single bitcode buffer into the composite.
-  auto mergeBitcodeIntoComposite =
-      [&](MemoryBufferRef BCBuf, StringRef DisplayName) -> Error {
-    auto M = parseBitcodeFile(BCBuf, *Ctx);
+  // Helper to parse and merge a single bitcode buffer into the composite.
+  auto mergeBitcodeIntoComposite = [&](MemoryBufferRef BCBuf,
+                                       StringRef DisplayName) -> Error {
+    auto M = [&] {
+      TimeTraceScope parseScope("EJitCross:ParseBitcode");
+      return parseBitcodeFile(BCBuf, *Ctx);
+    }();
     if (!M)
       return crossError("parse bitcode", DisplayName, M.takeError());
     if (ConsumedFileSet.insert(DisplayName).second)
@@ -573,6 +530,7 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
       Composite = std::move(*M);
       return Error::success();
     }
+    TimeTraceScope mergeScope("EJitCross:MergeModule");
     if (Linker(*Composite).linkInModule(std::move(*M), Linker::Flags::None))
       return crossError("merge module", DisplayName,
                         "Linker::linkInModule reported a conflict while "
@@ -580,70 +538,54 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
     return Error::success();
   };
 
-  for (StringRef F : InputFiles) {
-    auto Buf = MemoryBuffer::getFile(F);
-    if (!Buf)
-      return crossError("read input", F, errorCodeToError(Buf.getError()));
-    file_magic Magic = identify_magic(Buf->get()->getBuffer());
-
-    if (Magic == file_magic::archive && CrossArchives.contains(F)) {
-      auto ArOrErr = object::Archive::create(Buf->get()->getMemBufferRef());
-      if (!ArOrErr)
-        return crossError("read archive", F, ArOrErr.takeError());
-      Error Err = Error::success();
-      for (const auto &Child : (*ArOrErr)->children(Err)) {
-        auto ChildBuf = Child.getMemoryBufferRef();
-        if (!ChildBuf)
-          return crossError("read archive member", F, ChildBuf.takeError());
-        auto Obj = object::ObjectFile::createObjectFile(*ChildBuf);
-        if (!Obj) {
-          consumeError(Obj.takeError());
+  // ---- Phase 1+2: scan the *selected* object files (ctx.objectFiles, taken
+  // after lld finished symbol resolution) for a .ejit_cross section and merge
+  // each into the composite. Because lld has already decided which archive
+  // members, -l inputs and linker-script inputs are part of the link, iterating
+  // that set processes exactly the members that make up the AOT image: no ELF
+  // member-selection is re-implemented here and an unselected member is never
+  // merged or registered. Each buffer identifier is the canonical
+  // ObjFile::getName(), so ConsumedFiles matches lld's discard key for dropping
+  // the consumed .ejit_cross sections from the output. Any failure after a
+  // .ejit_cross section is observed aborts the link (never a silent AOT
+  // fallback).
+  bool HasCross = false;
+  {
+    TimeTraceScope detectScope("EJitCross:DetectScan");
+    for (MemoryBufferRef Obj : SelectedObjects) {
+      file_magic Magic = identify_magic(Obj.getBuffer());
+      if (Magic != file_magic::elf_relocatable &&
+          Magic != file_magic::elf_shared_object &&
+          Magic != file_magic::elf_executable)
+        continue;
+      auto ObjOrErr = object::ObjectFile::createObjectFile(Obj);
+      if (!ObjOrErr) {
+        consumeError(ObjOrErr.takeError());
+        continue; // not a relocatable object we understand; skip
+      }
+      for (const object::SectionRef &Sec : (*ObjOrErr)->sections()) {
+        Expected<StringRef> N = Sec.getName();
+        if (!N) {
+          consumeError(N.takeError());
           continue;
         }
-        for (const object::SectionRef &Sec : (*Obj)->sections()) {
-          Expected<StringRef> N = Sec.getName();
-          if (!N)
-            return crossError("read section name", F, N.takeError());
-          if (*N != kCrossSection)
-            continue;
-          Expected<StringRef> C = Sec.getContents();
-          if (!C)
-            return crossError("read section", F, C.takeError());
-          // ChildBuf.getBufferIdentifier() returns the canonical
-          // "archive_path(member_name)" string that lld's InputFiles
-          // uses for ObjFile::getName(), so ConsumedFiles will match.
-          StringRef DisplayName = ChildBuf->getBufferIdentifier();
-          if (Error E = mergeBitcodeIntoComposite(
-                  MemoryBufferRef(*C, DisplayName), DisplayName))
-            return E;
-        }
+        if (*N != kCrossSection)
+          continue;
+        Expected<StringRef> C = Sec.getContents();
+        if (!C)
+          return crossError("read section", Obj.getBufferIdentifier(),
+                            C.takeError());
+        HasCross = true;
+        StringRef DisplayName = Obj.getBufferIdentifier();
+        if (Error E = mergeBitcodeIntoComposite(
+                MemoryBufferRef(*C, DisplayName), DisplayName))
+          return E;
+        break; // at most one .ejit_cross section per object
       }
-      if (Err)
-        return crossError("iterate archive", F, std::move(Err));
-      continue;
-    }
-
-    if (Magic != file_magic::elf_relocatable &&
-        Magic != file_magic::elf_shared_object &&
-        Magic != file_magic::elf_executable)
-      continue;
-    auto Obj =
-        object::ObjectFile::createObjectFile(Buf->get()->getMemBufferRef());
-    if (!Obj)
-      return crossError("parse object", F, Obj.takeError());
-    for (const object::SectionRef &Sec : (*Obj)->sections()) {
-      Expected<StringRef> N = Sec.getName();
-      if (!N)
-        return crossError("read section name", F, N.takeError());
-      if (*N != kCrossSection)
-        continue;
-      Expected<StringRef> C = Sec.getContents();
-      if (!C)
-        return crossError("read section", F, C.takeError());
-      if (Error E = mergeBitcodeIntoComposite(MemoryBufferRef(*C, F), F))
-        return E;
     }
   }
+  if (!HasCross)
+    return EJitCrossLinkResult{}; // nothing to do: normal AOT path preserved
   if (!Composite)
     return crossError("merge", "<inputs>",
                       "a .ejit_cross section was detected but no module could "
@@ -651,7 +593,10 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
 
   // ---- Phase 3: entry discovery.
   SmallVector<Function *, 4> EntryFuncs;
-  collectEntryFunctions(*Composite, EntryFuncs);
+  {
+    TimeTraceScope entryScope("EJitCross:EntryScan");
+    collectEntryFunctions(*Composite, EntryFuncs);
+  }
   if (EntryFuncs.empty())
     return crossError("entry scan", "<composite>",
                       "merged .ejit_cross modules contain no ejit_entry "
@@ -659,9 +604,12 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
 
   // ---- Phase 4: union closure + trim, then real inlining, then re-annotate.
   {
+    TimeTraceScope unionScope("EJitCross:UnionClosure");
     SetVector<Function *> ClosureFuncs;
     SetVector<GlobalVariable *> ClosureGlobals;
-    computeTransitiveClosure(EntryFuncs, ClosureFuncs, ClosureGlobals);
+    SetVector<GlobalValue *> ClosureIndirect;
+    computeTransitiveClosure(EntryFuncs, ClosureFuncs, ClosureGlobals,
+                             ClosureIndirect);
     trimToClosure(*Composite, ClosureFuncs, ClosureGlobals);
   }
   // The composite exists only to produce JIT bitcode; it is not the native AOT
@@ -672,7 +620,10 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
   for (Function &F : *Composite)
     if (!F.isDeclaration())
       F.setDSOLocal(true);
-  runRealInliner(*Composite);
+  {
+    TimeTraceScope inlinerScope("EJitCross:Inliner");
+    runRealInliner(*Composite);
+  }
   reAnnotateMayConst(*Composite);
 
   // ---- Phase 5: per-entry bitcode + one registry, all owned by TmpM.
@@ -687,56 +638,129 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
   SetVector<Function *> ExternalFuncs;
   SetVector<GlobalVariable *> ExternalGlobals;
 
-  for (Function *F : EntryFuncs) {
-    auto PerFunc = CloneModule(*Composite);
-    Function *ClonedF = PerFunc->getFunction(F->getName());
-    if (!ClonedF)
-      return crossError("clone", F->getName(),
-                        "entry function vanished after cloning the composite");
-
-    SetVector<Function *> PerFuncs;
-    SetVector<GlobalVariable *> PerGlobals;
-    SmallVector<Function *, 1> Single{ClonedF};
-    computeTransitiveClosure(Single, PerFuncs, PerGlobals);
-    trimToClosure(*PerFunc, PerFuncs, PerGlobals);
-
-    // Externalise non-const global definitions so JITLink resolves them from
-    // the host image, mirroring the single-TU extractor.
-    for (GlobalVariable &GV : PerFunc->globals())
-      if (!GV.isDeclaration() && !GV.isConstant()) {
-        GV.setInitializer(nullptr);
-        GV.setLinkage(GlobalValue::ExternalLinkage);
+  {
+    TimeTraceScope perEntryScope("EJitCross:PerEntryExtraction");
+    for (Function *F : EntryFuncs) {
+      // Compute the entry's transitive closure directly on the composite. The
+      // previous implementation cloned the *entire* composite for every entry
+      // and then deleted ~everything outside the closure, making per-entry work
+      // scale with (entry count x composite size). Computing the closure first
+      // lets the clone below copy only the definitions this entry needs.
+      SetVector<Function *> SrcFuncs;
+      SetVector<GlobalVariable *> SrcGlobals;
+      SetVector<GlobalValue *> SrcIndirect;
+      {
+        TimeTraceScope closureScope("EJitCross:PerEntryClosure", F->getName());
+        SmallVector<Function *, 1> Single{F};
+        computeTransitiveClosure(Single, SrcFuncs, SrcGlobals, SrcIndirect);
       }
 
-    if (Error E = collectExternalSymbols(PerFuncs, PerGlobals, *TmpM,
-                                         ExternalFuncs, ExternalGlobals))
-      return crossError("collect external symbols", F->getName(), std::move(E));
+      // Selective clone: only closure functions/globals/aliases/ifuncs are
+      // cloned as definitions; everything else becomes a declaration (no body /
+      // no initializer), which is cheap and lets GlobalDCE drop it. Aliases and
+      // ifuncs are matched via the closure's Indirect set rather than an
+      // unconditional "true": GlobalDCE retains an *externally visible* dead
+      // alias/ifunc, so cloning all of them would leak unreferenced symbols
+      // into every per-entry module.
+      ValueToValueMapTy VMap;
+      std::unique_ptr<Module> PerFunc;
+      {
+        TimeTraceScope cloneScope("EJitCross:PerEntryClone", F->getName());
+        PerFunc = CloneModule(*Composite, VMap, [&](const GlobalValue *GV) {
+          if (auto *Fn = dyn_cast<Function>(GV))
+            return SrcFuncs.contains(const_cast<Function *>(Fn));
+          if (auto *G = dyn_cast<GlobalVariable>(GV))
+            return SrcGlobals.contains(const_cast<GlobalVariable *>(G));
+          // GlobalAlias / GlobalIFunc: keep only if the closure references it.
+          return SrcIndirect.contains(const_cast<GlobalValue *>(GV));
+        });
+      }
 
-    if (verifyModule(*PerFunc, &errs()))
-      return crossError("verify per-entry module", F->getName(),
-                        "cloned/trimmed module failed verification");
+      if (!isa_and_nonnull<Function>(VMap.lookup(F)))
+        return crossError(
+            "clone", F->getName(),
+            "entry function vanished after cloning the composite");
 
-    if (!SaveTempsPrefix.empty()) {
-      std::string Path = saveTempEntryPath(SaveTempsPrefix, F->getName());
-      if (Error E = writeModuleBitcode(*PerFunc, Path))
-        return crossError("save per-entry bitcode", Path, std::move(E));
+      // CloneModule always materialises every GlobalIFunc as a definition -- it
+      // does not consult the ShouldCloneDefinition callback for ifuncs -- and
+      // points each at its resolver. When an entry does not reference an ifunc,
+      // its resolver is only cloned as a declaration, which is an invalid ifunc
+      // ("resolver must be a definition"). Erase the ifuncs this entry's
+      // closure does not reference so only valid, referenced ifuncs remain.
+      {
+        SmallPtrSet<const GlobalValue *, 8> KeepIFuncs;
+        for (GlobalValue *GV : SrcIndirect)
+          if (isa<GlobalIFunc>(GV))
+            KeepIFuncs.insert(cast<GlobalValue>(VMap.lookup(GV)));
+        for (GlobalIFunc &GI : llvm::make_early_inc_range(PerFunc->ifuncs()))
+          if (!KeepIFuncs.contains(&GI)) {
+            GI.replaceAllUsesWith(UndefValue::get(GI.getType()));
+            GI.eraseFromParent();
+          }
+      }
+
+      // Translate the composite-side closure into the cloned module (every
+      // global has a VMap entry) so trimming and registry collection operate on
+      // the clone, matching the previous behaviour.
+      SetVector<Function *> PerFuncs;
+      SetVector<GlobalVariable *> PerGlobals;
+      for (Function *SF : SrcFuncs)
+        PerFuncs.insert(cast<Function>(VMap.lookup(SF)));
+      for (GlobalVariable *SG : SrcGlobals)
+        PerGlobals.insert(cast<GlobalVariable>(VMap.lookup(SG)));
+
+      {
+        TimeTraceScope trimScope("EJitCross:PerEntryTrim", F->getName());
+        trimToClosure(*PerFunc, PerFuncs, PerGlobals);
+      }
+
+      // Externalise non-const global definitions so JITLink resolves them from
+      // the host image, mirroring the single-TU extractor.
+      for (GlobalVariable &GV : PerFunc->globals())
+        if (!GV.isDeclaration() && !GV.isConstant()) {
+          GV.setInitializer(nullptr);
+          GV.setLinkage(GlobalValue::ExternalLinkage);
+        }
+
+      if (Error E = collectExternalSymbols(PerFuncs, PerGlobals, *TmpM,
+                                           ExternalFuncs, ExternalGlobals))
+        return crossError("collect external symbols", F->getName(),
+                          std::move(E));
+
+      {
+        TimeTraceScope verifyScope("EJitCross:PerEntryVerify", F->getName());
+        if (verifyModule(*PerFunc, &errs()))
+          return crossError("verify per-entry module", F->getName(),
+                            "cloned/trimmed module failed verification");
+      }
+
+      TimeTraceScope serializeScope("EJitCross:PerEntrySerialize",
+                                    F->getName());
+      if (!SaveTempsPrefix.empty()) {
+        std::string Path = saveTempEntryPath(SaveTempsPrefix, F->getName());
+        if (Error E = writeModuleBitcode(*PerFunc, Path))
+          return crossError("save per-entry bitcode", Path, std::move(E));
+      }
+
+      std::string BC;
+      raw_string_ostream OS(BC);
+      WriteBitcodeToFile(*PerFunc, OS);
+      OS.flush();
+      BitcodeGVs.push_back(embedBitcode(*TmpM, BC, F->getName()));
+      ValidEntryFuncs.push_back(F);
     }
-
-    std::string BC;
-    raw_string_ostream OS(BC);
-    WriteBitcodeToFile(*PerFunc, OS);
-    OS.flush();
-    BitcodeGVs.push_back(embedBitcode(*TmpM, BC, F->getName()));
-    ValidEntryFuncs.push_back(F);
   }
 
-  generateRegistryTable(*TmpM, ValidEntryFuncs, BitcodeGVs, ExternalFuncs,
-                        ExternalGlobals);
+  {
+    TimeTraceScope registryScope("EJitCross:RegistryGen");
+    generateRegistryTable(*TmpM, ValidEntryFuncs, BitcodeGVs, ExternalFuncs,
+                          ExternalGlobals);
 
-  // ---- Phase 6: verify the registry module before writing anything.
-  if (verifyModule(*TmpM, &errs()))
-    return crossError("verify registry module", "<ejit_cross_link>",
-                      "generated registry module failed verification");
+    // ---- Phase 6: verify the registry module before writing anything.
+    if (verifyModule(*TmpM, &errs()))
+      return crossError("verify registry module", "<ejit_cross_link>",
+                        "generated registry module failed verification");
+  }
 
   // ---- Phase 7: write the merged bitcode to a temp file. Cleanup of the
   // temp file is owned by the caller (Driver.cpp), which unlinks it once the
@@ -763,6 +787,11 @@ Expected<EJitCrossLinkResult> runEJitCrossLink(ArrayRef<std::string> InputFiles,
   EJitCrossLinkResult Result;
   Result.tempPath = std::string(TmpPath.str());
   Result.consumedFiles = std::move(ConsumedFiles);
+  Result.requiredSymbols.reserve(ExternalFuncs.size() + ExternalGlobals.size());
+  for (Function *F : ExternalFuncs)
+    Result.requiredSymbols.push_back(F->getName().str());
+  for (GlobalVariable *GV : ExternalGlobals)
+    Result.requiredSymbols.push_back(GV->getName().str());
   return Result;
 }
 

--- a/lld/ELF/EJitCrossLink.h
+++ b/lld/ELF/EJitCrossLink.h
@@ -7,6 +7,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBufferRef.h"
 #include <string>
 
 namespace lld {
@@ -15,22 +16,34 @@ namespace elf {
 struct EJitCrossLinkResult {
   std::string tempPath;
   llvm::SmallVector<std::string, 4> consumedFiles;
+  /// External symbols referenced by the generated registry. The driver uses
+  /// these names to let lld extract any matching lazy archive members before
+  /// accepting this result as final.
+  llvm::SmallVector<std::string, 8> requiredSymbols;
 };
 
-/// Merge the .ejit_cross bitcode sections of \p InputFiles, inline cross-TU
-/// callees into each ejit_entry, and write a single registry bitcode module to
-/// a temporary file whose path is returned.
+/// Merge the .ejit_cross bitcode sections carried by \p SelectedObjects, inline
+/// cross-TU callees into each ejit_entry, and write a single registry bitcode
+/// module to a temporary file whose path is returned.
+///
+/// \p SelectedObjects must be the object files lld actually selected for the
+/// link (ctx.objectFiles after symbol resolution), so archive members, -l
+/// inputs and linker-script inputs that were *not* pulled into the link are
+/// never merged. Each buffer's identifier must be the canonical
+/// ObjFile::getName(), so the returned consumedFiles match lld's key for
+/// discarding the consumed .ejit_cross sections from the output.
 ///
 /// Three-state result:
 ///   * an Error         - a .ejit_cross section was found but processing failed
 ///                        (the link must fail; never silently fall back to
 ///                        AOT);
-///   * an empty result  - no input carried a .ejit_cross section (normal skip);
+///   * an empty result  - no selected object carried a .ejit_cross section
+///                        (normal skip);
 ///   * a populated result - the temporary bitcode to add plus the exact input
 ///                          files whose sections were consumed. The caller owns
 ///                          cleanup of the temporary file.
 llvm::Expected<EJitCrossLinkResult>
-runEJitCrossLink(llvm::ArrayRef<std::string> InputFiles,
+runEJitCrossLink(llvm::ArrayRef<llvm::MemoryBufferRef> SelectedObjects,
                  llvm::StringRef TargetTriple,
                  llvm::StringRef SaveTempsPrefix = {});
 

--- a/lld/test/ELF/ejit-cross-inline-archive-select.ll
+++ b/lld/test/ELF/ejit-cross-inline-archive-select.ll
@@ -1,0 +1,165 @@
+# REQUIRES: x86
+## Archive member selection for --ejit-cross-inline. Cross-TU processing runs
+## after symbol resolution over ctx.objectFiles, so only the archive members lld
+## actually selects are merged and registered. This covers two regressions:
+##   1. a plain cross object listed *before* an archive must not stop the scan of
+##      later archive members. The previous pre-parse scanner used a single
+##      global "HasCross" flag to break out of the per-archive member loop, so
+##      once any earlier object had set it, only the first member of a following
+##      archive was inspected -- an entry in a later member was missed and the
+##      link failed with "no ejit_entry".
+##   2. an unselected entry member (even one whose symbols would conflict) must
+##      never enter the composite or the .ejit_bitcode registry.
+
+# RUN: rm -rf %t && split-file %s %t
+
+## helperx and both entry TUs carry .ejit_cross; plain does not.
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/helperx.ll -o %t/helperx.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/helperx.bc -o %t/helperx.o
+# RUN: llc -filetype=obj -relocation-model=pic %t/plain.ll -o %t/plain.o
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/entryA.ll -o %t/entryA.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/entryA.bc -o %t/entryA.o
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/entryB.ll -o %t/entryB.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/entryB.bc -o %t/entryB.o
+
+## Finding 1: a plain cross object (helperx.o, no entry) precedes an archive
+## whose *second* member (entryA.o) holds the selected entry; the first member
+## (plain.o) has no .ejit_cross. entryA is pulled via -u. The link must succeed
+## with exactly one registry and no leftover .ejit_cross.
+# RUN: llvm-ar crs %t/liblate.a %t/plain.o %t/entryA.o
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   --save-temps -u ejit_entry_A %t/helperx.o %t/liblate.a -o %t/late.so
+# RUN: llvm-readelf -S %t/late.so | FileCheck %s --check-prefix=LATE
+# LATE:     .ejit_bitcode
+# LATE-NOT: .ejit_cross
+## The selected entry is registered; the missed-member regression would have
+## produced no per-entry bitcode at all.
+# RUN: ls %t/late.so.ejit-cross.ejit_entry_A.bc
+
+## Finding 2: an archive holds two entry members that both define @gDup (a hard
+## conflict if both were merged). Only ejit_entry_A is selected, so only it is
+## registered and the unselected conflicting member is ignored.
+# RUN: llvm-ar crs %t/libtwo.a %t/entryA.o %t/entryB.o
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   --save-temps -u ejit_entry_A %t/libtwo.a %t/helperx.o -o %t/sel.so
+# RUN: llvm-readelf -S %t/sel.so | FileCheck %s --check-prefix=SEL
+# SEL:     .ejit_bitcode
+# SEL-NOT: .ejit_cross
+# RUN: ls %t/sel.so.ejit-cross.ejit_entry_A.bc
+# RUN: not ls %t/sel.so.ejit-cross.ejit_entry_B.bc
+
+## Input order must not change the result: swapping the archive and the direct
+## object still registers only the selected entry.
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   --save-temps -u ejit_entry_A %t/helperx.o %t/libtwo.a -o %t/sel2.so
+# RUN: ls %t/sel2.so.ejit-cross.ejit_entry_A.bc
+# RUN: not ls %t/sel2.so.ejit-cross.ejit_entry_B.bc
+
+## A registry can expose an archive dependency that the optimized native object
+## no longer has. Model that legitimate pre-O2/post-O2 difference explicitly:
+## late-entry.o has no native reference to late_helper, while its raw
+## .ejit_cross bitcode does. The provisional registry therefore selects
+## helper-late.o from the archive. Cross-link must iterate, consume the newly
+## selected member's .ejit_cross, and emit one final registry whose entry
+## contains the helper definition.
+# RUN: llvm-as %t/late-entry-cross.ll -o %t/late-entry-cross.bc
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/late-entry-native.s \
+# RUN:   -o %t/late-entry-native.o
+# RUN: llvm-objcopy --add-section=.ejit_cross=%t/late-entry-cross.bc \
+# RUN:   --set-section-flags=.ejit_cross=alloc,readonly \
+# RUN:   %t/late-entry-native.o %t/late-entry.o
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/helper-late.ll -o %t/helper-late.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/helper-late.bc \
+# RUN:   -o %t/helper-late.o
+# RUN: llvm-ar crs %t/liblatehelper.a %t/helper-late.o
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   --save-temps %t/late-entry.o %t/liblatehelper.a -o %t/late-helper.so
+# RUN: llvm-readelf -S %t/late-helper.so \
+# RUN:   | FileCheck %s --check-prefix=LATE-HELPER
+# LATE-HELPER:     .ejit_bitcode
+# LATE-HELPER-NOT: .ejit_cross
+# RUN: llvm-dis %t/late-helper.so.ejit-cross.late_entry.bc -o - \
+# RUN:   | FileCheck %s --check-prefix=LATE-IR
+# LATE-IR: define{{.*}} i32 @late_entry
+# LATE-IR: define{{.*}} i32 @late_helper
+
+#--- helperx.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @helperx_fn(i32 %x) noinline {
+  ret i32 %x
+}
+
+#--- plain.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @plain_fn() {
+  ret i32 0
+}
+
+#--- entryA.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare i32 @ext_sink(i32)
+@gDup = global i32 1
+
+define i32 @ejit_entry_A() !ejit.metadata !0 {
+  %v = load i32, ptr @gDup
+  %r = call i32 @ext_sink(i32 %v)
+  ret i32 %r
+}
+
+!ejit.metadata = !{}
+!0 = !{!{!"ejit_entry"}}
+
+#--- late-entry-cross.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare i32 @late_helper()
+
+define i32 @late_entry() !ejit.metadata !0 {
+  %v = call i32 @late_helper()
+  ret i32 %v
+}
+
+!ejit.metadata = !{}
+!0 = !{!{!"ejit_entry"}}
+
+#--- late-entry-native.s
+.text
+.globl late_entry
+.type late_entry,@function
+late_entry:
+  ret
+
+#--- helper-late.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @late_helper() noinline {
+  ret i32 99
+}
+
+#--- entryB.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare i32 @ext_sink(i32)
+@gDup = global i32 2
+
+define i32 @ejit_entry_B() !ejit.metadata !0 {
+  %v = load i32, ptr @gDup
+  %r = call i32 @ext_sink(i32 %v)
+  ret i32 %r
+}
+
+!ejit.metadata = !{}
+!0 = !{!{!"ejit_entry"}}

--- a/lld/test/ELF/ejit-cross-inline-refs.ll
+++ b/lld/test/ELF/ejit-cross-inline-refs.ll
@@ -1,0 +1,178 @@
+# REQUIRES: x86
+## Reference-form coverage for the selective (closure-only) per-entry clone.
+## The closure walk must keep every statically reachable definition an entry
+## needs, drop everything else, and preserve alias/ifunc/const/mutable/metadata
+## semantics. The internal verifyModule (run per entry) fails the link if the
+## clone ever drops a still-referenced definition, so a successful link plus the
+## disassembly checks below pin down the behaviour.
+
+# RUN: rm -rf %t && split-file %s %t
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/entry.ll -o %t/entry.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/entry.bc -o %t/entry.o
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/helper.ll -o %t/helper.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/helper.bc -o %t/helper.o
+
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   --save-temps %t/entry.o %t/helper.o -o %t/out.so
+# RUN: llvm-readelf -S %t/out.so | FileCheck %s --check-prefix=SECTION
+# SECTION: .ejit_bitcode
+
+## Entry one pulls in the full variety of reference forms. The internal
+## verifyModule (per entry) already guarantees no still-referenced definition
+## was dropped; these checks pin down the surviving symbols. O2 may devirtualise
+## a constant function-pointer load into a direct call, so we assert on the call
+## targets that must survive rather than on the (foldable) pointer tables. The
+## dead helper and the externally visible dead alias must never leak in.
+# RUN: llvm-dis %t/out.so.ejit-cross.ejit_entry_one.bc -o - \
+# RUN:   | FileCheck %s --check-prefix=ONE \
+# RUN:       --implicit-check-not=dead_helper --implicit-check-not=dead_alias
+# ONE-DAG: define{{.*}} i32 @ejit_entry_one
+## cross-TU helper and a helper reached only through invoke (a CallBase) with a
+## personality function both survive.
+# ONE-DAG: define internal i32 @shared_helper
+# ONE-DAG: define{{.*}} i32 @cross_helper
+# ONE-DAG: define internal i32 @invoke_helper{{.*}}personality
+## call targets reached via a function-pointer table, a constant aggregate and a
+## bitcast/const-expr pointer.
+# ONE-DAG: define internal i32 @tab_a
+# ONE-DAG: define internal i32 @agg_target
+# ONE-DAG: define internal i32 @ce_target
+## a referenced alias stays an alias; the referenced ifunc stays a valid ifunc
+## with its resolver definition.
+# ONE-DAG: @live_alias = internal alias
+# ONE-DAG: @my_ifunc = {{.*}}ifunc i32 (i32), ptr @ifunc_resolver
+# ONE-DAG: define internal i32 @alias_target
+# ONE-DAG: define internal{{.*}} ptr @ifunc_resolver
+## a mutable global and the may_const/period global are externalised
+## (declaration, no initializer); the external function/global stay declarations
+## so the JIT registry can resolve them.
+# ONE-DAG: @mut = external{{.*}}global i32
+# ONE-DAG: @period = external{{.*}}global [4 x i32]
+# ONE-DAG: declare i32 @ext_func
+# ONE-DAG: @ext_global = external global
+
+## Entry two only calls the shared helper, so its module contains that helper
+## but none of entry one's private closure.
+# RUN: llvm-dis %t/out.so.ejit-cross.ejit_entry_two.bc -o - \
+# RUN:   | FileCheck %s --check-prefix=TWO \
+# RUN:       --implicit-check-not=tab_a --implicit-check-not=agg_target \
+# RUN:       --implicit-check-not=live_alias --implicit-check-not=my_ifunc \
+# RUN:       --implicit-check-not=invoke_helper --implicit-check-not=dead_helper
+# TWO-DAG: define{{.*}} i32 @ejit_entry_two
+# TWO-DAG: define internal i32 @shared_helper
+
+#--- entry.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare i32 @ext_func(i32)
+declare i32 @__gxx_personality_v0(...)
+@ext_global = external global i32
+
+; Cross-TU helper defined in helper.ll.
+declare i32 @cross_helper(i32)
+
+; Function-pointer table (const global, initializer holds function addresses).
+@fptr_table = internal constant [2 x ptr] [ptr @tab_a, ptr @tab_b]
+; Function address embedded in a constant aggregate (struct).
+@agg = internal constant { ptr, i32 } { ptr @agg_target, i32 3 }
+; A const global that is kept verbatim.
+@const_tab = internal constant [3 x i32] [i32 1, i32 2, i32 3]
+; A mutable global -> externalised by the extractor.
+@mut = internal global i32 5
+; A period/may_const global carrying ejit metadata.
+@period = internal global [4 x i32] zeroinitializer, !ejit.metadata !20
+; const-expr (bitcast) callee.
+@ce_ptr = internal constant ptr bitcast (i32 (i32)* @ce_target to ptr)
+
+; A referenced alias (kept as an alias) and an unreferenced, externally visible
+; alias (must be dropped from every per-entry module).
+@live_alias = internal alias i32 (i32), ptr @alias_target
+@dead_alias = alias i32 (i32), ptr @alias_target
+
+; An ifunc that entry one calls.
+@my_ifunc = ifunc i32 (i32), ptr @ifunc_resolver
+
+define internal i32 @tab_a() noinline { ret i32 1 }
+define internal i32 @tab_b() noinline { ret i32 2 }
+define internal i32 @agg_target() noinline { ret i32 7 }
+define internal i32 @ce_target(i32 %x) noinline { ret i32 %x }
+define internal i32 @alias_target(i32 %x) noinline { ret i32 %x }
+
+define internal ptr @ifunc_resolver() {
+  ret ptr @ifunc_impl
+}
+define internal i32 @ifunc_impl(i32 %x) noinline { ret i32 %x }
+
+; Shared helper used by both entries.
+define internal i32 @shared_helper(i32 %x) noinline {
+  %e = call i32 @ext_func(i32 %x)
+  ret i32 %e
+}
+
+; Helper reached only through an invoke (CallBase) with a personality.
+define internal i32 @invoke_helper(i32 %x) noinline personality ptr @__gxx_personality_v0 {
+  %r = invoke i32 @ext_func(i32 %x) to label %ok unwind label %bad
+ok:
+  ret i32 %r
+bad:
+  %lp = landingpad { ptr, i32 } cleanup
+  ret i32 0
+}
+
+; Never referenced by an entry: must not appear in any per-entry module.
+define internal i32 @dead_helper() noinline { ret i32 999 }
+
+define i32 @ejit_entry_one(i32 %x) !ejit.metadata !0 {
+  %h = call i32 @shared_helper(i32 %x)
+  %c = call i32 @cross_helper(i32 %x)
+  %iv = call i32 @invoke_helper(i32 %x)
+  %p0 = getelementptr [2 x ptr], ptr @fptr_table, i64 0, i64 0
+  %f0 = load ptr, ptr %p0
+  %t = call i32 %f0()
+  %ap = getelementptr { ptr, i32 }, ptr @agg, i64 0, i32 0
+  %af = load ptr, ptr %ap
+  %a = call i32 %af()
+  %cef = load ptr, ptr @ce_ptr
+  %ce = call i32 %cef(i32 %x)
+  %al = call i32 @live_alias(i32 %x)
+  %if = call i32 @my_ifunc(i32 %x)
+  %m = load i32, ptr @mut
+  %eg = load i32, ptr @ext_global
+  %ct0 = getelementptr [3 x i32], ptr @const_tab, i64 0, i64 0
+  %ctv = load i32, ptr %ct0
+  %pp = getelementptr [4 x i32], ptr @period, i64 0, i64 0
+  %pv = load i32, ptr %pp
+  %s1 = add i32 %h, %c
+  %s2 = add i32 %s1, %iv
+  %s3 = add i32 %s2, %t
+  %s4 = add i32 %s3, %a
+  %s5 = add i32 %s4, %ce
+  %s6 = add i32 %s5, %al
+  %s7 = add i32 %s6, %if
+  %s8 = add i32 %s7, %m
+  %s9 = add i32 %s8, %eg
+  %s10 = add i32 %s9, %ctv
+  %s11 = add i32 %s10, %pv
+  ret i32 %s11
+}
+
+define i32 @ejit_entry_two(i32 %x) !ejit.metadata !0 {
+  %h = call i32 @shared_helper(i32 %x)
+  ret i32 %h
+}
+
+!ejit.metadata = !{}
+!0 = !{!{!"ejit_entry"}}
+!20 = !{!{!"ejit_may_const_field", i64 0}}
+
+#--- helper.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @cross_helper(i32 %x) noinline {
+  %r = mul i32 %x, 3
+  ret i32 %r
+}

--- a/lld/test/ELF/ejit-cross-inline-time-trace.ll
+++ b/lld/test/ELF/ejit-cross-inline-time-trace.ll
@@ -1,0 +1,86 @@
+# REQUIRES: x86
+## The EJIT cross-TU inline link path is instrumented with TimeTraceScopes so
+## its cost can be attributed per stage. The scopes must be:
+##   * emitted only under --time-trace (never in a default link), and
+##   * present for every major stage of the merge/extract pipeline.
+## This also doubles as the smallest repeatable input for the cross-link
+## benchmark (lld/utils/ejit-cross-link-bench.py generates larger variants).
+
+# RUN: rm -rf %t && split-file %s %t
+
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/a.ll -o %t/a.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/a.bc -o %t/a.o
+# RUN: opt -passes='default<O2>' -enable-ejit-bitcode -ejit-cross-inline \
+# RUN:   %t/b.ll -o %t/b.bc
+# RUN: llc -filetype=obj -relocation-model=pic %t/b.bc -o %t/b.o
+
+## With --time-trace the per-stage scopes are recorded in the trace file. A
+## fine granularity is required because the sub-stages of a tiny link are far
+## below the default 500us reporting threshold. Two inputs are linked so the
+## module-merge stage is exercised too.
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   --time-trace=%t/trace.json --time-trace-granularity=0 \
+# RUN:   %t/a.o %t/b.o -o %t/out.so
+# RUN: FileCheck %s --check-prefix=TRACE --input-file=%t/trace.json
+# TRACE-DAG: "name":"EJitCross:DetectScan"
+# TRACE-DAG: "name":"EJitCross:ParseBitcode"
+# TRACE-DAG: "name":"EJitCross:MergeModule"
+# TRACE-DAG: "name":"EJitCross:EntryScan"
+# TRACE-DAG: "name":"EJitCross:UnionClosure"
+# TRACE-DAG: "name":"EJitCross:Inliner"
+# TRACE-DAG: "name":"EJitCross:PerEntryExtraction"
+# TRACE-DAG: "name":"EJitCross:PerEntryClosure"
+# TRACE-DAG: "name":"EJitCross:PerEntryClone"
+# TRACE-DAG: "name":"EJitCross:PerEntryTrim"
+# TRACE-DAG: "name":"EJitCross:PerEntryVerify"
+# TRACE-DAG: "name":"EJitCross:PerEntrySerialize"
+# TRACE-DAG: "name":"EJitCross:RegistryGen"
+
+## A default link (no --time-trace) writes no trace file at all. When time
+## tracing is disabled each scope adds only the standard TimeTraceScope
+## inactive-profiler branch and emits no records/output. Assert both that the
+## link succeeds and that no trace file is produced (lld only writes
+## <output>.time-trace when --time-trace is passed).
+# RUN: rm -f %t/out2.so.time-trace
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   %t/a.o %t/b.o -o %t/out2.so
+# RUN: llvm-readelf -S %t/out2.so | FileCheck %s --check-prefix=NOTRACE
+# RUN: not ls %t/out2.so.time-trace
+# NOTRACE: .ejit_bitcode
+
+#--- a.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+declare i32 @sink(i32)
+declare i32 @helper_b()
+
+define internal i32 @helper_a(i32 %x) noinline {
+  %r = call i32 @sink(i32 %x)
+  ret i32 %r
+}
+
+define i32 @ejit_entry_a(i32 %x) !ejit.metadata !0 {
+  %h = call i32 @helper_a(i32 %x)
+  %b = call i32 @helper_b()
+  %r = add i32 %h, %b
+  ret i32 %r
+}
+
+define i32 @ejit_entry_b(i32 %x) !ejit.metadata !0 {
+  %h = call i32 @helper_a(i32 %x)
+  %r = add i32 %h, 1
+  ret i32 %r
+}
+
+!ejit.metadata = !{}
+!0 = !{!{!"ejit_entry"}}
+
+#--- b.ll
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+define i32 @helper_b() noinline {
+  ret i32 7
+}

--- a/lld/test/ELF/ejit-cross-inline.ll
+++ b/lld/test/ELF/ejit-cross-inline.ll
@@ -78,22 +78,25 @@
 # RUN:   %t/bad.o -o /dev/null 2>&1 | FileCheck %s --check-prefix=BADERR
 # BADERR: ejit-cross-inline: parse bitcode failed for {{.*}}bad.o
 
-## A literal archive with .ejit_cross members is processed inline (archive
-## support). The registry materialises and the consumed sections disappear.
+## A literal archive with .ejit_cross members is processed inline, but only for
+## the members lld actually selects. entry.o is pulled in via -u; helper.o is a
+## direct object. The registry materialises and the consumed sections disappear.
 # RUN: llvm-ar crs %t/libcross.a %t/entry.o
 # RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
-# RUN:   %t/libcross.a %t/helper.o -o %t/archive.so
+# RUN:   -u ejit_entry_fn %t/libcross.a %t/helper.o -o %t/archive.so
 # RUN: llvm-readelf -S %t/archive.so | FileCheck %s --check-prefix=ARCHIVE
 # ARCHIVE:     .ejit_bitcode
 # ARCHIVE-NOT: .ejit_cross
 
-## An archive selected through -l is not yet discovered by the cross-link scan
-## (it is resolved inside addLibrary and is not in OPT_INPUT). The member is
-## selected by lld but the .ejit_cross section passes through unconsumed,
-## producing a hard error. This is a documented limitation, not a silent drop.
-# RUN: not ld.lld --ejit-cross-inline -shared -u ejit_entry_fn -L%t -lcross \
-# RUN:   -o /dev/null 2>&1 | FileCheck %s --check-prefix=ARCHIVE-L
-# ARCHIVE-L: contains an unprocessed .ejit_cross section
+## An archive selected through -l is handled the same way: because cross-link
+## processing now runs after symbol resolution over ctx.objectFiles, the member
+## lld selects (here via -u) is discovered and its .ejit_cross is consumed. This
+## previously produced a hard "unprocessed .ejit_cross" error.
+# RUN: ld.lld --ejit-cross-inline -shared --unresolved-symbols=ignore-all \
+# RUN:   -u ejit_entry_fn -L%t -lcross -o %t/archive-l.so
+# RUN: llvm-readelf -S %t/archive-l.so | FileCheck %s --check-prefix=ARCHIVE-L
+# ARCHIVE-L:     .ejit_bitcode
+# ARCHIVE-L-NOT: .ejit_cross
 
 #--- entry.ll
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"

--- a/lld/utils/ejit-cross-link-bench.py
+++ b/lld/utils/ejit-cross-link-bench.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Repeatable benchmark for lld's EJIT cross-TU inline link path.
+
+The generated translation unit carries a ``.ejit_cross`` section holding many
+``ejit_entry`` functions; each entry pulls in a small private closure (a chain
+of ``noinline`` helpers plus a few private globals) while the composite as a
+whole contains every entry's closure. That shape is what stresses the per-entry
+extraction step: the composite is large, yet each entry needs only a slice.
+
+Measurement is split into three explicit, non-overlapping modes so that a wall
+time is never contaminated by diagnostic work:
+
+  --mode=production   No --save-temps, no --time-trace. This is the number that
+                      represents real link cost (wall time, peak RSS).
+  --mode=trace        --time-trace only. Reports per-stage share of the link.
+                      Its wall time is NOT a production result.
+  --mode=compare      --save-temps only. Reports total per-entry bitcode size
+                      and a hash, to prove the output is preserved.
+  --mode=all          Runs the three above in sequence with separate tables.
+
+With both --baseline-bin and --optimized-bin the production and compare tables
+show before/after columns (speedup, RSS, and per-entry bitcode hash equality).
+opt/llc are always taken from --optimized-bin (they are identical).
+
+Example:
+    lld/utils/ejit-cross-link-bench.py --mode=all \
+        --baseline-bin /tmp/baseline/bin \
+        --optimized-bin build_release_x86/bin \
+        --entries 1,8,32,64,128,256
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def gen_module(num_entries, helpers_per_entry, globals_per_entry):
+    """Emit LLVM IR: each entry_i owns a private helper chain and globals."""
+    out = []
+    out.append('target datalayout = '
+               '"e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"')
+    out.append('target triple = "x86_64-unknown-linux-gnu"')
+    out.append('')
+    out.append('declare i32 @ejit_extern_sink(i32)')
+    out.append('@ejit_extern_global = external global i32')
+    out.append('')
+    for e in range(num_entries):
+        for g in range(globals_per_entry):
+            out.append('@g_%d_%d = internal global i32 %d' % (e, g, e * 7 + g))
+        for h in range(helpers_per_entry):
+            nxt = ('call i32 @helper_%d_%d(i32 %%x)' % (e, h + 1)
+                   if h + 1 < helpers_per_entry
+                   else 'call i32 @ejit_extern_sink(i32 %x)')
+            gref = ('@g_%d_%d' % (e, h % globals_per_entry)
+                    if globals_per_entry else '@ejit_extern_global')
+            out.append('define internal i32 @helper_%d_%d(i32 %%x) noinline {'
+                       % (e, h))
+            out.append('  %%gv = load i32, ptr %s' % gref)
+            out.append('  %%c = %s' % nxt)
+            out.append('  %r = add i32 %c, %gv')
+            out.append('  ret i32 %r')
+            out.append('}')
+        out.append('define i32 @ejit_entry_%d(i32 %%x) !ejit.metadata !0 {' % e)
+        if helpers_per_entry:
+            out.append('  %%h = call i32 @helper_%d_0(i32 %%x)' % e)
+        else:
+            out.append('  %h = call i32 @ejit_extern_sink(i32 %x)')
+        out.append('  %eg = load i32, ptr @ejit_extern_global')
+        out.append('  %r = add i32 %h, %eg')
+        out.append('  ret i32 %r')
+        out.append('}')
+        out.append('')
+    out.append('!ejit.metadata = !{}')
+    out.append('!0 = !{!{!"ejit_entry"}}')
+    out.append('')
+    return '\n'.join(out)
+
+
+def run(cmd, capture_rss):
+    """Run cmd; return (wall_seconds, peak_rss_kb_or_None)."""
+    prefix = ['/usr/bin/time', '-v'] if capture_rss else []
+    start = time.monotonic()
+    proc = subprocess.run(prefix + cmd, stdout=subprocess.DEVNULL,
+                          stderr=subprocess.PIPE)
+    wall = time.monotonic() - start
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr.decode('utf-8', 'replace'))
+        raise SystemExit('command failed: %s' % ' '.join(cmd))
+    rss = None
+    if capture_rss:
+        for line in proc.stderr.decode('utf-8', 'replace').splitlines():
+            if 'Maximum resident set size' in line:
+                rss = int(line.rsplit(':', 1)[1].strip())
+    return wall, rss
+
+
+def best_of(cmd, capture_rss, repeats):
+    """Return the best (min) wall time over repeats and the max RSS seen."""
+    best_wall = None
+    best_rss = None
+    for _ in range(repeats):
+        wall, rss = run(cmd, capture_rss)
+        if best_wall is None or wall < best_wall:
+            best_wall = wall
+        if rss is not None and (best_rss is None or rss > best_rss):
+            best_rss = rss
+    return best_wall, best_rss
+
+
+def link_cmd(lld, obj, out, extra):
+    return [lld, '--ejit-cross-inline', '-shared',
+            '--unresolved-symbols=ignore-all', obj, '-o', out] + extra
+
+
+def per_entry_hash(workdir, out_name):
+    """Sha256 over the sorted per-entry .bc files produced by --save-temps."""
+    names = sorted(n for n in os.listdir(workdir)
+                   if n.startswith(out_name + '.ejit-cross.'))
+    h = hashlib.sha256()
+    total = 0
+    for n in names:
+        with open(os.path.join(workdir, n), 'rb') as f:
+            data = f.read()
+        h.update(n.encode())
+        h.update(data)
+        total += len(data)
+    return total, h.hexdigest()
+
+
+def per_entry_ir_hash(bins, workdir, out_name):
+    """Sha256 over the disassembled IR of the per-entry .bc files.
+
+    The textual IR is the semantically meaningful comparison: the raw bitcode
+    bytes can differ between the full-clone and closure-only paths (different
+    internal value ordering) even when the modules are identical. The cosmetic
+    '; ModuleID =' line is derived from the input file name by llvm-dis, so it
+    is stripped before hashing.
+    """
+    names = sorted(n for n in os.listdir(workdir)
+                   if n.startswith(out_name + '.ejit-cross.'))
+    h = hashlib.sha256()
+    dis = os.path.join(bins, 'llvm-dis')
+    for n in names:
+        proc = subprocess.run([dis, os.path.join(workdir, n), '-o', '-'],
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if proc.returncode != 0:
+            sys.stderr.write(proc.stderr.decode('utf-8', 'replace'))
+            raise SystemExit('llvm-dis failed on %s' % n)
+        for line in proc.stdout.decode('utf-8', 'replace').splitlines():
+            if line.startswith('; ModuleID ='):
+                continue
+            h.update(line.encode())
+            h.update(b'\n')
+    return h.hexdigest()
+
+
+def build_inputs(bins, workdir, count, helpers, globals_):
+    ll = os.path.join(workdir, 'm_%d.ll' % count)
+    bc = os.path.join(workdir, 'm_%d.bc' % count)
+    obj = os.path.join(workdir, 'm_%d.o' % count)
+    with open(ll, 'w') as f:
+        f.write(gen_module(count, helpers, globals_))
+    run([os.path.join(bins, 'opt'), '-passes=default<O2>',
+         '-enable-ejit-bitcode', '-ejit-cross-inline', ll, '-o', bc], False)
+    run([os.path.join(bins, 'llc'), '-filetype=obj', '-relocation-model=pic',
+         bc, '-o', obj], False)
+    return obj
+
+
+def mode_production(args, workdir, counts):
+    capture_rss = os.path.exists('/usr/bin/time')
+    have_base = bool(args.baseline_bin)
+    print('== production (no --save-temps, no --time-trace) ==')
+    if have_base:
+        print('# %-8s %13s %12s %8s %13s %12s' %
+              ('entries', 'base_wall_s', 'opt_wall_s', 'speedup',
+               'base_rss_kb', 'opt_rss_kb'))
+    else:
+        print('# %-8s %12s %12s' % ('entries', 'opt_wall_s', 'opt_rss_kb'))
+    for count in counts:
+        obj = build_inputs(args.optimized_bin, workdir, count,
+                           args.helpers, args.globals)
+        out = os.path.join(workdir, 'p_%d.so' % count)
+        opt_wall, opt_rss = best_of(
+            link_cmd(os.path.join(args.optimized_bin, 'ld.lld'), obj, out, []),
+            capture_rss, args.repeats)
+        if not have_base:
+            print('  %-8d %12.3f %12s' %
+                  (count, opt_wall, opt_rss if opt_rss is not None else 'n/a'))
+            continue
+        base_wall, base_rss = best_of(
+            link_cmd(os.path.join(args.baseline_bin, 'ld.lld'), obj, out, []),
+            capture_rss, args.repeats)
+        speedup = base_wall / opt_wall if opt_wall else 0.0
+        print('  %-8d %13.3f %12.3f %7.2fx %13s %12s' %
+              (count, base_wall, opt_wall, speedup,
+               base_rss if base_rss is not None else 'n/a',
+               opt_rss if opt_rss is not None else 'n/a'))
+
+
+def mode_trace(args, workdir, counts):
+    print('== trace (--time-trace only; phase share, NOT a production time) ==')
+    lld = os.path.join(args.optimized_bin, 'ld.lld')
+    for count in counts:
+        obj = build_inputs(args.optimized_bin, workdir, count,
+                           args.helpers, args.globals)
+        out = os.path.join(workdir, 't_%d.so' % count)
+        trace = out + '.time-trace'
+        run(link_cmd(lld, obj, out,
+                     ['--time-trace=' + trace, '--time-trace-granularity=0']),
+            False)
+        with open(trace) as f:
+            data = json.load(f)
+        totals = {}
+        for ev in data.get('traceEvents', []):
+            name = ev.get('name', '')
+            if name.startswith('EJitCross') and ev.get('ph') == 'X':
+                totals[name] = totals.get(name, 0) + ev.get('dur', 0)
+        print('  entries=%d' % count)
+        for k in sorted(totals, key=lambda n: -totals[n]):
+            print('      %-32s %10.3f ms' % (k, totals[k] / 1000.0))
+
+
+def mode_compare(args, workdir, counts):
+    have_base = bool(args.baseline_bin)
+    print('== compare (--save-temps; per-entry bitcode size and hash) ==')
+    if have_base:
+        print('# %-8s %14s %14s %9s %8s' %
+              ('entries', 'base_bc_bytes', 'opt_bc_bytes', 'raw_eq', 'ir_eq'))
+    else:
+        print('# %-8s %14s %18s' % ('entries', 'opt_bc_bytes', 'opt_hash16'))
+    for count in counts:
+        obj = build_inputs(args.optimized_bin, workdir, count,
+                           args.helpers, args.globals)
+        opt_out = os.path.join(workdir, 'c_opt_%d.so' % count)
+        run(link_cmd(os.path.join(args.optimized_bin, 'ld.lld'), obj, opt_out,
+                     ['--save-temps']), False)
+        opt_bytes, opt_hash = per_entry_hash(workdir,
+                                            os.path.basename(opt_out))
+        if not have_base:
+            print('  %-8d %14d %18s' % (count, opt_bytes, opt_hash[:16]))
+            continue
+        opt_ir = per_entry_ir_hash(args.optimized_bin, workdir,
+                                  os.path.basename(opt_out))
+        base_out = os.path.join(workdir, 'c_base_%d.so' % count)
+        run(link_cmd(os.path.join(args.baseline_bin, 'ld.lld'), obj, base_out,
+                     ['--save-temps']), False)
+        base_bytes, base_hash = per_entry_hash(workdir,
+                                              os.path.basename(base_out))
+        base_ir = per_entry_ir_hash(args.optimized_bin, workdir,
+                                   os.path.basename(base_out))
+        print('  %-8d %14d %14d %9s %8s' %
+              (count, base_bytes, opt_bytes,
+               'yes' if base_hash == opt_hash else 'no',
+               'yes' if base_ir == opt_ir else 'NO'))
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--optimized-bin', required=True,
+                    help='directory holding the optimized opt/llc/ld.lld')
+    ap.add_argument('--baseline-bin', default='',
+                    help='directory with a baseline ld.lld (for before/after)')
+    ap.add_argument('--mode', choices=['production', 'trace', 'compare', 'all'],
+                    default='all')
+    ap.add_argument('--entries', default='1,8,32,64,128,256')
+    ap.add_argument('--helpers', type=int, default=20)
+    ap.add_argument('--globals', type=int, default=6)
+    ap.add_argument('--repeats', type=int, default=3,
+                    help='production runs per point; the best wall is reported')
+    ap.add_argument('--keep', action='store_true')
+    args = ap.parse_args()
+
+    for tool in ('opt', 'llc', 'ld.lld'):
+        if not os.path.exists(os.path.join(args.optimized_bin, tool)):
+            raise SystemExit('missing tool: %s' % tool)
+    if args.baseline_bin and not os.path.exists(
+            os.path.join(args.baseline_bin, 'ld.lld')):
+        raise SystemExit('missing baseline ld.lld')
+
+    counts = [int(x) for x in args.entries.split(',')]
+    workdir = tempfile.mkdtemp(prefix='ejit-cross-bench.')
+    print('# work dir: %s' % workdir)
+    print('# helpers=%d globals=%d repeats=%d' %
+          (args.helpers, args.globals, args.repeats))
+    try:
+        modes = (['production', 'trace', 'compare']
+                 if args.mode == 'all' else [args.mode])
+        for m in modes:
+            if m == 'production':
+                mode_production(args, workdir, counts)
+            elif m == 'trace':
+                mode_trace(args, workdir, counts)
+            elif m == 'compare':
+                mode_compare(args, workdir, counts)
+    finally:
+        if args.keep:
+            print('# kept: %s' % workdir)
+        else:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Optimizes the `-fejit-cross-inline` extraction path and hardens archive-member handling.

- Replaces full-composite cloning per entry with selective definition cloning based on each entry's transitive closure.
- Preserves alias, ifunc, global-initializer, personality, function-pointer and constant-aggregate references.
- Uses lld's own archive selection and a fixed-point pass for late archive dependencies: provisional registry references may extract additional lazy members, and the composite is expanded until no new `.ejit_cross` objects appear.
- Adds `llvm::TimeTraceScope` instrumentation and a repeatable benchmark generator.
- Keeps the default link path unchanged when `--ejit-cross-inline` is not enabled.

## Root cause

The previous implementation cloned the complete merged module for every `ejit_entry` and then deleted almost all definitions. This produced approximately quadratic link time as entry count grew. Moving processing after symbol resolution also exposed a late archive-member case: registry references could select an additional helper after the first composite was built. The fixed-point flow resolves that dependency before injecting the final registry.

## Performance

At 256 generated entries, cross-inline processing improved from roughly `8.323 s` to `2.009 s` (about `4.1x`; prior best optimized run was `1.961 s`). Normalized emitted IR remains equivalent; raw bitcode byte ordering may differ.

## Validation

- `ninja -C build_release_x86 lld -j8`
- Cross-inline lit tests: `4/4` passed
- New late archive-helper test verifies that the selected helper definition appears in final IR
- LTO suite: `153 passed`; two failures reproduced on the baseline
- `git diff --check` clean

## 中文说明

本 PR 优化 `-fejit-cross-inline` 链接阶段：按每个入口函数的真实闭包选择性克隆定义，避免“每个入口完整复制整个大模块再裁剪”造成的近似平方级耗时。同时增加 archive 依赖的 fixed-point 处理，确保 provisional registry 新触发的 lazy archive member 也会进入最终 composite，不漏 helper、不重复注册。默认未开启 cross-inline 的链接路径不受影响。

This is opened as a draft for further review and production-link validation.