### PR TITLE
[EJIT] Add AArch64 JITLink branch-range diagnostics

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
@@ -1,0 +1,72 @@
+//===-- EJitLinkDiagPlugin.h - JITLink branch-reloc diagnostic plugin -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A LinkGraphLinkingLayer plugin that proves JITLink's special handling of
+// branch relocations on AArch64: when a BL/B target is external (e.g. an AOT
+// function) or out of the ±128MB direct-branch range, JITLink does NOT emit a
+// direct BL. Instead it routes the call through a PointerJumpStub in $__STUBS
+//
+//     ADRP x16, <got page> ; LDR x16, [x16, #<got off>] ; BR x16
+//
+// whose GOT entry (in $__GOT) holds the real target address.
+//
+// The plugin appends a PostFixup pass to every linked LinkGraph. After fixup
+// the graph carries the full chain JITLink built, so the pass can report each
+// branch relocation with:
+//   * the instruction label (bl / b / tbz / tbnz / b.cond), derived from the
+//     edge kind plus a 4-byte little-endian opcode read of the fixed-up bytes,
+//   * the fixup address, the resolved target, the PC-relative distance,
+//   * whether the branch was bridged through a stub+GOT (and the direct
+//     distance to the real target, so it is visible whether it exceeds the
+//     ±128MB BL range) or kept as a direct in-range branch.
+//
+// This is the post-link "assembly" view of the branch instructions, obtained
+// directly from inside JITLink - no separate dump-then-disassemble roundtrip,
+// and no MCDisassembler dependency (which is trimmed out of the embedded
+// build). Output goes through EJIT_DIAG_VERBOSE (SRE_printf on bare-metal).
+//
+// The plugin is always attached but does nothing unless the EJIT log level is
+// VERBOSE or above (ejit_set_log_level(EJIT_LOG_LVL_VERBOSE)); zero-cost
+// otherwise.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITLINKDIAGPLUGIN_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITLINKDIAGPLUGIN_H
+
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+
+namespace llvm {
+namespace ejit {
+
+class EJitLinkDiagPlugin : public orc::LinkGraphLinkingLayer::Plugin {
+public:
+  EJitLinkDiagPlugin() = default;
+
+  void modifyPassConfig(orc::MaterializationResponsibility &MR,
+                        jitlink::LinkGraph &G,
+                        jitlink::PassConfiguration &Config) override;
+
+  // Diagnostic-only plugin: link outcomes are never affected.
+  Error notifyFailed(orc::MaterializationResponsibility &MR) override {
+    return Error::success();
+  }
+  Error notifyRemovingResources(orc::JITDylib &JD,
+                                orc::ResourceKey K) override {
+    return Error::success();
+  }
+  void notifyTransferringResources(orc::JITDylib &JD, orc::ResourceKey DstKey,
+                                   orc::ResourceKey SrcKey) override {}
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITLINKDIAGPLUGIN_H

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -59,6 +59,7 @@ set(EJIT_SOURCES
   EJitRuntime.cpp
   EJitRegistryTable.c
   EJitOrcEngine.cpp
+  EJitLinkDiagPlugin.cpp
   EJitLibcallStubs.cpp
   EJitCompileDriver.cpp
   EJitRuntimeState.cpp

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLinkDiagPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLinkDiagPlugin.cpp
@@ -1,0 +1,196 @@
+//===-- EJitLinkDiagPlugin.cpp - JITLink branch-reloc diagnostic plugin ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h"
+
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/Error.h"
+#include "llvm/TargetParser/Triple.h"
+
+#include <string>
+
+using namespace llvm;
+using namespace llvm::ejit;
+using namespace llvm::jitlink;
+
+namespace {
+#ifdef EJIT_DIAG_ENABLE
+
+// AArch64 unconditional/conditional branch-immediate range: the signed 26-bit
+// (B/BL) / 19-bit (B.cond) / 14-bit (TBZ/TBNZ) displacement is in 4-byte
+// words, so the byte range of a direct B/BL is +-128MB. A target whose
+// PC-relative distance exceeds this cannot be reached by a direct BL and must
+// be bridged through a stub.
+static constexpr int64_t AArch64DirectBranchLimit = (1ll << 27); // 128 MiB
+
+static std::string symName(const Symbol &S) {
+  if (S.hasName())
+    return (*S.getName()).str();
+  return "<anon>";
+}
+
+// AArch64 instructions are always little-endian encoded, even in a big-endian
+// data (aarch64_be) build, so read the 4 fixup bytes as little-endian. Returns
+// 0 if the offset is out of bounds (treated as an unknown opcode by callers).
+static uint32_t readInstrLE(const Block &B, Edge::OffsetT Off) {
+  if (B.isZeroFill())
+    return 0;
+  ArrayRef<char> C = B.getContent();
+  if (Off + 4 > C.size())
+    return 0;
+  return *reinterpret_cast<const support::ulittle32_t *>(C.data() + Off);
+}
+
+// Human-readable label for a branch-class relocation, derived from the edge
+// kind plus the fixed-up opcode so B vs BL (and TBZ vs TBNZ) are distinguished.
+static const char *branchLabel(Edge::Kind K, const Block &B,
+                               Edge::OffsetT Off) {
+  uint32_t Instr = readInstrLE(B, Off);
+  switch (K) {
+  case aarch64::Branch26PCRel:
+    // B (0x14000000) / BL (0x94000000): bits [30:26] == 00101; bit 31 = L.
+    if ((Instr & 0x7C000000u) == 0x14000000u)
+      return (Instr & 0x80000000u) ? "bl" : "b";
+    return "bl/b";
+  case aarch64::TestAndBranch14PCRel:
+    // TBZ (0x36000000) / TBNZ (0x37000000): bits [30:25] == 011011;
+    // bit 24 = op (0 = TBZ, 1 = TBNZ).
+    if ((Instr & 0x7E000000u) == 0x36000000u)
+      return (Instr & 0x01000000u) ? "tbnz" : "tbz";
+    return "tbz/tbnz";
+  case aarch64::CondBranch19PCRel:
+    // B.cond (0x54000000); the condition lives in bits [3:0].
+    return "b.cond";
+  default:
+    return "branch";
+  }
+}
+
+static bool isBranchKind(Edge::Kind K) {
+  return K == aarch64::Branch26PCRel ||
+         K == aarch64::TestAndBranch14PCRel ||
+         K == aarch64::CondBranch19PCRel;
+}
+
+static bool isStubSymbol(const Symbol &S) {
+  return S.isDefined() && S.getBlock().getSection().getName() == "$__STUBS";
+}
+
+// Follow a $__STUBS PointerJumpStub to the real target it ultimately reaches:
+//   stub block --Page21/PageOffset12--> $__GOT entry --Pointer64--> real target
+// Returns nullptr if the chain does not match the expected stub layout.
+static const Symbol *followStubToRealTarget(const Symbol &StubSym) {
+  const Block &StubB = StubSym.getBlock();
+  const Symbol *GotSym = nullptr;
+  for (const Edge &E : StubB.edges())
+    if (E.getKind() == aarch64::Page21 ||
+        E.getKind() == aarch64::PageOffset12) {
+      GotSym = &E.getTarget();
+      break;
+    }
+  if (!GotSym || !GotSym->isDefined())
+    return nullptr;
+  const Block &GotB = GotSym->getBlock();
+  for (const Edge &E : GotB.edges())
+    if (E.getKind() == aarch64::Pointer64)
+      return &E.getTarget();
+  return nullptr;
+}
+
+static int64_t absVal(int64_t V) { return V < 0 ? -V : V; }
+
+// PostFixup pass body. Runs only when verbose diagnostics are enabled (see
+// modifyPassConfig). Never fails the link: all output is advisory.
+static Error reportLinkGraph(LinkGraph &G) {
+  unsigned stubbed = 0, direct = 0, outOfRange = 0;
+  bool headerPrinted = false;
+
+  for (Section &Sec : G.sections()) {
+    for (Block *B : Sec.blocks()) {
+      for (Edge &E : B->edges()) {
+        if (!isBranchKind(E.getKind()))
+          continue;
+
+        if (!headerPrinted) {
+          headerPrinted = true;
+          EJIT_DIAG_VERBOSE(
+              "linkdiag: graph=%s triple=%s -- branch relocation audit",
+              G.getName().c_str(), G.getTargetTriple().getTriple().c_str());
+        }
+
+        const char *Label = branchLabel(E.getKind(), *B, E.getOffset());
+        uint64_t FixupAddr = B->getFixupAddress(E).getValue();
+        Symbol &Target = E.getTarget();
+
+        if (isStubSymbol(Target)) {
+          ++stubbed;
+          uint64_t StubAddr = Target.getAddress().getValue();
+          const Symbol *Real = followStubToRealTarget(Target);
+          uint64_t RealAddr = Real ? Real->getAddress().getValue() : 0;
+          int64_t DirectDist =
+              Real ? (int64_t)RealAddr - (int64_t)FixupAddr : 0;
+          bool exceeds = Real && absVal(DirectDist) > AArch64DirectBranchLimit;
+          if (exceeds)
+            ++outOfRange;
+          EJIT_DIAG_VERBOSE(
+              "  [STUBBED] %s @0x%llx -> stub@0x%llx "
+              "(ADRP x16; LDR x16,[x16]; BR x16) -> $__GOT -> %s @0x%llx"
+              " | direct dist=%lld (%s +-128MB)",
+              Label, (unsigned long long)FixupAddr,
+              (unsigned long long)StubAddr,
+              Real ? symName(*Real).c_str() : "<?>", (unsigned long long)RealAddr,
+              (long long)DirectDist, exceeds ? "EXCEEDS" : "within");
+        } else {
+          ++direct;
+          uint64_t TargetAddr = Target.getAddress().getValue();
+          int64_t Disp = (int64_t)TargetAddr - (int64_t)FixupAddr;
+          EJIT_DIAG_VERBOSE("  [direct ] %s @0x%llx -> %s @0x%llx | dist=%lld",
+                            Label, (unsigned long long)FixupAddr,
+                            symName(Target).c_str(),
+                            (unsigned long long)TargetAddr, (long long)Disp);
+        }
+      }
+    }
+  }
+
+  if (headerPrinted)
+    EJIT_DIAG_VERBOSE(
+        "linkdiag: graph=%s summary: %u stubbed (%u exceed +-128MB), %u direct",
+        G.getName().c_str(), stubbed, outOfRange, direct);
+
+  return Error::success();
+}
+
+#endif // EJIT_DIAG_ENABLE
+} // namespace
+
+void EJitLinkDiagPlugin::modifyPassConfig(orc::MaterializationResponsibility &MR,
+                                          LinkGraph &G,
+                                          PassConfiguration &Config) {
+#ifdef EJIT_DIAG_ENABLE
+  // Zero-cost unless verbose diagnostics are requested. The level is checked
+  // here (rather than inside the pass) so no pass object is constructed when
+  // the feature is off.
+  if (gEJitDiagLevel < EJIT_LOG_LVL_VERBOSE)
+    return;
+
+  // Branch-relocation classification is AArch64-specific.
+  const Triple &TT = G.getTargetTriple();
+  if (TT.getArch() != Triple::aarch64 && TT.getArch() != Triple::aarch64_be)
+    return;
+
+  Config.PostFixupPasses.push_back(
+      [](LinkGraph &G) -> Error { return reportLinkGraph(G); });
+#else
+  (void)MR;
+  (void)G;
+  (void)Config;
+#endif
+}

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -5,11 +5,13 @@
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorSymbolDef.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
@@ -23,7 +25,10 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include <cstdlib>
+#include <cstring>
 #include <map>
+#include <memory>
 #include <string>
 
 #ifdef EJIT_FREESTANDING
@@ -39,7 +44,6 @@ extern "C" uint32_t SRE_TaskDelay(uint32_t tick);
 #ifdef EJIT_SRE_CODE_POOL
 #include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
-#include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #endif
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
@@ -581,6 +585,16 @@ EJitOrcEngine::Create(const Config &config,
   }
 
   engine->P->J = std::move(*J);
+
+  // Attach the JITLink branch-relocation diagnostic plugin. It appends a
+  // PostFixup pass that audits every AArch64 branch relocation and reports
+  // which ones JITLink bridged through a $__STUBS PointerJumpStub + $__GOT
+  // (because the direct BL target is external / out of +-128MB) instead of a
+  // direct BL. Zero-cost unless the log level is VERBOSE; output via
+  // EJIT_DIAG_VERBOSE (SRE_printf on bare-metal).
+  if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
+          &engine->P->J->getObjLinkingLayer()))
+    OLL->addPlugin(std::make_shared<EJitLinkDiagPlugin>());
 
   // Override the default error reporter (logErrorsToStdErr → errs() →
   // raw_fd_ostream) with a bare-metal-safe version using EJIT_DIAG.  On


### PR DESCRIPTION
## 中文说明

将 Homme `ejit-jitlink-range-diag` 分支上的 JITLink 分支重定位诊断移植到最新 `ejit_dev_spec4`。

### 改动

- 新增 `EJitLinkDiagPlugin`，在 AArch64/AArch64_BE JITLink `PostFixup` 阶段审计分支重定位。
- 区分直接分支与 `$__STUBS -> $__GOT -> real target` 路径。
- 输出 fixup、stub、真实目标地址及相对距离，并汇总 direct/stubbed 数量。
- 仅在 `EJIT_DIAG_ENABLE` 且运行时日志等级为 `VERBOSE` 时启用；其他情况下不添加诊断 pass。
- 适配当前主线的 `ObjectLinkingLayer` 创建及 code-pool 路径。

### 使用

```c
ejit_set_log_level(EJIT_LOG_LVL_VERBOSE);
```

预期日志包含：

```text
[STUBBED] bl ... -> stub -> GOT -> real target ...
[direct ] bl ... -> target ...
linkdiag: ... summary: N stubbed, M direct
```

### 验证状态

按要求本轮仅完成 rebase、冲突处理、`git diff --check` 和提交推送，尚未执行完整构建及 SRE 板测。因此先以 Draft PR 提交。

## English

Ports Homme's AArch64 JITLink branch-relocation diagnostic plugin onto the latest `ejit_dev_spec4`.

The plugin audits finalized branch relocations, distinguishes direct branches from `$__STUBS -> $__GOT -> real target` routing, and reports addresses, distances, and a per-graph summary. It is compiled under `EJIT_DIAG_ENABLE` and only installs the PostFixup diagnostic pass when the runtime log level is `VERBOSE`.

This is intentionally opened as a draft: the rebase/conflict resolution and whitespace checks are complete, while the full build and SRE hardware validation remain pending.