### PR TITLE
[EJIT] Restore and harden the per-core L0 dispatch cache

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -193,6 +193,7 @@ ALL_TESTS=(
   ejit_ptr_period_test
   ejit_trace_test
   ejit_volatile_test
+  ejit_l0_dispatch_test
 )
 
 # Per-test compile flags (e.g. for disabling global constructors)
@@ -237,6 +238,7 @@ EXTRA_SRCS[ejit_cross_inline_test]="ejit_lto_inline_test_b.c"
 
 declare -A TEST_ARGS
 TEST_ARGS[ejit_complex_test]="0 1 2 3"
+TEST_ARGS[ejit_l0_dispatch_test]="1"
 TEST_ARGS[ejit_fold_loop_test]="0"
 TEST_ARGS[ejit_opt_level_test]="L2"
 TEST_ARGS[ejit_multiversion_test]="0 3 7"

--- a/ejit_test/ejit_l0_dispatch_test.c
+++ b/ejit_test/ejit_l0_dispatch_test.c
@@ -1,0 +1,169 @@
+/**
+ * EJIT per-core L0 dispatch cache test.
+ *
+ * A missed invalidation shows up as a plausible number rather than an obvious
+ * failure, so each phase checks WHICH specialization ran.
+ *
+ * SCOPE: end-to-end smoke test, not per-hook coverage. It cannot isolate which
+ * retire hook did the work -- any path producing a new specialization also
+ * republishes, and cachePublish() retires every entry on its own. Removing the
+ * ejit_invalidate() or version-bump hook individually was verified NOT to fail
+ * this test. Per-hook invariants live in EJitSharedTaskPoolTest.cpp.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ejit_test_helpers.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
+
+#define N 8
+
+struct Cfg {
+  ejit_may_const uint32_t mode;
+  uint32_t counter;
+};
+ejit_period_arr(cell) struct Cfg g_cfg[N];
+
+/* The specialization folds g_cfg[ci].mode, so the returned value identifies
+ * which specialization ran. */
+ejit_entry uint32_t l0_probe(ejit_period_arr_ind(cell) uint8_t ci, uint32_t seed)
+{
+  return g_cfg[ci].mode * 1000u + seed;
+}
+
+static int failures;
+
+static void expect(uint32_t got, uint32_t want, const char *what) {
+  if (got == want) {
+    printf("  OK  : %s (= %u)\n", what, got);
+  } else {
+    printf("  FAIL: %s: got %u want %u\n", what, got, want);
+    failures++;
+  }
+}
+
+/* Resolve the specialization and fill the L0 for this identity. */
+static void warm(uint8_t ci) {
+  for (int i = 0; i < 64; i++)
+    (void)l0_probe(ci, 0);
+}
+
+int main(int argc, char **argv) {
+  const uint8_t ci = (argc > 1) ? (uint8_t)atoi(argv[1]) : 1;
+  ejit_config_t cfg;
+
+  for (int i = 0; i < N; i++) {
+    g_cfg[i].mode = 1;
+    g_cfg[i].counter = 0;
+  }
+
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.compileMode = EJIT_COMPILE_SYNC;
+  cfg.optLevel = EJIT_OPT_L2;
+  if (ejit_init(&cfg) != EJIT_OK) {
+    printf("  FAIL: ejit_init\n");
+    return 1;
+  }
+  ejit_activate("cell", ci);
+
+  printf("=== EJIT L0 dispatch cache ===\n");
+
+  /* 1. Baseline: a repeat dispatch still returns the right answer. */
+  warm(ci);
+  expect(l0_probe(ci, 7), 1007, "repeat dispatch after warm-up");
+
+  /* 2. ejit_invalidate() drops the cached specialization. It does not go
+   *    through cachePublish(), so the L0 is only retired if the runtime hooks
+   *    it explicitly -- this phase is what catches a missing hook. */
+  g_cfg[ci].mode = 2;
+  ejit_invalidate("cell", ci);
+  /* Checked on the FIRST call after the flush, before anything republishes.
+   * A republish bumps the epoch on its own, so warming up first would retire a
+   * stale entry for the wrong reason and the missing hook would go unnoticed. */
+  expect(l0_probe(ci, 7), 2007, "first call after ejit_invalidate");
+  warm(ci);
+  expect(l0_probe(ci, 7), 2007, "value after ejit_invalidate + recompile");
+
+  /* 3. Same for ejit_clear_cache(), which flushes everything at once. */
+  g_cfg[ci].mode = 3;
+  ejit_clear_cache();
+  expect(l0_probe(ci, 7), 3007, "first call after ejit_clear_cache");
+  warm(ci);
+  expect(l0_probe(ci, 7), 3007, "value after ejit_clear_cache + recompile");
+
+  /* 4. deactivate/activate bumps the instance version: a stale entry would run
+   *    a specialization built from the old constants. */
+  g_cfg[ci].mode = 4;
+  ejit_deactivate("cell", ci);
+  ejit_activate("cell", ci);
+  expect(l0_probe(ci, 7), 4007, "first call after deactivate/activate");
+  warm(ci);
+  expect(l0_probe(ci, 7), 4007, "value after deactivate/activate + recompile");
+
+  /* 5. While deactivated the call must fall back to the AOT body. */
+  g_cfg[ci].mode = 5;
+  ejit_deactivate("cell", ci);
+  expect(l0_probe(ci, 7), 5007, "value while the instance is deactivated");
+  ejit_activate("cell", ci);
+
+  /* 6. Two live instances must not share an entry -- what the per-function
+   *    inline cache cannot express. */
+  {
+    const uint8_t other = (uint8_t)((ci + 1) % N);
+    g_cfg[ci].mode = 6;
+    g_cfg[other].mode = 9;
+    ejit_activate("cell", other);
+    warm(ci);
+    warm(other);
+    expect(l0_probe(ci, 7), 6007, "instance A after two instances are warm");
+    expect(l0_probe(other, 7), 9007, "instance B after two instances are warm");
+  }
+
+  /* 7. A direct-mapped table evicts: an eviction must miss, never return
+   *    another identity's pointer. */
+  {
+    const uint8_t other = (uint8_t)((ci + 1) % N);
+    for (int i = 0; i < 200; i++) {
+      if (l0_probe(ci, 0) != 6000) {
+        printf("  FAIL: interleaved dispatch returned the wrong "
+               "specialization for A\n");
+        failures++;
+        break;
+      }
+      if (l0_probe(other, 0) != 9000) {
+        printf("  FAIL: interleaved dispatch returned the wrong "
+               "specialization for B\n");
+        failures++;
+        break;
+      }
+    }
+    if (!failures)
+      printf("  OK  : 200 interleaved dispatches across two instances\n");
+  }
+
+  /* 8. The table outlives the shared blob, so its entries survive a teardown
+   *    that invalidates every pointer they hold. */
+  ejit_shutdown();
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.compileMode = EJIT_COMPILE_SYNC;
+  cfg.optLevel = EJIT_OPT_L2;
+  if (ejit_init(&cfg) != EJIT_OK) {
+    printf("  FAIL: ejit_init after shutdown\n");
+    return 1;
+  }
+  ejit_activate("cell", ci);
+  g_cfg[ci].mode = 8;
+  warm(ci);
+  expect(l0_probe(ci, 7), 8007, "value after shutdown + re-init");
+
+  ejit_shutdown();
+
+  if (failures) {
+    printf("\n=== FAIL: %d failure(s) ===\n", failures);
+    return 1;
+  }
+  printf("\n=== PASS ===\n");
+  return 0;
+}

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -71,7 +71,10 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// the optional EJIT_SRE_TASKPOOL_NO_RECLAIM seqlock reader.
 /// v7: full IR/ASM payloads are worker-local again; shared dump state contains
 /// only a bounded filter and latest-capture metadata. publishSeq is unchanged.
-constexpr uint32_t kEJitSharedAbiVersion = 7u;
+/// v8: shared state gains dispatchEpoch for the hardened per-core L0 dispatch
+/// cache. Older owners do not maintain this invalidation protocol, so peers
+/// must reject a mixed-version blob even though the field fits old padding.
+constexpr uint32_t kEJitSharedAbiVersion = 8u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -34,6 +34,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h" // EJitCompileMode, status enum
+#include <atomic>
 #include <cstdint>
 
 namespace llvm {
@@ -139,23 +140,24 @@ void ejitIcacheClearAll();
 // No-op for an out-of-range funcIndex or null base.
 void ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
 
+/// One L0 slot, sized to a cache line. The identity is stored in full and
+/// re-checked on every hit, because the index hash is not injective: it selects
+/// a slot and nothing more, so a collision must evict, never answer.
 struct EJitL0Entry {
-  uint32_t key;   ///< packed identity; 0 = empty
-  uint32_t epoch; ///< dispatchEpoch this entry was filled at
-  uint32_t core;  ///< core that filled it
-  void *fn;
+  uint32_t seq; ///< even = stable, odd = mid-write
+  uint32_t epoch;
+  uint32_t core;
+  uint32_t funcIndex;
+  uint32_t numDims;
+  EJitDimPair dims[kEJitSharedMaxDims];
+  void *fn; ///< null = empty
 };
-constexpr uint32_t kEJitL0Slots = 64; // 1.5KB/core
+constexpr uint32_t kEJitL0Slots = 64; // 4KB/core
 
-// The three globals below are core-private: deliberately NOT in
+// The two globals below are core-private: deliberately NOT in
 // EJIT_SHARED_SECTION_ATTR, so each core's image holds its own copy and
 // probing generates no coherence traffic.
 extern EJitL0Entry gEJitL0[kEJitL0Slots];
-
-/// L0 hits on THIS core. Non-atomic: routing it through the shared cacheHits
-/// counter costs an atomic RMW measured at ~7ns, more than the probe it counts.
-/// getStats() folds it in.
-extern uint64_t gEJitL0Hits;
 
 /// The shared state this core's table was armed against, null if it has not
 /// passed the L0 gates. Not a member of EJitSharedTaskPool: that object lives
@@ -165,16 +167,21 @@ extern uint64_t gEJitL0Hits;
 /// fresh blob starts from a low epoch a stale entry can match by coincidence.
 extern const void *gEJitL0State;
 
-/// Never returns 0, so 0 stays "empty".
-inline uint32_t ejitL0Key(uint32_t funcIndex, const EJitDimPair *dims,
-                          uint32_t numDims) {
+inline bool dimsEqual(const EJitDimPair *a, const EJitDimPair *b,
+                      uint32_t numDims) {
+  for (uint32_t i = 0; i < numDims; ++i)
+    if (a[i].dimType != b[i].dimType || a[i].instanceId != b[i].instanceId)
+      return false;
+  return true;
+}
+
+/// Slot selection only; correctness never depends on this being injective.
+inline uint32_t ejitL0Index(uint32_t funcIndex, const EJitDimPair *dims,
+                            uint32_t numDims) {
   uint32_t k = funcIndex * 2654435761u;
   for (uint32_t i = 0; i < numDims; ++i)
-    k = (k ^ (dims[i].dimType * 31u + dims[i].instanceId)) * 2654435761u;
-  return k | 1u;
-}
-inline uint32_t ejitL0Index(uint32_t key) {
-  return (key >> 26) & (kEJitL0Slots - 1);
+    k = (k ^ (dims[i].dimType * 2654435761u) ^ dims[i].instanceId) * 2654435761u;
+  return (k >> 26) & (kEJitL0Slots - 1);
 }
 
 class EJitSharedTaskPool {
@@ -318,6 +325,12 @@ public:
     // UAF. Auto-disable the cache while a releaser is wired. Production wires
     // no releaser, so the gate stays open and the cache is unconditionally safe.
     icacheReclamationSafe_ = (fn == nullptr);
+    if (fn) {
+      // The gate is evaluated at fill, so blocking new fills is not enough:
+      // entries armed earlier would keep serving code the releaser may free.
+      gEJitL0State = nullptr;
+      retireDispatchCache();
+    }
   }
   void setPrepareCodeCallback(PrepareCodeCallback fn, void *ctx) {
     prepareCodeFn_ = fn;
@@ -498,24 +511,34 @@ public:
   bool l0Try(uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
              void **outFn) {
     // Inline: an out-of-line call costs more than the probe it performs.
-    if (!state_ || gEJitL0State != state_)
+    if (!state_ || gEJitL0State != state_ || numDims > kEJitSharedMaxDims)
       return false;
-    const uint32_t key = ejitL0Key(funcIndex, dims, numDims);
-    const EJitL0Entry &e = gEJitL0[ejitL0Index(key)];
-    // The core stamp is a constant compare on hardware, where the table is
-    // core-private. It matters where cores are SIMULATED in one process: there
-    // the table is shared, and a peer taking the owner's entry would skip
-    // peerPrepareSlot() and run code it has no execute permission for.
-    if (e.key != key || e.core != EJitCoreId::current() ||
-        e.epoch != state_->dispatchEpoch.loadRelaxed())
-      return false;
-    if (e.fn == nullptr)
-      return false;
-    ++gEJitL0Hits; // core-private, non-atomic: see the declaration
+    EJitL0Entry &e = gEJitL0[ejitL0Index(funcIndex, dims, numDims)];
 
-    *outFn = e.fn;
+    // Seqlock: core-private storage excludes other CORES, not preemption or
+    // interrupts on this one, which could otherwise leave a stale identity
+    // beside a new fnPtr. Signal fences suffice -- same-core ordering, not
+    // cross-core visibility.
+    const uint32_t s0 = e.seq;
+    if (s0 & 1u)
+      return false;
+    std::atomic_signal_fence(std::memory_order_acquire);
+
+    void *fn = e.fn;
+    const bool match = fn != nullptr && e.epoch == state_->dispatchEpoch.loadRelaxed() &&
+                       e.core == EJitCoreId::current() &&
+                       e.funcIndex == funcIndex && e.numDims == numDims &&
+                       dimsEqual(e.dims, dims, numDims);
+
+    std::atomic_signal_fence(std::memory_order_acquire);
+    if (e.seq != s0 || !match)
+      return false;
+
+    EJIT_STAT_INC(state_->counters.cacheHits);
+    *outFn = fn;
     return true;
   }
+
   void l0Fill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
               uint32_t numDims);
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -34,7 +34,6 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h" // EJitCompileMode, status enum
-#include <atomic>
 #include <cstdint>
 
 namespace llvm {
@@ -143,16 +142,20 @@ void ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
 /// One L0 slot, sized to a cache line. The identity is stored in full and
 /// re-checked on every hit, because the index hash is not injective: it selects
 /// a slot and nothing more, so a collision must evict, never answer.
-struct EJitL0Entry {
-  uint32_t seq; ///< even = stable, odd = mid-write
-  uint32_t epoch;
-  uint32_t core;
-  uint32_t funcIndex;
-  uint32_t numDims;
-  EJitDimPair dims[kEJitSharedMaxDims];
-  void *fn; ///< null = empty
+struct alignas(kEJitSharedCacheLine) EJitL0Entry {
+  EJitAtomicU32 seq; ///< even = stable, odd = mid-write
+  EJitAtomicU32 epoch;
+  EJitAtomicU32 core;
+  EJitAtomicU32 funcIndex;
+  EJitAtomicU32 numDims;
+  /// Each element preserves the full (dimType, instanceId) identity while
+  /// keeping one L0 entry exactly one cache line.
+  EJitAtomicU64 dims[kEJitSharedMaxDims];
+  EJitAtomicUPtr fn; ///< zero = empty
 };
 constexpr uint32_t kEJitL0Slots = 64; // 4KB/core
+static_assert(sizeof(EJitL0Entry) == kEJitSharedCacheLine,
+              "one L0 entry must occupy exactly one cache line");
 
 // The two globals below are core-private: deliberately NOT in
 // EJIT_SHARED_SECTION_ATTR, so each core's image holds its own copy and
@@ -165,12 +168,24 @@ extern EJitL0Entry gEJitL0[kEJitL0Slots];
 /// cores that never qualified. Holding the pointer rather than a bool also
 /// rejects entries armed against a DIFFERENT blob, which the epoch cannot: a
 /// fresh blob starts from a low epoch a stale entry can match by coincidence.
-extern const void *gEJitL0State;
+extern EJitAtomicUPtr gEJitL0State;
 
-inline bool dimsEqual(const EJitDimPair *a, const EJitDimPair *b,
-                      uint32_t numDims) {
+/// Serializes fills and table re-arming against same-core task preemption.
+/// A contending fill simply skips L0 population; the shared cache remains the
+/// authoritative fallback, so this lock is never spun on the dispatch path.
+extern EJitAtomicU32 gEJitL0Writer;
+
+/// Clear this core's L0 table and disarm it from any shared-state blob.
+void ejitL0ClearLocal();
+
+inline uint64_t ejitL0PackDim(const EJitDimPair &dim) {
+  return (static_cast<uint64_t>(dim.dimType) << 32) | dim.instanceId;
+}
+
+inline bool l0DimsEqual(const EJitL0Entry &entry, const EJitDimPair *dims,
+                        uint32_t numDims) {
   for (uint32_t i = 0; i < numDims; ++i)
-    if (a[i].dimType != b[i].dimType || a[i].instanceId != b[i].instanceId)
+    if (entry.dims[i].loadRelaxed() != ejitL0PackDim(dims[i]))
       return false;
   return true;
 }
@@ -328,7 +343,7 @@ public:
     if (fn) {
       // The gate is evaluated at fill, so blocking new fills is not enough:
       // entries armed earlier would keep serving code the releaser may free.
-      gEJitL0State = nullptr;
+      gEJitL0State.storeRelease(0);
       retireDispatchCache();
     }
   }
@@ -511,36 +526,42 @@ public:
   bool l0Try(uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
              void **outFn) {
     // Inline: an out-of-line call costs more than the probe it performs.
-    if (!state_ || gEJitL0State != state_ || numDims > kEJitSharedMaxDims)
+    if (!state_ || numDims > kEJitSharedMaxDims || !outFn ||
+        gEJitL0State.loadAcquire() != reinterpret_cast<uintptr_t>(state_))
       return false;
     EJitL0Entry &e = gEJitL0[ejitL0Index(funcIndex, dims, numDims)];
 
-    // Seqlock: core-private storage excludes other CORES, not preemption or
-    // interrupts on this one, which could otherwise leave a stale identity
-    // beside a new fnPtr. Signal fences suffice -- same-core ordering, not
-    // cross-core visibility.
-    const uint32_t s0 = e.seq;
+    // Every payload field is atomic: the sequence check rejects a torn
+    // snapshot, while the atomic payload accesses keep the protocol defined
+    // even when a same-core task/interrupt preempts the reader with a fill.
+    const uint32_t s0 = e.seq.loadAcquire();
     if (s0 & 1u)
       return false;
-    std::atomic_signal_fence(std::memory_order_acquire);
 
-    void *fn = e.fn;
-    const bool match = fn != nullptr && e.epoch == state_->dispatchEpoch.loadRelaxed() &&
-                       e.core == EJitCoreId::current() &&
-                       e.funcIndex == funcIndex && e.numDims == numDims &&
-                       dimsEqual(e.dims, dims, numDims);
+    const uintptr_t fn = e.fn.loadRelaxed();
+    const bool match =
+        fn != 0 &&
+        e.epoch.loadRelaxed() == state_->dispatchEpoch.loadAcquire() &&
+        e.core.loadRelaxed() == EJitCoreId::current() &&
+        e.funcIndex.loadRelaxed() == funcIndex &&
+        e.numDims.loadRelaxed() == numDims && l0DimsEqual(e, dims, numDims);
 
-    std::atomic_signal_fence(std::memory_order_acquire);
-    if (e.seq != s0 || !match)
+    if (e.seq.loadAcquire() != s0 || !match)
       return false;
 
     EJIT_STAT_INC(state_->counters.cacheHits);
-    *outFn = fn;
+    *outFn = reinterpret_cast<void *>(fn);
     return true;
   }
 
   void l0Fill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
-              uint32_t numDims);
+              uint32_t numDims, uint32_t expectedEpoch);
+
+  /// Snapshot taken immediately before the authoritative shared-cache lookup.
+  /// l0Fill accepts the result only while this epoch is still current.
+  uint32_t dispatchEpoch() const {
+    return state_ ? state_->dispatchEpoch.loadAcquire() : 0;
+  }
 
   /// Retire every core's L0. Must be called from every path that can
   /// invalidate an (identity -> fnPtr) mapping from OUTSIDE the taskpool --

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -32,6 +32,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitCodeRange.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h"
+#include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h" // EJitCompileMode, status enum
 #include <cstdint>
 
@@ -137,6 +138,44 @@ void ejitIcacheClearAll();
 // (name->funcIndex resolution) at ejit_auto_register / .ejit_period time.
 // No-op for an out-of-range funcIndex or null base.
 void ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
+
+struct EJitL0Entry {
+  uint32_t key;   ///< packed identity; 0 = empty
+  uint32_t epoch; ///< dispatchEpoch this entry was filled at
+  uint32_t core;  ///< core that filled it
+  void *fn;
+};
+constexpr uint32_t kEJitL0Slots = 64; // 1.5KB/core
+
+// The three globals below are core-private: deliberately NOT in
+// EJIT_SHARED_SECTION_ATTR, so each core's image holds its own copy and
+// probing generates no coherence traffic.
+extern EJitL0Entry gEJitL0[kEJitL0Slots];
+
+/// L0 hits on THIS core. Non-atomic: routing it through the shared cacheHits
+/// counter costs an atomic RMW measured at ~7ns, more than the probe it counts.
+/// getStats() folds it in.
+extern uint64_t gEJitL0Hits;
+
+/// The shared state this core's table was armed against, null if it has not
+/// passed the L0 gates. Not a member of EJitSharedTaskPool: that object lives
+/// in the compile driver and is SHARED, so one core would arm the probe for
+/// cores that never qualified. Holding the pointer rather than a bool also
+/// rejects entries armed against a DIFFERENT blob, which the epoch cannot: a
+/// fresh blob starts from a low epoch a stale entry can match by coincidence.
+extern const void *gEJitL0State;
+
+/// Never returns 0, so 0 stays "empty".
+inline uint32_t ejitL0Key(uint32_t funcIndex, const EJitDimPair *dims,
+                          uint32_t numDims) {
+  uint32_t k = funcIndex * 2654435761u;
+  for (uint32_t i = 0; i < numDims; ++i)
+    k = (k ^ (dims[i].dimType * 31u + dims[i].instanceId)) * 2654435761u;
+  return k | 1u;
+}
+inline uint32_t ejitL0Index(uint32_t key) {
+  return (key >> 26) & (kEJitL0Slots - 1);
+}
 
 class EJitSharedTaskPool {
 public:
@@ -449,6 +488,43 @@ public:
   // a different identity fills a different cell. No-op when reclamation is not
   // safe, the function is unregistered (no base wired) or numDims mismatches,
   // funcIndex is out of range, or fnPtr is null.
+  /// Per-core L0 dispatch cache: serves the (funcIndex, dims) identity the
+  /// bucket lookup would resolve, skipping the rwlock and the 16-slot scan.
+  ///
+  /// A hit hands back a raw fnPtr with NO read token, so it runs under the
+  /// same gate as the inline cache (icacheReclamationSafe_): with a releaser
+  /// wired, code can be freed under the caller and the cache auto-disables.
+  /// Callers receive kEJitNoBucket, which releaseRead() ignores.
+  bool l0Try(uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+             void **outFn) {
+    // Inline: an out-of-line call costs more than the probe it performs.
+    if (!state_ || gEJitL0State != state_)
+      return false;
+    const uint32_t key = ejitL0Key(funcIndex, dims, numDims);
+    const EJitL0Entry &e = gEJitL0[ejitL0Index(key)];
+    // The core stamp is a constant compare on hardware, where the table is
+    // core-private. It matters where cores are SIMULATED in one process: there
+    // the table is shared, and a peer taking the owner's entry would skip
+    // peerPrepareSlot() and run code it has no execute permission for.
+    if (e.key != key || e.core != EJitCoreId::current() ||
+        e.epoch != state_->dispatchEpoch.loadRelaxed())
+      return false;
+    if (e.fn == nullptr)
+      return false;
+    ++gEJitL0Hits; // core-private, non-atomic: see the declaration
+
+    *outFn = e.fn;
+    return true;
+  }
+  void l0Fill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
+              uint32_t numDims);
+
+  /// Retire every core's L0. Must be called from every path that can
+  /// invalidate an (identity -> fnPtr) mapping from OUTSIDE the taskpool --
+  /// ejit_clear_cache(), ejit_invalidate(), a compile-mode change -- since
+  /// those bypass cachePublish() and setInstanceEnabled().
+  void retireDispatchCache();
+
   void icacheFill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
                   uint32_t numDims);
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -79,6 +79,8 @@ namespace ejit {
 //===----------------------------------------------------------------------===//
 // Fixed capacities and the cache-line size used to avoid false sharing.
 //===----------------------------------------------------------------------===//
+/// Max dims in one identity; matches EJitSharedCacheSlot::dims.
+constexpr uint32_t kEJitSharedMaxDims = 4u;
 constexpr uint32_t kEJitSharedDimTypes = 8u;
 constexpr uint32_t kEJitSharedInstances = 256u;
 constexpr uint32_t kEJitSharedMaxFuncIndex = EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -83,6 +83,11 @@ constexpr uint32_t kEJitSharedDimTypes = 8u;
 constexpr uint32_t kEJitSharedInstances = 256u;
 constexpr uint32_t kEJitSharedMaxFuncIndex = EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX;
 constexpr uint32_t kEJitSharedCacheBuckets = EJIT_SRE_TASKPOOL_BUCKETS;
+
+/// Out-bucket for a lookup served without a read token (the per-core L0).
+/// releaseRead() ignores it, so the caller shape -- call fn, then release --
+/// needs no wrapper change.
+constexpr uint32_t kEJitNoBucket = 0xFFFFFFFFu;
 constexpr uint32_t kEJitSharedCacheSlots = EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS;
 constexpr uint32_t kEJitSharedQueueSlots = EJIT_SRE_TASKPOOL_QUEUE_CAPACITY;
 constexpr uint32_t kEJitSharedPoolSlots = EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS;
@@ -318,6 +323,13 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
   EJitAtomicU64 workerTaskId;       ///< platform worker task id (diagnostic)
   EJitAtomicU64 registrationFingerprint; ///< owner funcIndex/dimType mapping
                                          ///< digest; peers validate on attach
+  /// Bumps on any event that can invalidate a cached (identity -> fnPtr)
+  /// mapping: publish, eviction, version change, (re)initialization. Per-core
+  /// L0 entries record the epoch they were filled at and are discarded on a
+  /// mismatch. Read once per dispatch, written only on those rare events, so
+  /// the line stays Shared in every core's L1 rather than bouncing. Sits in
+  /// this cache line's padding, so sizeof() and later offsets are unchanged.
+  EJitAtomicU32 dispatchEpoch;
 
   //--- SwitchController state (own cache line)
   alignas(kEJitSharedCacheLine)

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -495,16 +495,16 @@ const ejit_error_t *ejit_get_last_error(void) {
 
 void ejit_set_compile_mode(ejit_compile_mode_t mode) {
   EJIT_DIAG("set_compile_mode mode=%u", static_cast<unsigned>(mode));
-  if (gEJIT)
-    (void)gEJIT->setCompileMode(mode == EJIT_COMPILE_ASYNC ? CompileMode::Async
-                                                           : CompileMode::Sync);
-#ifdef EJIT_SRE_SHARED_TASKPOOL
-  if (gEJIT)
-    if (auto *tp = gEJIT->sharedTaskPool())
-      tp->retireDispatchCache();
-#endif
-  else
+  if (!gEJIT) {
     EJIT_DIAG("set_compile_mode reject: not initialized");
+    return;
+  }
+  (void)gEJIT->setCompileMode(mode == EJIT_COMPILE_ASYNC ? CompileMode::Async
+                                                        : CompileMode::Sync);
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (auto *tp = gEJIT->sharedTaskPool())
+    tp->retireDispatchCache();
+#endif
 }
 
 ejit_compile_mode_t ejit_get_compile_mode(void) {
@@ -636,6 +636,12 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
   // so a hit still hands back outBucket for ejit_taskpool_release_read and a
   // disabled instance never returns stale code. A true miss falls through to
   // compileOrGet unchanged (enqueue/dedup/compile).
+  void *l0Fn = nullptr;
+  if (tp->l0Try(funcIndex, dimsCast, numDims, &l0Fn)) {
+    if (outFn) *outFn = l0Fn;
+    if (outBucket) *outBucket = kEJitNoBucket;
+    return EJIT_OK;
+  }
   auto fast = tp->tryCacheHit(funcIndex, dimsCast, numDims);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -646,6 +652,8 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                       funcIndex, static_cast<unsigned>(fast.status),
                       fast.fnPtr);
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dimsCast, numDims);
+    if (fast.fnPtr)
+      tp->l0Fill(funcIndex, fast.fnPtr, dimsCast, numDims);
     return taskpoolStatus(fast.status);
   }
 
@@ -658,6 +666,8 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
   EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u status=%u fn=%p",
                     funcIndex, static_cast<unsigned>(r.status), r.fnPtr);
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dimsCast, numDims);
+  if (r.fnPtr)
+    tp->l0Fill(funcIndex, r.fnPtr, dimsCast, numDims);
   return taskpoolStatus(r.status);
 }
 
@@ -694,6 +704,12 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
 
+  void *l0Fn = nullptr;
+  if (tp->l0Try(funcIndex, nullptr, 0, &l0Fn)) {
+    if (outFn) *outFn = l0Fn;
+    if (outBucket) *outBucket = kEJitNoBucket;
+    return EJIT_OK;
+  }
   auto fast = tp->tryCacheHit0D(funcIndex);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -709,6 +725,8 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
   if (outBucket)
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, nullptr, 0);
+  if (r.fnPtr)
+    tp->l0Fill(funcIndex, r.fnPtr, nullptr, 0);
   return taskpoolStatus(r.status);
 }
 
@@ -778,6 +796,12 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
     return EJIT_ERR_INVALID_PARAM;
 
   const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
+  void *l0Fn = nullptr;
+  if (tp->l0Try(funcIndex, dims, 2, &l0Fn)) {
+    if (outFn) *outFn = l0Fn;
+    if (outBucket) *outBucket = kEJitNoBucket;
+    return EJIT_OK;
+  }
   auto fast = tp->tryCacheHit2D(funcIndex, dim0, inst0, dim1, inst1);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -785,6 +809,8 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
     if (outBucket)
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 2);
+    if (fast.fnPtr)
+      tp->l0Fill(funcIndex, fast.fnPtr, dims, 2);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 2, /*fallback=*/nullptr);
@@ -793,6 +819,8 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
   if (outBucket)
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 2);
+  if (r.fnPtr)
+    tp->l0Fill(funcIndex, r.fnPtr, dims, 2);
   return taskpoolStatus(r.status);
 }
 
@@ -816,6 +844,12 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
     return EJIT_ERR_INVALID_PARAM;
 
   const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
+  void *l0Fn = nullptr;
+  if (tp->l0Try(funcIndex, dims, 3, &l0Fn)) {
+    if (outFn) *outFn = l0Fn;
+    if (outBucket) *outBucket = kEJitNoBucket;
+    return EJIT_OK;
+  }
   auto fast =
       tp->tryCacheHit3D(funcIndex, dim0, inst0, dim1, inst1, dim2, inst2);
   if (fast.fastPathTerminal) {
@@ -824,6 +858,8 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
     if (outBucket)
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 3);
+    if (fast.fnPtr)
+      tp->l0Fill(funcIndex, fast.fnPtr, dims, 3);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 3, /*fallback=*/nullptr);
@@ -832,6 +868,8 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
   if (outBucket)
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 3);
+  if (r.fnPtr)
+    tp->l0Fill(funcIndex, r.fnPtr, dims, 3);
   return taskpoolStatus(r.status);
 }
 
@@ -858,6 +896,12 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
 
   const EJitDimPair dims[4] = {
       {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
+  void *l0Fn = nullptr;
+  if (tp->l0Try(funcIndex, dims, 4, &l0Fn)) {
+    if (outFn) *outFn = l0Fn;
+    if (outBucket) *outBucket = kEJitNoBucket;
+    return EJIT_OK;
+  }
   auto fast = tp->tryCacheHit4D(funcIndex, dim0, inst0, dim1, inst1, dim2,
                                 inst2, dim3, inst3);
   if (fast.fastPathTerminal) {
@@ -866,6 +910,8 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
     if (outBucket)
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 4);
+    if (fast.fnPtr)
+      tp->l0Fill(funcIndex, fast.fnPtr, dims, 4);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 4, /*fallback=*/nullptr);
@@ -874,6 +920,8 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
   if (outBucket)
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 4);
+  if (r.fnPtr)
+    tp->l0Fill(funcIndex, r.fnPtr, dims, 4);
   return taskpoolStatus(r.status);
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -35,6 +35,11 @@ using namespace llvm::ejit;
 
 static EJit *gEJIT = nullptr;
 
+// Returned only by the shared-taskpool L0 path, which takes no bucket read
+// token. Keep the C-ABI sentinel independent of the shared-state header so a
+// private-taskpool build does not acquire a shared-only dependency.
+constexpr uint32_t kEJitRuntimeNoBucket = UINT32_MAX;
+
 #ifdef EJIT_FREESTANDING
 extern "C" uint64_t SRE_CycleCountGet64(void);
 #endif
@@ -381,7 +386,11 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
               funcName);
     return;
   }
+#ifdef EJIT_SRE_SHARED_TASKPOOL
   ejitIcacheRegisterSlot(idx, slot, numDims);
+#else
+  (void)numDims;
+#endif
   EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
                     funcName, idx, numDims);
 }
@@ -578,6 +587,35 @@ inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
   (void)numDims;
 #endif
 }
+
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+inline bool ejitL0Try(EJitSharedTaskPool *tp, uint32_t funcIndex,
+                      const EJitDimPair *dims, uint32_t numDims, void **outFn) {
+  return tp->l0Try(funcIndex, dims, numDims, outFn);
+}
+
+inline uint32_t ejitL0Epoch(EJitSharedTaskPool *tp) {
+  return tp->dispatchEpoch();
+}
+
+inline void ejitL0Fill(EJitSharedTaskPool *tp, uint32_t funcIndex, void *fnPtr,
+                       const EJitDimPair *dims, uint32_t numDims,
+                       uint32_t expectedEpoch) {
+  tp->l0Fill(funcIndex, fnPtr, dims, numDims, expectedEpoch);
+}
+#else
+// L0 is a shared-taskpool optimization. Keep the private taskpool ABI on its
+// established bucket path without requiring methods it does not implement.
+inline bool ejitL0Try(EJitTaskPool *, uint32_t, const EJitDimPair *, uint32_t,
+                      void **) {
+  return false;
+}
+
+inline uint32_t ejitL0Epoch(EJitTaskPool *) { return 0; }
+
+inline void ejitL0Fill(EJitTaskPool *, uint32_t, void *, const EJitDimPair *,
+                       uint32_t, uint32_t) {}
+#endif
 } // namespace
 
 ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
@@ -637,11 +675,13 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
   // disabled instance never returns stale code. A true miss falls through to
   // compileOrGet unchanged (enqueue/dedup/compile).
   void *l0Fn = nullptr;
-  if (tp->l0Try(funcIndex, dimsCast, numDims, &l0Fn)) {
+  if (ejitL0Try(tp, funcIndex, dimsCast, numDims, &l0Fn)) {
     if (outFn) *outFn = l0Fn;
-    if (outBucket) *outBucket = kEJitNoBucket;
+    if (outBucket)
+      *outBucket = kEJitRuntimeNoBucket;
     return EJIT_OK;
   }
+  const uint32_t l0Epoch = ejitL0Epoch(tp);
   auto fast = tp->tryCacheHit(funcIndex, dimsCast, numDims);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -653,7 +693,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                       fast.fnPtr);
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dimsCast, numDims);
     if (fast.fnPtr)
-      tp->l0Fill(funcIndex, fast.fnPtr, dimsCast, numDims);
+      ejitL0Fill(tp, funcIndex, fast.fnPtr, dimsCast, numDims, l0Epoch);
     return taskpoolStatus(fast.status);
   }
 
@@ -667,7 +707,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                     funcIndex, static_cast<unsigned>(r.status), r.fnPtr);
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dimsCast, numDims);
   if (r.fnPtr)
-    tp->l0Fill(funcIndex, r.fnPtr, dimsCast, numDims);
+    ejitL0Fill(tp, funcIndex, r.fnPtr, dimsCast, numDims, l0Epoch);
   return taskpoolStatus(r.status);
 }
 
@@ -705,11 +745,13 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
     return EJIT_ERR_NOT_ACTIVE;
 
   void *l0Fn = nullptr;
-  if (tp->l0Try(funcIndex, nullptr, 0, &l0Fn)) {
+  if (ejitL0Try(tp, funcIndex, nullptr, 0, &l0Fn)) {
     if (outFn) *outFn = l0Fn;
-    if (outBucket) *outBucket = kEJitNoBucket;
+    if (outBucket)
+      *outBucket = kEJitRuntimeNoBucket;
     return EJIT_OK;
   }
+  const uint32_t l0Epoch = ejitL0Epoch(tp);
   auto fast = tp->tryCacheHit0D(funcIndex);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -717,6 +759,8 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
     if (outBucket)
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, nullptr, 0);
+    if (fast.fnPtr)
+      ejitL0Fill(tp, funcIndex, fast.fnPtr, nullptr, 0, l0Epoch);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, nullptr, 0, /*fallback=*/nullptr);
@@ -726,7 +770,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, nullptr, 0);
   if (r.fnPtr)
-    tp->l0Fill(funcIndex, r.fnPtr, nullptr, 0);
+    ejitL0Fill(tp, funcIndex, r.fnPtr, nullptr, 0, l0Epoch);
   return taskpoolStatus(r.status);
 }
 
@@ -747,15 +791,16 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
 
   const EJitDimPair dims[1] = {{dim0, inst0}};
   // Per-core L0: steady-state hit with no rwlock, scan, or read token.
-  // kEJitNoBucket tells the caller no token was taken.
+  // kEJitRuntimeNoBucket tells the caller no token was taken.
   void *l0Fn = nullptr;
-  if (tp->l0Try(funcIndex, dims, 1, &l0Fn)) {
+  if (ejitL0Try(tp, funcIndex, dims, 1, &l0Fn)) {
     if (outFn)
       *outFn = l0Fn;
     if (outBucket)
-      *outBucket = kEJitNoBucket;
+      *outBucket = kEJitRuntimeNoBucket;
     return EJIT_OK;
   }
+  const uint32_t l0Epoch = ejitL0Epoch(tp);
   auto fast = tp->tryCacheHit1D(funcIndex, dim0, inst0);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -764,7 +809,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 1);
     if (fast.fnPtr)
-      tp->l0Fill(funcIndex, fast.fnPtr, dims, 1);
+      ejitL0Fill(tp, funcIndex, fast.fnPtr, dims, 1, l0Epoch);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 1, /*fallback=*/nullptr);
@@ -774,7 +819,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 1);
   if (r.fnPtr)
-    tp->l0Fill(funcIndex, r.fnPtr, dims, 1);
+    ejitL0Fill(tp, funcIndex, r.fnPtr, dims, 1, l0Epoch);
   return taskpoolStatus(r.status);
 }
 
@@ -797,11 +842,13 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
 
   const EJitDimPair dims[2] = {{dim0, inst0}, {dim1, inst1}};
   void *l0Fn = nullptr;
-  if (tp->l0Try(funcIndex, dims, 2, &l0Fn)) {
+  if (ejitL0Try(tp, funcIndex, dims, 2, &l0Fn)) {
     if (outFn) *outFn = l0Fn;
-    if (outBucket) *outBucket = kEJitNoBucket;
+    if (outBucket)
+      *outBucket = kEJitRuntimeNoBucket;
     return EJIT_OK;
   }
+  const uint32_t l0Epoch = ejitL0Epoch(tp);
   auto fast = tp->tryCacheHit2D(funcIndex, dim0, inst0, dim1, inst1);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -810,7 +857,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 2);
     if (fast.fnPtr)
-      tp->l0Fill(funcIndex, fast.fnPtr, dims, 2);
+      ejitL0Fill(tp, funcIndex, fast.fnPtr, dims, 2, l0Epoch);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 2, /*fallback=*/nullptr);
@@ -820,7 +867,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 2);
   if (r.fnPtr)
-    tp->l0Fill(funcIndex, r.fnPtr, dims, 2);
+    ejitL0Fill(tp, funcIndex, r.fnPtr, dims, 2, l0Epoch);
   return taskpoolStatus(r.status);
 }
 
@@ -845,11 +892,13 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
 
   const EJitDimPair dims[3] = {{dim0, inst0}, {dim1, inst1}, {dim2, inst2}};
   void *l0Fn = nullptr;
-  if (tp->l0Try(funcIndex, dims, 3, &l0Fn)) {
+  if (ejitL0Try(tp, funcIndex, dims, 3, &l0Fn)) {
     if (outFn) *outFn = l0Fn;
-    if (outBucket) *outBucket = kEJitNoBucket;
+    if (outBucket)
+      *outBucket = kEJitRuntimeNoBucket;
     return EJIT_OK;
   }
+  const uint32_t l0Epoch = ejitL0Epoch(tp);
   auto fast =
       tp->tryCacheHit3D(funcIndex, dim0, inst0, dim1, inst1, dim2, inst2);
   if (fast.fastPathTerminal) {
@@ -859,7 +908,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 3);
     if (fast.fnPtr)
-      tp->l0Fill(funcIndex, fast.fnPtr, dims, 3);
+      ejitL0Fill(tp, funcIndex, fast.fnPtr, dims, 3, l0Epoch);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 3, /*fallback=*/nullptr);
@@ -869,7 +918,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 3);
   if (r.fnPtr)
-    tp->l0Fill(funcIndex, r.fnPtr, dims, 3);
+    ejitL0Fill(tp, funcIndex, r.fnPtr, dims, 3, l0Epoch);
   return taskpoolStatus(r.status);
 }
 
@@ -897,11 +946,13 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
   const EJitDimPair dims[4] = {
       {dim0, inst0}, {dim1, inst1}, {dim2, inst2}, {dim3, inst3}};
   void *l0Fn = nullptr;
-  if (tp->l0Try(funcIndex, dims, 4, &l0Fn)) {
+  if (ejitL0Try(tp, funcIndex, dims, 4, &l0Fn)) {
     if (outFn) *outFn = l0Fn;
-    if (outBucket) *outBucket = kEJitNoBucket;
+    if (outBucket)
+      *outBucket = kEJitRuntimeNoBucket;
     return EJIT_OK;
   }
+  const uint32_t l0Epoch = ejitL0Epoch(tp);
   auto fast = tp->tryCacheHit4D(funcIndex, dim0, inst0, dim1, inst1, dim2,
                                 inst2, dim3, inst3);
   if (fast.fastPathTerminal) {
@@ -911,7 +962,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 4);
     if (fast.fnPtr)
-      tp->l0Fill(funcIndex, fast.fnPtr, dims, 4);
+      ejitL0Fill(tp, funcIndex, fast.fnPtr, dims, 4, l0Epoch);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 4, /*fallback=*/nullptr);
@@ -921,7 +972,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 4);
   if (r.fnPtr)
-    tp->l0Fill(funcIndex, r.fnPtr, dims, 4);
+    ejitL0Fill(tp, funcIndex, r.fnPtr, dims, 4, l0Epoch);
   return taskpoolStatus(r.status);
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -451,14 +451,24 @@ void *ejit_compile_or_get(uint64_t cacheKey, void **out_pfn) {
 
 void ejit_clear_cache(void) {
   EJIT_DIAG("clear_cache");
-  if (gEJIT)
-    gEJIT->clearCache();
+  if (!gEJIT)
+    return;
+  gEJIT->clearCache();
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (auto *tp = gEJIT->sharedTaskPool())
+    tp->retireDispatchCache();
+#endif
 }
 
 void ejit_invalidate(const char *periodName, uint8_t cellIdx) {
   EJIT_DIAG("invalidate(%s,%u)", periodName, cellIdx);
-  if (gEJIT)
-    gEJIT->invalidateByPeriod(periodName, cellIdx);
+  if (!gEJIT)
+    return;
+  gEJIT->invalidateByPeriod(periodName, cellIdx);
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (auto *tp = gEJIT->sharedTaskPool())
+    tp->retireDispatchCache();
+#endif
 }
 
 ejit_status_t ejit_get_stats(ejit_stats_t *stats) {
@@ -488,6 +498,11 @@ void ejit_set_compile_mode(ejit_compile_mode_t mode) {
   if (gEJIT)
     (void)gEJIT->setCompileMode(mode == EJIT_COMPILE_ASYNC ? CompileMode::Async
                                                            : CompileMode::Sync);
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  if (gEJIT)
+    if (auto *tp = gEJIT->sharedTaskPool())
+      tp->retireDispatchCache();
+#endif
   else
     EJIT_DIAG("set_compile_mode reject: not initialized");
 }
@@ -713,6 +728,16 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
     return EJIT_ERR_INVALID_PARAM;
 
   const EJitDimPair dims[1] = {{dim0, inst0}};
+  // Per-core L0: steady-state hit with no rwlock, scan, or read token.
+  // kEJitNoBucket tells the caller no token was taken.
+  void *l0Fn = nullptr;
+  if (tp->l0Try(funcIndex, dims, 1, &l0Fn)) {
+    if (outFn)
+      *outFn = l0Fn;
+    if (outBucket)
+      *outBucket = kEJitNoBucket;
+    return EJIT_OK;
+  }
   auto fast = tp->tryCacheHit1D(funcIndex, dim0, inst0);
   if (fast.fastPathTerminal) {
     if (outFn)
@@ -720,6 +745,8 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
     if (outBucket)
       *outBucket = fast.bucketIndex;
     ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 1);
+    if (fast.fnPtr)
+      tp->l0Fill(funcIndex, fast.fnPtr, dims, 1);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, dims, 1, /*fallback=*/nullptr);
@@ -728,6 +755,8 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
   if (outBucket)
     *outBucket = r.bucketIndex;
   ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 1);
+  if (r.fnPtr)
+    tp->l0Fill(funcIndex, r.fnPtr, dims, 1);
   return taskpoolStatus(r.status);
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+#include <atomic>
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
@@ -276,7 +277,6 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
 // stable in steady state and entries only miss while warming.
 //===----------------------------------------------------------------------===//
 EJitL0Entry llvm::ejit::gEJitL0[kEJitL0Slots];
-uint64_t llvm::ejit::gEJitL0Hits = 0;
 const void *llvm::ejit::gEJitL0State = nullptr;
 
 void EJitSharedTaskPool::retireDispatchCache() {
@@ -288,6 +288,8 @@ void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
                                 const EJitDimPair *dims, uint32_t numDims) {
   if (!icacheReclamationSafe_ || !state_ || !fnPtr)
     return;
+  if (numDims > kEJitSharedMaxDims)
+    return;
   if (state_->initState.loadAcquire() != kReady)
     return;
 #if !defined(EJIT_SRE_SHARED_CODE_POINTERS)
@@ -295,16 +297,26 @@ void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
     return;
 #endif
   gEJitL0State = state_;
-  const uint32_t key = ejitL0Key(funcIndex, dims, numDims);
-  EJitL0Entry &e = gEJitL0[ejitL0Index(key)];
-  // Read the epoch BEFORE publishing the entry, so a bump racing the fill
-  // leaves a stale epoch (a miss), never a fresh epoch on a stale pointer.
-  // Plain stores: the table is core-private, ordered by program order.
+  EJitL0Entry &e = gEJitL0[ejitL0Index(funcIndex, dims, numDims)];
+
+  // Read the epoch BEFORE publishing, so a bump racing the fill leaves a stale
+  // epoch (a miss), never a fresh epoch on a stale pointer.
   const uint32_t epoch = state_->dispatchEpoch.loadAcquire();
+
+  // Seqlock writer: odd while the payload is inconsistent.
+  e.seq = e.seq + 1u;
+  std::atomic_signal_fence(std::memory_order_release);
+
   e.fn = fnPtr;
   e.core = EJitCoreId::current();
-  e.key = key;
+  e.funcIndex = funcIndex;
+  e.numDims = numDims;
+  for (uint32_t i = 0; i < numDims; ++i)
+    e.dims[i] = dims[i];
   e.epoch = epoch;
+
+  std::atomic_signal_fence(std::memory_order_release);
+  e.seq = e.seq + 1u;
 }
 
 void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
@@ -2240,8 +2252,7 @@ void EJitSharedTaskPool::getDiagnostics(EJitSharedDiagnostics &out) const {
           static_cast<uint32_t>(EJitSharedSlotState::Ready))
         ++ready;
   out.cacheReadyCount = ready;
-  // L0 hits are cache hits that never touched the shared counter.
-  out.cacheHits = state_->counters.cacheHits.loadRelaxed() + gEJitL0Hits;
+  out.cacheHits = state_->counters.cacheHits.loadRelaxed();
   out.asyncEnqueues = state_->counters.asyncEnqueues.loadRelaxed();
   out.asyncCompiles = state_->counters.asyncCompiles.loadRelaxed();
   out.alreadyPending = state_->counters.alreadyPending.loadRelaxed();

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -17,10 +17,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
-#include <atomic>
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
-#include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
+#include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -269,15 +268,41 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
 // Per-core L0 dispatch cache
 //
 // A direct-mapped table in core-private memory, in front of the bucket lookup.
-// A hit is a key compare plus one read of the shared dispatchEpoch: no atomics,
-// no scan, no cache-line ownership transfer.
+// A hit is a full identity compare plus one read of the shared dispatchEpoch:
+// only atomic loads, no RMW, no scan, and no cache-line ownership transfer.
 //
 // Invalidation is coarse on purpose -- any epoch bump retires every core's
 // whole table. Publishes cluster in warm-up and then stop, so the epoch is
 // stable in steady state and entries only miss while warming.
 //===----------------------------------------------------------------------===//
 EJitL0Entry llvm::ejit::gEJitL0[kEJitL0Slots];
-const void *llvm::ejit::gEJitL0State = nullptr;
+EJitAtomicUPtr llvm::ejit::gEJitL0State;
+EJitAtomicU32 llvm::ejit::gEJitL0Writer;
+
+namespace {
+void clearL0Entry(EJitL0Entry &entry) {
+  const uint32_t seq = entry.seq.loadRelaxed();
+  entry.seq.storeRelease(seq | 1u);
+  entry.epoch.storeRelaxed(0);
+  entry.core.storeRelaxed(kEJitInvalidCoreId);
+  entry.funcIndex.storeRelaxed(0);
+  entry.numDims.storeRelaxed(0);
+  for (uint32_t i = 0; i < kEJitSharedMaxDims; ++i)
+    entry.dims[i].storeRelaxed(0);
+  entry.fn.storeRelaxed(0);
+  entry.seq.storeRelease((seq | 1u) + 1u);
+}
+} // namespace
+
+void llvm::ejit::ejitL0ClearLocal() {
+  uint32_t unlocked = 0;
+  if (!gEJitL0Writer.compareExchange(unlocked, 1))
+    return;
+  gEJitL0State.storeRelease(0);
+  for (uint32_t i = 0; i < kEJitL0Slots; ++i)
+    clearL0Entry(gEJitL0[i]);
+  gEJitL0Writer.storeRelease(0);
+}
 
 void EJitSharedTaskPool::retireDispatchCache() {
   if (state_)
@@ -285,7 +310,8 @@ void EJitSharedTaskPool::retireDispatchCache() {
 }
 
 void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
-                                const EJitDimPair *dims, uint32_t numDims) {
+                                const EJitDimPair *dims, uint32_t numDims,
+                                uint32_t expectedEpoch) {
   if (!icacheReclamationSafe_ || !state_ || !fnPtr)
     return;
   if (numDims > kEJitSharedMaxDims)
@@ -296,27 +322,50 @@ void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
   if (EJitCoreId::current() != state_->ownerCoreId.loadRelaxed())
     return;
 #endif
-  gEJitL0State = state_;
+
+  // Same-core task preemption can nest a fill. Never spin here: skipping one
+  // population only sends the next dispatch through the authoritative shared
+  // cache. The successful writer owns all entry mutation until release.
+  uint32_t unlocked = 0;
+  if (!gEJitL0Writer.compareExchange(unlocked, 1))
+    return;
+
+  const uintptr_t stateTag = reinterpret_cast<uintptr_t>(state_);
+  if (gEJitL0State.loadAcquire() != stateTag) {
+    // Disarm before clearing so a preempting reader cannot consume an entry
+    // from the previous shared blob under the new blob's epoch.
+    gEJitL0State.storeRelease(0);
+    for (uint32_t i = 0; i < kEJitL0Slots; ++i)
+      clearL0Entry(gEJitL0[i]);
+    gEJitL0State.storeRelease(stateTag);
+  }
+
   EJitL0Entry &e = gEJitL0[ejitL0Index(funcIndex, dims, numDims)];
 
-  // Read the epoch BEFORE publishing, so a bump racing the fill leaves a stale
-  // epoch (a miss), never a fresh epoch on a stale pointer.
-  const uint32_t epoch = state_->dispatchEpoch.loadAcquire();
+  // The token was captured before the authoritative bucket lookup. If any
+  // publish/version/invalidation raced that lookup, never re-arm an old result
+  // under the new epoch. The next call simply uses the shared cache again.
+  if (expectedEpoch == 0 ||
+      state_->dispatchEpoch.loadAcquire() != expectedEpoch) {
+    gEJitL0Writer.storeRelease(0);
+    return;
+  }
 
-  // Seqlock writer: odd while the payload is inconsistent.
-  e.seq = e.seq + 1u;
-  std::atomic_signal_fence(std::memory_order_release);
-
-  e.fn = fnPtr;
-  e.core = EJitCoreId::current();
-  e.funcIndex = funcIndex;
-  e.numDims = numDims;
+  // Atomic seqlock writer: odd while the payload is inconsistent. Payload
+  // fields are atomic as well, so a preempting reader has no C++ data race.
+  const uint32_t seq = e.seq.loadRelaxed();
+  e.seq.storeRelease(seq | 1u);
+  e.fn.storeRelaxed(reinterpret_cast<uintptr_t>(fnPtr));
+  e.core.storeRelaxed(EJitCoreId::current());
+  e.funcIndex.storeRelaxed(funcIndex);
+  e.numDims.storeRelaxed(numDims);
   for (uint32_t i = 0; i < numDims; ++i)
-    e.dims[i] = dims[i];
-  e.epoch = epoch;
-
-  std::atomic_signal_fence(std::memory_order_release);
-  e.seq = e.seq + 1u;
+    e.dims[i].storeRelaxed(ejitL0PackDim(dims[i]));
+  for (uint32_t i = numDims; i < kEJitSharedMaxDims; ++i)
+    e.dims[i].storeRelaxed(0);
+  e.epoch.storeRelaxed(expectedEpoch);
+  e.seq.storeRelease((seq | 1u) + 1u);
+  gEJitL0Writer.storeRelease(0);
 }
 
 void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
@@ -1437,7 +1486,8 @@ namespace {
 // activated via ejit_activate before the JIT will compile it. This matches
 // the non-shared EJitRuntimeState::isActive default (no entry => inactive).
 // setInstanceEnabled(true) flips 0->1 and bumps version on first activate.
-void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
+void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
+                       uint32_t nextDispatchEpoch) {
   for (uint32_t d = 0; d < kEJitSharedDimTypes; ++d)
     for (uint32_t i = 0; i < kEJitSharedInstances; ++i) {
       st->enabled[d][i].storeRelaxed(0);
@@ -1445,14 +1495,10 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
     }
   st->mode.storeRelaxed(mode);
   st->anyInstanceActivated.storeRelaxed(0);
-  // dispatchEpoch is BUMPED, never reset. A per-core L0 entry filled under a
-  // previous pool instance must not validate under this one, and the entries
-  // outlive the shared blob (they live in core-private memory). Monotonic
-  // bumping guarantees the mismatch; resetting to a fixed value would let a
-  // stale entry match again after a re-init. On a genuinely fresh blob the
-  // starting value is arbitrary, which is harmless: the L0 tables are zeroed
-  // BSS and l0Key() never returns 0, so no entry can match anyway.
-  st->dispatchEpoch.fetchAdd(1);
+  // Preserve monotonic invalidation across re-initialization. The caller reads
+  // the old value before this field-by-field reset; fresh shared storage must
+  // be zero-filled, just like initState and generation.
+  st->dispatchEpoch.storeRelaxed(nextDispatchEpoch);
   for (uint32_t i = 0; i < kEJitSharedMaxFuncIndex; ++i)
     st->inFlight[i].storeRelaxed(0);
   for (uint32_t i = 0; i < kEJitSharedQueueSlots; ++i) {
@@ -1564,7 +1610,11 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       // We are the owner. Build the whole blob, then publish Ready LAST.
       uint32_t self = EJitCoreId::current();
       uint32_t nextGen = state_->generation.loadRelaxed() + 1;
-      initSharedStorage(state_, static_cast<uint32_t>(configuredMode_));
+      uint32_t nextDispatchEpoch = state_->dispatchEpoch.loadRelaxed() + 1;
+      if (nextDispatchEpoch == 0)
+        nextDispatchEpoch = 1;
+      initSharedStorage(state_, static_cast<uint32_t>(configuredMode_),
+                        nextDispatchEpoch);
       state_->generation.storeRelease(nextGen);
       state_->ownerCoreId.storeRelease(self);
       state_->codeSharingEnabled.storeRelease(codeSharingEnabled_ ? 1u : 0u);
@@ -1653,7 +1703,7 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
 void EJitSharedTaskPool::ownerShutdown() {
   // Disarm this core's L0: its entries hold code pointers about to become
   // invalid. Peers stay armed but cannot match after the epoch bump below.
-  gEJitL0State = nullptr;
+  gEJitL0State.storeRelease(0);
   if (state_)
     state_->dispatchEpoch.fetchAdd(1);
   if (!state_ || !isOwner_)

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -264,6 +264,49 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
   return true;
 }
 
+//===----------------------------------------------------------------------===//
+// Per-core L0 dispatch cache
+//
+// A direct-mapped table in core-private memory, in front of the bucket lookup.
+// A hit is a key compare plus one read of the shared dispatchEpoch: no atomics,
+// no scan, no cache-line ownership transfer.
+//
+// Invalidation is coarse on purpose -- any epoch bump retires every core's
+// whole table. Publishes cluster in warm-up and then stop, so the epoch is
+// stable in steady state and entries only miss while warming.
+//===----------------------------------------------------------------------===//
+EJitL0Entry llvm::ejit::gEJitL0[kEJitL0Slots];
+uint64_t llvm::ejit::gEJitL0Hits = 0;
+const void *llvm::ejit::gEJitL0State = nullptr;
+
+void EJitSharedTaskPool::retireDispatchCache() {
+  if (state_)
+    state_->dispatchEpoch.fetchAdd(1);
+}
+
+void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
+                                const EJitDimPair *dims, uint32_t numDims) {
+  if (!icacheReclamationSafe_ || !state_ || !fnPtr)
+    return;
+  if (state_->initState.loadAcquire() != kReady)
+    return;
+#if !defined(EJIT_SRE_SHARED_CODE_POINTERS)
+  if (EJitCoreId::current() != state_->ownerCoreId.loadRelaxed())
+    return;
+#endif
+  gEJitL0State = state_;
+  const uint32_t key = ejitL0Key(funcIndex, dims, numDims);
+  EJitL0Entry &e = gEJitL0[ejitL0Index(key)];
+  // Read the epoch BEFORE publishing the entry, so a bump racing the fill
+  // leaves a stale epoch (a miss), never a fresh epoch on a stale pointer.
+  // Plain stores: the table is core-private, ordered by program order.
+  const uint32_t epoch = state_->dispatchEpoch.loadAcquire();
+  e.fn = fnPtr;
+  e.core = EJitCoreId::current();
+  e.key = key;
+  e.epoch = epoch;
+}
+
 void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
                                     const EJitDimPair *dims, uint32_t numDims) {
   if (!icacheReclamationSafe_)
@@ -328,6 +371,8 @@ bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
   uint8_t desired = enabled ? 1 : 0;
   if (state_->enabled[dimType][instanceId].compareExchange(expected, desired)) {
     state_->version[dimType][instanceId].fetchAdd(1);
+    // Cached L0 entries carry no version, so retire them all.
+    state_->dispatchEpoch.fetchAdd(1);
     // Latch on the first successful enable of ANY instance: this brackets the
     // init→activate window during which instanceDisabled hits are tallied
     // separately (instanceDisabledPreActivate) for diagnosing the pre-activate
@@ -1335,6 +1380,8 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   target->executableCoreMask.storeRelease(
       OwnerCore < 64 ? (uint64_t{1} << OwnerCore) : 0);
   target->state.storeRelease(static_cast<uint32_t>(EJitSharedSlotState::Ready));
+  // Published a new fnPtr, or evicted the slot that held one.
+  state_->dispatchEpoch.fetchAdd(1);
   bucketWriteRelease(B);
 
   // Release the slot's PREVIOUS code OUTSIDE the bucket lock (the callback may
@@ -1349,6 +1396,9 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
 }
 
 void EJitSharedTaskPool::releaseRead(uint32_t bucketIndex) {
+  // Served from the L0: no token was taken.
+  if (bucketIndex == kEJitNoBucket)
+    return;
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
   // A load-only seqlock hit takes no read token and deliberately returns the
   // one-past-the-end bucket as a sentinel. Wrappers still call releaseRead()
@@ -1383,6 +1433,14 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
     }
   st->mode.storeRelaxed(mode);
   st->anyInstanceActivated.storeRelaxed(0);
+  // dispatchEpoch is BUMPED, never reset. A per-core L0 entry filled under a
+  // previous pool instance must not validate under this one, and the entries
+  // outlive the shared blob (they live in core-private memory). Monotonic
+  // bumping guarantees the mismatch; resetting to a fixed value would let a
+  // stale entry match again after a re-init. On a genuinely fresh blob the
+  // starting value is arbitrary, which is harmless: the L0 tables are zeroed
+  // BSS and l0Key() never returns 0, so no entry can match anyway.
+  st->dispatchEpoch.fetchAdd(1);
   for (uint32_t i = 0; i < kEJitSharedMaxFuncIndex; ++i)
     st->inFlight[i].storeRelaxed(0);
   for (uint32_t i = 0; i < kEJitSharedQueueSlots; ++i) {
@@ -1581,6 +1639,11 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
 }
 
 void EJitSharedTaskPool::ownerShutdown() {
+  // Disarm this core's L0: its entries hold code pointers about to become
+  // invalid. Peers stay armed but cannot match after the epoch bump below.
+  gEJitL0State = nullptr;
+  if (state_)
+    state_->dispatchEpoch.fetchAdd(1);
   if (!state_ || !isOwner_)
     return;
   EJIT_DIAG("shared taskpool owner shutdown begin");
@@ -2177,7 +2240,8 @@ void EJitSharedTaskPool::getDiagnostics(EJitSharedDiagnostics &out) const {
           static_cast<uint32_t>(EJitSharedSlotState::Ready))
         ++ready;
   out.cacheReadyCount = ready;
-  out.cacheHits = state_->counters.cacheHits.loadRelaxed();
+  // L0 hits are cache hits that never touched the shared counter.
+  out.cacheHits = state_->counters.cacheHits.loadRelaxed() + gEJitL0Hits;
   out.asyncEnqueues = state_->counters.asyncEnqueues.loadRelaxed();
   out.asyncCompiles = state_->counters.asyncCompiles.loadRelaxed();
   out.alreadyPending = state_->counters.alreadyPending.loadRelaxed();

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1594,12 +1594,12 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
   EXPECT_TRUE(r.readyButNotShareable);
 }
 
-// 16/17 ABI v7 layout: the slot carries the executable range as fixed-width,
+// 16/17 ABI v8 layout: the slot carries the executable range as fixed-width,
 // naturally-aligned scalars (read back by value — endian-safe), the pool-split
 // table is POD, dump state contains metadata only, and each bucket carries the
 // NO_RECLAIM seqlock publishSeq word.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 7u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 8u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -2770,11 +2770,7 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
 namespace {
 /// Process-globals standing in for core-private storage: no test may inherit
 /// them from the one before it.
-void resetL0ForTest() {
-  for (uint32_t i = 0; i < kEJitL0Slots; ++i)
-    gEJitL0[i] = EJitL0Entry{};
-  gEJitL0State = nullptr;
-}
+void resetL0ForTest() { ejitL0ClearLocal(); }
 } // namespace
 
 TEST_F(SharedTaskPoolTest, L0ServesARepeatDispatch) {
@@ -2787,7 +2783,7 @@ TEST_F(SharedTaskPoolTest, L0ServesARepeatDispatch) {
   void *out = nullptr;
   EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out)) << "cold table must miss";
 
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   EXPECT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
   EXPECT_EQ(out, codeFor(kFunc));
 
@@ -2804,13 +2800,13 @@ TEST_F(SharedTaskPoolTest, L0RetiredByPublishAndByVersionChange) {
   const EJitDimPair dims[1] = {{0, 1}};
   void *out = nullptr;
 
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
 
   publish(pool, 9);
   EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out)) << "publish must retire the L0";
 
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
 
   // L0 entries carry no version of their own.
@@ -2827,13 +2823,50 @@ TEST_F(SharedTaskPoolTest, L0RetiredByExplicitFlush) {
   const EJitDimPair dims[1] = {{0, 1}};
   void *out = nullptr;
 
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
 
   // ejit_clear_cache() / ejit_invalidate() / a compile-mode change reach the
   // L0 only through this hook.
   pool.retireDispatchCache();
   EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out));
+}
+
+TEST_F(SharedTaskPoolTest, L0RejectsResultResolvedBeforeEpochChange) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const uint32_t kFunc = 5;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  // Model the C-ABI race: an authoritative cache lookup resolves fnPtr, then
+  // activation/invalidation changes the epoch before the L0 fill executes.
+  const uint32_t lookupEpoch = pool.dispatchEpoch();
+  pool.retireDispatchCache();
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, lookupEpoch);
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out))
+      << "an old lookup result must not be tagged with the new epoch";
+}
+
+TEST_F(SharedTaskPoolTest, L0NestedWriterSkipsFillWithoutCorruptingEntry) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const uint32_t kFunc = 5;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  // Model a same-core task/interrupt entering l0Fill while another fill is
+  // preempted. The nested writer never spins and leaves the table untouched.
+  gEJitL0Writer.storeRelease(1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out));
+  gEJitL0Writer.storeRelease(0);
+
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
+  EXPECT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+  EXPECT_EQ(out, codeFor(kFunc));
 }
 
 TEST_F(SharedTaskPoolTest, L0EntryIsNotServedToAnotherCore) {
@@ -2845,7 +2878,7 @@ TEST_F(SharedTaskPoolTest, L0EntryIsNotServedToAnotherCore) {
   void *out = nullptr;
 
   EJitCoreId::setCurrentForTest(0);
-  owner.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  owner.l0Fill(kFunc, codeFor(kFunc), dims, 1, owner.dispatchEpoch());
   ASSERT_TRUE(owner.l0Try(kFunc, dims, 1, &out));
 
   // Cannot arise on hardware (core-private table), but can where cores are
@@ -2866,9 +2899,9 @@ TEST_F(SharedTaskPoolTest, L0DoesNotSurviveANewSharedBlob) {
 
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
-  ASSERT_NE(gEJitL0State, nullptr);
+  ASSERT_NE(gEJitL0State.loadAcquire(), 0u);
 
   // The table outlives the shared blob. A fresh blob starts from a low
   // dispatchEpoch, so the epoch alone cannot separate the two instances -- the
@@ -2893,7 +2926,7 @@ TEST_F(SharedTaskPoolTest, L0DoesNotSurviveAReInitialization) {
 
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
 
   // Same blob, torn down and stood back up: entries still point into a code
@@ -2906,7 +2939,7 @@ TEST_F(SharedTaskPoolTest, L0DoesNotSurviveAReInitialization) {
       << "an entry from the previous pool instance must not validate";
 
   // ...and the cache re-arms normally afterwards.
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   EXPECT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
 }
 
@@ -2921,7 +2954,7 @@ TEST_F(SharedTaskPoolTest, L0RefusesToArmWhileAReleaserIsWired) {
   // With a releaser wired, code can be freed under a caller, and an L0 hit
   // carries no read token. Same gate the inline cache uses.
   pool.setReleaser([](void *, void *) {}, nullptr);
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out));
 }
 
@@ -2935,7 +2968,7 @@ TEST_F(SharedTaskPoolTest, L0EntriesAreRetiredWhenAReleaserIsWiredLater) {
   const EJitDimPair dims[1] = {{0, 1}};
   void *out = nullptr;
 
-  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1, pool.dispatchEpoch());
   ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
 
   pool.setReleaser([](void *, void *) {}, nullptr);
@@ -2965,20 +2998,21 @@ TEST_F(SharedTaskPoolTest, L0PartiallyWrittenEntryIsNotServed) {
   const EJitDimPair a[1] = {{0, 1}};
   void *out = nullptr;
 
-  pool.l0Fill(20, codeFor(20), a, 1);
+  pool.l0Fill(20, codeFor(20), a, 1, pool.dispatchEpoch());
   ASSERT_TRUE(pool.l0Try(20, a, 1, &out));
   ASSERT_EQ(out, codeFor(20));
 
   // The interleaving a preempted fill leaves: odd sequence, fnPtr replaced,
   // identity not yet updated.
   EJitL0Entry &e = gEJitL0[ejitL0Index(20, a, 1)];
-  e.seq = e.seq + 1u;
-  e.fn = codeFor(21);
+  uint32_t seq = e.seq.loadRelaxed();
+  e.seq.storeRelease(seq | 1u);
+  e.fn.storeRelaxed(reinterpret_cast<uintptr_t>(codeFor(21)));
 
   EXPECT_FALSE(pool.l0Try(20, a, 1, &out))
       << "a half-written entry must not be served";
 
-  e.seq = e.seq + 1u; // writer completes
+  e.seq.storeRelease((seq | 1u) + 1u); // writer completes
   EXPECT_TRUE(pool.l0Try(20, a, 1, &out));
 }
 
@@ -3001,8 +3035,9 @@ TEST_F(SharedTaskPoolTest, L0CollidingIdentitiesNeverCrossServe) {
   }
   ASSERT_TRUE(found) << "no colliding identity found in the instance space";
 
-  pool.l0Fill(30, codeFor(30), a, 1);
-  pool.l0Fill(30, codeFor(31), b, 1); // evicts a from the shared slot
+  pool.l0Fill(30, codeFor(30), a, 1, pool.dispatchEpoch());
+  pool.l0Fill(30, codeFor(31), b, 1,
+              pool.dispatchEpoch()); // evicts a from the shared slot
 
   EXPECT_FALSE(pool.l0Try(30, a, 1, &out))
       << "the evicted identity must miss, not receive the evictor's pointer";
@@ -3013,8 +3048,8 @@ TEST_F(SharedTaskPoolTest, L0CollidingIdentitiesNeverCrossServe) {
   resetL0ForTest();
   const EJitDimPair c[1] = {{0, 31}};
   const EJitDimPair d[1] = {{1, 0}};
-  pool.l0Fill(30, codeFor(32), c, 1);
-  pool.l0Fill(30, codeFor(33), d, 1);
+  pool.l0Fill(30, codeFor(32), c, 1, pool.dispatchEpoch());
+  pool.l0Fill(30, codeFor(33), d, 1, pool.dispatchEpoch());
   if (pool.l0Try(30, c, 1, &out))
     EXPECT_EQ(out, codeFor(32)) << "(0,31) served (1,0)'s specialization";
   if (pool.l0Try(30, d, 1, &out))
@@ -3023,8 +3058,8 @@ TEST_F(SharedTaskPoolTest, L0CollidingIdentitiesNeverCrossServe) {
   // Same funcIndex, differing arity must not alias.
   resetL0ForTest();
   const EJitDimPair two[2] = {{0, 31}, {0, 0}};
-  pool.l0Fill(30, codeFor(34), c, 1);
-  pool.l0Fill(30, codeFor(35), two, 2);
+  pool.l0Fill(30, codeFor(34), c, 1, pool.dispatchEpoch());
+  pool.l0Fill(30, codeFor(35), two, 2, pool.dispatchEpoch());
   if (pool.l0Try(30, c, 1, &out))
     EXPECT_EQ(out, codeFor(34)) << "1D identity served a 2D entry";
   if (pool.l0Try(30, two, 2, &out))
@@ -3032,8 +3067,8 @@ TEST_F(SharedTaskPoolTest, L0CollidingIdentitiesNeverCrossServe) {
 
   // Different funcIndex, identical dims must not alias.
   resetL0ForTest();
-  pool.l0Fill(30, codeFor(36), c, 1);
-  pool.l0Fill(31, codeFor(37), c, 1);
+  pool.l0Fill(30, codeFor(36), c, 1, pool.dispatchEpoch());
+  pool.l0Fill(31, codeFor(37), c, 1, pool.dispatchEpoch());
   if (pool.l0Try(30, c, 1, &out))
     EXPECT_NE(out, codeFor(37)) << "funcIndex 30 served funcIndex 31's entry";
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2759,4 +2759,185 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
   ejitIcacheClearAll();
 }
 
+//===----------------------------------------------------------------------===//
+// Per-core L0 dispatch cache
+//
+// Nothing on the hit path re-checks what makes it safe, so each invariant is
+// pinned here. Getting one wrong yields a stale or dangling code pointer, which
+// no value assertion elsewhere would catch.
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Process-globals standing in for core-private storage: no test may inherit
+/// them from the one before it.
+void resetL0ForTest() {
+  for (uint32_t i = 0; i < kEJitL0Slots; ++i)
+    gEJitL0[i] = EJitL0Entry{};
+  gEJitL0State = nullptr;
+  gEJitL0Hits = 0;
+}
+} // namespace
+
+TEST_F(SharedTaskPoolTest, L0ServesARepeatDispatchAndCountsIt) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const uint32_t kFunc = 3;
+  const EJitDimPair dims[1] = {{0, 1}};
+
+  void *out = nullptr;
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out)) << "cold table must miss";
+
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  EXPECT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+  EXPECT_EQ(out, codeFor(kFunc));
+  EXPECT_EQ(gEJitL0Hits, 1u);
+
+  // A different identity must miss, not return the wrong pointer.
+  const EJitDimPair other[1] = {{0, 2}};
+  EXPECT_FALSE(pool.l0Try(kFunc, other, 1, &out));
+}
+
+TEST_F(SharedTaskPoolTest, L0RetiredByPublishAndByVersionChange) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const uint32_t kFunc = 4;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+
+  publish(pool, 9);
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out)) << "publish must retire the L0";
+
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+
+  // L0 entries carry no version of their own.
+  pool.setInstanceEnabled(0, 1, true);
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out))
+      << "version change must retire the L0";
+}
+
+TEST_F(SharedTaskPoolTest, L0RetiredByExplicitFlush) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const uint32_t kFunc = 5;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+
+  // ejit_clear_cache() / ejit_invalidate() / a compile-mode change reach the
+  // L0 only through this hook.
+  pool.retireDispatchCache();
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out));
+}
+
+TEST_F(SharedTaskPoolTest, L0EntryIsNotServedToAnotherCore) {
+  resetL0ForTest();
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  const uint32_t kFunc = 6;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  EJitCoreId::setCurrentForTest(0);
+  owner.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  ASSERT_TRUE(owner.l0Try(kFunc, dims, 1, &out));
+
+  // Cannot arise on hardware (core-private table), but can where cores are
+  // simulated: a peer taking the owner's entry would skip peerPrepareSlot().
+  EJitCoreId::setCurrentForTest(1);
+  EXPECT_FALSE(owner.l0Try(kFunc, dims, 1, &out))
+      << "a peer must not be served the owner's entry";
+
+  EJitCoreId::setCurrentForTest(0);
+  EXPECT_TRUE(owner.l0Try(kFunc, dims, 1, &out)) << "owner still hits";
+}
+
+TEST_F(SharedTaskPoolTest, L0DoesNotSurviveANewSharedBlob) {
+  resetL0ForTest();
+  const uint32_t kFunc = 7;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+  ASSERT_NE(gEJitL0State, nullptr);
+
+  // The table outlives the shared blob. A fresh blob starts from a low
+  // dispatchEpoch, so the epoch alone cannot separate the two instances -- the
+  // entry must be rejected because it was armed against another state.
+  auto other = std::make_unique<EJitSharedTaskPoolState>();
+  EJitSharedTaskPool fresh;
+  EJitCoreId::setCurrentForTest(0);
+  fresh.bind(other.get());
+  fresh.setCompiler(&mockCompile, nullptr);
+  fresh.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(fresh.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_FALSE(fresh.l0Try(kFunc, dims, 1, &out))
+      << "an entry armed against a previous blob must not validate";
+}
+
+TEST_F(SharedTaskPoolTest, L0DoesNotSurviveAReInitialization) {
+  resetL0ForTest();
+  const uint32_t kFunc = 11;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+
+  // Same blob, torn down and stood back up: entries still point into a code
+  // pool that has been reset.
+  EJitCoreId::setCurrentForTest(0);
+  pool.ownerShutdown();
+  ASSERT_EQ(pool.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out))
+      << "an entry from the previous pool instance must not validate";
+
+  // ...and the cache re-arms normally afterwards.
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  EXPECT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+}
+
+TEST_F(SharedTaskPoolTest, L0RefusesToArmWhileAReleaserIsWired) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const uint32_t kFunc = 8;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  // With a releaser wired, code can be freed under a caller, and an L0 hit
+  // carries no read token. Same gate the inline cache uses.
+  pool.setReleaser([](void *, void *) {}, nullptr);
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out));
+  EXPECT_EQ(gEJitL0Hits, 0u);
+}
+
+TEST_F(SharedTaskPoolTest, ReleaseReadIgnoresTheNoBucketSentinel) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  // The wrapper calls releaseRead() unconditionally, so kEJitNoBucket must be
+  // a no-op rather than a spurious decrement of a real bucket.
+  pool.releaseRead(kEJitNoBucket);
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
+    EXPECT_EQ(state_->buckets[b].readers.loadRelaxed(), 0u)
+        << "bucket " << b << " reader count disturbed";
+}
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2774,11 +2774,10 @@ void resetL0ForTest() {
   for (uint32_t i = 0; i < kEJitL0Slots; ++i)
     gEJitL0[i] = EJitL0Entry{};
   gEJitL0State = nullptr;
-  gEJitL0Hits = 0;
 }
 } // namespace
 
-TEST_F(SharedTaskPoolTest, L0ServesARepeatDispatchAndCountsIt) {
+TEST_F(SharedTaskPoolTest, L0ServesARepeatDispatch) {
   resetL0ForTest();
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
@@ -2791,7 +2790,6 @@ TEST_F(SharedTaskPoolTest, L0ServesARepeatDispatchAndCountsIt) {
   pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
   EXPECT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
   EXPECT_EQ(out, codeFor(kFunc));
-  EXPECT_EQ(gEJitL0Hits, 1u);
 
   // A different identity must miss, not return the wrong pointer.
   const EJitDimPair other[1] = {{0, 2}};
@@ -2925,7 +2923,24 @@ TEST_F(SharedTaskPoolTest, L0RefusesToArmWhileAReleaserIsWired) {
   pool.setReleaser([](void *, void *) {}, nullptr);
   pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
   EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out));
-  EXPECT_EQ(gEJitL0Hits, 0u);
+}
+
+// The gate is evaluated at fill, so wiring a releaser AFTER entries are armed
+// must retire them.
+TEST_F(SharedTaskPoolTest, L0EntriesAreRetiredWhenAReleaserIsWiredLater) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const uint32_t kFunc = 12;
+  const EJitDimPair dims[1] = {{0, 1}};
+  void *out = nullptr;
+
+  pool.l0Fill(kFunc, codeFor(kFunc), dims, 1);
+  ASSERT_TRUE(pool.l0Try(kFunc, dims, 1, &out));
+
+  pool.setReleaser([](void *, void *) {}, nullptr);
+  EXPECT_FALSE(pool.l0Try(kFunc, dims, 1, &out))
+      << "an armed entry must not survive a releaser being wired";
 }
 
 TEST_F(SharedTaskPoolTest, ReleaseReadIgnoresTheNoBucketSentinel) {
@@ -2938,6 +2953,89 @@ TEST_F(SharedTaskPoolTest, ReleaseReadIgnoresTheNoBucketSentinel) {
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
     EXPECT_EQ(state_->buckets[b].readers.loadRelaxed(), 0u)
         << "bucket " << b << " reader count disturbed";
+}
+
+// A fill interrupted between its payload stores must not leave an old identity
+// paired with the new fnPtr. Core-private storage excludes other CORES, not
+// preemption on this one, so the seqlock is what makes the entry atomic.
+TEST_F(SharedTaskPoolTest, L0PartiallyWrittenEntryIsNotServed) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  const EJitDimPair a[1] = {{0, 1}};
+  void *out = nullptr;
+
+  pool.l0Fill(20, codeFor(20), a, 1);
+  ASSERT_TRUE(pool.l0Try(20, a, 1, &out));
+  ASSERT_EQ(out, codeFor(20));
+
+  // The interleaving a preempted fill leaves: odd sequence, fnPtr replaced,
+  // identity not yet updated.
+  EJitL0Entry &e = gEJitL0[ejitL0Index(20, a, 1)];
+  e.seq = e.seq + 1u;
+  e.fn = codeFor(21);
+
+  EXPECT_FALSE(pool.l0Try(20, a, 1, &out))
+      << "a half-written entry must not be served";
+
+  e.seq = e.seq + 1u; // writer completes
+  EXPECT_TRUE(pool.l0Try(20, a, 1, &out));
+}
+
+// Two identities landing in the same slot must evict each other, never
+// cross-serve. The colliding pair is SEARCHED FOR rather than hard-coded, so
+// the test keeps its meaning if the hash changes.
+TEST_F(SharedTaskPoolTest, L0CollidingIdentitiesNeverCrossServe) {
+  resetL0ForTest();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  void *out = nullptr;
+
+  const EJitDimPair a[1] = {{0, 1}};
+  const uint32_t slot = ejitL0Index(30, a, 1);
+  EJitDimPair b[1] = {{0, 0}};
+  bool found = false;
+  for (uint32_t inst = 2; inst < kEJitSharedInstances && !found; ++inst) {
+    b[0].instanceId = inst;
+    found = ejitL0Index(30, b, 1) == slot;
+  }
+  ASSERT_TRUE(found) << "no colliding identity found in the instance space";
+
+  pool.l0Fill(30, codeFor(30), a, 1);
+  pool.l0Fill(30, codeFor(31), b, 1); // evicts a from the shared slot
+
+  EXPECT_FALSE(pool.l0Try(30, a, 1, &out))
+      << "the evicted identity must miss, not receive the evictor's pointer";
+  ASSERT_TRUE(pool.l0Try(30, b, 1, &out));
+  EXPECT_EQ(out, codeFor(31));
+
+  // The pair the old packed key aliased via dimType*31 + instanceId.
+  resetL0ForTest();
+  const EJitDimPair c[1] = {{0, 31}};
+  const EJitDimPair d[1] = {{1, 0}};
+  pool.l0Fill(30, codeFor(32), c, 1);
+  pool.l0Fill(30, codeFor(33), d, 1);
+  if (pool.l0Try(30, c, 1, &out))
+    EXPECT_EQ(out, codeFor(32)) << "(0,31) served (1,0)'s specialization";
+  if (pool.l0Try(30, d, 1, &out))
+    EXPECT_EQ(out, codeFor(33)) << "(1,0) served (0,31)'s specialization";
+
+  // Same funcIndex, differing arity must not alias.
+  resetL0ForTest();
+  const EJitDimPair two[2] = {{0, 31}, {0, 0}};
+  pool.l0Fill(30, codeFor(34), c, 1);
+  pool.l0Fill(30, codeFor(35), two, 2);
+  if (pool.l0Try(30, c, 1, &out))
+    EXPECT_EQ(out, codeFor(34)) << "1D identity served a 2D entry";
+  if (pool.l0Try(30, two, 2, &out))
+    EXPECT_EQ(out, codeFor(35));
+
+  // Different funcIndex, identical dims must not alias.
+  resetL0ForTest();
+  pool.l0Fill(30, codeFor(36), c, 1);
+  pool.l0Fill(31, codeFor(37), c, 1);
+  if (pool.l0Try(30, c, 1, &out))
+    EXPECT_NE(out, codeFor(37)) << "funcIndex 30 served funcIndex 31's entry";
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

This PR restores the per-core L0 dispatch-cache optimization from PR #104 on top of the current `ejit_dev_spec4` tip, then hardens its synchronization and build isolation.

本 PR 在当前 `ejit_dev_spec4` 基线上恢复 PR #104 的核内 L0 dispatch cache，并修复原实现中的并发正确性和构建隔离问题。

## Root cause / 原因

The original L0 payload used ordinary fields plus `std::atomic_signal_fence`. A signal fence only constrains compiler reordering and does not make same-core task/interrupt preemption data-race-free. A reader could therefore observe a partially published entry.

The original fill also sampled `dispatchEpoch` after the authoritative shared-cache lookup. If activation, invalidation, publication, or reinitialization raced the lookup, a stale `fnPtr` could be republished under the new epoch and later returned directly by the fast path.

PR #104 also leaked shared-only L0 symbols into the private-taskpool C API implementation, breaking the taskpool-ON/shared-OFF build.

原实现使用普通字段配合 `atomic_signal_fence`，无法解决同核任务抢占带来的 C++ data race；同时 epoch 在共享 cache lookup 之后读取，可能把旧函数指针标记成新 epoch。另有 shared-only 依赖污染 private taskpool 构建的问题。

## Changes / 改动

- Store every L0 payload field with EJIT atomics and publish entries with an atomic seqlock protocol.
- Keep each entry exactly one 64-byte cache line; the table remains 4 KiB per core.
- Add a non-spinning same-core writer gate. A nested fill skips population and falls back to the authoritative shared cache.
- Capture an epoch token before the authoritative lookup and reject the L0 fill if the epoch changes.
- Preserve the complete `funcIndex + arity + dimensions + core + epoch` identity check.
- Fix the missing 0D terminal-hit L0 fill.
- Isolate L0/icache calls to shared-taskpool builds; private taskpool retains its existing bucket path.
- Bump the shared-state ABI from v7 to v8 so mixed binaries reject the changed protocol.

## Validation / 验证

- Shared/no-reclaim L0 tests: **13/13 passed**.
- Shared production `EJitRuntime.cpp.o` and `EJitSharedTaskPool.cpp.o`: built successfully.
- Private taskpool (`EJIT_SRE_TASKPOOL=ON`, shared taskpool OFF) `EJitRuntime.cpp.o`: built successfully.
- No undefined `__atomic_*`, pthread, mutex, or condition-variable symbols in the modified production objects.
- `git diff --check`: clean.
- Full shared-taskpool test runs retain the baseline's known configuration-dependent peer/4K failures; all L0 tests pass in both token and no-reclaim configurations.

## Platform note / 上板注意

The shared ABI is now v8, so every core must use the same binary. Real SRE validation should still cover same-core preemption, concurrent activation/invalidation, and multi-core warm-up before this is marked ready.