### PR TITLE
[EJIT] Introduce icache sync for ejit-inline-cache

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -388,7 +388,7 @@ def doit_gc_merge(args):
         # the app object's reference is anchored by .init_array, so the SRE link
         # then fails on an undefined symbol. The production wrapper reads
         # @__ejit_icache_fn_<name> directly (no ejit_icache_try call).
-        # ejitIcacheRegisterSlot/gIcacheFnSlots are reachable from these roots +
+        # ejitIcacheRegisterSlot/gIcacheSlots are reachable from these roots +
         # ejit_init's .ejit_period walk, no explicit root needed.
         "ejit_register_icache_slot",
         "ejit_register_icache_epoch",

--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -382,14 +382,16 @@ def doit_gc_merge(args):
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
         "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped",
         "ejit_dump_all",
-        # Inline-cache: ejit_register_icache_slot is called from
-        # ejit_auto_register (AOT) when -ejit-inline-cache is on, not from the
-        # runtime, so gc-merge's --gc-sections would discard it without this GC
-        # root. The production wrapper reads @__ejit_icache_fn_<name> directly
-        # (no ejit_icache_try call). ejitIcacheRegisterSlot/gIcacheFnSlots are
-        # reachable from this root + ejit_init's .ejit_period walk, no explicit
-        # root needed.
+        # Inline-cache: both of these are called from ejit_auto_register (AOT)
+        # when -ejit-inline-cache is on, never from the runtime, so
+        # gc-merge's --gc-sections discards them without these GC roots -- and
+        # the app object's reference is anchored by .init_array, so the SRE link
+        # then fails on an undefined symbol. The production wrapper reads
+        # @__ejit_icache_fn_<name> directly (no ejit_icache_try call).
+        # ejitIcacheRegisterSlot/gIcacheFnSlots are reachable from these roots +
+        # ejit_init's .ejit_period walk, no explicit root needed.
         "ejit_register_icache_slot",
+        "ejit_register_icache_epoch",
     ]
 
     defined = set()

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitAtomic.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitAtomic.h
@@ -92,6 +92,13 @@ public:
   /// bit) without a read-modify-write race.
   T fetchAnd(T v) { return __atomic_fetch_and(&value_, v, __ATOMIC_ACQ_REL); }
 
+  /// Address of the underlying storage, for the one consumer that cannot go
+  /// through this class: the AOT-emitted inline-cache probe, which loads the
+  /// shared icache epoch inline. That read is a PLAIN load -- observing a stale
+  /// epoch costs at most one more call into the previous specialization, never
+  /// incorrectness, so it needs no acquire (see EJitIcacheEpochRef).
+  const T *raw() const { return &value_; }
+
 private:
   // mutable so const load helpers can form a non-const pointer for the builtin.
   mutable T value_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -88,6 +88,13 @@ constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 // ejit_icache_try call - so the hit path is one load + null-check + indirect
 // call. Signature: void ejit_register_icache_slot(const char *name, void *slot).
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
+// Hands the AOT-emitted @__ejit_icache_epoch window to the runtime plus the
+// probe contract version. Emitted into ejit_auto_register BEFORE any
+// ejit_register_icache_slot call: the runtime declines a slot whose window it
+// has not been given. The static .ejit_period registry carries the same two
+// facts in the icache entry's name2 / size fields.
+// Signature: void ejit_register_icache_epoch(void *window, uint32_t probeAbi).
+constexpr const char *FN_REGISTER_ICACHE_EPOCH = "ejit_register_icache_epoch";
 
 // Contract version between the AOT-emitted inline-cache probe and the runtime.
 // Bumped whenever the probe's obligations change, and stamped into the high 32

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -15,6 +15,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITCOMMON_H
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h" // kEJitIcacheProbeAbi
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -81,36 +82,18 @@ constexpr const char *FN_REGISTER_PERIOD_ARRAY = "ejit_register_period_array";
 constexpr const char *FN_REGISTER_STATIC_VAR = "ejit_register_static_var";
 constexpr const char *FN_REGISTER_LIFECYCLE = "ejit_register_lifecycle";
 constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
-// Per-function inline-cache slot registration: the wrapper's per-function
-// @__ejit_icache_fn_<name> global (a frozen, sticky specialization pointer) is
-// registered by name so the runtime can backfill it on a successful resolve
-// (icacheFill). The wrapper reads it directly with an inline plain load - no
-// ejit_icache_try call - so the hit path is one load + null-check, the
-// shared-epoch check, then the indirect call.
-// Signature: void ejit_register_icache_slot(const char *name, void *slot).
+// Per-function inline-cache slot registration. Carries the cell array base,
+// its dimensionality, and the epoch window + probe ABI of the object it came
+// from, so a mixed link cannot let a pre-epoch TU register against a newer TU's
+// window. Signature:
+//   void ejit_register_icache_slot(const char *name, void *slot,
+//                                  uint32_t numDims, void *window,
+//                                  uint32_t probeAbi).
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
-// Hands the AOT-emitted @__ejit_icache_epoch window to the runtime plus the
-// probe contract version. Emitted into ejit_auto_register BEFORE any
-// ejit_register_icache_slot call: the runtime declines a slot whose window it
-// has not been given. The static .ejit_period registry carries the same two
-// facts in the icache entry's name2 / size fields.
-// Signature: void ejit_register_icache_epoch(void *window, uint32_t probeAbi).
-constexpr const char *FN_REGISTER_ICACHE_EPOCH = "ejit_register_icache_epoch";
 
-// Contract version between the AOT-emitted inline-cache probe and the runtime.
-// Bumped whenever the probe's obligations change, and stamped into the high 32
-// bits of the static-registry `size` field (the low 32 carry numDims, which is
-// <= 4) so a mismatch is detected at init instead of silently mis-executing.
-//
-//   1 = cell load + null check only. Invalidation depends entirely on the
-//       core reaching a sync point, so a core that only ever hits runs a stale
-//       specialization forever.
-//   2 = adds the shared-epoch freshness check (see EJitIcacheEpochRef).
-//
-// An object built by an older clang reports 0 in those bits; the runtime treats
-// anything < kEJitIcacheProbeAbi as "this build cannot invalidate a hot core"
-// and says so loudly at init rather than running quietly wrong.
-constexpr uint32_t kEJitIcacheProbeAbi = 2;
+// kEJitIcacheProbeAbi lives in EJitSharedPlatform.h so the runtime, the AOT
+// pass and the standalone taskpool tests share one definition. The static
+// registry stamps it into the high 32 bits of `size` (low 32 = numDims).
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -88,6 +88,21 @@ constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 // ejit_icache_try call - so the hit path is one load + null-check + indirect
 // call. Signature: void ejit_register_icache_slot(const char *name, void *slot).
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
+
+// Contract version between the AOT-emitted inline-cache probe and the runtime.
+// Bumped whenever the probe's obligations change, and stamped into the high 32
+// bits of the static-registry `size` field (the low 32 carry numDims, which is
+// <= 4) so a mismatch is detected at init instead of silently mis-executing.
+//
+//   1 = cell load + null check only. Invalidation depends entirely on the
+//       core reaching a sync point, so a core that only ever hits runs a stale
+//       specialization forever.
+//   2 = adds the shared-epoch freshness check (see EJitIcacheEpochRef).
+//
+// An object built by an older clang reports 0 in those bits; the runtime treats
+// anything < kEJitIcacheProbeAbi as "this build cannot invalidate a hot core"
+// and says so loudly at init rather than running quietly wrong.
+constexpr uint32_t kEJitIcacheProbeAbi = 2;
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -84,9 +84,10 @@ constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 // Per-function inline-cache slot registration: the wrapper's per-function
 // @__ejit_icache_fn_<name> global (a frozen, sticky specialization pointer) is
 // registered by name so the runtime can backfill it on a successful resolve
-// (icacheFill). The wrapper reads it directly with an inline atomic load - no
-// ejit_icache_try call - so the hit path is one load + null-check + indirect
-// call. Signature: void ejit_register_icache_slot(const char *name, void *slot).
+// (icacheFill). The wrapper reads it directly with an inline plain load - no
+// ejit_icache_try call - so the hit path is one load + null-check, the
+// shared-epoch check, then the indirect call.
+// Signature: void ejit_register_icache_slot(const char *name, void *slot).
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
 // Hands the AOT-emitted @__ejit_icache_epoch window to the runtime plus the
 // probe contract version. Emitted into ejit_auto_register BEFORE any

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -154,30 +154,18 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut);
 // funcIndex global; a capacity failure is recorded so ejit_init can fail.
 void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 
-// Register the wrapper's per-function inline-cache slot (@__ejit_icache_fn_<name>
-// global address) by name, with its dimensionality (number of ejit_dim params).
-// The runtime writes the frozen specialization pointer through the [D]^numDims
-// cell at [i0][i1]... on a successful resolve (icacheFill); the wrapper reads
-// the cell directly on the hit path (GEP + one plain load + null-check, then
-// the shared-epoch check, then the indirect call - no ejit_icache_try call).
-// Keys the slot by the SAME registry funcIndex assigned by
-// ejit_register_funcindex. Called by AOT auto-registration.
-// A null slot or capacity exhaustion is recorded; the base stays null and the
-// probe misses. Also declined when no epoch window has been registered yet (see
-// ejit_register_icache_epoch): the probe reads the window without a null check,
-// so a wired-up cell with no window behind it faults on the first hit.
+// Register a per-function inline-cache slot with the evidence that its wrapper
+// carries the current probe contract: \p window is that object's
+// @__ejit_icache_epoch, \p probeAbi the version it was built against. Declined
+// on probeAbi != kEJitIcacheProbeAbi, a null/conflicting window, or numDims
+// above the cap; a declined slot leaves its cell null so every call resolves
+// through the taskpool.
 void ejit_register_icache_slot(const char *funcName, void *slot,
-                               uint32_t numDims);
+                               uint32_t numDims, void *window,
+                               uint32_t probeAbi);
 
-// Hand over the AOT-emitted @__ejit_icache_epoch window (the { seen, shared }
-// pair the probe compares on every call) and the probe contract version the
-// object was built against. Emitted by AOT auto-registration before the slot
-// registrations. Passing the window by ADDRESS is what guarantees the runtime
-// writes the bytes the probe reads - see ejitIcacheBindEpochWindow.
-//
-// A \p probeAbi below kEJitIcacheProbeAbi leaves the window unbound, which makes
-// every later ejit_register_icache_slot decline: the inline cache stays off and
-// all calls resolve through the taskpool - correct, just without the fast path.
+// Superseded by the window/probeAbi parameters above. No-op, kept so an object
+// built before that change still links.
 void ejit_register_icache_epoch(void *window, uint32_t probeAbi);
 
 // Bring the CALLING core's inline cache up to date, dropping every cached

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -170,12 +170,15 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
 // specialization if a period toggled since this core last synced. Cheap when
 // nothing changed (one shared load); a no-op when the inline cache is not used.
 //
-// Cells are core-private, so ejit_deactivate only drains the core it runs on.
-// The runtime also syncs a core whenever it resolves through the taskpool, which
-// covers any core with a cold cell. A core whose cells are ALL warm never enters
-// the runtime and so never observes the toggle: such a core must call this
-// itself, once per period boundary, or it keeps running specializations built
-// for the previous period values.
+// Cells are core-private, so ejit_deactivate only drains the core it runs on,
+// and the runtime syncs a core whenever it resolves through the taskpool. A core
+// whose cells are ALL warm reaches neither -- so the wrapper's probe compares
+// the shared epoch on every call and treats a mismatch as a miss, which routes
+// that core through the taskpool and drains it. Correctness therefore does NOT
+// depend on calling this.
+//
+// It remains useful to force the drain at a known point (tests, or to move the
+// one-off re-resolve cost off a latency-critical call) but it is optional.
 void ejit_icache_sync(void);
 
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -162,9 +162,22 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 // indirect call, no ejit_icache_try call). Keys the slot by the SAME registry
 // funcIndex assigned by ejit_register_funcindex. Called by AOT auto-registration.
 // A null slot or capacity exhaustion is recorded; the base stays null and the
-// probe misses.
+// probe misses. Also declined when no epoch window has been registered yet (see
+// ejit_register_icache_epoch): the probe reads the window without a null check,
+// so a wired-up cell with no window behind it faults on the first hit.
 void ejit_register_icache_slot(const char *funcName, void *slot,
                                uint32_t numDims);
+
+// Hand over the AOT-emitted @__ejit_icache_epoch window (the { seen, shared }
+// pair the probe compares on every call) and the probe contract version the
+// object was built against. Emitted by AOT auto-registration before the slot
+// registrations. Passing the window by ADDRESS is what guarantees the runtime
+// writes the bytes the probe reads - see ejitIcacheBindEpochWindow.
+//
+// A \p probeAbi below kEJitIcacheProbeAbi leaves the window unbound, which makes
+// every later ejit_register_icache_slot decline: the inline cache stays off and
+// all calls resolve through the taskpool - correct, just without the fast path.
+void ejit_register_icache_epoch(void *window, uint32_t probeAbi);
 
 // Bring the CALLING core's inline cache up to date, dropping every cached
 // specialization if a period toggled since this core last synced. Cheap when

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -166,6 +166,18 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 void ejit_register_icache_slot(const char *funcName, void *slot,
                                uint32_t numDims);
 
+// Bring the CALLING core's inline cache up to date, dropping every cached
+// specialization if a period toggled since this core last synced. Cheap when
+// nothing changed (one shared load); a no-op when the inline cache is not used.
+//
+// Cells are core-private, so ejit_deactivate only drains the core it runs on.
+// The runtime also syncs a core whenever it resolves through the taskpool, which
+// covers any core with a cold cell. A core whose cells are ALL warm never enters
+// the runtime and so never observes the toggle: such a core must call this
+// itself, once per period boundary, or it keeps running specializations built
+// for the previous period values.
+void ejit_icache_sync(void);
+
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index
 // only; there is no array-pointer dimension in the active state (a period name
 // with multiple arrays is activated as a whole for that instance).

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -158,9 +158,10 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 // global address) by name, with its dimensionality (number of ejit_dim params).
 // The runtime writes the frozen specialization pointer through the [D]^numDims
 // cell at [i0][i1]... on a successful resolve (icacheFill); the wrapper reads
-// the cell directly on the hit path (GEP + one atomic load + null-check +
-// indirect call, no ejit_icache_try call). Keys the slot by the SAME registry
-// funcIndex assigned by ejit_register_funcindex. Called by AOT auto-registration.
+// the cell directly on the hit path (GEP + one plain load + null-check, then
+// the shared-epoch check, then the indirect call - no ejit_icache_try call).
+// Keys the slot by the SAME registry funcIndex assigned by
+// ejit_register_funcindex. Called by AOT auto-registration.
 // A null slot or capacity exhaustion is recorded; the base stays null and the
 // probe misses. Also declined when no epoch window has been registered yet (see
 // ejit_register_icache_epoch): the probe reads the window without a null check,

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -71,7 +71,11 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// the optional EJIT_SRE_TASKPOOL_NO_RECLAIM seqlock reader.
 /// v7: full IR/ASM payloads are worker-local again; shared dump state contains
 /// only a bounded filter and latest-capture metadata. publishSeq is unchanged.
-constexpr uint32_t kEJitSharedAbiVersion = 7u;
+/// v8: the SwitchController line gains icacheEpoch, bumped on every
+/// setInstanceEnabled transition so each core can drain its per-core inline
+/// cache after an activate/deactivate. (dispatchEpoch, added alongside for the
+/// per-core L0, sits in existing cache-line padding and shifts nothing.)
+constexpr uint32_t kEJitSharedAbiVersion = 8u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -75,8 +75,6 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// setInstanceEnabled CALL so each core can drain its per-core inline cache
 /// after an activate/deactivate — including one issued by a core that lost the
 /// CAS on the shared enabled bit but still rewrote its own period values.
-/// (dispatchEpoch, added alongside for the per-core L0, sits in existing
-/// cache-line padding and shifts nothing.)
 constexpr uint32_t kEJitSharedAbiVersion = 8u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -72,9 +72,11 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// v7: full IR/ASM payloads are worker-local again; shared dump state contains
 /// only a bounded filter and latest-capture metadata. publishSeq is unchanged.
 /// v8: the SwitchController line gains icacheEpoch, bumped on every
-/// setInstanceEnabled transition so each core can drain its per-core inline
-/// cache after an activate/deactivate. (dispatchEpoch, added alongside for the
-/// per-core L0, sits in existing cache-line padding and shifts nothing.)
+/// setInstanceEnabled CALL so each core can drain its per-core inline cache
+/// after an activate/deactivate — including one issued by a core that lost the
+/// CAS on the shared enabled bit but still rewrote its own period values.
+/// (dispatchEpoch, added alongside for the per-core L0, sits in existing
+/// cache-line padding and shifts nothing.)
 constexpr uint32_t kEJitSharedAbiVersion = 8u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -77,6 +77,16 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// CAS on the shared enabled bit but still rewrote its own period values.
 constexpr uint32_t kEJitSharedAbiVersion = 8u;
 
+/// Contract version between the AOT-emitted inline-cache probe and the runtime,
+/// carried by every icache registration.
+///   1 = cell load + null check only; a core that only ever hits never
+///       invalidates.
+///   2 = adds the shared-epoch freshness check (see EJitIcacheEpochRef).
+/// The runtime requires EQUALITY: the number moves when the probe's obligations
+/// change, so a higher one means obligations this runtime does not implement.
+/// An object built before the stamp existed reports 0.
+constexpr uint32_t kEJitIcacheProbeAbi = 2;
+
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -84,16 +84,17 @@ enum class EJitWorkerStep : uint32_t {
 //===----------------------------------------------------------------------===//
 // Per-function inline cache (v2: sticky monomorphic).
 //
-// A single global slot per funcIndex holding a FROZEN specialization pointer:
-// written once (first resolution, one-shot CAS) and read forever. No version /
-// dims / generation re-validation, no refill, and no release_read on the hit
-// path - the probe is a single acquire load + null check.
+// A cell per (funcIndex, dim identity) holding a specialization pointer, read
+// with no version / dims / generation re-validation and no release_read - the
+// probe is a single load + null check.
 //
-// Correctness rests on a hard precondition: every ejit_entry's specialization
-// is invariant for process lifetime (period toggles do not change the baked
-// code; each entry is monomorphic - always called with one dim identity). If
-// that ever fails the cache silently runs a stale specialization; the safety
-// gate below does NOT cover that, only UAF.
+// A cell therefore cannot be invalidated in place. Instead an activate or
+// deactivate bumps the shared icacheEpoch, and each core drains its whole table
+// when it next observes a change (icacheSyncEpoch). Cells are core-private, so
+// the toggling core cannot reach a peer's table; publishing an epoch and
+// observing it per core is what makes the invalidation cross-core. A core that
+// only ever hits never reaches a sync point and must call ejit_icache_sync()
+// itself - see that declaration.
 //
 // Lifetime safety: JIT code is never physically freed in production (NO_RECLAIM
 // + no releaseFn_ wired), so a cached pointer can never dangle. v2 does NO
@@ -664,8 +665,26 @@ public:
   /// those bypass cachePublish() and setInstanceEnabled().
   void retireDispatchCache();
 
+  //
+  // Requires the caller to have run icacheSyncEpoch() before resolving fnPtr:
+  // the fill is DROPPED if the epoch moved since, because fnPtr may then be
+  // specialized for the pre-toggle period values.
   void icacheFill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
                   uint32_t numDims);
+
+  /// Bring THIS core's inline cache up to date with the shared icacheEpoch,
+  /// draining every cell if a period toggled since this core last synced.
+  /// Returns true if a drain occurred. Also drains when this core last synced
+  /// against a DIFFERENT blob, which the epoch alone cannot catch: a fresh blob
+  /// restarts from a low epoch a stale seen-epoch can match by coincidence.
+  ///
+  /// Draining is all-or-nothing: toggles are rare, so the refill is paid once
+  /// per toggle rather than adding a check to the hit path.
+  ///
+  /// Called from ejit_deactivate (the toggling core) and at compile_or_get
+  /// entry, before any bucket lock is taken - a drain must never run under a
+  /// read token.
+  bool icacheSyncEpoch();
 
   //--- consumer path (worker / test) -----------------------------------------
   bool pollOne();

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -128,6 +128,13 @@ enum class EJitWorkerStep : uint32_t {
 #ifndef EJIT_ICACHE_MAX_DIMS
 #define EJIT_ICACHE_MAX_DIMS 4u
 #endif
+// How many filled cell indices a slot remembers so a drain can clear exactly
+// those. Beyond this the drain falls back to walking the whole array, so the
+// cap only trades memory (4 bytes per entry per slot, core-private) for how
+// many distinct dim identities one core can touch between two drains.
+#ifndef EJIT_ICACHE_DRAIN_LIST
+#define EJIT_ICACHE_DRAIN_LIST 16u
+#endif
 
 //===----------------------------------------------------------------------===//
 // Probe-visible epoch reference: core-private storage, shared target.
@@ -167,10 +174,14 @@ void ejitIcacheBindEpochWindow(void *window);
 /// Whether a probe window has been bound on this core.
 ///
 /// The probe reads `shared` WITHOUT a null check, on the strength of "a non-null
-/// cell implies a fill, hence registration, hence a bound window". That only
-/// holds if no registration path can wire a cell up without handing over the
-/// window, so ejit_register_icache_slot() consults this and declines otherwise.
+/// cell implies a fill, hence registration, hence a bound window". That holds
+/// because ejitIcacheRegisterSlot() binds the window it was handed before
+/// wiring the cell up, and declines any entry that brings none.
 bool ejitIcacheEpochWindowBound();
+
+/// The window currently bound on this core, or null. Diagnostic, and the way a
+/// caller can check that two registrations name the same merged window.
+void *ejitIcacheBoundWindow();
 
 // Test/diagnostic: clear every icache slot. The slot-pointer table is
 // process-static storage shared across pool instances, so tests clear it
@@ -182,10 +193,21 @@ void ejitIcacheClearAll();
 // them for a multi-version entry), and \p numDims is its dimensionality. The
 // runtime writes the frozen specialization pointer through the cell at
 // [i0][i1]... (linearized from dims) on a successful resolve (icacheFill); the
-// wrapper reads the cell directly. Called from ejit_register_icache_slot
+// wrapper reads the cell directly. Called from ejit_register_icache_entry
 // (name->funcIndex resolution) at ejit_auto_register / .ejit_period time.
-// No-op for an out-of-range funcIndex or null base.
-void ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
+//
+// \p window and \p probeAbi are the ENTRY'S OWN evidence that its wrapper
+// carries the current probe contract. Per-entry, not a process-global
+// handshake: a global "is some window bound?" gate is satisfied by whichever TU
+// registered first, so in a mixed link a pre-epoch TU would register against a
+// newer TU's window and get cells its probe can never invalidate.
+//
+// Returns false (registering nothing) for an out-of-range funcIndex, a null
+// base, numDims above the cap, probeAbi != kEJitIcacheProbeAbi, a null window,
+// or a window disagreeing with one already bound. Declining is the safe
+// degradation: the cell stays null and the taskpool serves every call.
+bool ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims,
+                            void *window, uint32_t probeAbi);
 
 /// Diagnostic: dump every registered icache slot to the diagnostic log.
 /// Shows funcIndex, base pointer, numDims, and cell[0] (the scalar or

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -128,12 +128,22 @@ enum class EJitWorkerStep : uint32_t {
 #ifndef EJIT_ICACHE_MAX_DIMS
 #define EJIT_ICACHE_MAX_DIMS 4u
 #endif
-// How many filled cell indices a slot remembers so a drain can clear exactly
-// those. Beyond this the drain falls back to walking the whole array, so the
-// cap only trades memory (4 bytes per entry per slot, core-private) for how
-// many distinct dim identities one core can touch between two drains.
+// Capacity of the ONE core-private log of (slot, cell) pairs filled since the
+// last drain, which lets the drain clear exactly those cells instead of walking
+// all EJIT_ICACHE_FUNC_SLOTS entries. Beyond this the drain falls back to that
+// walk, whole-array clearing every touched slot.
+//
+// The log is global, NOT per slot: a per-slot list is reserved for all
+// EJIT_ICACHE_FUNC_SLOTS (4096) entries however few a core calls, so 16 entries
+// would cost 64B x 4096 = 256KB of core-private BSS, while the same 16 entries
+// cost 128 bytes once here. That is what makes a generous cap affordable.
+//
+// Size it above the number of distinct (entry, dim identity) pairs one core
+// resolves between two period toggles -- roughly the count of ejit_entry
+// functions it calls, since the usual shape is one identity per core. 1024
+// covers the ~435-entry field image with headroom, for 8KB.
 #ifndef EJIT_ICACHE_DRAIN_LIST
-#define EJIT_ICACHE_DRAIN_LIST 16u
+#define EJIT_ICACHE_DRAIN_LIST 1024u
 #endif
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -90,11 +90,14 @@ enum class EJitWorkerStep : uint32_t {
 //
 // A cell therefore cannot be invalidated in place. Instead an activate or
 // deactivate bumps the shared icacheEpoch, and each core drains its whole table
-// when it next observes a change (icacheSyncEpoch). Cells are core-private, so
-// the toggling core cannot reach a peer's table; publishing an epoch and
-// observing it per core is what makes the invalidation cross-core. A core that
-// only ever hits never reaches a sync point and must call ejit_icache_sync()
-// itself - see that declaration.
+// when it observes a change (icacheSyncEpoch). Cells are core-private, so the
+// toggling core cannot reach a peer's table; publishing an epoch and having
+// each core observe it is what makes the invalidation cross-core.
+//
+// The probe itself checks that epoch on every call (see EJitIcacheEpochRef), so
+// a core discovers a toggle even if it never misses and never reaches any other
+// sync point. ejit_icache_sync() remains available but is no longer required
+// for correctness.
 //
 // Lifetime safety: JIT code is never physically freed in production (NO_RECLAIM
 // + no releaseFn_ wired), so a cached pointer can never dangle. v2 does NO
@@ -125,6 +128,40 @@ enum class EJitWorkerStep : uint32_t {
 #ifndef EJIT_ICACHE_MAX_DIMS
 #define EJIT_ICACHE_MAX_DIMS 4u
 #endif
+
+//===----------------------------------------------------------------------===//
+// Probe-visible epoch reference: core-private storage, shared target.
+//
+// The probe compares `seen` against `*shared` on every call. Cells are
+// core-private .bss, so a toggling core cannot reach a peer's table -- it can
+// only publish. Having the READER consult shared memory inverts that, so a core
+// that always hits still observes the toggle without cooperating.
+//
+// `shared` is bound when the pool binds its state, and is null before that. The
+// probe checks the cell FIRST: a non-null cell implies a fill, hence
+// registration, hence `shared` is bound -- so no null check is needed.
+//
+// Both loads are plain: a stale read costs at most one more call into the
+// previous specialization, the same window a racing drain already has.
+//===----------------------------------------------------------------------===//
+struct EJitIcacheEpochRef {
+  /// Epoch this core last drained at. 64-bit purely so it pairs with `shared`
+  /// in one ldp -- the value itself is the 32-bit icacheEpoch.
+  uint64_t seen;
+  const uint32_t *shared; ///< -> blob icacheEpoch; null until the pool binds
+};
+
+/// Bind the probe's epoch window. \p window is the address of the AOT-emitted
+/// @__ejit_icache_epoch, handed over at registration (name2 of the icache
+/// entry) exactly like a cell array base.
+///
+/// The runtime deliberately does NOT define that symbol. If it did, the probe's
+/// reference and the runtime's definition would have to be matched up by the
+/// linker, and any mismatch (visibility, GOT, a copy relocation) would leave
+/// them on different storage -- silently, because a zeroed window reads
+/// seen == *shared == 0, i.e. "always fresh", and every core keeps hitting a
+/// stale cell. Binding by address makes them the same bytes by construction.
+void ejitIcacheBindEpochWindow(void *window);
 
 // Test/diagnostic: clear every icache slot. The slot-pointer table is
 // process-static storage shared across pool instances, so tests clear it

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -86,7 +86,7 @@ enum class EJitWorkerStep : uint32_t {
 //
 // A cell per (funcIndex, dim identity) holding a specialization pointer, read
 // with no version / dims / generation re-validation and no release_read - the
-// probe is a single load + null check.
+// probe is a plain load + null check, then the epoch check below.
 //
 // A cell therefore cannot be invalidated in place. Instead an activate or
 // deactivate bumps the shared icacheEpoch, and each core drains its whole table
@@ -137,9 +137,10 @@ enum class EJitWorkerStep : uint32_t {
 // only publish. Having the READER consult shared memory inverts that, so a core
 // that always hits still observes the toggle without cooperating.
 //
-// `shared` is bound when the pool binds its state, and is null before that. The
-// probe checks the cell FIRST: a non-null cell implies a fill, hence
-// registration, hence `shared` is bound -- so no null check is needed.
+// `shared` is bound by the first icacheSyncEpoch() on this core, and is null
+// before that. The probe checks the cell FIRST: a non-null cell implies a fill,
+// every fill is preceded by a sync on the same core, so `shared` is bound by
+// then -- which is why the probe needs no null check on it.
 //
 // Both loads are plain: a stale read costs at most one more call into the
 // previous specialization, the same window a racing drain already has.
@@ -658,10 +659,11 @@ public:
   // NOTE: the production hit path does NOT use icacheTry. With -ejit-inline-cache
   // the ejit_entry wrapper reads its per-function @__ejit_icache_fn_<name> slot
   // directly - a GEP into the [D]^numDims array by the ejit_dim arg values, one
-  // acquire load + null-check + indirect call, NO ejit_icache_try call, NO
-  // per-call guards. icacheTry is retained for unit tests / diagnostics: on a
-  // hit it sets *outFn to the frozen specialization for the given dims (call
-  // with NO releaseRead) and returns true; on a miss returns false. It keeps
+  // plain load + null-check, the shared-epoch check, then the indirect call. NO
+  // ejit_icache_try call, NO per-call guards. icacheTry is retained for unit
+  // tests / diagnostics: on a hit it sets *outFn to the frozen specialization
+  // for the given dims (call with NO releaseRead) and returns true; on a miss
+  // returns false. It keeps
   // the reclamation-safety, pool-Ready, range, and cross-core code-sharing gates
   // (the latter matters in non-shared test builds; the wrapper's inline probe is
   // only enabled under EJIT_SRE_SHARED_CODE_POINTERS, where the gate is

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -637,17 +637,25 @@ public:
   void releaseRead(uint32_t bucketIndex);
   /// Drive one end of a period-value mutation window for a lifecycle instance.
   ///
-  /// Two facts here must not be conflated: the shared `enabled` bit is the JIT
-  /// compile gate and is CAS'd, so only the first caller in each direction moves
-  /// it; the version and the two epochs instead say "the values under this
-  /// instance may now differ from what a cached specialization was baked with",
-  /// which is true for EVERY caller. Period data is core-private while the
-  /// specialization is SHARED, so N cores each bracket their own writes over the
-  /// one shared bit - publishing only on the transition loses every core but the
-  /// first, and their writes land in a window nothing announced.
+  /// Three things move here, on two different triggers.
   ///
-  /// \returns whether the enabled BIT flipped. The publication happens either
-  /// way.
+  /// The shared `enabled` bit is the JIT compile gate and is CAS'd, so only the
+  /// first caller in each direction moves it.
+  ///
+  /// The two EPOCHS move on EVERY call. Period data is core-private while the
+  /// specialization is SHARED, so N cores each bracket their own writes over the
+  /// one shared bit; a caller that lost the CAS may still have rewritten its own
+  /// copy, and neither the L0 nor the inline cache stores a version, so an epoch
+  /// is the only thing that can drop what they cached.
+  ///
+  /// version[] moves ONLY on a real transition. Its consumer is runCompile's
+  /// checkpoints, which DISCARD a finished compile when it changes - so bumping
+  /// it for a call that changed nothing aborts in-flight compiles. Every core
+  /// activating the periods it shares is the normal startup shape, and a dropped
+  /// compile is never re-enqueued, so an unconditional bump there stalls the JIT
+  /// permanently.
+  ///
+  /// \returns whether the enabled BIT flipped. The epochs publish either way.
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read
   /// counterpart of setInstanceEnabled, and the single cross-core source of

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -163,6 +163,14 @@ struct EJitIcacheEpochRef {
 /// stale cell. Binding by address makes them the same bytes by construction.
 void ejitIcacheBindEpochWindow(void *window);
 
+/// Whether a probe window has been bound on this core.
+///
+/// The probe reads `shared` WITHOUT a null check, on the strength of "a non-null
+/// cell implies a fill, hence registration, hence a bound window". That only
+/// holds if no registration path can wire a cell up without handing over the
+/// window, so ejit_register_icache_slot() consults this and declines otherwise.
+bool ejitIcacheEpochWindowBound();
+
 // Test/diagnostic: clear every icache slot. The slot-pointer table is
 // process-static storage shared across pool instances, so tests clear it
 // between cases to avoid stale cross-test leakage.
@@ -626,6 +634,19 @@ public:
                                    uint32_t inst2, uint32_t dim3,
                                    uint32_t inst3);
   void releaseRead(uint32_t bucketIndex);
+  /// Drive one end of a period-value mutation window for a lifecycle instance.
+  ///
+  /// Two facts here must not be conflated: the shared `enabled` bit is the JIT
+  /// compile gate and is CAS'd, so only the first caller in each direction moves
+  /// it; the version and the two epochs instead say "the values under this
+  /// instance may now differ from what a cached specialization was baked with",
+  /// which is true for EVERY caller. Period data is core-private while the
+  /// specialization is SHARED, so N cores each bracket their own writes over the
+  /// one shared bit - publishing only on the transition loses every core but the
+  /// first, and their writes land in a window nothing announced.
+  ///
+  /// \returns whether the enabled BIT flipped. The publication happens either
+  /// way.
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read
   /// counterpart of setInstanceEnabled, and the single cross-core source of

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -343,6 +343,13 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
       EJitAtomicU8 enabled[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 version[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 mode; ///< EJitCompileMode (Off=0, Async=1)
+  EJitAtomicU32 icacheEpoch; ///< bumped by every setInstanceEnabled transition.
+                             ///< The inline cache stores a bare fnPtr with no
+                             ///< version, so an activate/deactivate cannot
+                             ///< invalidate individual cells; each core instead
+                             ///< compares this against its private seen-epoch
+                             ///< and drains its whole table when they diverge
+                             ///< (icacheSyncEpoch). Bumped, never reset.
   EJitAtomicU32 anyInstanceActivated; ///< 1 once any instance first
                                       ///< setInstanceEnabled(true); gates the
                                       ///< instanceDisabledPreActivate counter.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -343,16 +343,13 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
       EJitAtomicU8 enabled[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 version[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 mode; ///< EJitCompileMode (Off=0, Async=1)
-  EJitAtomicU32 icacheEpoch; ///< bumped by every setInstanceEnabled CALL, not
-                             ///< only the one that moves the bit: only the
-                             ///< first of N cores wins the CAS, so the rest
-                             ///< would go unannounced.
-                             ///< The inline cache stores a bare fnPtr with no
-                             ///< version, so an activate/deactivate cannot
-                             ///< invalidate individual cells; each core instead
-                             ///< compares this against its private seen-epoch
-                             ///< and drains its whole table when they diverge
-                             ///< (icacheSyncEpoch). Bumped, never reset.
+  EJitAtomicU32 icacheEpoch; ///< inline-cache invalidation counter. Bumped by
+                             ///< every setInstanceEnabled CALL, not only the
+                             ///< one that moves the bit: only the first of N
+                             ///< cores wins the CAS, so the rest would go
+                             ///< unannounced. Each core compares it against its
+                             ///< private seen-epoch and drains its whole table
+                             ///< when they diverge. Bumped, never reset.
   EJitAtomicU32 anyInstanceActivated; ///< 1 once any instance first
                                       ///< setInstanceEnabled(true); gates the
                                       ///< instanceDisabledPreActivate counter.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -343,7 +343,10 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
       EJitAtomicU8 enabled[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 version[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 mode; ///< EJitCompileMode (Off=0, Async=1)
-  EJitAtomicU32 icacheEpoch; ///< bumped by every setInstanceEnabled transition.
+  EJitAtomicU32 icacheEpoch; ///< bumped by every setInstanceEnabled CALL, not
+                             ///< only the one that moves the bit: only the
+                             ///< first of N cores wins the CAS, so the rest
+                             ///< would go unannounced.
                              ///< The inline cache stores a bare fnPtr with no
                              ///< version, so an activate/deactivate cannot
                              ///< invalidate individual cells; each core instead

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -215,44 +215,33 @@ EJit::EJit(const Config &config) : config_(config) {
                             e->name1 ? e->name1 : "");
             break;
           }
+          // Each entry carries its own probe contract: numDims in the low 32
+          // bits of size, the probe version in the high 32, the epoch window in
+          // name2. An object predating the stamp reports 0 and is declined.
           uint32_t numDims = static_cast<uint32_t>(e->size);
-          // High 32 bits carry the probe contract version (kEJitIcacheProbeAbi).
-          // An object built before the stamp existed reports 0.
           uint32_t probeAbi = static_cast<uint32_t>(e->size >> 32);
-          if (probeAbi < kEJitIcacheProbeAbi) {
-            // This probe cannot observe a period toggle: it has no shared-epoch
-            // check, so a core that only ever hits would keep calling a
-            // specialization built for the previous period values -- silently,
-            // forever. Leave the slot UNREGISTERED. The cell then stays null,
-            // every call misses to the taskpool, and results stay correct; only
-            // the fast path is lost. Far better than running quietly wrong.
-            EJIT_DIAG("icache DISABLED for %s: probe ABI %u < %u (object "
-                      "predates the shared-epoch check -- rebuild it with THIS "
-                      "clang; the runtime alone is not enough)",
-                      e->name1, probeAbi,
-                      static_cast<unsigned>(kEJitIcacheProbeAbi));
-            break;
-          }
-          // name2 carries the probe's epoch window (see
-          // ejitIcacheBindEpochWindow). Binding by address is what guarantees
-          // the runtime writes the bytes the probe reads. Not optional: the
-          // probe reads the window with no null check, so registering the slot
-          // without one turns the first hit into a null dereference.
-          if (!e->name2) {
-            EJIT_DIAG("icache DISABLED for %s: registry entry carries no epoch "
-                      "window (malformed object)",
-                      e->name1);
-            break;
-          }
-          ejitIcacheBindEpochWindow(
-              const_cast<void *>(static_cast<const void *>(e->name2)));
           uint32_t idx = EJitFuncRegistry::instance().resolveAssign(e->name1);
-          if (idx != kEJitInvalidFuncIndex)
-            ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr), numDims);
-          else
+          if (idx == kEJitInvalidFuncIndex) {
             recordInitError(EJIT_ERR_CACHE_FULL,
                             "funcIndex capacity exhausted for icache slot",
                             e->name1);
+            break;
+          }
+          if (!ejitIcacheRegisterSlot(
+                  idx, const_cast<void *>(e->ptr), numDims,
+                  const_cast<void *>(static_cast<const void *>(e->name2)),
+                  probeAbi)) {
+            // Declined: the cell stays null, every call to this function
+            // resolves through the taskpool. Correct, just without the fast
+            // path -- and far better than a probe that cannot observe a period
+            // toggle running quietly wrong forever.
+            EJIT_DIAG("icache DISABLED for %s: probeAbi=%u (expected %u) "
+                      "window=%p numDims=%u -- rebuild this object with THIS "
+                      "clang; the runtime alone is not enough",
+                      e->name1, probeAbi,
+                      static_cast<unsigned>(kEJitIcacheProbeAbi),
+                      static_cast<const void *>(e->name2), numDims);
+          }
           break;
         }
         default:

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -235,10 +235,17 @@ EJit::EJit(const Config &config) : config_(config) {
           }
           // name2 carries the probe's epoch window (see
           // ejitIcacheBindEpochWindow). Binding by address is what guarantees
-          // the runtime writes the bytes the probe reads.
-          if (e->name2)
-            ejitIcacheBindEpochWindow(
-                const_cast<void *>(static_cast<const void *>(e->name2)));
+          // the runtime writes the bytes the probe reads. Not optional: the
+          // probe reads the window with no null check, so registering the slot
+          // without one turns the first hit into a null dereference.
+          if (!e->name2) {
+            EJIT_DIAG("icache DISABLED for %s: registry entry carries no epoch "
+                      "window (malformed object)",
+                      e->name1);
+            break;
+          }
+          ejitIcacheBindEpochWindow(
+              const_cast<void *>(static_cast<const void *>(e->name2)));
           uint32_t idx = EJitFuncRegistry::instance().resolveAssign(e->name1);
           if (idx != kEJitInvalidFuncIndex)
             ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr), numDims);

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -216,6 +216,29 @@ EJit::EJit(const Config &config) : config_(config) {
             break;
           }
           uint32_t numDims = static_cast<uint32_t>(e->size);
+          // High 32 bits carry the probe contract version (kEJitIcacheProbeAbi).
+          // An object built before the stamp existed reports 0.
+          uint32_t probeAbi = static_cast<uint32_t>(e->size >> 32);
+          if (probeAbi < kEJitIcacheProbeAbi) {
+            // This probe cannot observe a period toggle: it has no shared-epoch
+            // check, so a core that only ever hits would keep calling a
+            // specialization built for the previous period values -- silently,
+            // forever. Leave the slot UNREGISTERED. The cell then stays null,
+            // every call misses to the taskpool, and results stay correct; only
+            // the fast path is lost. Far better than running quietly wrong.
+            EJIT_DIAG("icache DISABLED for %s: probe ABI %u < %u (object "
+                      "predates the shared-epoch check -- rebuild it with THIS "
+                      "clang; the runtime alone is not enough)",
+                      e->name1, probeAbi,
+                      static_cast<unsigned>(kEJitIcacheProbeAbi));
+            break;
+          }
+          // name2 carries the probe's epoch window (see
+          // ejitIcacheBindEpochWindow). Binding by address is what guarantees
+          // the runtime writes the bytes the probe reads.
+          if (e->name2)
+            ejitIcacheBindEpochWindow(
+                const_cast<void *>(static_cast<const void *>(e->name2)));
           uint32_t idx = EJitFuncRegistry::instance().resolveAssign(e->name1);
           if (idx != kEJitInvalidFuncIndex)
             ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr), numDims);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -388,7 +388,9 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
 
 namespace {
 // Drain THIS core's inline cache if a period toggled since it last synced.
-// A no-op in a non-shared build. Must run before any bucket lock is taken.
+// Reached from the taskpool entry points, i.e. the miss path -- which is where
+// the probe sends a call once it sees the shared epoch move. No-op in a
+// non-shared build. Must run before any bucket lock is taken.
 inline void ejitIcacheSyncThisCore() {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr) {
@@ -425,7 +427,6 @@ ejit_status_t ejit_deactivate(const char *periodName, uint8_t cellIdx) {
   if (!gEJIT->deactivate(periodName, cellIdx))
     return EJIT_ERR_INVALID_PARAM; // unknown lifecycle: nothing changed.
   gEJIT->invalidateByPeriod(periodName, cellIdx);
-  ejitIcacheSyncThisCore();
   return EJIT_OK;
 }
 
@@ -449,7 +450,6 @@ ejit_status_t ejit_deactivate_all(const char *periodName) {
   if (!gEJIT->deactivateAll(periodName))
     return EJIT_ERR_INVALID_PARAM;
   gEJIT->invalidateAllByPeriod(periodName);
-  ejitIcacheSyncThisCore();
   return EJIT_OK;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -347,28 +347,22 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
 }
 
 void ejit_register_icache_slot(const char *funcName, void *slot,
-                               uint32_t numDims) {
+                               uint32_t numDims, void *window,
+                               uint32_t probeAbi) {
   // Wire the wrapper's per-function @__ejit_icache_fn_<name> slot into the
   // runtime slot registry, keyed by the SAME registry funcIndex
-  // ejit_register_funcindex assigns by name. numDims is the [D]^numDims shape
-  // so icacheFill can linearize. The wrapper reads the cell directly on the
-  // icache hit path; icacheFill writes the frozen specialization pointer through
-  // it on resolve. Idempotent by name (resolveAssign is). A null slot or
-  // unresolvable name is recorded; the base stays null and the wrapper's probe
-  // cleanly misses -> taskpool fallback.
+  // ejit_register_funcindex assigns by name. \p window and \p probeAbi are this
+  // object's own evidence that its probe carries the shared-epoch check.
   if (!funcName || !slot) {
     EJIT_DIAG("register_icache_slot reject: name=%p slot=%p",
               (const void *)funcName, slot);
     return;
   }
-  EJIT_DIAG_VERBOSE("register_icache_slot name=%s numDims=%u", funcName, numDims);
 #ifdef EJIT_SRE_TASKPOOL
   if (gEJIT && gEJIT->registrationFrozen()) {
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_INVALID_PARAM, "icache slot registration after init is frozen",
         funcName);
-    EJIT_DIAG("register_icache_slot reject name=%s: registration frozen",
-              funcName);
     return;
   }
 #endif
@@ -377,54 +371,40 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_CACHE_FULL, "funcIndex capacity exhausted for icache slot",
         funcName);
-    EJIT_DIAG("register_icache_slot FAIL name=%s: funcIndex capacity exhausted",
-              funcName);
     return;
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
-  // The probe reads the epoch window with no null check, on the strength of "a
-  // non-null cell implies registration implies a bound window". Wiring up a cell
-  // before the window exists breaks that as a fault on the first hit, not as a
-  // miss, so decline instead.
-  if (!ejitIcacheEpochWindowBound()) {
+  if (!ejitIcacheRegisterSlot(idx, slot, numDims, window, probeAbi)) {
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_INVALID_PARAM,
-        "icache slot registered before its epoch window (object needs "
-        "ejit_register_icache_epoch, or its probe ABI was rejected)",
+        "icache slot declined (probe ABI mismatch, missing/conflicting epoch "
+        "window, or numDims above the cap)",
         funcName);
-    EJIT_DIAG("register_icache_slot reject name=%s: no epoch window bound "
-              "(inline cache stays off; calls resolve through the taskpool)",
-              funcName);
+    EJIT_DIAG("icache DISABLED for %s: probeAbi=%u (expected %u) window=%p "
+              "bound=%p numDims=%u -- rebuild this object with THIS clang",
+              funcName, probeAbi,
+              static_cast<unsigned>(kEJitIcacheProbeAbi), window,
+              ejitIcacheBoundWindow(), numDims);
     return;
   }
-#endif
-  ejitIcacheRegisterSlot(idx, slot, numDims);
   EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
                     funcName, idx, numDims);
-}
-
-void ejit_register_icache_epoch(void *window, uint32_t probeAbi) {
-#ifdef EJIT_SRE_SHARED_TASKPOOL
-  if (!window) {
-    EJIT_DIAG("register_icache_epoch reject: null window");
-    return;
-  }
-  if (probeAbi < kEJitIcacheProbeAbi) {
-    // Leaving the window unbound makes every following slot registration
-    // decline, so cells stay null and all calls miss to the taskpool. Correct,
-    // unlike a probe that cannot see a period toggle.
-    EJIT_DIAG("icache DISABLED: probe ABI %u < %u (object predates the "
-              "shared-epoch check -- rebuild it with THIS clang; the runtime "
-              "alone is not enough)",
-              probeAbi, static_cast<unsigned>(kEJitIcacheProbeAbi));
-    return;
-  }
-  ejitIcacheBindEpochWindow(window);
 #else
+  (void)slot;
+  (void)numDims;
   (void)window;
   (void)probeAbi;
 #endif
 }
+
+// Superseded: the window now travels with each slot. Kept as a no-op so an
+// object built before that change still links; it must NOT bind anything,
+// since a process-global window is what let a pre-epoch TU register.
+void ejit_register_icache_epoch(void *window, uint32_t probeAbi) {
+  (void)window;
+  (void)probeAbi;
+}
+
 
 namespace {
 // Drain THIS core's inline cache if a period toggled since it last synced.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -386,6 +386,22 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
                     funcName, idx, numDims);
 }
 
+namespace {
+// Drain THIS core's inline cache if a period toggled since it last synced.
+// A no-op in a non-shared build. Must run before any bucket lock is taken.
+inline void ejitIcacheSyncThisCore() {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr) {
+    if (sp->icacheSyncEpoch())
+      EJIT_DIAG("icache drained on core %u (period toggle)",
+                EJitCoreId::current());
+  }
+#endif
+}
+} // namespace
+
+void ejit_icache_sync(void) { ejitIcacheSyncThisCore(); }
+
 ejit_status_t ejit_activate(const char *periodName, uint8_t cellIdx) {
   if (!gEJIT) {
     EJIT_DIAG("activate(%s,%u) failed: not initialized", periodName, cellIdx);
@@ -409,6 +425,7 @@ ejit_status_t ejit_deactivate(const char *periodName, uint8_t cellIdx) {
   if (!gEJIT->deactivate(periodName, cellIdx))
     return EJIT_ERR_INVALID_PARAM; // unknown lifecycle: nothing changed.
   gEJIT->invalidateByPeriod(periodName, cellIdx);
+  ejitIcacheSyncThisCore();
   return EJIT_OK;
 }
 
@@ -432,6 +449,7 @@ ejit_status_t ejit_deactivate_all(const char *periodName) {
   if (!gEJIT->deactivateAll(periodName))
     return EJIT_ERR_INVALID_PARAM;
   gEJIT->invalidateAllByPeriod(periodName);
+  ejitIcacheSyncThisCore();
   return EJIT_OK;
 }
 
@@ -570,6 +588,9 @@ inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
     EJIT_DIAG("icacheFillOnSuccess SKIP func=%u: fnPtr is null", funcIndex);
     return;
   }
+  // Called with the caller's bucket read token held, so this must stay a single
+  // store. The epoch sync runs at compile_or_get entry instead, before any
+  // taskpool lock is taken; icacheFill itself drops a fill that a toggle raced.
   EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr;
   if (!sp) {
     EJIT_DIAG("icacheFillOnSuccess SKIP func=%u: no shared pool (gEJIT=%p)",
@@ -607,6 +628,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     EJIT_DIAG("taskpool_compile_or_get reject func=%u: no taskpool", funcIndex);
     return EJIT_ERR_NOT_ACTIVE;
   }
+  ejitIcacheSyncThisCore();
 
   if (numDims > 4) {
     EJIT_DIAG("taskpool_compile_or_get reject func=%u: numDims=%u > 4",
@@ -709,6 +731,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  ejitIcacheSyncThisCore();
 
   void *l0Fn = nullptr;
   if (tp->l0Try(funcIndex, nullptr, 0, &l0Fn)) {
@@ -748,6 +771,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  ejitIcacheSyncThisCore();
   if (!ejitTaskpoolDimInRange(dim0, inst0))
     return EJIT_ERR_INVALID_PARAM;
 
@@ -797,6 +821,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  ejitIcacheSyncThisCore();
   if (!ejitTaskpoolDimInRange(dim0, inst0) ||
       !ejitTaskpoolDimInRange(dim1, inst1))
     return EJIT_ERR_INVALID_PARAM;
@@ -844,6 +869,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  ejitIcacheSyncThisCore();
   if (!ejitTaskpoolDimInRange(dim0, inst0) ||
       !ejitTaskpoolDimInRange(dim1, inst1) ||
       !ejitTaskpoolDimInRange(dim2, inst2))
@@ -894,6 +920,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  ejitIcacheSyncThisCore();
   if (!ejitTaskpoolDimInRange(dim0, inst0) ||
       !ejitTaskpoolDimInRange(dim1, inst1) ||
       !ejitTaskpoolDimInRange(dim2, inst2) ||

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -381,9 +381,49 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
               funcName);
     return;
   }
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  // The probe reads the epoch window with no null check, on the strength of "a
+  // non-null cell implies registration implies a bound window". Wiring up a cell
+  // before the window exists breaks that as a fault on the first hit, not as a
+  // miss, so decline instead.
+  if (!ejitIcacheEpochWindowBound()) {
+    EJitRegistrationStore::instance().recordError(
+        EJIT_ERR_INVALID_PARAM,
+        "icache slot registered before its epoch window (object needs "
+        "ejit_register_icache_epoch, or its probe ABI was rejected)",
+        funcName);
+    EJIT_DIAG("register_icache_slot reject name=%s: no epoch window bound "
+              "(inline cache stays off; calls resolve through the taskpool)",
+              funcName);
+    return;
+  }
+#endif
   ejitIcacheRegisterSlot(idx, slot, numDims);
   EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
                     funcName, idx, numDims);
+}
+
+void ejit_register_icache_epoch(void *window, uint32_t probeAbi) {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (!window) {
+    EJIT_DIAG("register_icache_epoch reject: null window");
+    return;
+  }
+  if (probeAbi < kEJitIcacheProbeAbi) {
+    // Leaving the window unbound makes every following slot registration
+    // decline, so cells stay null and all calls miss to the taskpool. Correct,
+    // unlike a probe that cannot see a period toggle.
+    EJIT_DIAG("icache DISABLED: probe ABI %u < %u (object predates the "
+              "shared-epoch check -- rebuild it with THIS clang; the runtime "
+              "alone is not enough)",
+              probeAbi, static_cast<unsigned>(kEJitIcacheProbeAbi));
+    return;
+  }
+  ejitIcacheBindEpochWindow(window);
+#else
+  (void)window;
+  (void)probeAbi;
+#endif
 }
 
 namespace {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -152,18 +152,41 @@ constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 struct EJitIcacheSlotReg {
   uintptr_t *base;
   uint32_t numDims;
-  // The cells this core has written since its last drain, so the drain clears
-  // exactly those. Fills land at icacheLinearize(dims), i.e. sparsely at
-  // whichever dim identities this core calls: a drain can neither stop at the
-  // first zero cell (identity 5 alone leaves 0..4 zero) nor bound itself to
-  // [min,max] cheaply -- identities 0 and 15 of a 4D entry span the whole
-  // 65536-cell array. Recording the indices costs one store on the miss path
-  // and makes the drain O(identities this core actually used), which is 1 for
-  // the usual one-identity-per-core shape.
-  uint32_t fills;                          // 0 = nothing to clear
-  uint32_t filled[EJIT_ICACHE_DRAIN_LIST]; // valid while fills <= the cap
+  // Nonzero once this core writes any cell of this slot, cleared by the drain.
+  // Only a flag: the cell indices live in the one global gIcacheDirty log
+  // below, not here. Kept per slot so the overflow path can skip untouched
+  // entries instead of whole-array clearing a 65536-cell 4D slot for nothing.
+  uint32_t touched;
 };
+// 16 bytes x EJIT_ICACHE_FUNC_SLOTS (4096) = 64KB of core-private BSS. The
+// funcIndex space is dense, so this table is sized for EVERY entry in the image
+// while only the handful a core actually calls are ever non-null -- which is
+// why the recorded cell indices must NOT live in here. Reserving a per-slot
+// drain list costs its size x 4096 no matter how few slots are used (a 16-entry
+// list would add 64B x 4096 = 256KB); the global log below costs its size once.
 EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
+
+// The cells this core has written since its last drain, so the drain clears
+// exactly those. Fills land at icacheLinearize(dims), i.e. sparsely at whichever
+// dim identities this core calls: a drain can neither stop at the first zero
+// cell (identity 5 alone leaves 0..4 zero) nor bound itself to [min,max] cheaply
+// -- identities 0 and 15 of a 4D entry span the whole 65536-cell array.
+// Recording (slot, cell) costs one store on the miss path and makes the drain
+// O(cells this core actually filled) -- typically one per hot entry -- instead
+// of a walk over all EJIT_ICACHE_FUNC_SLOTS entries.
+//
+// One log for all slots, because demand is global and tiny: a core fills a cell
+// only on a taskpool resolve, so the total between two drains is bounded by the
+// entries it actually calls, not by the size of the slot table.
+struct EJitIcacheDirtyEnt {
+  uint32_t funcIndex;
+  uint32_t cell;
+};
+EJitIcacheDirtyEnt gIcacheDirty[EJIT_ICACHE_DRAIN_LIST];
+uint32_t gIcacheDirtyCount = 0;
+// Set when a fill arrives with the log already full. The log then no longer
+// names every dirty cell, so the drain must fall back to the slot-table walk.
+bool gIcacheDirtyOverflow = false;
 
 // The blob this core's seen-epoch was taken from. Part of the key because a
 // fresh blob restarts the epoch at 0, which a stale seen-epoch could match by
@@ -242,7 +265,11 @@ bool llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
 
   gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
   gIcacheSlots[funcIndex].numDims = numDims;
-  gIcacheSlots[funcIndex].fills = 0;
+  // Any cells this slot had logged belong to the previous registration. They
+  // stay in the log; the drain re-validates each entry against the base and
+  // shape registered at drain time, so a stale one is dropped or lands
+  // harmlessly inside the new array.
+  gIcacheSlots[funcIndex].touched = 0;
   return true;
 }
 
@@ -256,8 +283,12 @@ void llvm::ejit::ejitIcacheClearAll() {
   for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
     gIcacheSlots[f].base = nullptr;
     gIcacheSlots[f].numDims = 0;
-    gIcacheSlots[f].fills = 0;
+    gIcacheSlots[f].touched = 0;
   }
+  // The log names cells of the slots just unregistered: drop it, or the next
+  // drain would walk entries whose bases are gone.
+  gIcacheDirtyCount = 0;
+  gIcacheDirtyOverflow = false;
   gIcacheSeenEpoch = 0;
   if (gProbeEpoch)
     gProbeEpoch->seen = 0;
@@ -274,25 +305,41 @@ void llvm::ejit::ejitIcacheClearAll() {
 // running it (code is never freed under the gate this cache requires), so
 // zeroing only affects subsequent probes.
 static void icacheDrainCells() {
-  for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
-    EJitIcacheSlotReg &reg = gIcacheSlots[f];
-    if (!reg.base)
-      continue;
-    if (!reg.fills)
-      continue; // never filled since the last drain: nothing to clear
-    if (reg.numDims > EJIT_ICACHE_MAX_DIMS)
-      continue; // defence in depth: never walk past a mis-sized array
-    const uintptr_t cells = icacheCellCount(reg.numDims);
-    if (reg.fills <= EJIT_ICACHE_DRAIN_LIST) {
-      for (uint32_t i = 0; i < reg.fills; ++i)
-        if (reg.filled[i] < cells)
-          reg.base[reg.filled[i]] = 0;
-    } else {
-      for (uintptr_t c = 0; c < cells; ++c) // more identities than we recorded
-        reg.base[c] = 0;
+  if (!gIcacheDirtyOverflow) {
+    // The log names every dirty cell: clear exactly those and touch nothing
+    // else. No walk over the slot table at all.
+    for (uint32_t i = 0; i < gIcacheDirtyCount; ++i) {
+      const EJitIcacheDirtyEnt &ent = gIcacheDirty[i];
+      EJitIcacheSlotReg &reg = gIcacheSlots[ent.funcIndex];
+      // The slot may have been unregistered, or re-registered against a
+      // different base/shape, since the fill was logged. Zeroing a cell is
+      // always safe (it can only cause a miss), but it must land inside the
+      // array that is registered NOW.
+      if (!reg.base || reg.numDims > EJIT_ICACHE_MAX_DIMS)
+        continue;
+      if (ent.cell < icacheCellCount(reg.numDims))
+        reg.base[ent.cell] = 0;
+      reg.touched = 0;
     }
-    reg.fills = 0;
+  } else {
+    // The log dropped at least one cell, so it no longer names everything that
+    // is dirty: fall back to whole-array clearing every touched slot.
+    for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
+      EJitIcacheSlotReg &reg = gIcacheSlots[f];
+      if (!reg.base)
+        continue;
+      if (!reg.touched)
+        continue; // never filled since the last drain: nothing to clear
+      if (reg.numDims > EJIT_ICACHE_MAX_DIMS)
+        continue; // defence in depth: never walk past a mis-sized array
+      const uintptr_t cells = icacheCellCount(reg.numDims);
+      for (uintptr_t c = 0; c < cells; ++c)
+        reg.base[c] = 0;
+      reg.touched = 0;
+    }
   }
+  gIcacheDirtyCount = 0;
+  gIcacheDirtyOverflow = false;
 }
 
 bool EJitSharedTaskPool::icacheSyncEpoch() {
@@ -524,9 +571,14 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   // No atomic/release: same-core, and the read's data dependency on the pointer
   // orders this store-before-use.
   uintptr_t idx = icacheLinearize(dims, numDims);
-  if (reg.fills < EJIT_ICACHE_DRAIN_LIST)
-    reg.filled[reg.fills] = static_cast<uint32_t>(idx);
-  ++reg.fills;
+  // Log the cell so the next drain can clear it without walking the table. A
+  // full log is not an error: it only costs the drain its precise path.
+  if (gIcacheDirtyCount < EJIT_ICACHE_DRAIN_LIST)
+    gIcacheDirty[gIcacheDirtyCount++] =
+        EJitIcacheDirtyEnt{funcIndex, static_cast<uint32_t>(idx)};
+  else
+    gIcacheDirtyOverflow = true;
+  reg.touched = 1;
   reg.base[idx] = reinterpret_cast<uintptr_t>(fnPtr);
   EJIT_DIAG("icacheFill OK func=%u dims=%u idx=%zu fn=%p cell[0]=%p",
             funcIndex, numDims, (size_t)idx, fnPtr, (void *)reg.base[0]);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -155,12 +155,20 @@ struct EJitIcacheSlotReg {
 };
 EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
 
-// This core's view of the shared icacheEpoch, and the blob it was taken from.
-// Core-private like the cells themselves (default BSS, zero-filled). The state
-// pointer is part of the key because a fresh blob restarts the epoch from 0,
-// which a stale seen-epoch could match by coincidence.
-uint32_t gIcacheSeenEpoch = 0;
+// The blob this core's seen-epoch was taken from. Part of the key because a
+// fresh blob restarts the epoch at 0, which a stale seen-epoch could match by
+// coincidence. Core-private like the cells (default BSS, zero-filled).
+//
+// The authoritative seen-epoch is gIcacheSeenEpoch below; it is mirrored into
+// the probe's window (gProbeEpoch) so the inline probe can read it without a
+// call. See ejitIcacheBindEpochWindow for why the window is owned by the AOT
+// object rather than defined here.
 const void *gIcacheSeenState = nullptr;
+uint32_t gIcacheSeenEpoch = 0;
+
+// The probe's window, owned by the AOT object and registered by address (see
+// ejitIcacheBindEpochWindow). Core-private like everything else here.
+EJitIcacheEpochRef *gProbeEpoch = nullptr;
 
 uintptr_t icacheCellCount(uint32_t numDims) {
   uintptr_t n = 1;
@@ -181,6 +189,14 @@ static uintptr_t icacheLinearize(const EJitDimPair *dims, uint32_t numDims) {
 }
 
 } // namespace
+
+// Probe-visible epoch reference. Core-private BSS: `seen` is this core's last
+// drained epoch, `shared` points into the blob so the probe can observe a peer's
+// toggle without that peer being able to reach this core's cells.
+void llvm::ejit::ejitIcacheBindEpochWindow(void *window) {
+  gProbeEpoch = static_cast<EJitIcacheEpochRef *>(window);
+  EJIT_DIAG_VERBOSE("icache epoch window bound: %p", window);
+}
 
 void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
                                         uint32_t numDims) {
@@ -210,6 +226,8 @@ void llvm::ejit::ejitIcacheClearAll() {
     gIcacheSlots[f].numDims = 0;
   }
   gIcacheSeenEpoch = 0;
+  if (gProbeEpoch)
+    gProbeEpoch->seen = 0;
   gIcacheSeenState = nullptr;
 }
 
@@ -238,10 +256,20 @@ bool EJitSharedTaskPool::icacheSyncEpoch() {
   // Read the epoch BEFORE draining, so a toggle racing this drain leaves the
   // seen-epoch behind (one more drain later), never ahead (a missed drain).
   const uint32_t epoch = state_->icacheEpoch.loadAcquire();
+  // Bind the probe's window onto the shared word. Done here because every fill
+  // is preceded by a sync on the same core, so a cell can never become non-null
+  // while `shared` is still null -- which is exactly what lets the probe skip a
+  // null check and read the epoch only after the cell tests non-null.
+  if (gProbeEpoch)
+    gProbeEpoch->shared = state_->icacheEpoch.raw();
   if (gIcacheSeenState == state_ && gIcacheSeenEpoch == epoch)
     return false;
   icacheDrainCells();
   gIcacheSeenEpoch = epoch;
+  // Publish LAST: until this store lands the probe still sees the old epoch and
+  // keeps missing, which is the safe direction.
+  if (gProbeEpoch)
+    gProbeEpoch->seen = epoch;
   gIcacheSeenState = state_;
   return true;
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -198,6 +198,8 @@ void llvm::ejit::ejitIcacheBindEpochWindow(void *window) {
   EJIT_DIAG_VERBOSE("icache epoch window bound: %p", window);
 }
 
+bool llvm::ejit::ejitIcacheEpochWindowBound() { return gProbeEpoch != nullptr; }
+
 void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
                                         uint32_t numDims) {
   if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !base)
@@ -526,21 +528,25 @@ bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
   }
   uint8_t expected = enabled ? 0 : 1;
   uint8_t desired = enabled ? 1 : 0;
-  if (state_->enabled[dimType][instanceId].compareExchange(expected, desired)) {
-    state_->version[dimType][instanceId].fetchAdd(1);
-    // Neither the L0 nor the inline cache stores a version, so the bump above
-    // is invisible to both: each has its own epoch to drain against.
-    state_->dispatchEpoch.fetchAdd(1);
-    state_->icacheEpoch.fetchAdd(1);
-    // Latch on the first successful enable of ANY instance: this brackets the
-    // init→activate window during which instanceDisabled hits are tallied
-    // separately (instanceDisabledPreActivate) for diagnosing the pre-activate
-    // fallback storm. Once latched it stays 1 until the next (re)initialization.
-    if (enabled)
-      state_->anyInstanceActivated.storeRelease(1);
-    return true;
-  }
-  return false;
+  const bool flipped =
+      state_->enabled[dimType][instanceId].compareExchange(expected, desired);
+
+  // Publish UNCONDITIONALLY -- see the header. The CAS owns the shared compile
+  // gate; the version and epochs answer "could a cached specialization have been
+  // baked from values that have since changed?", and for a caller that lost the
+  // CAS that is still yes -- it has its own core-private copy to rewrite.
+  state_->version[dimType][instanceId].fetchAdd(1);
+  // Neither the L0 nor the inline cache stores a version, so the bump above is
+  // invisible to both: each has its own epoch to drain against.
+  state_->dispatchEpoch.fetchAdd(1);
+  state_->icacheEpoch.fetchAdd(1);
+  // Latch on the first enable of ANY instance: this brackets the init→activate
+  // window during which instanceDisabled hits are tallied separately
+  // (instanceDisabledPreActivate) for diagnosing the pre-activate fallback
+  // storm. Once latched it stays 1 until the next (re)initialization.
+  if (enabled)
+    state_->anyInstanceActivated.storeRelease(1);
+  return flipped;
 }
 
 bool EJitSharedTaskPool::versionsCurrent(const EJitCompileRequest &req) const {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -152,6 +152,16 @@ constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 struct EJitIcacheSlotReg {
   uintptr_t *base;
   uint32_t numDims;
+  // The cells this core has written since its last drain, so the drain clears
+  // exactly those. Fills land at icacheLinearize(dims), i.e. sparsely at
+  // whichever dim identities this core calls: a drain can neither stop at the
+  // first zero cell (identity 5 alone leaves 0..4 zero) nor bound itself to
+  // [min,max] cheaply -- identities 0 and 15 of a 4D entry span the whole
+  // 65536-cell array. Recording the indices costs one store on the miss path
+  // and makes the drain O(identities this core actually used), which is 1 for
+  // the usual one-identity-per-core shape.
+  uint32_t fills;                          // 0 = nothing to clear
+  uint32_t filled[EJIT_ICACHE_DRAIN_LIST]; // valid while fills <= the cap
 };
 EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
 
@@ -200,10 +210,13 @@ void llvm::ejit::ejitIcacheBindEpochWindow(void *window) {
 
 bool llvm::ejit::ejitIcacheEpochWindowBound() { return gProbeEpoch != nullptr; }
 
-void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
-                                        uint32_t numDims) {
+void *llvm::ejit::ejitIcacheBoundWindow() { return gProbeEpoch; }
+
+bool llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
+                                        uint32_t numDims, void *window,
+                                        uint32_t probeAbi) {
   if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !base)
-    return;
+    return false;
   // numDims sizes the [D]^numDims cell array the drain walks, so an out-of-cap
   // value is a write far past the end of the wrapper's global. The AOT pass
   // never emits one (it skips entries above the cap), but numDims arrives here
@@ -211,9 +224,26 @@ void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
   // than trust it. Leaving the slot unregistered is the documented safe
   // degradation: probes miss and the taskpool serves every call.
   if (numDims > EJIT_ICACHE_MAX_DIMS)
-    return;
+    return false;
+
+  // The probe contract is carried PER SLOT: a global "is some window bound?"
+  // gate is satisfied by whichever TU registered first, so in a mixed link a
+  // pre-epoch TU's slots would register against a newer TU's window and get
+  // cells its probe can never invalidate.
+  if (probeAbi != kEJitIcacheProbeAbi || !window)
+    return false;
+  // @__ejit_icache_epoch is linkonce_odr, so a correct link leaves exactly one
+  // window. A second address means the copies were not merged: that probe reads
+  // storage the runtime never writes, which reads as "always fresh" forever.
+  if (gProbeEpoch && gProbeEpoch != window)
+    return false;
+  if (!gProbeEpoch)
+    ejitIcacheBindEpochWindow(window);
+
   gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
   gIcacheSlots[funcIndex].numDims = numDims;
+  gIcacheSlots[funcIndex].fills = 0;
+  return true;
 }
 
 void llvm::ejit::ejitIcacheClearAll() {
@@ -226,11 +256,15 @@ void llvm::ejit::ejitIcacheClearAll() {
   for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
     gIcacheSlots[f].base = nullptr;
     gIcacheSlots[f].numDims = 0;
+    gIcacheSlots[f].fills = 0;
   }
   gIcacheSeenEpoch = 0;
   if (gProbeEpoch)
     gProbeEpoch->seen = 0;
   gIcacheSeenState = nullptr;
+  // "No slots" and "no window" are the same empty state; leaving one bound
+  // would make the next registration compare against a dead window.
+  gProbeEpoch = nullptr;
 }
 
 // Zero every registered cell array, so every probe misses and the next call
@@ -244,11 +278,20 @@ static void icacheDrainCells() {
     EJitIcacheSlotReg &reg = gIcacheSlots[f];
     if (!reg.base)
       continue;
+    if (!reg.fills)
+      continue; // never filled since the last drain: nothing to clear
     if (reg.numDims > EJIT_ICACHE_MAX_DIMS)
       continue; // defence in depth: never walk past a mis-sized array
     const uintptr_t cells = icacheCellCount(reg.numDims);
-    for (uintptr_t c = 0; c < cells; ++c)
-      reg.base[c] = 0;
+    if (reg.fills <= EJIT_ICACHE_DRAIN_LIST) {
+      for (uint32_t i = 0; i < reg.fills; ++i)
+        if (reg.filled[i] < cells)
+          reg.base[reg.filled[i]] = 0;
+    } else {
+      for (uintptr_t c = 0; c < cells; ++c) // more identities than we recorded
+        reg.base[c] = 0;
+    }
+    reg.fills = 0;
   }
 }
 
@@ -481,6 +524,9 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   // No atomic/release: same-core, and the read's data dependency on the pointer
   // orders this store-before-use.
   uintptr_t idx = icacheLinearize(dims, numDims);
+  if (reg.fills < EJIT_ICACHE_DRAIN_LIST)
+    reg.filled[reg.fills] = static_cast<uint32_t>(idx);
+  ++reg.fills;
   reg.base[idx] = reinterpret_cast<uintptr_t>(fnPtr);
   EJIT_DIAG("icacheFill OK func=%u dims=%u idx=%zu fn=%p cell[0]=%p",
             funcIndex, numDims, (size_t)idx, fnPtr, (void *)reg.base[0]);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -155,6 +155,20 @@ struct EJitIcacheSlotReg {
 };
 EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
 
+// This core's view of the shared icacheEpoch, and the blob it was taken from.
+// Core-private like the cells themselves (default BSS, zero-filled). The state
+// pointer is part of the key because a fresh blob restarts the epoch from 0,
+// which a stale seen-epoch could match by coincidence.
+uint32_t gIcacheSeenEpoch = 0;
+const void *gIcacheSeenState = nullptr;
+
+uintptr_t icacheCellCount(uint32_t numDims) {
+  uintptr_t n = 1;
+  for (uint32_t i = 0; i < numDims; ++i)
+    n *= EJIT_ICACHE_DIM_SIZE;
+  return n;
+}
+
 // Linearize the dim identity to a flat cell index, row-major, dim0 = leftmost
 // ejit_dim param (MUST match the AOT [D]^numDims array declaration order). D is
 // EJIT_ICACHE_DIM_SIZE (power-of-2). numDims=0 -> idx 0 (the scalar cell). No
@@ -172,6 +186,14 @@ void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
                                         uint32_t numDims) {
   if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !base)
     return;
+  // numDims sizes the [D]^numDims cell array the drain walks, so an out-of-cap
+  // value is a write far past the end of the wrapper's global. The AOT pass
+  // never emits one (it skips entries above the cap), but numDims arrives here
+  // from a uint64 registry field and from the public C ABI, so reject it rather
+  // than trust it. Leaving the slot unregistered is the documented safe
+  // degradation: probes miss and the taskpool serves every call.
+  if (numDims > EJIT_ICACHE_MAX_DIMS)
+    return;
   gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
   gIcacheSlots[funcIndex].numDims = numDims;
 }
@@ -187,6 +209,52 @@ void llvm::ejit::ejitIcacheClearAll() {
     gIcacheSlots[f].base = nullptr;
     gIcacheSlots[f].numDims = 0;
   }
+  gIcacheSeenEpoch = 0;
+  gIcacheSeenState = nullptr;
+}
+
+// Zero every registered cell array, so every probe misses and the next call
+// re-resolves through the taskpool. The bases stay registered (unlike
+// ejitIcacheClearAll); the wrapper globals are only emptied. Safe against a
+// concurrent wrapper on this core: a probe that already loaded a pointer keeps
+// running it (code is never freed under the gate this cache requires), so
+// zeroing only affects subsequent probes.
+static void icacheDrainCells() {
+  for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
+    EJitIcacheSlotReg &reg = gIcacheSlots[f];
+    if (!reg.base)
+      continue;
+    if (reg.numDims > EJIT_ICACHE_MAX_DIMS)
+      continue; // defence in depth: never walk past a mis-sized array
+    const uintptr_t cells = icacheCellCount(reg.numDims);
+    for (uintptr_t c = 0; c < cells; ++c)
+      reg.base[c] = 0;
+  }
+}
+
+bool EJitSharedTaskPool::icacheSyncEpoch() {
+  if (!state_)
+    return false;
+  // Read the epoch BEFORE draining, so a toggle racing this drain leaves the
+  // seen-epoch behind (one more drain later), never ahead (a missed drain).
+  const uint32_t epoch = state_->icacheEpoch.loadAcquire();
+  if (gIcacheSeenState == state_ && gIcacheSeenEpoch == epoch)
+    return false;
+  icacheDrainCells();
+  gIcacheSeenEpoch = epoch;
+  gIcacheSeenState = state_;
+  return true;
+}
+
+// True when this core's cells are still valid under the CURRENT shared epoch.
+// The taskpool entry point syncs (setting the seen-epoch) before resolving, so a
+// toggle landing during the resolve makes this false and the fill is dropped --
+// without it the fill would store a pointer specialized for the pre-toggle
+// period values and no later sync would notice, because the seen-epoch was
+// already brought up to date.
+static bool icacheEpochCurrent(const EJitSharedTaskPoolState *state) {
+  return state && gIcacheSeenState == state &&
+         gIcacheSeenEpoch == state->icacheEpoch.loadAcquire();
 }
 
 void llvm::ejit::ejitDumpIcacheSlots() {
@@ -373,12 +441,14 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
               funcIndex, (void *)reg.base, reg.numDims, numDims);
     return; // unregistered, or shape mismatch: nowhere to write.
   }
+  // A period toggled between this core's pre-resolve sync and now, so fnPtr may
+  // be specialized for the old values: drop it and let the next call re-resolve.
+  if (!icacheEpochCurrent(state_))
+    return;
   // Plain store: the slot is per-core private, so this write (on the calling
   // core) is ordered before the wrapper's read (same core) by program order.
-  // The specialization is invariant per identity under the contract + NO_RECLAIM,
-  // so overwriting on a later resolve (same pointer) is harmless -- no one-shot
-  // CAS is needed. No atomic/release: same-core, and the read's data dependency
-  // on the pointer orders this store-before-use.
+  // No atomic/release: same-core, and the read's data dependency on the pointer
+  // orders this store-before-use.
   uintptr_t idx = icacheLinearize(dims, numDims);
   reg.base[idx] = reinterpret_cast<uintptr_t>(fnPtr);
   EJIT_DIAG("icacheFill OK func=%u dims=%u idx=%zu fn=%p cell[0]=%p",
@@ -430,8 +500,10 @@ bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
   uint8_t desired = enabled ? 1 : 0;
   if (state_->enabled[dimType][instanceId].compareExchange(expected, desired)) {
     state_->version[dimType][instanceId].fetchAdd(1);
-    // Cached L0 entries carry no version, so retire them all.
+    // Neither the L0 nor the inline cache stores a version, so the bump above
+    // is invisible to both: each has its own epoch to drain against.
     state_->dispatchEpoch.fetchAdd(1);
+    state_->icacheEpoch.fetchAdd(1);
     // Latch on the first successful enable of ANY instance: this brackets the
     // init→activate window during which instanceDisabled hits are tallied
     // separately (instanceDisabledPreActivate) for diagnosing the pre-activate
@@ -1735,6 +1807,10 @@ void EJitSharedTaskPool::ownerShutdown() {
   state_->ownerCoreId.storeRelease(kEJitInvalidCoreId);
   state_->workerTaskId.storeRelease(0);
   state_->generation.storeRelease(state_->generation.loadRelaxed() + 1);
+  // Retire every core's inline cache: a re-initialization reuses this blob, so
+  // the epoch (not the blob address) is the only thing that can tell a core its
+  // cells point into the previous generation's code.
+  state_->icacheEpoch.fetchAdd(1);
   state_->initState.storeRelease(
       static_cast<uint32_t>(EJitSharedInitState::Uninitialized));
   isOwner_ = false;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -342,9 +342,10 @@ uint32_t EJitSharedTaskPool::instanceVersion(uint32_t dimType,
 //
 // The production hit path does NOT call icacheTry: the ejit_entry wrapper reads
 // its own @__ejit_icache_fn_<name> global directly (GEP into the [D]^numDims
-// array by the ejit_dim arg values + acquire load + null check + indirect call,
-// no call, no per-call guards). icacheTry is retained for unit tests and
-// diagnostics. icacheFill writes the specialization pointer through the cell at
+// array by the ejit_dim arg values + plain load + null check, the shared-epoch
+// check, then the indirect call; no call, no per-call guards). icacheTry is
+// retained for unit tests and diagnostics.
+// icacheFill writes the specialization pointer through the cell at
 // [i0][i1]... (linearized from dims) on a successful resolve; it is a frozen,
 // one-shot fill PER CELL - each identity's cell is written once and never
 // refilled, so a cell's pointer is always the correct (invariant) specialization

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -532,15 +532,25 @@ bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
   const bool flipped =
       state_->enabled[dimType][instanceId].compareExchange(expected, desired);
 
-  // Publish UNCONDITIONALLY -- see the header. The CAS owns the shared compile
-  // gate; the version and epochs answer "could a cached specialization have been
-  // baked from values that have since changed?", and for a caller that lost the
-  // CAS that is still yes -- it has its own core-private copy to rewrite.
-  state_->version[dimType][instanceId].fetchAdd(1);
-  // Neither the L0 nor the inline cache stores a version, so the bump above is
-  // invisible to both: each has its own epoch to drain against.
+  // The epochs publish UNCONDITIONALLY. Neither the L0 nor the inline cache
+  // stores a version, so an epoch is the only thing that can invalidate them,
+  // and a caller that LOST the CAS may still have rewritten its own
+  // core-private period values -- so the answer to "could a cached
+  // specialization have been baked from values that have since changed?" is
+  // still yes for it.
   state_->dispatchEpoch.fetchAdd(1);
   state_->icacheEpoch.fetchAdd(1);
+
+  // version[] answers a NARROWER question -- "did the state of THIS instance
+  // change?" -- and has a different consumer: runCompile's checkpoints, which
+  // DISCARD a finished compile when it moves. So it must move only on a real
+  // transition. Bumping it on a lost CAS aborts in-flight compiles for a call
+  // that changed nothing, and N cores activating the same instance at startup
+  // (the normal shape: every core activates the periods it shares) then drop
+  // the worker's result N-1 times. Nothing re-enqueues a dropped compile, so
+  // the JIT never publishes and every core waits forever.
+  if (flipped)
+    state_->version[dimType][instanceId].fetchAdd(1);
   // Latch on the first enable of ANY instance: this brackets the init→activate
   // window during which instanceDisabled hits are tallied separately
   // (instanceDisabledPreActivate) for diagnosing the pre-activate fallback

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -425,15 +425,15 @@ emitIcacheSlotRegistration(Module &M,
   auto *I32Ty = Type::getInt32Ty(Ctx);
   auto *I64Ty = Type::getInt64Ty(Ctx);
 
-  // void ejit_register_icache_slot(const char *name, void *slot, uint32_t numDims)
-  // numDims tells the runtime the [D]^numDims shape so icacheFill can linearize.
-  M.getOrInsertFunction(
-      FN_REGISTER_ICACHE_SLOT,
-      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy, I32Ty}, false));
-  // void ejit_register_icache_epoch(void *window, uint32_t probeAbi)
-  M.getOrInsertFunction(
-      FN_REGISTER_ICACHE_EPOCH,
-      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, I32Ty}, false));
+  // void ejit_register_icache_slot(const char *name, void *slot,
+  //                                 uint32_t numDims, void *window,
+  //                                 uint32_t probeAbi)
+  // numDims gives the [D]^numDims shape for icacheFill; window + probeAbi are
+  // this object's proof that its probe carries the shared-epoch check.
+  M.getOrInsertFunction(FN_REGISTER_ICACHE_SLOT,
+                        FunctionType::get(Type::getVoidTy(Ctx),
+                                          {PtrTy, PtrTy, I32Ty, PtrTy, I32Ty},
+                                          false));
 
   Function *AutoReg = M.getFunction(FN_AUTO_REGISTER);
   bool CreatedAutoReg = false;
@@ -446,22 +446,18 @@ emitIcacheSlotRegistration(Module &M,
     CreatedAutoReg = true;
   }
   Instruction *Ret = AutoReg->getEntryBlock().getTerminator();
-  // The window FIRST: the runtime declines a slot it has no window for. This is
-  // the constructor path's counterpart of the name2/size fields the static
-  // registry entries below carry.
-  {
-    IRBuilder<> Builder(Ret);
-    Builder.CreateCall(
-        M.getFunction(FN_REGISTER_ICACHE_EPOCH),
-        {ConstantExpr::getBitCast(getOrCreateIcacheEpochGlobal(M), PtrTy),
-         ConstantInt::get(I32Ty, kEJitIcacheProbeAbi)});
-  }
+  // Each entry carries its own window + probe version: the constructor path's
+  // counterpart of the name2/size fields the static registry entries carry.
+  Constant *EpochWindow =
+      ConstantExpr::getBitCast(getOrCreateIcacheEpochGlobal(M), PtrTy);
   FunctionCallee FnReg = M.getFunction(FN_REGISTER_ICACHE_SLOT);
   for (auto &KV : Fns) {
     IRBuilder<> Builder(Ret);
     Value *Name = Builder.CreateGlobalString(KV.first);
     Builder.CreateCall(FnReg, {Name, Builder.CreateBitCast(KV.second.GV, PtrTy),
-                               ConstantInt::get(I32Ty, KV.second.NumDims)});
+                               ConstantInt::get(I32Ty, KV.second.NumDims),
+                               EpochWindow,
+                               ConstantInt::get(I32Ty, kEJitIcacheProbeAbi)});
   }
 
   if (EnableEJitGlobalCtors && CreatedAutoReg)
@@ -982,7 +978,14 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       SharedPLoad->setAlignment(Align(8));
       Value *Seen = SeenLoad;
       Value *SharedP = SharedPLoad;
+      // ATOMIC: `seen` and `shared` are core-private, but peers update *shared
+      // with an RMW, so a plain load here would be a data race rather than
+      // bounded staleness. monotonic is enough -- single-location coherence is
+      // the whole question, the cell it guards was written by this core, and
+      // the slow path re-reads with acquire. Lowers to the same LDR on AArch64;
+      // acquire would cost an LDAR per hit.
       auto *CurLoad = B.CreateLoad(I32Ty, SharedP, "ejit_ic_epoch");
+      CurLoad->setAtomic(AtomicOrdering::Monotonic);
       CurLoad->setAlignment(Align(4));
       Value *CurEpoch = CurLoad;
       Value *IFresh = B.CreateICmpEQ(

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -429,6 +429,10 @@ emitIcacheSlotRegistration(Module &M,
   M.getOrInsertFunction(
       FN_REGISTER_ICACHE_SLOT,
       FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy, I32Ty}, false));
+  // void ejit_register_icache_epoch(void *window, uint32_t probeAbi)
+  M.getOrInsertFunction(
+      FN_REGISTER_ICACHE_EPOCH,
+      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, I32Ty}, false));
 
   Function *AutoReg = M.getFunction(FN_AUTO_REGISTER);
   bool CreatedAutoReg = false;
@@ -441,6 +445,16 @@ emitIcacheSlotRegistration(Module &M,
     CreatedAutoReg = true;
   }
   Instruction *Ret = AutoReg->getEntryBlock().getTerminator();
+  // The window FIRST: the runtime declines a slot it has no window for. This is
+  // the constructor path's counterpart of the name2/size fields the static
+  // registry entries below carry.
+  {
+    IRBuilder<> Builder(Ret);
+    Builder.CreateCall(
+        M.getFunction(FN_REGISTER_ICACHE_EPOCH),
+        {ConstantExpr::getBitCast(getOrCreateIcacheEpochGlobal(M), PtrTy),
+         ConstantInt::get(I32Ty, kEJitIcacheProbeAbi)});
+  }
   FunctionCallee FnReg = M.getFunction(FN_REGISTER_ICACHE_SLOT);
   for (auto &KV : Fns) {
     IRBuilder<> Builder(Ret);

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -282,6 +282,54 @@ static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
   return GV;
 }
 
+// The probe's epoch window: { i64 seen, ptr shared }, DEFINED here.
+//
+// Owned by the AOT object, like the @__ejit_icache_fn_ cells, and for the same
+// reason: the probe must read the very bytes the runtime writes. Declaring it
+// extern and letting the linker match it up invites the two to land on
+// different storage (visibility, GOT, copy relocations), and the failure is
+// silent -- a zeroed window reads seen == *shared == 0, i.e. "always fresh",
+// so every core keeps hitting a stale cell.
+//
+// linkonce_odr: every TU with a probe emits one; the linker keeps a single
+// copy. Ordinary .bss, so it is core-private exactly like the cells. The
+// runtime is handed this address at registration (name2 of the icache entry)
+// and writes seen/shared through it.
+static GlobalVariable *getOrCreateIcacheEpochGlobal(Module &M) {
+  const char *GVName = "__ejit_icache_epoch";
+  if (auto *Existing = M.getGlobalVariable(GVName)) {
+    // The TU may already have DECLARED it (a test that prints the window, say).
+    // Upgrade the declaration to a definition rather than returning it as-is:
+    // leaving it undefined puts the probe back on cross-module resolution,
+    // which is exactly the failure this ownership change removes -- and it
+    // would be silent, because an unbound window reads as "always fresh".
+    if (Existing->isDeclaration()) {
+      Existing->setLinkage(GlobalValue::LinkOnceODRLinkage);
+      Existing->setInitializer(
+          ConstantAggregateZero::get(Existing->getValueType()));
+      Existing->setVisibility(GlobalValue::HiddenVisibility);
+      Existing->setDSOLocal(true);
+      if (Existing->getAlign().valueOrOne() < Align(8))
+        Existing->setAlignment(Align(8));
+    }
+    return Existing;
+  }
+  LLVMContext &Ctx = M.getContext();
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *PtrTy = PointerType::getUnqual(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+  auto *Ty = StructType::get(Ctx, {I64Ty, PtrTy});
+  auto *GV = new GlobalVariable(M, Ty, /*isConstant=*/false,
+                                GlobalValue::LinkOnceODRLinkage,
+                                ConstantAggregateZero::get(Ty), GVName);
+  GV->setAlignment(Align(8));
+  // A local definition, so the probe reaches it with adrp+add rather than a
+  // GOT load -- one fewer dependent load on the hit path.
+  GV->setVisibility(GlobalValue::HiddenVisibility);
+  GV->setDSOLocal(true);
+  return GV;
+}
+
 // Emit registration that fills each per-function dense-funcIndex global with
 // the index the process-global EJitFuncRegistry assigns by name: ejit_register_
 // funcindex() calls in ejit_auto_register (constructor path) plus private
@@ -418,11 +466,22 @@ emitIcacheSlotRegistration(Module &M,
   };
   SmallVector<Constant *, 16> Entries;
   for (auto &KV : Fns) {
+    // name2 (spare for icache entries) carries the probe's epoch window, so the
+    // runtime writes seen/shared into the object the probe actually reads.
+    Constant *EpochWin =
+        ConstantExpr::getBitCast(getOrCreateIcacheEpochGlobal(M), PtrTy);
     Entries.push_back(ConstantStruct::get(
         EntryTy, {ConstantInt::get(I32Ty, EJIT_REG_ICACHE_SLOT),
-                  makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
+                  makeStrGV(KV.first), EpochWin,
                   ConstantExpr::getBitCast(KV.second.GV, PtrTy),
-                  ConstantInt::get(I64Ty, KV.second.NumDims)}));
+                  // low 32: numDims. high 32: the probe contract version, so
+                  // the runtime can tell an epoch-checking probe from one built
+                  // before the check existed (see kEJitIcacheProbeAbi).
+                  ConstantInt::get(I64Ty,
+                                   static_cast<uint64_t>(KV.second.NumDims) |
+                                       (static_cast<uint64_t>(
+                                            kEJitIcacheProbeAbi)
+                                        << 32))}));
   }
   if (Entries.empty())
     return;
@@ -850,6 +909,9 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
+      // Created in control-flow order so the emitted IR reads top to bottom:
+      // entry -> epoch -> dispatch -> miss.
+      auto *JitIcacheEpoch = BasicBlock::Create(Ctx, "jit_icache_epoch", F);
       auto *JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
       auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
       IRBuilder<> B(JitEntry);
@@ -885,7 +947,34 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
       IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
                                {IHit, ConstantInt::getTrue(Ctx)});
-      B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
+      B.CreateCondBr(IHit, JitIcacheEpoch, JitMiss);
+
+      // Freshness: seen == *shared. A mismatch means a period toggled since this
+      // core last drained, so fall into the miss path, which drains and refills.
+      // Checked after the null test so `shared` is known bound (see
+      // EJitIcacheEpochRef).
+      B.SetInsertPoint(JitIcacheEpoch);
+      GlobalVariable *EpochGV = getOrCreateIcacheEpochGlobal(M);
+      auto *EpochTy = cast<StructType>(EpochGV->getValueType());
+      Value *SeenPtr = B.CreateStructGEP(EpochTy, EpochGV, 0, "ejit_ic_seen_p");
+      auto *SeenLoad =
+          B.CreateLoad(Type::getInt64Ty(Ctx), SeenPtr, "ejit_ic_seen");
+      SeenLoad->setAlignment(Align(8)); // 8 so seen+shared can pair in one ldp
+      Value *SharedPP =
+          B.CreateStructGEP(EpochTy, EpochGV, 1, "ejit_ic_shared_pp");
+      auto *SharedPLoad = B.CreateLoad(PtrTy, SharedPP, "ejit_ic_shared_p");
+      SharedPLoad->setAlignment(Align(8));
+      Value *Seen = SeenLoad;
+      Value *SharedP = SharedPLoad;
+      auto *CurLoad = B.CreateLoad(I32Ty, SharedP, "ejit_ic_epoch");
+      CurLoad->setAlignment(Align(4));
+      Value *CurEpoch = CurLoad;
+      Value *IFresh = B.CreateICmpEQ(
+          B.CreateZExt(CurEpoch, Type::getInt64Ty(Ctx)), Seen,
+          "ejit_icache_fresh");
+      IFresh = B.CreateIntrinsic(Intrinsic::expect, {IFresh->getType()},
+                                 {IFresh, ConstantInt::getTrue(Ctx)});
+      B.CreateCondBr(IFresh, JitIcacheDispatch, JitMiss);
 
       // Hit: tail-call the cached specialization directly (no release_read).
       // With -ejit-wrapper-timing the wrapper is NOT frame-less (JitEntry emits

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -57,9 +57,10 @@ static cl::opt<bool> EJitWrapperTiming(
 
 // Emit a per-function inline-cache probe DIRECTLY in the ejit_entry wrapper
 // (not a call). On a hit the wrapper loads its per-function @__ejit_icache_fn_
-// <name> slot (one atomic acquire load), null-checks it, and tail-calls the
-// cached specialization - NO ejit_icache_try call, NO read-token, NO per-call
-// guards, NO funcIndex/IdxValid on the hit path. Just "pointer non-null? jump".
+// <name> slot (one plain load), null-checks it, confirms the shared epoch has
+// not moved since this core last drained, and tail-calls the cached
+// specialization - NO ejit_icache_try call, NO read-token, NO per-call guards,
+// NO funcIndex/IdxValid on the hit path.
 // On a miss it falls through to jit_slow -> ejit_taskpool_compile_or_get, which
 // fills the slot on success (icacheFill). v2: sticky monomorphic - the slot is
 // filled once (first resolution) and read forever, so the probe needs no
@@ -250,10 +251,11 @@ struct IcacheSlotInfo {
 // Per-function pointer-typed global holding the frozen inline-cache slot: the
 // specialization pointer once resolved, null until then. Internal linkage (each
 // module's copy is wired into the runtime slot-pointer table by name at
-// registration). 8-byte aligned so the atomic acquire load / one-shot CAS the
-// runtime pairs against it are lock-free on aarch64. The wrapper reads it
-// DIRECTLY (load atomic acquire + null-check + indirect call) - no
-// ejit_icache_try call, no per-call guards - so the hit path is one load.
+// registration). 8-byte aligned so the load is a single lock-free access on
+// aarch64. The wrapper reads it DIRECTLY (plain load + null-check, then the
+// shared-epoch check, then the indirect call) - no ejit_icache_try call, no
+// per-call guards. The cell is core-private, so the fill and the read are
+// same-core and no atomic/acquire is needed.
 //
 // Multi-version: the global is a [D]^NumDims array (D = EJIT_ICACHE_DIM_SIZE,
 // power-of-2) indexed by the ejit_dim argument values, so each dim identity
@@ -315,7 +317,6 @@ static GlobalVariable *getOrCreateIcacheEpochGlobal(Module &M) {
     return Existing;
   }
   LLVMContext &Ctx = M.getContext();
-  auto *I32Ty = Type::getInt32Ty(Ctx);
   auto *PtrTy = PointerType::getUnqual(Ctx);
   auto *I64Ty = Type::getInt64Ty(Ctx);
   auto *Ty = StructType::get(Ctx, {I64Ty, PtrTy});
@@ -541,8 +542,9 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       FN_TASKPOOL_RELEASE_READ,
       FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false));
   // With -ejit-inline-cache the wrapper reads its per-function
-  // @__ejit_icache_fn_<name> slot directly (one atomic load + null-check +
-  // indirect call) - no ejit_icache_try call, no per-call guards.
+  // @__ejit_icache_fn_<name> slot directly (one plain load + null-check, the
+  // shared-epoch check, then the indirect call) - no ejit_icache_try call, no
+  // per-call guards.
 
   auto isAlreadyWrapped = [](Function &F) -> bool {
     if (!F.getEntryBlock().getName().starts_with("jit_entry"))

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-epoch.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-epoch.ll
@@ -51,6 +51,15 @@
 ; previous specialization, so no atomic/acquire is emitted.
 ; CHECK-NOT: load atomic
 
+; The CONSTRUCTOR path must carry the same two facts: the static registry above
+; is only walked when forceStaticRegistry is set or the constructor produced
+; nothing, so a default init sees ONLY these calls. Without the window, cells
+; fill normally while `shared` stays null and the first hit faults. The runtime
+; declines a slot it has no window for, hence the window is registered FIRST.
+; CHECK-LABEL: define internal void @ejit_auto_register()
+; CHECK: call void @ejit_register_icache_epoch(ptr @__ejit_icache_epoch, i32 2)
+; CHECK-NEXT: call void @ejit_register_icache_slot(ptr {{.*}}, ptr @__ejit_icache_fn_dim_entry, i32 1)
+
 ; Flag off: no probe, so nothing reads the epoch and the symbol never appears.
 ; OFF-NOT: __ejit_icache_epoch
 ; OFF-NOT: jit_icache_epoch

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-epoch.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-epoch.ll
@@ -34,10 +34,13 @@
 ; ... then the epoch check, which is only reached with a non-null cell -- so a
 ; fill has happened, so the runtime has bound `shared` and no null check on it
 ; is required.
+; seen/shared are core-private, so they stay plain loads. *shared is not: peers
+; update it with an RMW, so it is atomic. monotonic lowers to the same LDR on
+; AArch64; acquire would cost an LDAR per hit.
 ; CHECK: jit_icache_epoch:
 ; CHECK: %ejit_ic_seen = load i64, ptr @__ejit_icache_epoch, align 8
 ; CHECK: %ejit_ic_shared_p = load ptr, ptr getelementptr {{.*}} @__ejit_icache_epoch, i32 0, i32 1
-; CHECK: %ejit_ic_epoch = load i32, ptr %ejit_ic_shared_p
+; CHECK: %ejit_ic_epoch = load atomic i32, ptr %ejit_ic_shared_p monotonic, align 4
 ; CHECK: %ejit_icache_fresh = icmp eq
 ; CHECK: br i1 {{.*}}, label %jit_icache_dispatch, label %jit_miss
 
@@ -47,18 +50,15 @@
 ; CHECK: jit_miss:
 ; CHECK: musttail call i32 @dim_entry_miss(
 
-; Both loads are plain: a stale read costs at most one extra call into the
-; previous specialization, so no atomic/acquire is emitted.
-; CHECK-NOT: load atomic
+; The cell itself is core-private, so its load stays plain.
+; CHECK-NOT: %ejit_ic_fn = load atomic
 
-; The CONSTRUCTOR path must carry the same two facts: the static registry above
-; is only walked when forceStaticRegistry is set or the constructor produced
-; nothing, so a default init sees ONLY these calls. Without the window, cells
-; fill normally while `shared` stays null and the first hit faults. The runtime
-; declines a slot it has no window for, hence the window is registered FIRST.
+; The CONSTRUCTOR path carries the same two facts per entry, in one call (the
+; static registry above is only walked when forceStaticRegistry is set or the
+; constructor produced nothing). Per-entry, not a global handshake: that would
+; let a pre-epoch TU register against a newer TU's window in a mixed link.
 ; CHECK-LABEL: define internal void @ejit_auto_register()
-; CHECK: call void @ejit_register_icache_epoch(ptr @__ejit_icache_epoch, i32 2)
-; CHECK-NEXT: call void @ejit_register_icache_slot(ptr {{.*}}, ptr @__ejit_icache_fn_dim_entry, i32 1)
+; CHECK: call void @ejit_register_icache_slot(ptr {{.*}}, ptr @__ejit_icache_fn_dim_entry, i32 1, ptr @__ejit_icache_epoch, i32 2)
 
 ; Flag off: no probe, so nothing reads the epoch and the symbol never appears.
 ; OFF-NOT: __ejit_icache_epoch

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-epoch.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-epoch.ll
@@ -1,0 +1,70 @@
+; Inline-cache probe: shared-epoch freshness check.
+;
+; Cells are core-private, so a core that toggles a period cannot reach a peer's
+; cells -- it can only bump the shared icacheEpoch. The probe therefore reads
+; that epoch on EVERY call and treats a mismatch as a miss. Without this, a core
+; whose cells are all warm never enters the runtime, never observes the toggle,
+; and keeps running a specialization built for the previous period values.
+;
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s --check-prefix=OFF
+; RUN: opt -passes=ejit-wrapper-gen,ejit-wrapper-gen -ejit-inline-cache -S %s \
+; RUN:   | FileCheck %s --check-prefix=IDEM
+
+; The OBJECT owns the window -- a definition, not a declaration. If it were
+; extern, the probe's reference and the runtime's definition would have to be
+; matched by the linker, and a mismatch would leave them on different storage:
+; a zeroed window reads seen == *shared == 0, i.e. "always fresh", so every core
+; would keep hitting a stale cell with no diagnostic at all.
+; linkonce_odr merges the per-TU copies; hidden keeps the address at adrp+add.
+; CHECK: @__ejit_icache_epoch = linkonce_odr hidden global { i64, ptr } zeroinitializer
+
+; Its address reaches the runtime through the icache registry entry's spare
+; field (name2), so the runtime writes the bytes the probe reads. The i64 packs
+; the probe contract version above numDims.
+; CHECK: @.ejit.registry.icache {{.*}}ptr @__ejit_icache_epoch, ptr @__ejit_icache_fn_dim_entry, i64 8589934593
+
+; CHECK-LABEL: define i32 @dim_entry(
+; The cell load and its null test come first ...
+; CHECK: %ejit_ic_slot = getelementptr {{.*}} @__ejit_icache_fn_dim_entry
+; CHECK: %ejit_ic_fn = load ptr, ptr %ejit_ic_slot
+; CHECK: %ejit_icache_hit = icmp ne ptr %ejit_ic_fn, null
+; CHECK: br i1 {{.*}}, label %jit_icache_epoch, label %jit_miss
+
+; ... then the epoch check, which is only reached with a non-null cell -- so a
+; fill has happened, so the runtime has bound `shared` and no null check on it
+; is required.
+; CHECK: jit_icache_epoch:
+; CHECK: %ejit_ic_seen = load i64, ptr @__ejit_icache_epoch, align 8
+; CHECK: %ejit_ic_shared_p = load ptr, ptr getelementptr {{.*}} @__ejit_icache_epoch, i32 0, i32 1
+; CHECK: %ejit_ic_epoch = load i32, ptr %ejit_ic_shared_p
+; CHECK: %ejit_icache_fresh = icmp eq
+; CHECK: br i1 {{.*}}, label %jit_icache_dispatch, label %jit_miss
+
+; Stale -> the miss path, which drains this core's cells and re-resolves.
+; CHECK: jit_icache_dispatch:
+; CHECK: musttail call i32 %ejit_ic_fn(
+; CHECK: jit_miss:
+; CHECK: musttail call i32 @dim_entry_miss(
+
+; Both loads are plain: a stale read costs at most one extra call into the
+; previous specialization, so no atomic/acquire is emitted.
+; CHECK-NOT: load atomic
+
+; Flag off: no probe, so nothing reads the epoch and the symbol never appears.
+; OFF-NOT: __ejit_icache_epoch
+; OFF-NOT: jit_icache_epoch
+
+; Re-running the pass must not emit a second check.
+; IDEM-COUNT-1: %ejit_icache_fresh
+
+
+define i32 @dim_entry(i8 %idx) !ejit.metadata !0 {
+entry:
+  %c = zext i8 %idx to i32
+  ret i32 %c
+}
+
+!0 = !{!1, !2}
+!1 = !{!"ejit_entry", i32 1}
+!2 = !{!"ejit_period_arr_ind", !"cell", i32 0}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -76,14 +76,18 @@
 ; ICACHE: jit_icache_epoch:
 ; ICACHE: %ejit_ic_seen = load i64, ptr @__ejit_icache_epoch
 ; ICACHE: %ejit_ic_shared_p = load ptr, ptr getelementptr {{.*}} @__ejit_icache_epoch, i32 0, i32 1
-; ICACHE: %ejit_ic_epoch = load i32, ptr %ejit_ic_shared_p
+; The shared word is written by peers with an atomic RMW, so the probe reads it
+; atomically. monotonic lowers to the same LDR as a plain load on AArch64.
+; ICACHE: %ejit_ic_epoch = load atomic i32, ptr %ejit_ic_shared_p monotonic
 ; ICACHE: %ejit_icache_fresh = icmp eq
 ; ICACHE: br i1 {{.*}}, label %jit_icache_dispatch, label %jit_miss
 
-; --- registration carries numDims (3rd arg): 0 / 1 / 2 (DAG: order-independent). ---
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0)
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1)
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 2)
+; --- registration carries numDims (3rd arg): 0 / 1 / 2, and each entry carries
+; --- its OWN window + probe ABI so a mixed link cannot let a pre-epoch TU
+; --- register against a newer TU's window (DAG: order-independent). ---
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0, ptr @__ejit_icache_epoch, i32 2)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1, ptr @__ejit_icache_epoch, i32 2)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 2, ptr @__ejit_icache_epoch, i32 2)
 
 ; --- Default (flag OFF): no icache anywhere; original compile_or_get path. ---
 ; NOICACHE-LABEL: define i32 @one_dim_entry(

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -21,6 +21,7 @@
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-wrapper-timing -S %s | FileCheck %s --check-prefix=TIMING
 
 ; --- icache globals: [D]^numDims, D=8 (EJIT_ICACHE_DIM_SIZE). 0D is scalar. ---
+; ICACHE-DAG: @__ejit_icache_epoch = linkonce_odr hidden global { i64, ptr }
 ; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, align 8
 ; ICACHE-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, align 8
 ; ICACHE-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, align 8
@@ -68,6 +69,17 @@
 ; OPT-SAME: #[[MISS_ATTRS]]
 ; OPT-DAG: attributes #[[MISS_ATTRS]] = { cold noinline }
 
+; --- Epoch freshness: the probe compares this core's seen epoch against the
+; --- SHARED one on every call, so a core that only ever hits still observes a
+; --- period toggle performed by a core that cannot reach its cells. Checked
+; --- after the cell null test, so the shared pointer is known bound. ---
+; ICACHE: jit_icache_epoch:
+; ICACHE: %ejit_ic_seen = load i64, ptr @__ejit_icache_epoch
+; ICACHE: %ejit_ic_shared_p = load ptr, ptr getelementptr {{.*}} @__ejit_icache_epoch, i32 0, i32 1
+; ICACHE: %ejit_ic_epoch = load i32, ptr %ejit_ic_shared_p
+; ICACHE: %ejit_icache_fresh = icmp eq
+; ICACHE: br i1 {{.*}}, label %jit_icache_dispatch, label %jit_miss
+
 ; --- registration carries numDims (3rd arg): 0 / 1 / 2 (DAG: order-independent). ---
 ; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0)
 ; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1)
@@ -76,6 +88,7 @@
 ; --- Default (flag OFF): no icache anywhere; original compile_or_get path. ---
 ; NOICACHE-LABEL: define i32 @one_dim_entry(
 ; NOICACHE-NOT: __ejit_icache_fn
+; NOICACHE-NOT: __ejit_icache_epoch
 ; NOICACHE-NOT: ejit_register_icache_slot
 ; NOICACHE: call i32 @ejit_taskpool_compile_or_get_1d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
 

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -205,6 +205,16 @@ bool startOkIgnoreCtx(void * /*ctx*/,
   return true;
 }
 
+// A well-formed registration. In a correct link every entry names the one
+// linkonce_odr @__ejit_icache_epoch, so honour a window a test bound
+// explicitly. The mixed-version tests call the entry point directly.
+EJitIcacheEpochRef gTestWindow;
+bool registerSlot(uint32_t funcIndex, void *base, uint32_t numDims) {
+  void *w = ejitIcacheBoundWindow();
+  return ejitIcacheRegisterSlot(funcIndex, base, numDims,
+                                w ? w : &gTestWindow, kEJitIcacheProbeAbi);
+}
+
 EJitDimPair dim(uint32_t t, uint32_t i) { return EJitDimPair{t, i}; }
 
 class SharedTaskPoolTest : public ::testing::Test {
@@ -2685,7 +2695,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheStickyFrozen) {
   // Register a per-function icache slot (the wrapper's @__ejit_icache_fn_
   // global, here a test-local stand-in) so icacheFill has somewhere to write.
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
   // compile_or_get syncs at entry before every fill; mirror that here.
@@ -2738,9 +2748,12 @@ TEST_F(SharedTaskPoolTest, InlineCacheHighFuncIndex) {
   // Top of the table: funcIndex = EJIT_ICACHE_FUNC_SLOTS - 1.
   constexpr uint32_t kTop = EJIT_ICACHE_FUNC_SLOTS - 1;
   uintptr_t slotTop = 0;
-  ejitIcacheRegisterSlot(kTop, &slotTop, 0);
+  registerSlot(kTop, &slotTop, 0);
   void *fnTop = codeFor(kTop);
   void *out = nullptr;
+  // compile_or_get syncs at entry before every fill; mirror that here, or
+  // icacheFill drops the fill as raced by a toggle it never saw.
+  pool.icacheSyncEpoch();
 
   EXPECT_FALSE(pool.icacheTry(kTop, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
@@ -2751,7 +2764,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheHighFuncIndex) {
   // Mid-table index that the old 64-slot table would have dropped.
   constexpr uint32_t kMid = 2000;
   uintptr_t slotMid = 0;
-  ejitIcacheRegisterSlot(kMid, &slotMid, 0);
+  registerSlot(kMid, &slotMid, 0);
   void *fnMid = codeFor(kMid);
   pool.icacheFill(kMid, fnMid, nullptr, 0);
   EXPECT_TRUE(pool.icacheTry(kMid, nullptr, 0, &out));
@@ -2775,7 +2788,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
   pool.icacheSyncEpoch();
@@ -2816,7 +2829,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
   // runtime reaches cells through an EJitAtomicUPtr* + linearized index.
   constexpr uint32_t D = EJIT_ICACHE_DIM_SIZE;
   uintptr_t slots[D][D] = {};
-  ejitIcacheRegisterSlot(kFunc, &slots[0][0], 2);
+  registerSlot(kFunc, &slots[0][0], 2);
   pool.icacheSyncEpoch();
 
   void *fn00 = codeFor(kFunc);
@@ -3339,7 +3352,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheDrainsOnPeriodToggle) {
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
 
@@ -3408,7 +3421,7 @@ TEST_F(SharedTaskPoolTest, TwoCoresReconfiguringBothInvalidate) {
   bringUpOwner(pool);
   constexpr uint32_t kDim = 0, kInst = 5, kFunc = 9;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
 
@@ -3438,6 +3451,187 @@ TEST_F(SharedTaskPoolTest, TwoCoresReconfiguringBothInvalidate) {
   // consumer discards in-flight compiles. See NoTransitionDoesNotBumpVersion.
   EXPECT_EQ(pool.state()->version[kDim][kInst].loadAcquire(), vBeforeB);
   EXPECT_GT(pool.state()->version[kDim][kInst].loadAcquire(), v0);
+
+  ejitIcacheClearAll();
+}
+
+//===----------------------------------------------------------------------===//
+// Mixed-version links: the probe contract travels per entry, so a TU built
+// before the epoch check existed can never register against a newer TU's
+// window and get cells its probe cannot invalidate.
+//===----------------------------------------------------------------------===//
+
+// New TU first, then old. The old TU must NOT inherit the bound window.
+TEST_F(SharedTaskPoolTest, MixedVersionNewThenOldDeclinesTheOldTU) {
+  ejitIcacheClearAll();
+  EJitIcacheEpochRef windowNew{};
+  uintptr_t cellNew = 0, cellOld = 0;
+
+  EXPECT_TRUE(ejitIcacheRegisterSlot(1, &cellNew, 0, &windowNew,
+                                     kEJitIcacheProbeAbi));
+  ASSERT_EQ(ejitIcacheBoundWindow(), &windowNew);
+
+  // A pre-epoch object reports ABI 0 and brings no window; a global gate would
+  // say "a window is bound, go ahead".
+  EXPECT_FALSE(ejitIcacheRegisterSlot(2, &cellOld, 0, nullptr, 0))
+      << "a pre-epoch TU rode in on the new TU's window";
+  // Naming the window does not help it either: the version is what is checked.
+  EXPECT_FALSE(ejitIcacheRegisterSlot(2, &cellOld, 0, &windowNew, 0));
+  EXPECT_FALSE(ejitIcacheRegisterSlot(2, &cellOld, 0, &windowNew, 1));
+
+  ejitIcacheClearAll();
+}
+
+// Old TU first: it is declined and leaves nothing bound, so the new TU still
+// comes up with a working cache.
+TEST_F(SharedTaskPoolTest, MixedVersionOldThenNewStillServesTheNewTU) {
+  ejitIcacheClearAll();
+  EJitIcacheEpochRef windowNew{};
+  uintptr_t cellOld = 0, cellNew = 0;
+
+  EXPECT_FALSE(ejitIcacheRegisterSlot(1, &cellOld, 0, nullptr, 0));
+  EXPECT_EQ(ejitIcacheBoundWindow(), nullptr)
+      << "a declined entry must not bind a window";
+
+  EXPECT_TRUE(ejitIcacheRegisterSlot(2, &cellNew, 0, &windowNew,
+                                     kEJitIcacheProbeAbi));
+  EXPECT_EQ(ejitIcacheBoundWindow(), &windowNew);
+
+  ejitIcacheClearAll();
+}
+
+// A future version means obligations this runtime does not implement.
+TEST_F(SharedTaskPoolTest, FutureProbeAbiIsRejected) {
+  ejitIcacheClearAll();
+  EJitIcacheEpochRef window{};
+  uintptr_t cell = 0;
+  EXPECT_FALSE(ejitIcacheRegisterSlot(1, &cell, 0, &window,
+                                      kEJitIcacheProbeAbi + 1));
+  EXPECT_EQ(ejitIcacheBoundWindow(), nullptr);
+  ejitIcacheClearAll();
+}
+
+// Two window addresses means the linkonce_odr copies were not merged, so one
+// probe would read storage the runtime never writes.
+TEST_F(SharedTaskPoolTest, ConflictingEpochWindowIsRejected) {
+  ejitIcacheClearAll();
+  EJitIcacheEpochRef windowA{}, windowB{};
+  uintptr_t cellA = 0, cellB = 0;
+
+  EXPECT_TRUE(ejitIcacheRegisterSlot(1, &cellA, 0, &windowA,
+                                     kEJitIcacheProbeAbi));
+  EXPECT_FALSE(ejitIcacheRegisterSlot(2, &cellB, 0, &windowB,
+                                      kEJitIcacheProbeAbi));
+  EXPECT_EQ(ejitIcacheBoundWindow(), &windowA) << "the first binding stands";
+
+  ejitIcacheClearAll();
+}
+
+// A declined entry is never half wired up: its cell stays null, so the taskpool
+// serves every call.
+TEST_F(SharedTaskPoolTest, DeclinedEntryLeavesNoCellWired) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 6;
+  uintptr_t cell = 0;
+  void *out = nullptr;
+
+  EXPECT_FALSE(ejitIcacheRegisterSlot(kFunc, &cell, 0, nullptr, 0));
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0);
+
+  EXPECT_EQ(cell, 0u) << "a declined entry must never be filled";
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  ejitIcacheClearAll();
+}
+
+// The drain walks only the index range this core actually filled. It must NOT
+// stop at the first zero cell: fills land at the dim identity, so a core using
+// instance 5 alone leaves 0..4 zero with a live pointer behind them.
+TEST_F(SharedTaskPoolTest, DrainClearsSparseCellsBeyondALeadingHole) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 4;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  ASSERT_TRUE(registerSlot(kFunc, cells, 1));
+
+  pool.icacheSyncEpoch();
+  const EJitDimPair five[1] = {{0, 5}};
+  const EJitDimPair eleven[1] = {{0, 11}};
+  pool.icacheFill(kFunc, codeFor(kFunc), five, 1);
+  pool.icacheFill(kFunc, codeFor(kFunc + 1), eleven, 1);
+  ASSERT_NE(cells[5], 0u);
+  ASSERT_NE(cells[11], 0u);
+  ASSERT_EQ(cells[0], 0u) << "the leading hole the drain must not stop at";
+
+  pool.setInstanceEnabled(0, 5, true);
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  for (uint32_t i = 0; i < EJIT_ICACHE_DIM_SIZE; ++i)
+    EXPECT_EQ(cells[i], 0u) << "cell " << i << " survived the drain";
+
+  ejitIcacheClearAll();
+}
+
+// More distinct identities than the slot records: the drain falls back to the
+// whole array rather than clearing only the ones it remembered.
+TEST_F(SharedTaskPoolTest, DrainFallsBackWhenTheFilledListOverflows) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 9;
+  // A 2D entry: 256 cells, so more distinct identities than the list holds.
+  constexpr uint32_t kUsed = EJIT_ICACHE_DRAIN_LIST + 4u;
+  static_assert(kUsed <= EJIT_ICACHE_DIM_SIZE * EJIT_ICACHE_DIM_SIZE,
+                "need more cells than the list holds to exercise the fallback");
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE][EJIT_ICACHE_DIM_SIZE] = {};
+  ASSERT_TRUE(registerSlot(kFunc, &cells[0][0], 2));
+  pool.icacheSyncEpoch();
+
+  for (uint32_t i = 0; i < kUsed; ++i) {
+    const EJitDimPair d[2] = {{0, i / EJIT_ICACHE_DIM_SIZE},
+                              {1, i % EJIT_ICACHE_DIM_SIZE}};
+    pool.icacheFill(kFunc, codeFor(kFunc + i), d, 2);
+  }
+  for (uint32_t i = 0; i < kUsed; ++i)
+    ASSERT_NE(cells[i / EJIT_ICACHE_DIM_SIZE][i % EJIT_ICACHE_DIM_SIZE], 0u)
+        << "identity " << i;
+
+  pool.setInstanceEnabled(0, 1, true);
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  for (uint32_t i = 0; i < kUsed; ++i)
+    EXPECT_EQ(cells[i / EJIT_ICACHE_DIM_SIZE][i % EJIT_ICACHE_DIM_SIZE], 0u)
+        << "identity " << i << " survived the overflow drain";
+
+  ejitIcacheClearAll();
+}
+
+// A slot with no fills since the last drain is skipped entirely, so an
+// untouched 4D entry costs nothing instead of 16^4 stores.
+TEST_F(SharedTaskPoolTest, DrainSkipsSlotsWithNoFills) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 7;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  ASSERT_TRUE(registerSlot(kFunc, cells, 1));
+  pool.icacheSyncEpoch();
+
+  // Poison a cell behind the runtime's back: a drain that thinks this slot has
+  // fills would clear it, one that tracks fills correctly leaves it alone.
+  cells[3] = 0xDEADBEEF;
+  pool.setInstanceEnabled(0, 1, true);
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_EQ(cells[3], 0xDEADBEEFu) << "drained a slot it never filled";
+
+  // ...and once really filled, the next drain does clear it.
+  const EJitDimPair d[1] = {{0, 3}};
+  pool.icacheFill(kFunc, codeFor(kFunc), d, 1);
+  pool.setInstanceEnabled(0, 1, false);
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_EQ(cells[3], 0u);
 
   ejitIcacheClearAll();
 }
@@ -3478,8 +3672,8 @@ TEST_F(SharedTaskPoolTest, InlineCacheDrainCoversAllCellsAndFunctions) {
   constexpr uint32_t kFuncB = 7;
   uintptr_t cells2d[D][D] = {};
   uintptr_t cell0d = 0;
-  ejitIcacheRegisterSlot(kFuncA, &cells2d[0][0], 2);
-  ejitIcacheRegisterSlot(kFuncB, &cell0d, 0);
+  registerSlot(kFuncA, &cells2d[0][0], 2);
+  registerSlot(kFuncB, &cell0d, 0);
 
   // Fill the corners of the 2-dim array (including the LAST cell, which catches
   // a drain that under-counts the array) plus the unrelated 0-dim function.
@@ -3516,7 +3710,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheDrainsAgainstADifferentBlob) {
   // Blob A: arm, warm, and leave the core's seen-epoch at A's CURRENT value.
   EJitSharedTaskPool poolA;
   bringUpOwner(poolA); // binds the fixture's state_
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   poolA.icacheSyncEpoch();
   poolA.icacheFill(kFunc, fn, nullptr, 0);
   ASSERT_TRUE(poolA.icacheTry(kFunc, nullptr, 0, &out));
@@ -3555,7 +3749,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheDrainsAcrossAReInitialization) {
 
   EJitSharedTaskPool poolA;
   bringUpOwner(poolA);
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   poolA.icacheSyncEpoch();
   poolA.icacheFill(kFunc, fn, nullptr, 0);
   ASSERT_TRUE(poolA.icacheTry(kFunc, nullptr, 0, &out));
@@ -3584,7 +3778,7 @@ TEST_F(SharedTaskPoolTest, DeactivateReactivateServesTheNewSpecialization) {
   constexpr uint32_t kFunc = 3;
   constexpr uint32_t kDim = 0, kInst = 5;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *fnOldValues = codeFor(kFunc);
   void *fnNewValues = codeFor(kFunc + 1);
   ASSERT_NE(fnOldValues, fnNewValues);
@@ -3629,7 +3823,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheRejectsOutOfCapNumDims) {
   // A one-cell array deliberately registered with a wildly wrong shape. If
   // registration accepted it, the drain below would run off the end of it.
   uintptr_t lone = 0x1234;
-  ejitIcacheRegisterSlot(kFunc, &lone, EJIT_ICACHE_MAX_DIMS + 1u);
+  registerSlot(kFunc, &lone, EJIT_ICACHE_MAX_DIMS + 1u);
 
   void *out = nullptr;
   EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out)) << "slot must be unregistered";
@@ -3642,7 +3836,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheRejectsOutOfCapNumDims) {
   // off-by-one that disables legitimate 4-dim entries.
   ejitIcacheClearAll();
   std::vector<uintptr_t> maxCells(1u << (4u * 4u), 0); // D=16 ^ 4 dims
-  ejitIcacheRegisterSlot(kFunc, maxCells.data(), EJIT_ICACHE_MAX_DIMS);
+  registerSlot(kFunc, maxCells.data(), EJIT_ICACHE_MAX_DIMS);
   pool.icacheSyncEpoch();
   EJitDimPair d4[4] = {{0, 1}, {0, 2}, {0, 3}, {0, 4}};
   pool.icacheFill(kFunc, codeFor(kFunc), d4, 4);
@@ -3664,7 +3858,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheDrainStillRunsWhileAReleaserIsWired) {
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *out = nullptr;
 
   pool.icacheSyncEpoch();
@@ -3698,7 +3892,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheSlotRegisteredAfterADrainIsUsable) {
   uintptr_t early = 0, late = 0xDEAD;
   void *out = nullptr;
 
-  ejitIcacheRegisterSlot(kEarly, &early, 0);
+  registerSlot(kEarly, &early, 0);
   pool.icacheSyncEpoch();
   pool.icacheFill(kEarly, codeFor(kEarly), nullptr, 0);
   ASSERT_TRUE(pool.icacheTry(kEarly, nullptr, 0, &out));
@@ -3708,7 +3902,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheSlotRegisteredAfterADrainIsUsable) {
   EXPECT_EQ(early, 0u);
 
   // Registered only now: the drain already ran, so nothing zeroed this cell.
-  ejitIcacheRegisterSlot(kLate, &late, 0);
+  registerSlot(kLate, &late, 0);
   late = 0; // the wrapper's global is zero-initialised in .bss
   pool.icacheFill(kLate, codeFor(kLate), nullptr, 0);
   EXPECT_TRUE(pool.icacheTry(kLate, nullptr, 0, &out));
@@ -3732,7 +3926,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheFillDroppedWhenAToggleRacesTheResolve) {
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
 
@@ -3765,7 +3959,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheResolveFillSurvivesAPendingDrain) {
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *stale = codeFor(kFunc);
   void *fresh = codeFor(kFunc + 1);
   void *out = nullptr;
@@ -3845,7 +4039,7 @@ TEST_F(SharedTaskPoolTest, IcacheEpochRefDivergesOnToggleWithoutAnySync) {
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 11;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
 
   pool.icacheSyncEpoch();
   pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0);

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -3575,35 +3575,80 @@ TEST_F(SharedTaskPoolTest, DrainClearsSparseCellsBeyondALeadingHole) {
   ejitIcacheClearAll();
 }
 
-// More distinct identities than the slot records: the drain falls back to the
-// whole array rather than clearing only the ones it remembered.
+// More filled cells than the global log holds: the drain falls back to walking
+// the slot table and whole-array clearing every touched slot, instead of
+// clearing only the cells it managed to record.
 TEST_F(SharedTaskPoolTest, DrainFallsBackWhenTheFilledListOverflows) {
   ejitIcacheClearAll();
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 9;
-  // A 2D entry: 256 cells, so more distinct identities than the list holds.
+  constexpr uint32_t kD = EJIT_ICACHE_DIM_SIZE;
+  // A 3D entry: kD^3 cells, so this one slot alone can outrun the log.
   constexpr uint32_t kUsed = EJIT_ICACHE_DRAIN_LIST + 4u;
-  static_assert(kUsed <= EJIT_ICACHE_DIM_SIZE * EJIT_ICACHE_DIM_SIZE,
-                "need more cells than the list holds to exercise the fallback");
-  uintptr_t cells[EJIT_ICACHE_DIM_SIZE][EJIT_ICACHE_DIM_SIZE] = {};
-  ASSERT_TRUE(registerSlot(kFunc, &cells[0][0], 2));
+  static_assert(kUsed <= kD * kD * kD,
+                "need more cells than the log holds to exercise the fallback");
+  // Flat, in the row-major order icacheLinearize produces, so the identity
+  // (i/kD^2, (i/kD)%kD, i%kD) lands exactly on cells[i].
+  uintptr_t cells[kD * kD * kD] = {};
+  ASSERT_TRUE(registerSlot(kFunc, cells, 3));
   pool.icacheSyncEpoch();
 
   for (uint32_t i = 0; i < kUsed; ++i) {
-    const EJitDimPair d[2] = {{0, i / EJIT_ICACHE_DIM_SIZE},
-                              {1, i % EJIT_ICACHE_DIM_SIZE}};
-    pool.icacheFill(kFunc, codeFor(kFunc + i), d, 2);
+    const EJitDimPair d[3] = {
+        {0, i / (kD * kD)}, {1, (i / kD) % kD}, {2, i % kD}};
+    pool.icacheFill(kFunc, codeFor(kFunc + i), d, 3);
   }
   for (uint32_t i = 0; i < kUsed; ++i)
-    ASSERT_NE(cells[i / EJIT_ICACHE_DIM_SIZE][i % EJIT_ICACHE_DIM_SIZE], 0u)
-        << "identity " << i;
+    ASSERT_NE(cells[i], 0u) << "identity " << i;
 
   pool.setInstanceEnabled(0, 1, true);
   EXPECT_TRUE(pool.icacheSyncEpoch());
   for (uint32_t i = 0; i < kUsed; ++i)
-    EXPECT_EQ(cells[i / EJIT_ICACHE_DIM_SIZE][i % EJIT_ICACHE_DIM_SIZE], 0u)
+    EXPECT_EQ(cells[i], 0u)
         << "identity " << i << " survived the overflow drain";
+
+  ejitIcacheClearAll();
+}
+
+// The drain log is ONE table shared by every slot, so a drain has to resolve
+// each entry back to its own slot. Interleaving fills across slots would come
+// out right for free with a per-slot list; with a shared log it is the thing
+// that can break, and a cell drained against the wrong base is a silent stale
+// hit. Stays under the cap so this exercises the precise path, not the walk.
+TEST_F(SharedTaskPoolTest, DrainLogIsSharedAcrossSlots) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kSlots = 8;
+  constexpr uint32_t kD = EJIT_ICACHE_DIM_SIZE;
+  static_assert(kSlots * 2 <= EJIT_ICACHE_DRAIN_LIST,
+                "must stay under the cap to test the precise drain path");
+  uintptr_t cells[kSlots][kD] = {};
+  for (uint32_t s = 0; s < kSlots; ++s)
+    ASSERT_TRUE(registerSlot(s, cells[s], 1));
+  pool.icacheSyncEpoch();
+
+  // Two identities per slot, interleaved so no slot's entries are contiguous.
+  for (uint32_t id : {3u, 11u})
+    for (uint32_t s = 0; s < kSlots; ++s) {
+      const EJitDimPair d[1] = {{0, id}};
+      pool.icacheFill(s, codeFor(s * kD + id), d, 1);
+    }
+  for (uint32_t s = 0; s < kSlots; ++s) {
+    ASSERT_NE(cells[s][3], 0u) << "slot " << s;
+    ASSERT_NE(cells[s][11], 0u) << "slot " << s;
+    cells[s][7] = 0xDEADBEEF; // never filled: the precise drain must miss it
+  }
+
+  pool.setInstanceEnabled(0, 1, true);
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  for (uint32_t s = 0; s < kSlots; ++s) {
+    EXPECT_EQ(cells[s][3], 0u) << "slot " << s << " identity 3 survived";
+    EXPECT_EQ(cells[s][11], 0u) << "slot " << s << " identity 11 survived";
+    EXPECT_EQ(cells[s][7], 0xDEADBEEFu)
+        << "slot " << s << " lost a cell it never filled";
+  }
 
   ejitIcacheClearAll();
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -3428,17 +3428,43 @@ TEST_F(SharedTaskPoolTest, TwoCoresReconfiguringBothInvalidate) {
   const uint32_t vBeforeB = pool.state()->version[kDim][kInst].loadAcquire();
   EXPECT_FALSE(pool.setInstanceEnabled(kDim, kInst, true)); // core B activate
 
-  // Core B's bracket moved the version, so a specialization compiled against
-  // anything core A published is rejected by versionsCurrent ...
-  EXPECT_GT(pool.state()->version[kDim][kInst].loadAcquire(), vBeforeB)
-      << "core B's reconfiguration never reached the taskpool";
-  EXPECT_GT(pool.state()->version[kDim][kInst].loadAcquire(), v0);
-  // ... and it moved the icache epoch, so every core drains its cells.
+  // Core B's bracket moved the icache epoch, so every core drains its cells --
+  // which is what makes its write visible, since a cell holds no version.
   EXPECT_TRUE(pool.icacheSyncEpoch());
   EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(slot, 0u);
 
+  // version[] does NOT move for core B: it changed no shared state, and its
+  // consumer discards in-flight compiles. See NoTransitionDoesNotBumpVersion.
+  EXPECT_EQ(pool.state()->version[kDim][kInst].loadAcquire(), vBeforeB);
+  EXPECT_GT(pool.state()->version[kDim][kInst].loadAcquire(), v0);
+
   ejitIcacheClearAll();
+}
+
+// A call that moves no shared state must not bump version[]. runCompile's
+// checkpoints DISCARD a finished compile when the version changes, and nothing
+// re-enqueues a dropped one -- so a redundant activate that bumped the version
+// would abort whatever the worker had in flight, permanently. Every core
+// activating the periods it shares is the normal startup shape, so this is the
+// difference between the JIT publishing and the JIT never publishing at all.
+TEST_F(SharedTaskPoolTest, NoTransitionDoesNotBumpVersion) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kDim = 0, kInst = 3;
+
+  ASSERT_TRUE(pool.setInstanceEnabled(kDim, kInst, true)); // first core wins
+  const uint32_t v = pool.state()->version[kDim][kInst].loadAcquire();
+  const uint32_t e = pool.state()->icacheEpoch.loadAcquire();
+
+  // 20 more cores activate the same instance, as they do at startup.
+  for (int i = 0; i < 20; ++i)
+    EXPECT_FALSE(pool.setInstanceEnabled(kDim, kInst, true));
+
+  EXPECT_EQ(pool.state()->version[kDim][kInst].loadAcquire(), v)
+      << "a redundant activate aborts every in-flight compile";
+  // The epochs still move: those callers may have rewritten core-private data.
+  EXPECT_GT(pool.state()->icacheEpoch.loadAcquire(), e);
 }
 
 // The drain covers EVERY cell of a multi-dim array and every registered

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -3383,13 +3383,60 @@ TEST_F(SharedTaskPoolTest, InlineCacheDrainsOnPeriodToggle) {
   EXPECT_TRUE(pool.icacheSyncEpoch());
   EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
 
-  // A rejected toggle (already in that state) does NOT bump the epoch, so it
-  // does not cost a spurious drain.
+  // A toggle that does not move the BIT still drains: it is a second core
+  // bracketing its own period writes over the shared bit -- see
+  // TwoCoresReconfiguringBothInvalidate.
   pool.icacheFill(kFunc, fn, nullptr, 0);
-  EXPECT_FALSE(pool.setInstanceEnabled(0, 5, false)); // already disabled
-  EXPECT_FALSE(pool.icacheSyncEpoch());
-  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
-  EXPECT_EQ(out, fn);
+  EXPECT_FALSE(pool.setInstanceEnabled(0, 5, false)); // bit already 0 ...
+  EXPECT_TRUE(pool.icacheSyncEpoch());                // ... but still published
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, nullptr);
+
+  ejitIcacheClearAll();
+}
+
+// Why the drain above is not gated on the enabled bit moving.
+//
+// Period DATA is core-private; the specialization compiled from it is SHARED, so
+// every core brackets its own writes over one shared enabled bit and only the
+// first in each direction wins the CAS. Publishing on the transition alone loses
+// every other core: their writes land in a window nothing announced, and they
+// keep being served a peer's pre-write values -- silently, forever.
+TEST_F(SharedTaskPoolTest, TwoCoresReconfiguringBothInvalidate) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kDim = 0, kInst = 5, kFunc = 9;
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  ASSERT_TRUE(pool.setInstanceEnabled(kDim, kInst, true)); // steady state
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  ASSERT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  // Interleave two cores exactly as the SRE reconfiguration path does. Core A
+  // wins both CASes; core B loses both, and it is core B's write (between the
+  // two calls it makes) that must still be announced.
+  const uint32_t v0 = pool.state()->version[kDim][kInst].loadAcquire();
+  EXPECT_TRUE(pool.setInstanceEnabled(kDim, kInst, false));  // core A deactivate
+  EXPECT_FALSE(pool.setInstanceEnabled(kDim, kInst, false)); // core B deactivate
+  EXPECT_TRUE(pool.setInstanceEnabled(kDim, kInst, true));   // core A activate
+  // ... core B writes ITS copy of the period values here ...
+  const uint32_t vBeforeB = pool.state()->version[kDim][kInst].loadAcquire();
+  EXPECT_FALSE(pool.setInstanceEnabled(kDim, kInst, true)); // core B activate
+
+  // Core B's bracket moved the version, so a specialization compiled against
+  // anything core A published is rejected by versionsCurrent ...
+  EXPECT_GT(pool.state()->version[kDim][kInst].loadAcquire(), vBeforeB)
+      << "core B's reconfiguration never reached the taskpool";
+  EXPECT_GT(pool.state()->version[kDim][kInst].loadAcquire(), v0);
+  // ... and it moved the icache epoch, so every core drains its cells.
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(slot, 0u);
 
   ejitIcacheClearAll();
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -3711,4 +3711,94 @@ TEST_F(SharedTaskPoolTest, InlineCacheResolveFillSurvivesAPendingDrain) {
   ejitIcacheClearAll();
 }
 
+//===----------------------------------------------------------------------===//
+// __ejit_icache_epoch: the window the AOT probe reads on every call.
+//
+// These assert the CONDITION the probe evaluates (seen == *shared), not
+// icacheTry -- icacheTry models a raw cell read and deliberately does not check
+// the epoch, because it stands in for the cell load alone.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, IcacheEpochRefIsBoundBySync) {
+  ejitIcacheClearAll();
+  // Stand in for the AOT-emitted @__ejit_icache_epoch: the runtime writes
+  // through the address it is given, so the test can watch the exact bytes a
+  // probe would read.
+  EJitIcacheEpochRef window{};
+  ejitIcacheBindEpochWindow(&window);
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+
+  pool.icacheSyncEpoch();
+
+  // Bound at the blob's epoch word: this is what lets the probe observe a
+  // toggle performed by a core that cannot reach this core's cells.
+  ASSERT_EQ(window.shared, pool.state()->icacheEpoch.raw());
+  EXPECT_EQ(window.seen, *window.shared)
+      << "probe would take the miss path with nothing having changed";
+
+  ejitIcacheBindEpochWindow(nullptr);
+  ejitIcacheClearAll();
+}
+
+// The window the runtime writes MUST be the one the probe reads. Binding by
+// address is what guarantees it; this pins that contract.
+TEST_F(SharedTaskPoolTest, IcacheEpochWindowIsTheBoundObject) {
+  ejitIcacheClearAll();
+  EJitIcacheEpochRef windowA{}, windowB{};
+  ejitIcacheBindEpochWindow(&windowA);
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  pool.icacheSyncEpoch();
+  ASSERT_NE(windowA.shared, nullptr);
+
+  // Rebinding moves every subsequent publish to the new object, and the old one
+  // is left untouched -- an unbound/stale window never silently keeps updating.
+  const uint64_t staleSeen = windowA.seen;
+  ejitIcacheBindEpochWindow(&windowB);
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 3, true));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_EQ(windowA.seen, staleSeen) << "unbound window still being written";
+  EXPECT_EQ(windowB.seen, *windowB.shared);
+
+  ejitIcacheBindEpochWindow(nullptr);
+  ejitIcacheClearAll();
+}
+
+TEST_F(SharedTaskPoolTest, IcacheEpochRefDivergesOnToggleWithoutAnySync) {
+  ejitIcacheClearAll();
+  EJitIcacheEpochRef window{};
+  ejitIcacheBindEpochWindow(&window);
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 11;
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0);
+  ASSERT_NE(slot, 0u); // warm: this core would now hit forever
+
+  // Steady state: probe passes, so a hit dispatches.
+  ASSERT_EQ(window.seen, *window.shared);
+
+  // A toggle on ANOTHER core. This core does NOT sync -- it is the "always
+  // hits, never enters the runtime" case the drain alone cannot reach.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 7, true));
+
+  // The cell is still warm (nothing drained it) ...
+  EXPECT_NE(slot, 0u);
+  // ... but the probe's comparison now FAILS, so the call takes the miss path
+  // and gets drained there. This is the whole point of the shared epoch.
+  EXPECT_NE(window.seen, *window.shared)
+      << "a core that only ever hits would keep running the old specialization";
+
+  // Taking the miss path drains and re-arms: the probe passes again.
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_EQ(slot, 0u);
+  EXPECT_EQ(window.seen, *window.shared);
+
+  ejitIcacheBindEpochWindow(nullptr);
+  ejitIcacheClearAll();
+}
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1646,12 +1646,13 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
   EXPECT_TRUE(r.readyButNotShareable);
 }
 
-// 16/17 ABI v7 layout: the slot carries the executable range as fixed-width,
+// 16/17 ABI v8 layout: the slot carries the executable range as fixed-width,
 // naturally-aligned scalars (read back by value — endian-safe), the pool-split
-// table is POD, dump state contains metadata only, and each bucket carries the
-// NO_RECLAIM seqlock publishSeq word.
+// table is POD, dump state contains metadata only, each bucket carries the
+// NO_RECLAIM seqlock publishSeq word, and the SwitchController line carries
+// icacheEpoch.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 7u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 8u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -2687,6 +2688,8 @@ TEST_F(SharedTaskPoolTest, InlineCacheStickyFrozen) {
   ejitIcacheRegisterSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
+  // compile_or_get syncs at entry before every fill; mirror that here.
+  pool.icacheSyncEpoch();
 
   // Cold icache misses (empty slot).
   EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
@@ -2697,9 +2700,10 @@ TEST_F(SharedTaskPoolTest, InlineCacheStickyFrozen) {
   EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
 
-  // Frozen: a period toggle bumps the version, but v2 does NOT re-validate, so
-  // the cached specialization is still served (the slot is never refilled or
-  // invalidated). This is the v2 contract - the specialization is invariant.
+  // Frozen between syncs: a period toggle bumps the version, and the cell holds
+  // no version, so the cached specialization is still served until this core
+  // syncs. Invalidation is published (icacheEpoch) and observed per core, never
+  // re-checked on the probe -- see InlineCacheDrainsOnPeriodToggle.
   ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
   ASSERT_TRUE(pool.setInstanceEnabled(0, 5, false)); // bump version
   EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
@@ -2774,6 +2778,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
   ejitIcacheRegisterSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
+  pool.icacheSyncEpoch();
 
   // Before a releaser: fill -> hit.
   pool.icacheFill(kFunc, fn, nullptr, 0);
@@ -2812,6 +2817,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
   constexpr uint32_t D = EJIT_ICACHE_DIM_SIZE;
   uintptr_t slots[D][D] = {};
   ejitIcacheRegisterSlot(kFunc, &slots[0][0], 2);
+  pool.icacheSyncEpoch();
 
   void *fn00 = codeFor(kFunc);
   void *fn01 = codeFor(kFunc + 1);
@@ -3320,6 +3326,389 @@ TEST_F(SharedTaskPoolTest, AsyncServiceUnavailableWithoutAWorker) {
   ASSERT_EQ(state_->initState.loadAcquire(),
             static_cast<uint32_t>(EJitSharedInitState::Ready));
   EXPECT_FALSE(owner.asyncServiceAvailable());
+}
+
+//===----------------------------------------------------------------------===//
+// Epoch-driven drain: a period toggle cannot invalidate a cell (no version in
+// the cell) and cannot reach a peer core (cells are core-private), so the
+// toggle publishes icacheEpoch and each core drains its own table on sync.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, InlineCacheDrainsOnPeriodToggle) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  // Arm this core against the blob FIRST (the initial sync always drains, which
+  // is what makes a core that boots with a stale table safe), then warm.
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  ASSERT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  ASSERT_EQ(out, fn);
+
+  // No toggle -> sync reports no drain and the warm cell SURVIVES. (Guards
+  // against a drain that fires unconditionally, which would make the assertions
+  // below pass for the wrong reason.)
+  EXPECT_FALSE(pool.icacheSyncEpoch());
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+
+  // Activate: the epoch moves, but the probe still hits until this core syncs
+  // -- the drain is observed, never checked on the hit path.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+
+  // Sync -> drained: the cell is empty and the next call must re-resolve.
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, nullptr);
+  EXPECT_EQ(slot, 0u);
+
+  // Idempotent: a second sync with no further toggle does nothing.
+  EXPECT_FALSE(pool.icacheSyncEpoch());
+
+  // The registration SURVIVES the drain (unlike ejitIcacheClearAll, which
+  // unregisters), so the next resolve refills the same wired cell.
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+
+  // Deactivate drains too -- both directions of the toggle bump the epoch.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, false));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  // A rejected toggle (already in that state) does NOT bump the epoch, so it
+  // does not cost a spurious drain.
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_FALSE(pool.setInstanceEnabled(0, 5, false)); // already disabled
+  EXPECT_FALSE(pool.icacheSyncEpoch());
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+
+  ejitIcacheClearAll();
+}
+
+// The drain covers EVERY cell of a multi-dim array and every registered
+// function, not just the one that happened to be probed.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainCoversAllCellsAndFunctions) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t D = EJIT_ICACHE_DIM_SIZE;
+  constexpr uint32_t kFuncA = 3;
+  constexpr uint32_t kFuncB = 7;
+  uintptr_t cells2d[D][D] = {};
+  uintptr_t cell0d = 0;
+  ejitIcacheRegisterSlot(kFuncA, &cells2d[0][0], 2);
+  ejitIcacheRegisterSlot(kFuncB, &cell0d, 0);
+
+  // Fill the corners of the 2-dim array (including the LAST cell, which catches
+  // a drain that under-counts the array) plus the unrelated 0-dim function.
+  EJitDimPair id00[2] = {{0, 0}, {0, 0}};
+  EJitDimPair idLast[2] = {{0, D - 1}, {0, D - 1}};
+  pool.icacheSyncEpoch(); // arm before warming
+  pool.icacheFill(kFuncA, codeFor(kFuncA), id00, 2);
+  pool.icacheFill(kFuncA, codeFor(kFuncA + 1), idLast, 2);
+  pool.icacheFill(kFuncB, codeFor(kFuncB), nullptr, 0);
+  ASSERT_NE(cells2d[0][0], 0u);
+  ASSERT_NE(cells2d[D - 1][D - 1], 0u);
+  ASSERT_NE(cell0d, 0u);
+
+  ASSERT_TRUE(pool.setInstanceEnabled(1, 2, true));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+
+  EXPECT_EQ(cells2d[0][0], 0u);
+  EXPECT_EQ(cells2d[D - 1][D - 1], 0u);
+  EXPECT_EQ(cell0d, 0u); // a toggle on ANY instance drains every function
+
+  ejitIcacheClearAll();
+}
+
+// A fresh shared blob restarts icacheEpoch from a low value that a stale
+// seen-epoch can match by coincidence, so the sync keys on the blob identity
+// too. Without that, cells filled against the previous blob would survive.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainsAgainstADifferentBlob) {
+  ejitIcacheClearAll();
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  // Blob A: arm, warm, and leave the core's seen-epoch at A's CURRENT value.
+  EJitSharedTaskPool poolA;
+  bringUpOwner(poolA); // binds the fixture's state_
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  poolA.icacheSyncEpoch();
+  poolA.icacheFill(kFunc, fn, nullptr, 0);
+  ASSERT_TRUE(poolA.icacheTry(kFunc, nullptr, 0, &out));
+  ASSERT_EQ(out, fn);
+  const uint32_t seenEpoch = poolA.state()->icacheEpoch.loadAcquire();
+
+  // Blob B: a genuinely separate region, whose epoch is forced to EQUAL the
+  // epoch this core last synced against. The epoch comparison alone therefore
+  // says "up to date" and only the blob-identity check can catch this.
+  auto stateB = std::make_unique<EJitSharedTaskPoolState>();
+  EJitSharedTaskPool poolB;
+  EJitCoreId::setCurrentForTest(0);
+  poolB.bind(stateB.get());
+  poolB.setCompiler(&mockCompile, nullptr);
+  poolB.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(poolB.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  ASSERT_NE(poolB.state(), poolA.state());
+  stateB->icacheEpoch.storeRelease(seenEpoch);
+
+  EXPECT_TRUE(poolB.icacheSyncEpoch()); // drained on blob identity alone
+  EXPECT_FALSE(poolB.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(slot, 0u);
+
+  ejitIcacheClearAll();
+}
+
+// A re-initialization REUSES the blob, so the blob-identity check cannot see it
+// and the epoch must carry the signal: cells filled in the previous generation
+// point at code that generation owned, and must not survive into the next one.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainsAcrossAReInitialization) {
+  ejitIcacheClearAll();
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  EJitSharedTaskPool poolA;
+  bringUpOwner(poolA);
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  poolA.icacheSyncEpoch();
+  poolA.icacheFill(kFunc, fn, nullptr, 0);
+  ASSERT_TRUE(poolA.icacheTry(kFunc, nullptr, 0, &out));
+  poolA.ownerShutdown();
+
+  // Same blob, next generation. The blob ADDRESS is unchanged, so only the
+  // epoch bumped by ownerShutdown can make this core drain.
+  EJitSharedTaskPool poolB;
+  bringUpOwner(poolB);
+  ASSERT_EQ(poolB.state(), poolA.state()); // genuinely the same blob
+  EXPECT_TRUE(poolB.icacheSyncEpoch());
+  EXPECT_FALSE(poolB.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(slot, 0u);
+
+  ejitIcacheClearAll();
+}
+
+// End-to-end deactivate semantics, and the defect this exists to fix: a period
+// is deactivated, its values change, it is reactivated, and the entry must run
+// the NEW specialization. Before the epoch drain the cell kept serving the
+// pointer baked with the old values, silently and forever.
+TEST_F(SharedTaskPoolTest, DeactivateReactivateServesTheNewSpecialization) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  constexpr uint32_t kDim = 0, kInst = 5;
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  void *fnOldValues = codeFor(kFunc);
+  void *fnNewValues = codeFor(kFunc + 1);
+  ASSERT_NE(fnOldValues, fnNewValues);
+  void *out = nullptr;
+
+  // Period active, entry warmed with the specialization for the old values.
+  ASSERT_TRUE(pool.setInstanceEnabled(kDim, kInst, true));
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kFunc, fnOldValues, nullptr, 0);
+  ASSERT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  ASSERT_EQ(out, fnOldValues);
+
+  // ejit_deactivate: the C API toggles the instance and then syncs this core.
+  ASSERT_TRUE(pool.setInstanceEnabled(kDim, kInst, false));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  // Period values change while inactive, then ejit_activate.
+  ASSERT_TRUE(pool.setInstanceEnabled(kDim, kInst, true));
+
+  // The next call misses, re-resolves, and fills the NEW pointer (the resolve
+  // path syncs at entry, so the activate's epoch bump is absorbed first).
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kFunc, fnNewValues, nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fnNewValues);
+
+  ejitIcacheClearAll();
+}
+
+// An out-of-cap numDims must be REJECTED at registration. The drain walks
+// [D]^numDims cells and zeroes each, so a bogus value is a write far past the
+// end of the wrapper's global -- 16^5 cells is 8MB, 16^8 is 34GB, and it would
+// happen on every ejit_deactivate. numDims reaches the runtime from a uint64
+// registry field and from the public C ABI, so it cannot be assumed sane.
+TEST_F(SharedTaskPoolTest, InlineCacheRejectsOutOfCapNumDims) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+
+  // A one-cell array deliberately registered with a wildly wrong shape. If
+  // registration accepted it, the drain below would run off the end of it.
+  uintptr_t lone = 0x1234;
+  ejitIcacheRegisterSlot(kFunc, &lone, EJIT_ICACHE_MAX_DIMS + 1u);
+
+  void *out = nullptr;
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out)) << "slot must be unregistered";
+  pool.icacheSyncEpoch();
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_TRUE(pool.icacheSyncEpoch()); // drains; must not touch the lone cell
+  EXPECT_EQ(lone, 0x1234u) << "drain wrote through a rejected registration";
+
+  // The cap itself is still accepted, so the rejection is a bound and not an
+  // off-by-one that disables legitimate 4-dim entries.
+  ejitIcacheClearAll();
+  std::vector<uintptr_t> maxCells(1u << (4u * 4u), 0); // D=16 ^ 4 dims
+  ejitIcacheRegisterSlot(kFunc, maxCells.data(), EJIT_ICACHE_MAX_DIMS);
+  pool.icacheSyncEpoch();
+  EJitDimPair d4[4] = {{0, 1}, {0, 2}, {0, 3}, {0, 4}};
+  pool.icacheFill(kFunc, codeFor(kFunc), d4, 4);
+  EXPECT_TRUE(pool.icacheTry(kFunc, d4, 4, &out));
+  EXPECT_EQ(out, codeFor(kFunc));
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 6, true));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_FALSE(pool.icacheTry(kFunc, d4, 4, &out)) << "4-dim array must drain";
+
+  ejitIcacheClearAll();
+}
+
+// The reclamation gate disables the cache but must not disable the drain: a
+// releaser wired mid-life means code can be freed, so cells must still be
+// emptied rather than left holding pointers that are about to dangle.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainStillRunsWhileAReleaserIsWired) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  void *out = nullptr;
+
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0);
+  ASSERT_NE(slot, 0u);
+
+  // Wire a releaser: the cache auto-disables (probe misses, fill no-ops) but
+  // the warm cell is still physically there and the wrapper reads it directly,
+  // so a toggle must still zero it.
+  ReleaseLog rel;
+  pool.setReleaser(&mockRelease, &rel);
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out)); // gate closed
+  ASSERT_NE(slot, 0u) << "the gate must not clear cells by itself";
+
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_EQ(slot, 0u) << "drain must run even with the cache gated off";
+
+  pool.setReleaser(nullptr, nullptr);
+  ejitIcacheClearAll();
+}
+
+// A slot registered AFTER a drain must start empty and stay usable: late
+// registration is normal on SRE, where auto-registration order across TUs is
+// not fixed.
+TEST_F(SharedTaskPoolTest, InlineCacheSlotRegisteredAfterADrainIsUsable) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kEarly = 3, kLate = 4;
+  uintptr_t early = 0, late = 0xDEAD;
+  void *out = nullptr;
+
+  ejitIcacheRegisterSlot(kEarly, &early, 0);
+  pool.icacheSyncEpoch();
+  pool.icacheFill(kEarly, codeFor(kEarly), nullptr, 0);
+  ASSERT_TRUE(pool.icacheTry(kEarly, nullptr, 0, &out));
+
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_EQ(early, 0u);
+
+  // Registered only now: the drain already ran, so nothing zeroed this cell.
+  ejitIcacheRegisterSlot(kLate, &late, 0);
+  late = 0; // the wrapper's global is zero-initialised in .bss
+  pool.icacheFill(kLate, codeFor(kLate), nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kLate, nullptr, 0, &out));
+  EXPECT_EQ(out, codeFor(kLate));
+
+  // ...and a later toggle drains the late slot too.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 6, true));
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  EXPECT_EQ(late, 0u);
+
+  ejitIcacheClearAll();
+}
+
+// A toggle landing BETWEEN the pre-resolve sync and the fill must drop the
+// fill. Otherwise the cell would hold a pointer specialized for the pre-toggle
+// values while the seen-epoch was already brought up to date, so no later sync
+// would ever drain it -- a permanently stale cell.
+TEST_F(SharedTaskPoolTest, InlineCacheFillDroppedWhenAToggleRacesTheResolve) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  // compile_or_get entry: sync, bringing this core level with the epoch.
+  pool.icacheSyncEpoch();
+
+  // ...the resolve runs, and a period toggles on another core meanwhile.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+
+  // ...the resolve returns and fills. The fill must be DROPPED: fn was
+  // specialized under the pre-toggle values.
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_EQ(slot, 0u);
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  // Once this core syncs again, fills are accepted normally.
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  pool.icacheFill(kFunc, fn, nullptr, 0);
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+
+  ejitIcacheClearAll();
+}
+
+// The resolve path syncs BEFORE it fills, so a toggle that lands just before a
+// cold resolve cannot wipe the freshly resolved pointer.
+TEST_F(SharedTaskPoolTest, InlineCacheResolveFillSurvivesAPendingDrain) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  void *stale = codeFor(kFunc);
+  void *fresh = codeFor(kFunc + 1);
+  void *out = nullptr;
+
+  pool.icacheSyncEpoch(); // arm before warming
+  pool.icacheFill(kFunc, stale, nullptr, 0);
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true)); // drain now pending
+
+  // Mirror ejitIcacheFillOnSuccess: sync, then fill with the fresh resolve.
+  EXPECT_TRUE(pool.icacheSyncEpoch());
+  pool.icacheFill(kFunc, fresh, nullptr, 0);
+
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fresh); // the fresh fill survived, the stale one did not
+
+  ejitIcacheClearAll();
 }
 
 } // namespace


### PR DESCRIPTION
`-ejit-inline-cache` gives each core its own table of specialization pointers in core private BSS. A cell holds a bare `fnPtr` with no version, so nothing invalidates it, the taskpool compares a slot's `versions[]` against the live instance version, and the inline cache has no equivalent. `ejit_deactivate` changes that version but the cell keeps serving, so a period that is deactivated, has its values changed and is reactivated keeps running the specialization baked with the old values!

This patch introduces `icacheEpoch`, a shared word that `setInstanceEnabled` and `ownerShutdown` change on every transition. Each core compares it against a core private seen value and drains its whole table when the two differ. That is what propagates a deactivation to the other cores.

A core whose cells are all warm never enters the runtime and never observes a toggle, `ejit_icache_sync()` is added for that case and must be called once per period boundary on such a core.

Added a couple of unit tests.

The wrapper hit path is unchanged and no AOT pass is touched. `compile_or_get` gains 3.3 ns on a miss, and `ejit_deactivate` 50-165 ns depending on the registered footprint.

Assisted-by: Claude Opus 5