### PR TITLE
[EJIT] Relax in-range AArch64 JITLink branch stubs

### DIFF
--- a/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
+++ b/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
@@ -158,6 +158,13 @@ EJitOrcEngine::Create(const EJitConfig& config) {
     }
     engine->J = std::move(*JOrErr);
 
+    // PreFixup: resolved AArch64 B/BL calls that JITLink initially routed
+    // through a standard stub+GOT chain are changed back to a direct branch
+    // when the final target is within the architectural ±128 MiB range.
+    if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
+            &engine->J->getObjLinkingLayer()))
+        OLL->addPlugin(std::make_shared<EJitLinkOptimizationPlugin>());
+
     // 步骤 3: 注册 IRTransformLayer 回调
     // 完整的 JIT Pipeline: 参数替换 → InstCombine → StructFieldPass → IPSCCP →
     //   InstCombine → StructFieldPass → 标准优化 (详见 §2.4)
@@ -202,6 +209,19 @@ EJitOrcEngine::Create(const EJitConfig& config) {
     return engine;
 }
 ```
+
+### 2.1.2 AArch64 近目标分支松弛
+
+JITLink 会先为外部 `B/BL` 目标建立
+`branch -> $__STUBS -> $__GOT -> destination` 链。代码池与 AOT 代码距离较近时，
+`EJitLinkOptimizationPlugin` 在 `PreFixup` 阶段读取已经解析的最终地址；若
+`Branch26PCRel` 的位移处于 `[-2^27, 2^27 - 4]` 字节且四字节对齐，则将边直接
+指向最终目标，由正常 fixup 编码单条 `B/BL`。远目标、未解析目标、非标准 stub
+链和非零 GOT addend 均保留原 stub 路径。
+
+该优化只发生在链接阶段，不增加运行时热路径状态，也不改变 code-pool/shared
+taskpool ABI。已经分配的 stub/GOT 不主动删除，因此本改动降低执行开销，但不以
+缩小本次 JITLink allocation 为目标。
 
 ---
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
@@ -7,13 +7,15 @@
 //===----------------------------------------------------------------------===//
 //
 // A LinkGraphLinkingLayer plugin that proves JITLink's special handling of
-// branch relocations on AArch64: when a BL/B target is external (e.g. an AOT
-// function) or out of the ±128MB direct-branch range, JITLink does NOT emit a
-// direct BL. Instead it routes the call through a PointerJumpStub in $__STUBS
+// branch relocations on AArch64. JITLink initially routes external BL/B
+// targets through a PointerJumpStub in $__STUBS
 //
 //     ADRP x16, <got page> ; LDR x16, [x16, #<got off>] ; BR x16
 //
-// whose GOT entry (in $__GOT) holds the real target address.
+// whose GOT entry (in $__GOT) holds the real target address. EJIT's preceding
+// optimization pass may retarget this branch to the resolved destination when
+// it falls within the architectural direct-branch range. Out-of-range targets
+// retain the original stub chain.
 //
 // The plugin appends a PostFixup pass to every linked LinkGraph. After fixup
 // the graph carries the full chain JITLink built, so the pass can report each

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h
@@ -1,0 +1,43 @@
+//===-- EJitLinkOptimizationPlugin.h - EJIT JITLink optimizations ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITLINKOPTIMIZATIONPLUGIN_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITLINKOPTIMIZATIONPLUGIN_H
+
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+
+namespace llvm {
+namespace ejit {
+
+/// Retarget AArch64 B/BL edges from standard JITLink pointer-jump stubs to
+/// their resolved destination when that destination is directly reachable.
+LLVM_ABI Error relaxAArch64BranchStubs(jitlink::LinkGraph &G);
+
+class EJitLinkOptimizationPlugin : public orc::LinkGraphLinkingLayer::Plugin {
+public:
+  void modifyPassConfig(orc::MaterializationResponsibility &MR,
+                        jitlink::LinkGraph &G,
+                        jitlink::PassConfiguration &Config) override;
+
+  Error notifyFailed(orc::MaterializationResponsibility &MR) override {
+    return Error::success();
+  }
+  Error notifyRemovingResources(orc::JITDylib &JD,
+                                orc::ResourceKey K) override {
+    return Error::success();
+  }
+  void notifyTransferringResources(orc::JITDylib &JD, orc::ResourceKey DstKey,
+                                   orc::ResourceKey SrcKey) override {}
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITLINKOPTIMIZATIONPLUGIN_H

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -60,6 +60,7 @@ set(EJIT_SOURCES
   EJitRegistryTable.c
   EJitOrcEngine.cpp
   EJitLinkDiagPlugin.cpp
+  EJitLinkOptimizationPlugin.cpp
   EJitLibcallStubs.cpp
   EJitCompileDriver.cpp
   EJitRuntimeState.cpp

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
@@ -1,0 +1,132 @@
+//===-- EJitLinkOptimizationPlugin.cpp - EJIT JITLink optimizations -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
+
+#include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/TargetParser/Triple.h"
+
+#include <limits>
+
+using namespace llvm;
+using namespace llvm::ejit;
+using namespace llvm::jitlink;
+
+namespace {
+
+static bool isStubSymbol(const Symbol &S) {
+  return S.isDefined() && S.getOffset() == 0 &&
+         S.getSize() == sizeof(aarch64::PointerJumpStubContent) &&
+         S.getBlock().getSize() == sizeof(aarch64::PointerJumpStubContent) &&
+         S.getBlock().getSection().getName() ==
+             aarch64::PLTTableManager::getSectionName();
+}
+
+// Match the standard JITLink AArch64 pointer-jump chain:
+//   branch -> stub --Page21/PageOffset12--> GOT --Pointer64--> destination.
+static Symbol *getPointerJumpStubDestination(Symbol &Stub) {
+  if (!isStubSymbol(Stub))
+    return nullptr;
+
+  Symbol *GOTEntry = nullptr;
+  bool SawPage21 = false;
+  bool SawPageOffset12 = false;
+  for (Edge &E : Stub.getBlock().edges()) {
+    if (E.getKind() == aarch64::Page21) {
+      if (SawPage21 || E.getOffset() != 0 || E.getAddend() != 0)
+        return nullptr;
+      SawPage21 = true;
+    } else if (E.getKind() == aarch64::PageOffset12) {
+      if (SawPageOffset12 || E.getOffset() != 4 || E.getAddend() != 0)
+        return nullptr;
+      SawPageOffset12 = true;
+    } else {
+      continue;
+    }
+    if (GOTEntry && GOTEntry != &E.getTarget())
+      return nullptr;
+    GOTEntry = &E.getTarget();
+  }
+  if (!SawPage21 || !SawPageOffset12 || !GOTEntry || !GOTEntry->isDefined() ||
+      GOTEntry->getOffset() != 0 || GOTEntry->getSize() != 8 ||
+      GOTEntry->getBlock().getSize() != 8 ||
+      GOTEntry->getBlock().getSection().getName() !=
+          aarch64::GOTTableManager::getSectionName())
+    return nullptr;
+
+  Symbol *Destination = nullptr;
+  for (Edge &E : GOTEntry->getBlock().edges()) {
+    if (E.getKind() != aarch64::Pointer64)
+      continue;
+    if (Destination || E.getOffset() != 0 || E.getAddend() != 0)
+      return nullptr;
+    Destination = &E.getTarget();
+  }
+  return Destination;
+}
+
+static bool isDirectBranchReachable(uint64_t FixupAddr, uint64_t TargetAddr,
+                                    int64_t Addend) {
+  constexpr uint64_t MaxInt64 =
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  if (FixupAddr > MaxInt64 || TargetAddr > MaxInt64)
+    return false;
+
+  int64_t Delta = 0;
+  if (SubOverflow(static_cast<int64_t>(TargetAddr),
+                  static_cast<int64_t>(FixupAddr), Delta) ||
+      AddOverflow(Delta, Addend, Delta))
+    return false;
+
+  // Branch26PCRel stores a signed 26-bit count of four-byte instructions:
+  // [-2^27, 2^27 - 4] bytes, with four-byte alignment.
+  return (Delta & 3) == 0 && isInt<28>(Delta);
+}
+
+} // namespace
+
+Error llvm::ejit::relaxAArch64BranchStubs(LinkGraph &G) {
+  const Triple &TT = G.getTargetTriple();
+  if (TT.getArch() != Triple::aarch64 && TT.getArch() != Triple::aarch64_be)
+    return Error::success();
+
+  for (Section &Sec : G.sections()) {
+    for (Block *B : Sec.blocks()) {
+      for (Edge &E : B->edges()) {
+        if (E.getKind() != aarch64::Branch26PCRel)
+          continue;
+
+        Symbol *Destination = getPointerJumpStubDestination(E.getTarget());
+        if (!Destination || Destination->isExternal())
+          continue;
+
+        uint64_t FixupAddr = B->getFixupAddress(E).getValue();
+        uint64_t TargetAddr = Destination->getAddress().getValue();
+        if (isDirectBranchReachable(FixupAddr, TargetAddr, E.getAddend()))
+          E.setTarget(*Destination);
+      }
+    }
+  }
+  return Error::success();
+}
+
+void EJitLinkOptimizationPlugin::modifyPassConfig(
+    orc::MaterializationResponsibility &MR, LinkGraph &G,
+    PassConfiguration &Config) {
+  (void)MR;
+  const Triple &TT = G.getTargetTriple();
+  if (TT.getArch() != Triple::aarch64 && TT.getArch() != Triple::aarch64_be)
+    return;
+
+  // PreFixup runs after allocation and external-symbol lookup, so both the
+  // call site and final destination addresses are known. Retargeting here
+  // leaves the already-allocated stub/GOT layout intact while allowing the
+  // normal Branch26PCRel fixup to emit a direct B/BL displacement.
+  Config.PreFixupPasses.push_back(relaxAArch64BranchStubs);
+}

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -6,6 +6,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h"
+#include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
@@ -586,12 +587,20 @@ EJitOrcEngine::Create(const Config &config,
 
   engine->P->J = std::move(*J);
 
+  // Retarget standard AArch64 pointer-jump stubs to their final destination
+  // when the resolved B/BL displacement fits the architectural range. This
+  // plugin must run before the diagnostic plugin so PostFixup reporting sees
+  // the actual direct/stubbed result.
+  if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
+          &engine->P->J->getObjLinkingLayer()))
+    OLL->addPlugin(std::make_shared<EJitLinkOptimizationPlugin>());
+
   // Attach the JITLink branch-relocation diagnostic plugin. It appends a
   // PostFixup pass that audits every AArch64 branch relocation and reports
-  // which ones JITLink bridged through a $__STUBS PointerJumpStub + $__GOT
-  // (because the direct BL target is external / out of +-128MB) instead of a
-  // direct BL. INFO emits one summary per graph; VERBOSE additionally emits
-  // each relocation. Output uses SRE_printf on bare-metal.
+  // which ones remain bridged through a $__STUBS PointerJumpStub + $__GOT
+  // (because the resolved target is out of +-128MB or the chain is not safe to
+  // relax) instead of a direct BL. INFO emits one summary per graph; VERBOSE
+  // additionally emits each relocation. Output uses SRE_printf on bare-metal.
   if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
           &engine->P->J->getObjLinkingLayer()))
     OLL->addPlugin(std::make_shared<EJitLinkDiagPlugin>());

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_unittest(EJITTests
   EJitRuntimeTest.cpp
   EJitFieldOffsetTest.cpp
+  EJitLinkOptimizationPluginTest.cpp
 
   PARTIAL_SOURCES_INTENDED
   )

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitLinkOptimizationPluginTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitLinkOptimizationPluginTest.cpp
@@ -1,0 +1,125 @@
+//===-- EJitLinkOptimizationPluginTest.cpp --------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
+
+#include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::ejit;
+using namespace llvm::jitlink;
+
+namespace {
+
+struct BranchStubGraph {
+  std::unique_ptr<LinkGraph> G;
+  Edge *Branch = nullptr;
+  Symbol *Stub = nullptr;
+  Symbol *Destination = nullptr;
+};
+
+void expectSuccess(Error Err) {
+  if (Err)
+    ADD_FAILURE() << toString(std::move(Err));
+}
+
+BranchStubGraph makeBranchStubGraph(uint64_t FixupAddr, uint64_t TargetAddr,
+                                    int64_t Addend = 0,
+                                    Triple::ArchType Arch = Triple::aarch64,
+                                    int64_t GOTAddend = 0) {
+  Triple TT;
+  TT.setArch(Arch);
+  auto G = std::make_unique<LinkGraph>(
+      "branch-stub", std::make_shared<orc::SymbolStringPool>(), TT,
+      SubtargetFeatures(), aarch64::getEdgeKindName);
+
+  Section &Text =
+      G->createSection("$__TEXT", orc::MemProt::Read | orc::MemProt::Exec);
+  static const char BranchContent[4] = {};
+  auto &BranchBlock = G->createContentBlock(Text, BranchContent,
+                                            orc::ExecutorAddr(FixupAddr), 4, 0);
+
+  Symbol &Destination = G->addAbsoluteSymbol(
+      G->intern("destination"), orc::ExecutorAddr(TargetAddr), 0,
+      Linkage::Strong, Scope::Default, true);
+
+  Section &GOT = G->createSection(aarch64::GOTTableManager::getSectionName(),
+                                  orc::MemProt::Read);
+  Symbol &GOTEntry = aarch64::createAnonymousPointer(
+      *G, GOT, &Destination, static_cast<uint64_t>(GOTAddend));
+  GOTEntry.getBlock().setAddress(orc::ExecutorAddr(FixupAddr + 0x2000));
+
+  Section &Stubs = G->createSection(aarch64::PLTTableManager::getSectionName(),
+                                    orc::MemProt::Read | orc::MemProt::Exec);
+  Symbol &Stub = aarch64::createAnonymousPointerJumpStub(*G, Stubs, GOTEntry);
+  Stub.getBlock().setAddress(orc::ExecutorAddr(FixupAddr + 0x1000));
+
+  BranchBlock.addEdge(aarch64::Branch26PCRel, 0, Stub, Addend);
+  Edge *Branch = &*BranchBlock.edges().begin();
+  return {std::move(G), Branch, &Stub, &Destination};
+}
+
+TEST(EJitLinkOptimizationPlugin, RelaxesInRangeForwardBranch) {
+  auto T = makeBranchStubGraph(0x10000000, 0x17fffffc);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, RelaxesInRangeBackwardBranch) {
+  auto T = makeBranchStubGraph(0x18000000, 0x10000000);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsPositiveBoundaryStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x18000000);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsOutOfRangeBranchStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x20000000);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsMisalignedDestinationStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001002);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, AccountsForBranchAddend) {
+  auto T = makeBranchStubGraph(0x10000000, 0x18000000, -4);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsNonstandardGOTAddendStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::aarch64, 4);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsNonstandardStubEdgeStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000);
+  for (Edge &E : T.Stub->getBlock().edges())
+    if (E.getKind() == aarch64::Page21)
+      E.setAddend(4);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, SupportsBigEndianTarget) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::aarch64_be);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, IgnoresOtherArchitectures) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::x86_64);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+} // namespace


### PR DESCRIPTION
## 中文说明

### 问题

固定 code pool 已经能把 JIT 代码放到 AOT 代码的 ±128 MiB 范围内，但 AArch64 JITLink 对外部调用仍保留：

```
BL stub
stub: ADRP + LDR + BR
GOT: resolved target
```

板上诊断因此出现 `17 stubbed (0 exceed ±128MB), 0 direct`：地址已经足够近，但仍支付 stub/GOT 间接跳转开销。

### 修改

新增一个 EJIT JITLink `PreFixup` 插件。外部符号解析和内存分配完成后，插件仅识别 LLVM AArch64 table manager 生成的标准链：

```
Branch26PCRel -> $__STUBS -> $__GOT -> resolved destination
```

若最终位移四字节对齐且位于 `[-2^27, 2^27 - 4]` 字节范围内，branch edge 直接改指向最终目标，由正常 JITLink fixup 编码单条 `B/BL`。

远目标、未解析目标、非标准 stub/GOT 布局、非零 GOT addend、非 AArch64 目标均保持原 stub 路径。已分配的 stub/GOT 不删除，因此不改变 allocation 布局或生命周期。

### 影响

- 仅链接期生效，不增加运行时 atomic、共享状态或热路径判断。
- 不修改 code pool、taskpool、shared ABI 或平台接口。
- 固定近地址场景预期诊断由 `17 stubbed / 0 direct` 变为 `0 stubbed / 17 direct`。
- 远地址（例如此前约 2.7 GiB）继续安全使用 stub/GOT。

## English

A fixed code pool can place JIT code within AArch64's direct branch range of AOT code, but JITLink initially routes external calls through a pointer-jump stub and GOT even when the resolved destination is reachable.

This PR adds a `PreFixup` EJIT JITLink plugin that strictly recognizes the standard AArch64 `Branch26PCRel -> $__STUBS -> $__GOT -> destination` chain. Once allocation and external lookup have resolved final addresses, an aligned in-range edge is retargeted to the destination and the normal JITLink fixup emits a direct `B/BL`.

The matcher is deliberately conservative. Out-of-range, unresolved, malformed/nonstandard, non-zero-GOT-addend, and non-AArch64 cases retain the original stub path. Existing stub/GOT allocation is left intact.

## Validation

- `ninja -C build_verify -j8 LLVMEJIT EJITTests`: build/link passed.
- New relaxation tests: **10/10 passed**.
- Remaining suite excluding two existing baseline `may_const` assertion failures: **114/114 passed**.
- Covered forward/backward range boundaries, exact positive overflow, misalignment, branch addend, nonstandard GOT/stub edges, AArch64 big-endian, and non-AArch64 targets.
- `git diff --check` and clang-format checks passed.

Real SRE validation should confirm the JITLink summary changes from in-range stubbed calls to direct calls and remeasure the long-call benchmark.