### PR TITLE
[EJIT] Report AArch64 JITLink range summary at INFO

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
@@ -28,11 +28,12 @@
 // This is the post-link "assembly" view of the branch instructions, obtained
 // directly from inside JITLink - no separate dump-then-disassemble roundtrip,
 // and no MCDisassembler dependency (which is trimmed out of the embedded
-// build). Output goes through EJIT_DIAG_VERBOSE (SRE_printf on bare-metal).
+// build). Output goes through EJIT_DIAG/EJIT_DIAG_VERBOSE (SRE_printf on
+// bare-metal).
 //
-// The plugin is always attached but does nothing unless the EJIT log level is
-// VERBOSE or above (ejit_set_log_level(EJIT_LOG_LVL_VERBOSE)); zero-cost
-// otherwise.
+// The plugin is always attached. At INFO it prints only one summary per graph;
+// VERBOSE additionally prints every branch relocation. It does nothing when
+// diagnostics are OFF.
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLinkDiagPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLinkDiagPlugin.cpp
@@ -106,8 +106,9 @@ static const Symbol *followStubToRealTarget(const Symbol &StubSym) {
 
 static int64_t absVal(int64_t V) { return V < 0 ? -V : V; }
 
-// PostFixup pass body. Runs only when verbose diagnostics are enabled (see
-// modifyPassConfig). Never fails the link: all output is advisory.
+// PostFixup pass body. INFO prints only the final summary; VERBOSE also prints
+// the header and every relocation. Never fails the link: all output is
+// advisory.
 static Error reportLinkGraph(LinkGraph &G) {
   unsigned stubbed = 0, direct = 0, outOfRange = 0;
   bool headerPrinted = false;
@@ -161,7 +162,7 @@ static Error reportLinkGraph(LinkGraph &G) {
   }
 
   if (headerPrinted)
-    EJIT_DIAG_VERBOSE(
+    EJIT_DIAG(
         "linkdiag: graph=%s summary: %u stubbed (%u exceed +-128MB), %u direct",
         G.getName().c_str(), stubbed, outOfRange, direct);
 
@@ -175,10 +176,9 @@ void EJitLinkDiagPlugin::modifyPassConfig(orc::MaterializationResponsibility &MR
                                           LinkGraph &G,
                                           PassConfiguration &Config) {
 #ifdef EJIT_DIAG_ENABLE
-  // Zero-cost unless verbose diagnostics are requested. The level is checked
-  // here (rather than inside the pass) so no pass object is constructed when
-  // the feature is off.
-  if (gEJitDiagLevel < EJIT_LOG_LVL_VERBOSE)
+  // Avoid constructing the pass when diagnostics are disabled. INFO emits one
+  // summary per graph; relocation-level detail remains VERBOSE-only.
+  if (gEJitDiagLevel < EJIT_LOG_LVL_INFO)
     return;
 
   // Branch-relocation classification is AArch64-specific.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -590,8 +590,8 @@ EJitOrcEngine::Create(const Config &config,
   // PostFixup pass that audits every AArch64 branch relocation and reports
   // which ones JITLink bridged through a $__STUBS PointerJumpStub + $__GOT
   // (because the direct BL target is external / out of +-128MB) instead of a
-  // direct BL. Zero-cost unless the log level is VERBOSE; output via
-  // EJIT_DIAG_VERBOSE (SRE_printf on bare-metal).
+  // direct BL. INFO emits one summary per graph; VERBOSE additionally emits
+  // each relocation. Output uses SRE_printf on bare-metal.
   if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
           &engine->P->J->getObjLinkingLayer()))
     OLL->addPlugin(std::make_shared<EJitLinkDiagPlugin>());


### PR DESCRIPTION
## 中文说明

这是 PR #107 的 INFO-summary 版本，包含同一套 AArch64 JITLink 分支重定位诊断，并调整日志分级：

- `INFO / LEVEL1`：每个 LinkGraph 仅输出一行 summary；
- `VERBOSE / LEVEL2`：额外输出 header 以及每条 `[STUBBED]` / `[direct]` 明细；
- `OFF`：不安装诊断 pass，不扫描重定位。

LEVEL1 示例：

```text
[EJIT] reportLinkGraph:... linkdiag: graph=... summary: 3 stubbed (3 exceed +-128MB), 12 direct
```

这样默认 INFO 能确认是否产生远距离 stub，同时不会被逐条重定位日志淹没。需要定位具体函数和地址时再切换到 VERBOSE。

本 PR 包含：

1. PR #107 的 JITLink range diagnostic plugin；
2. 独立 follow-up commit `4ce458c8dcfc`，将 summary 降到 INFO，明细保持 VERBOSE。

按要求未等待完整构建，已完成 `git diff --check`。

## English

This is the INFO-summary variant of PR #107.

- INFO/LEVEL1 emits one summary line per LinkGraph.
- VERBOSE/LEVEL2 additionally emits the per-relocation `[STUBBED]` and `[direct]` details.
- OFF does not install the diagnostic pass.

The default INFO level therefore exposes whether long-range stubs were generated without flooding the board log. Full build and SRE validation remain pending, so this PR is opened as a draft.