### PR TITLE
[EJIT] Relax in-range JITLink stubs to direct branches (within +-128MiB)

### DIFF
--- a/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
+++ b/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
@@ -158,12 +158,22 @@ EJitOrcEngine::Create(const EJitConfig& config) {
     }
     engine->J = std::move(*JOrErr);
 
-    // PreFixup: resolved AArch64 B/BL calls that JITLink initially routed
-    // through a standard stub+GOT chain are changed back to a direct branch
-    // when the final target is within the architectural ±128 MiB range.
+    // PreFixup: retarget standard AArch64 pointer-jump stubs (branch ->
+    // $__STUBS -> $__GOT -> destination) to a direct B/BL when the resolved
+    // displacement fits the architectural ±128 MiB range. This plugin must
+    // run before the diagnostic plugin so PostFixup reporting sees the actual
+    // direct/stubbed result.
     if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
             &engine->J->getObjLinkingLayer()))
         OLL->addPlugin(std::make_shared<EJitLinkOptimizationPlugin>());
+
+    // PostFixup: EJitLinkDiagPlugin audits every AArch64 branch relocation
+    // and reports which remain bridged through a stub+GOT (out of ±128 MiB
+    // or unsafe chain) instead of a direct BL. INFO emits one summary per
+    // graph; VERBOSE additionally emits each relocation.
+    if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
+            &engine->J->getObjLinkingLayer()))
+        OLL->addPlugin(std::make_shared<EJitLinkDiagPlugin>());
 
     // 步骤 3: 注册 IRTransformLayer 回调
     // 完整的 JIT Pipeline: 参数替换 → InstCombine → StructFieldPass → IPSCCP →
@@ -216,8 +226,27 @@ JITLink 会先为外部 `B/BL` 目标建立
 `branch -> $__STUBS -> $__GOT -> destination` 链。代码池与 AOT 代码距离较近时，
 `EJitLinkOptimizationPlugin` 在 `PreFixup` 阶段读取已经解析的最终地址；若
 `Branch26PCRel` 的位移处于 `[-2^27, 2^27 - 4]` 字节且四字节对齐，则将边直接
-指向最终目标，由正常 fixup 编码单条 `B/BL`。远目标、未解析目标、非标准 stub
-链和非零 GOT addend 均保留原 stub 路径。
+指向最终目标，由正常 fixup 编码单条 `B/BL`。否则保留原 stub 路径。
+
+**门控用地址，不用 `isExternal()`**：JITLink 的 `applyLookupResult` 在 PreFixup
+之前用 `Sym->getAddressable().setAddress(addr)` 解析外部符号，但**不**把它转成
+`isAbsolute`，所以已解析的外部符号 `isExternal()` 仍为 `true`。若用
+`if (Destination->isExternal()) continue` 门控，会把每个已解析外部 stub 全部跳过
+-> 0 放松（这是曾出现的 bug）。pass 改为按地址门控
+`if (TargetAddr == 0) continue`，仅跳过真正未解析的（如弱引用无定义的外部）。
+
+**skip 分类与审计**：pass 在 `EJIT_DIAG` INFO 行按原因分类每个 stubbed
+`Branch26PCRel`，与三个 skip 计数器对齐：`chain-mismatch`（stub/GOT 链不匹配，
+含非零 GOT addend）、`unresolved`（`TargetAddr == 0`）、`out-of-range`（超
+±128 MiB 或未对齐），以及 `relaxed`（已放松计数）。格式：
+`relaxAArch64BranchStubs: graph=<name> Branch26PCRel: <total> total,
+<stubbed> stubbed (chain-mismatch=<cm> unresolved=<ur> out-of-range=<oor>),
+<relaxed> relaxed`。
+
+**PostFixup 审计**：`EJitLinkDiagPlugin`（紧跟 optimization plugin 之后注册）对
+每条 AArch64 分支重定位审计：INFO 汇总 "N stubbed (M exceed ±128MB)"，VERBOSE
+逐条打印 `[STUBBED] <reloc> -> <target> (<dist>, within/EXCEEDS ±128MB)`。顺序
+固定（optimization 先、diag 后），使 PostFixup 审计看到放松后的真实结果。
 
 该优化只发生在链接阶段，不增加运行时热路径状态，也不改变 code-pool/shared
 taskpool ABI。已经分配的 stub/GOT 不主动删除，因此本改动降低执行开销，但不以
@@ -1634,6 +1663,13 @@ llvm/include/llvm/ExecutionEngine/EJIT/
 
 // EJitCodePoolMemoryManagerTest.cpp, EJitCodePoolTest.cpp
 // - JITLink layout / executable ranges / 2M and 4K sealing / failures
+
+// EJitLinkOptimizationPluginTest.cpp
+// - relaxAArch64BranchStubs: forward/backward/in-range/boundary/out-of-range/
+//   misaligned/addend/GOT-addend/big-endian/other-arch
+// - setAddress 流程: RelaxesSetAddressResolvedExternal (in-range 外部符号经
+//   applyLookupResult 的 setAddress 解析后必须放松)、KeepsUnresolvedExternalStubbed
+//   (TargetAddr==0 不放松) -- 锁定 "门控用地址不用 isExternal()" 修复
 ```
 
 ### 8.2 集成测试

--- a/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
+++ b/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
@@ -158,6 +158,13 @@ EJitOrcEngine::Create(const EJitConfig& config) {
     }
     engine->J = std::move(*JOrErr);
 
+    // PreFixup: resolved AArch64 B/BL calls that JITLink initially routed
+    // through a standard stub+GOT chain are changed back to a direct branch
+    // when the final target is within the architectural ±128 MiB range.
+    if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
+            &engine->J->getObjLinkingLayer()))
+        OLL->addPlugin(std::make_shared<EJitLinkOptimizationPlugin>());
+
     // 步骤 3: 注册 IRTransformLayer 回调
     // 完整的 JIT Pipeline: 参数替换 → InstCombine → StructFieldPass → IPSCCP →
     //   InstCombine → StructFieldPass → 标准优化 (详见 §2.4)
@@ -202,6 +209,19 @@ EJitOrcEngine::Create(const EJitConfig& config) {
     return engine;
 }
 ```
+
+### 2.1.2 AArch64 近目标分支松弛
+
+JITLink 会先为外部 `B/BL` 目标建立
+`branch -> $__STUBS -> $__GOT -> destination` 链。代码池与 AOT 代码距离较近时，
+`EJitLinkOptimizationPlugin` 在 `PreFixup` 阶段读取已经解析的最终地址；若
+`Branch26PCRel` 的位移处于 `[-2^27, 2^27 - 4]` 字节且四字节对齐，则将边直接
+指向最终目标，由正常 fixup 编码单条 `B/BL`。远目标、未解析目标、非标准 stub
+链和非零 GOT addend 均保留原 stub 路径。
+
+该优化只发生在链接阶段，不增加运行时热路径状态，也不改变 code-pool/shared
+taskpool ABI。已经分配的 stub/GOT 不主动删除，因此本改动降低执行开销，但不以
+缩小本次 JITLink allocation 为目标。
 
 ---
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h
@@ -7,13 +7,15 @@
 //===----------------------------------------------------------------------===//
 //
 // A LinkGraphLinkingLayer plugin that proves JITLink's special handling of
-// branch relocations on AArch64: when a BL/B target is external (e.g. an AOT
-// function) or out of the ±128MB direct-branch range, JITLink does NOT emit a
-// direct BL. Instead it routes the call through a PointerJumpStub in $__STUBS
+// branch relocations on AArch64. JITLink initially routes external BL/B
+// targets through a PointerJumpStub in $__STUBS
 //
 //     ADRP x16, <got page> ; LDR x16, [x16, #<got off>] ; BR x16
 //
-// whose GOT entry (in $__GOT) holds the real target address.
+// whose GOT entry (in $__GOT) holds the real target address. EJIT's preceding
+// optimization pass may retarget this branch to the resolved destination when
+// it falls within the architectural direct-branch range. Out-of-range targets
+// retain the original stub chain.
 //
 // The plugin appends a PostFixup pass to every linked LinkGraph. After fixup
 // the graph carries the full chain JITLink built, so the pass can report each

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h
@@ -1,0 +1,43 @@
+//===-- EJitLinkOptimizationPlugin.h - EJIT JITLink optimizations ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITLINKOPTIMIZATIONPLUGIN_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITLINKOPTIMIZATIONPLUGIN_H
+
+#include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/LinkGraphLinkingLayer.h"
+
+namespace llvm {
+namespace ejit {
+
+/// Retarget AArch64 B/BL edges from standard JITLink pointer-jump stubs to
+/// their resolved destination when that destination is directly reachable.
+LLVM_ABI Error relaxAArch64BranchStubs(jitlink::LinkGraph &G);
+
+class EJitLinkOptimizationPlugin : public orc::LinkGraphLinkingLayer::Plugin {
+public:
+  void modifyPassConfig(orc::MaterializationResponsibility &MR,
+                        jitlink::LinkGraph &G,
+                        jitlink::PassConfiguration &Config) override;
+
+  Error notifyFailed(orc::MaterializationResponsibility &MR) override {
+    return Error::success();
+  }
+  Error notifyRemovingResources(orc::JITDylib &JD,
+                                orc::ResourceKey K) override {
+    return Error::success();
+  }
+  void notifyTransferringResources(orc::JITDylib &JD, orc::ResourceKey DstKey,
+                                   orc::ResourceKey SrcKey) override {}
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITLINKOPTIMIZATIONPLUGIN_H

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -60,6 +60,7 @@ set(EJIT_SOURCES
   EJitRegistryTable.c
   EJitOrcEngine.cpp
   EJitLinkDiagPlugin.cpp
+  EJitLinkOptimizationPlugin.cpp
   EJitLibcallStubs.cpp
   EJitCompileDriver.cpp
   EJitRuntimeState.cpp

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLinkDiagPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLinkDiagPlugin.cpp
@@ -140,7 +140,7 @@ static Error reportLinkGraph(LinkGraph &G) {
           bool exceeds = Real && absVal(DirectDist) > AArch64DirectBranchLimit;
           if (exceeds)
             ++outOfRange;
-          EJIT_DIAG_VERBOSE(
+          EJIT_DIAG(
               "  [STUBBED] %s @0x%llx -> stub@0x%llx "
               "(ADRP x16; LDR x16,[x16]; BR x16) -> $__GOT -> %s @0x%llx"
               " | direct dist=%lld (%s +-128MB)",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
@@ -100,7 +100,7 @@ Error llvm::ejit::relaxAArch64BranchStubs(LinkGraph &G) {
   // Diagnostic counters (INFO): categorize why each stubbed Branch26PCRel was
   // or was not relaxed, so the "stubbed (0 exceed +-128MB)" audit line can be
   // reconciled with what this pass actually did.
-  unsigned total = 0, stubbed = 0, chainMismatch = 0, external = 0,
+  unsigned total = 0, stubbed = 0, chainMismatch = 0, unresolved = 0,
            outOfRange = 0, relaxed = 0;
 
   for (Section &Sec : G.sections()) {
@@ -130,13 +130,18 @@ Error llvm::ejit::relaxAArch64BranchStubs(LinkGraph &G) {
           ++chainMismatch;
           continue;
         }
-        if (Destination->isExternal()) {
-          ++external;
-          continue;
-        }
-
         uint64_t FixupAddr = B->getFixupAddress(E).getValue();
         uint64_t TargetAddr = Destination->getAddress().getValue();
+        if (TargetAddr == 0) {
+          // Genuinely unresolved (e.g. a weakly-referenced external whose
+          // lookup found no definition). NOTE: JITLink's applyLookupResult
+          // resolves non-weak externals before PreFixup but leaves
+          // isExternal() true (it sets the address without converting to
+          // isAbsolute), so we must gate on the address, NOT isExternal() -
+          // otherwise every resolved external stub is wrongly skipped.
+          ++unresolved;
+          continue;
+        }
         if (!isDirectBranchReachable(FixupAddr, TargetAddr, E.getAddend())) {
           ++outOfRange;
           continue;
@@ -147,9 +152,9 @@ Error llvm::ejit::relaxAArch64BranchStubs(LinkGraph &G) {
     }
   }
   EJIT_DIAG("relaxAArch64BranchStubs: graph=%s Branch26PCRel: %u total, "
-            "%u stubbed (chain-mismatch=%u external=%u out-of-range=%u), "
+            "%u stubbed (chain-mismatch=%u unresolved=%u out-of-range=%u), "
             "%u relaxed",
-            G.getName().c_str(), total, stubbed, chainMismatch, external,
+            G.getName().c_str(), total, stubbed, chainMismatch, unresolved,
             outOfRange, relaxed);
   return Error::success();
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
 
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/JITLink/aarch64.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/TargetParser/Triple.h"
@@ -96,23 +97,60 @@ Error llvm::ejit::relaxAArch64BranchStubs(LinkGraph &G) {
   if (TT.getArch() != Triple::aarch64 && TT.getArch() != Triple::aarch64_be)
     return Error::success();
 
+  // Diagnostic counters (INFO): categorize why each stubbed Branch26PCRel was
+  // or was not relaxed, so the "stubbed (0 exceed +-128MB)" audit line can be
+  // reconciled with what this pass actually did.
+  unsigned total = 0, stubbed = 0, chainMismatch = 0, external = 0,
+           outOfRange = 0, relaxed = 0;
+
   for (Section &Sec : G.sections()) {
     for (Block *B : Sec.blocks()) {
       for (Edge &E : B->edges()) {
         if (E.getKind() != aarch64::Branch26PCRel)
           continue;
+        ++total;
 
-        Symbol *Destination = getPointerJumpStubDestination(E.getTarget());
-        if (!Destination || Destination->isExternal())
+        Symbol &Tgt = E.getTarget();
+        // Loose stub check (matches EJitLinkDiagPlugin's isStubSymbol): a
+        // defined symbol whose block is in $__STUBS. This is the population the
+        // diag plugin counts as "stubbed"; the sub-counters below then pin why
+        // each was or was not relaxed.
+        if (!Tgt.isDefined() ||
+            Tgt.getBlock().getSection().getName() != "$__STUBS")
+          continue; // direct target, not a stub
+        ++stubbed;
+
+        Symbol *Destination = getPointerJumpStubDestination(Tgt);
+        if (!Destination) {
+          // Stub is non-standard: strict isStubSymbol (size/offset) or the
+          // Page21/PageOffset12/Pointer64 chain (addends, GOT size) did not
+          // match. The diag plugin's loose followStubToRealTarget may still
+          // resolve these, so they appear as "stubbed (within +-128MB)" in the
+          // audit without being relaxable.
+          ++chainMismatch;
           continue;
+        }
+        if (Destination->isExternal()) {
+          ++external;
+          continue;
+        }
 
         uint64_t FixupAddr = B->getFixupAddress(E).getValue();
         uint64_t TargetAddr = Destination->getAddress().getValue();
-        if (isDirectBranchReachable(FixupAddr, TargetAddr, E.getAddend()))
-          E.setTarget(*Destination);
+        if (!isDirectBranchReachable(FixupAddr, TargetAddr, E.getAddend())) {
+          ++outOfRange;
+          continue;
+        }
+        E.setTarget(*Destination);
+        ++relaxed;
       }
     }
   }
+  EJIT_DIAG("relaxAArch64BranchStubs: graph=%s Branch26PCRel: %u total, "
+            "%u stubbed (chain-mismatch=%u external=%u out-of-range=%u), "
+            "%u relaxed",
+            G.getName().c_str(), total, stubbed, chainMismatch, external,
+            outOfRange, relaxed);
   return Error::success();
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.cpp
@@ -1,0 +1,132 @@
+//===-- EJitLinkOptimizationPlugin.cpp - EJIT JITLink optimizations -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
+
+#include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "llvm/Support/MathExtras.h"
+#include "llvm/TargetParser/Triple.h"
+
+#include <limits>
+
+using namespace llvm;
+using namespace llvm::ejit;
+using namespace llvm::jitlink;
+
+namespace {
+
+static bool isStubSymbol(const Symbol &S) {
+  return S.isDefined() && S.getOffset() == 0 &&
+         S.getSize() == sizeof(aarch64::PointerJumpStubContent) &&
+         S.getBlock().getSize() == sizeof(aarch64::PointerJumpStubContent) &&
+         S.getBlock().getSection().getName() ==
+             aarch64::PLTTableManager::getSectionName();
+}
+
+// Match the standard JITLink AArch64 pointer-jump chain:
+//   branch -> stub --Page21/PageOffset12--> GOT --Pointer64--> destination.
+static Symbol *getPointerJumpStubDestination(Symbol &Stub) {
+  if (!isStubSymbol(Stub))
+    return nullptr;
+
+  Symbol *GOTEntry = nullptr;
+  bool SawPage21 = false;
+  bool SawPageOffset12 = false;
+  for (Edge &E : Stub.getBlock().edges()) {
+    if (E.getKind() == aarch64::Page21) {
+      if (SawPage21 || E.getOffset() != 0 || E.getAddend() != 0)
+        return nullptr;
+      SawPage21 = true;
+    } else if (E.getKind() == aarch64::PageOffset12) {
+      if (SawPageOffset12 || E.getOffset() != 4 || E.getAddend() != 0)
+        return nullptr;
+      SawPageOffset12 = true;
+    } else {
+      continue;
+    }
+    if (GOTEntry && GOTEntry != &E.getTarget())
+      return nullptr;
+    GOTEntry = &E.getTarget();
+  }
+  if (!SawPage21 || !SawPageOffset12 || !GOTEntry || !GOTEntry->isDefined() ||
+      GOTEntry->getOffset() != 0 || GOTEntry->getSize() != 8 ||
+      GOTEntry->getBlock().getSize() != 8 ||
+      GOTEntry->getBlock().getSection().getName() !=
+          aarch64::GOTTableManager::getSectionName())
+    return nullptr;
+
+  Symbol *Destination = nullptr;
+  for (Edge &E : GOTEntry->getBlock().edges()) {
+    if (E.getKind() != aarch64::Pointer64)
+      continue;
+    if (Destination || E.getOffset() != 0 || E.getAddend() != 0)
+      return nullptr;
+    Destination = &E.getTarget();
+  }
+  return Destination;
+}
+
+static bool isDirectBranchReachable(uint64_t FixupAddr, uint64_t TargetAddr,
+                                    int64_t Addend) {
+  constexpr uint64_t MaxInt64 =
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  if (FixupAddr > MaxInt64 || TargetAddr > MaxInt64)
+    return false;
+
+  int64_t Delta = 0;
+  if (SubOverflow(static_cast<int64_t>(TargetAddr),
+                  static_cast<int64_t>(FixupAddr), Delta) ||
+      AddOverflow(Delta, Addend, Delta))
+    return false;
+
+  // Branch26PCRel stores a signed 26-bit count of four-byte instructions:
+  // [-2^27, 2^27 - 4] bytes, with four-byte alignment.
+  return (Delta & 3) == 0 && isInt<28>(Delta);
+}
+
+} // namespace
+
+Error llvm::ejit::relaxAArch64BranchStubs(LinkGraph &G) {
+  const Triple &TT = G.getTargetTriple();
+  if (TT.getArch() != Triple::aarch64 && TT.getArch() != Triple::aarch64_be)
+    return Error::success();
+
+  for (Section &Sec : G.sections()) {
+    for (Block *B : Sec.blocks()) {
+      for (Edge &E : B->edges()) {
+        if (E.getKind() != aarch64::Branch26PCRel)
+          continue;
+
+        Symbol *Destination = getPointerJumpStubDestination(E.getTarget());
+        if (!Destination || Destination->isExternal())
+          continue;
+
+        uint64_t FixupAddr = B->getFixupAddress(E).getValue();
+        uint64_t TargetAddr = Destination->getAddress().getValue();
+        if (isDirectBranchReachable(FixupAddr, TargetAddr, E.getAddend()))
+          E.setTarget(*Destination);
+      }
+    }
+  }
+  return Error::success();
+}
+
+void EJitLinkOptimizationPlugin::modifyPassConfig(
+    orc::MaterializationResponsibility &MR, LinkGraph &G,
+    PassConfiguration &Config) {
+  (void)MR;
+  const Triple &TT = G.getTargetTriple();
+  if (TT.getArch() != Triple::aarch64 && TT.getArch() != Triple::aarch64_be)
+    return;
+
+  // PreFixup runs after allocation and external-symbol lookup, so both the
+  // call site and final destination addresses are known. Retargeting here
+  // leaves the already-allocated stub/GOT layout intact while allowing the
+  // normal Branch26PCRel fixup to emit a direct B/BL displacement.
+  Config.PreFixupPasses.push_back(relaxAArch64BranchStubs);
+}

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -6,6 +6,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h"
+#include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
@@ -586,12 +587,20 @@ EJitOrcEngine::Create(const Config &config,
 
   engine->P->J = std::move(*J);
 
+  // Retarget standard AArch64 pointer-jump stubs to their final destination
+  // when the resolved B/BL displacement fits the architectural range. This
+  // plugin must run before the diagnostic plugin so PostFixup reporting sees
+  // the actual direct/stubbed result.
+  if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
+          &engine->P->J->getObjLinkingLayer()))
+    OLL->addPlugin(std::make_shared<EJitLinkOptimizationPlugin>());
+
   // Attach the JITLink branch-relocation diagnostic plugin. It appends a
   // PostFixup pass that audits every AArch64 branch relocation and reports
-  // which ones JITLink bridged through a $__STUBS PointerJumpStub + $__GOT
-  // (because the direct BL target is external / out of +-128MB) instead of a
-  // direct BL. INFO emits one summary per graph; VERBOSE additionally emits
-  // each relocation. Output uses SRE_printf on bare-metal.
+  // which ones remain bridged through a $__STUBS PointerJumpStub + $__GOT
+  // (because the resolved target is out of +-128MB or the chain is not safe to
+  // relax) instead of a direct BL. INFO emits one summary per graph; VERBOSE
+  // additionally emits each relocation. Output uses SRE_printf on bare-metal.
   if (auto *OLL = dyn_cast<orc::ObjectLinkingLayer>(
           &engine->P->J->getObjLinkingLayer()))
     OLL->addPlugin(std::make_shared<EJitLinkDiagPlugin>());

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_unittest(EJITTests
   EJitRuntimeTest.cpp
   EJitFieldOffsetTest.cpp
+  EJitLinkOptimizationPluginTest.cpp
 
   PARTIAL_SOURCES_INTENDED
   )

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitLinkOptimizationPluginTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitLinkOptimizationPluginTest.cpp
@@ -26,7 +26,8 @@ void expectSuccess(Error Err) {
 BranchStubGraph makeBranchStubGraph(uint64_t FixupAddr, uint64_t TargetAddr,
                                     int64_t Addend = 0,
                                     Triple::ArchType Arch = Triple::aarch64,
-                                    int64_t GOTAddend = 0) {
+                                    int64_t GOTAddend = 0,
+                                    bool ResolveViaSetAddress = false) {
   Triple TT;
   TT.setArch(Arch);
   auto G = std::make_unique<LinkGraph>(
@@ -39,9 +40,18 @@ BranchStubGraph makeBranchStubGraph(uint64_t FixupAddr, uint64_t TargetAddr,
   auto &BranchBlock = G->createContentBlock(Text, BranchContent,
                                             orc::ExecutorAddr(FixupAddr), 4, 0);
 
-  Symbol &Destination = G->addAbsoluteSymbol(
-      G->intern("destination"), orc::ExecutorAddr(TargetAddr), 0,
-      Linkage::Strong, Scope::Default, true);
+  Symbol &Destination =
+      ResolveViaSetAddress
+          ? G->addExternalSymbol("destination", 0, false)
+          : G->addAbsoluteSymbol(G->intern("destination"),
+                                 orc::ExecutorAddr(TargetAddr), 0,
+                                 Linkage::Strong, Scope::Default, true);
+  if (ResolveViaSetAddress)
+    // Mirror JITLink's applyLookupResult: resolve the external symbol's
+    // address via setAddress WITHOUT clearing isExternal() (makeAbsolute and
+    // addAbsoluteSymbol both clear it). The pass must gate on the address, not
+    // isExternal(), or it skips every resolved external stub.
+    Destination.getAddressable().setAddress(orc::ExecutorAddr(TargetAddr));
 
   Section &GOT = G->createSection(aarch64::GOTTableManager::getSectionName(),
                                   orc::MemProt::Read);
@@ -118,6 +128,27 @@ TEST(EJitLinkOptimizationPlugin, SupportsBigEndianTarget) {
 
 TEST(EJitLinkOptimizationPlugin, IgnoresOtherArchitectures) {
   auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::x86_64);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+// C3 regression: applyLookupResult resolves externals via setAddress, which
+// keeps isExternal()=true (makeAbsolute and addAbsoluteSymbol both clear it).
+// The pass must gate on the address, not isExternal(), or it skips every
+// resolved external stub. These mirror the real resolution flow.
+TEST(EJitLinkOptimizationPlugin, RelaxesSetAddressResolvedExternal) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::aarch64, 0,
+                               /*ResolveViaSetAddress=*/true);
+  EXPECT_TRUE(T.Destination->isExternal()); // setAddress did not clear it
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsUnresolvedExternalStubbed) {
+  // setAddress(0): genuinely unresolved (e.g. weak external with no defn).
+  auto T = makeBranchStubGraph(0x10000000, 0, 0, Triple::aarch64, 0,
+                               /*ResolveViaSetAddress=*/true);
+  EXPECT_TRUE(T.Destination->isExternal());
   expectSuccess(relaxAArch64BranchStubs(*T.G));
   EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitLinkOptimizationPluginTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitLinkOptimizationPluginTest.cpp
@@ -1,0 +1,125 @@
+//===-- EJitLinkOptimizationPluginTest.cpp --------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
+
+#include "llvm/ExecutionEngine/JITLink/aarch64.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::ejit;
+using namespace llvm::jitlink;
+
+namespace {
+
+struct BranchStubGraph {
+  std::unique_ptr<LinkGraph> G;
+  Edge *Branch = nullptr;
+  Symbol *Stub = nullptr;
+  Symbol *Destination = nullptr;
+};
+
+void expectSuccess(Error Err) {
+  if (Err)
+    ADD_FAILURE() << toString(std::move(Err));
+}
+
+BranchStubGraph makeBranchStubGraph(uint64_t FixupAddr, uint64_t TargetAddr,
+                                    int64_t Addend = 0,
+                                    Triple::ArchType Arch = Triple::aarch64,
+                                    int64_t GOTAddend = 0) {
+  Triple TT;
+  TT.setArch(Arch);
+  auto G = std::make_unique<LinkGraph>(
+      "branch-stub", std::make_shared<orc::SymbolStringPool>(), TT,
+      SubtargetFeatures(), aarch64::getEdgeKindName);
+
+  Section &Text =
+      G->createSection("$__TEXT", orc::MemProt::Read | orc::MemProt::Exec);
+  static const char BranchContent[4] = {};
+  auto &BranchBlock = G->createContentBlock(Text, BranchContent,
+                                            orc::ExecutorAddr(FixupAddr), 4, 0);
+
+  Symbol &Destination = G->addAbsoluteSymbol(
+      G->intern("destination"), orc::ExecutorAddr(TargetAddr), 0,
+      Linkage::Strong, Scope::Default, true);
+
+  Section &GOT = G->createSection(aarch64::GOTTableManager::getSectionName(),
+                                  orc::MemProt::Read);
+  Symbol &GOTEntry = aarch64::createAnonymousPointer(
+      *G, GOT, &Destination, static_cast<uint64_t>(GOTAddend));
+  GOTEntry.getBlock().setAddress(orc::ExecutorAddr(FixupAddr + 0x2000));
+
+  Section &Stubs = G->createSection(aarch64::PLTTableManager::getSectionName(),
+                                    orc::MemProt::Read | orc::MemProt::Exec);
+  Symbol &Stub = aarch64::createAnonymousPointerJumpStub(*G, Stubs, GOTEntry);
+  Stub.getBlock().setAddress(orc::ExecutorAddr(FixupAddr + 0x1000));
+
+  BranchBlock.addEdge(aarch64::Branch26PCRel, 0, Stub, Addend);
+  Edge *Branch = &*BranchBlock.edges().begin();
+  return {std::move(G), Branch, &Stub, &Destination};
+}
+
+TEST(EJitLinkOptimizationPlugin, RelaxesInRangeForwardBranch) {
+  auto T = makeBranchStubGraph(0x10000000, 0x17fffffc);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, RelaxesInRangeBackwardBranch) {
+  auto T = makeBranchStubGraph(0x18000000, 0x10000000);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsPositiveBoundaryStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x18000000);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsOutOfRangeBranchStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x20000000);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsMisalignedDestinationStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001002);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, AccountsForBranchAddend) {
+  auto T = makeBranchStubGraph(0x10000000, 0x18000000, -4);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsNonstandardGOTAddendStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::aarch64, 4);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, KeepsNonstandardStubEdgeStubbed) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000);
+  for (Edge &E : T.Stub->getBlock().edges())
+    if (E.getKind() == aarch64::Page21)
+      E.setAddend(4);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+TEST(EJitLinkOptimizationPlugin, SupportsBigEndianTarget) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::aarch64_be);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Destination);
+}
+
+TEST(EJitLinkOptimizationPlugin, IgnoresOtherArchitectures) {
+  auto T = makeBranchStubGraph(0x10000000, 0x10001000, 0, Triple::x86_64);
+  expectSuccess(relaxAArch64BranchStubs(*T.G));
+  EXPECT_EQ(&T.Branch->getTarget(), T.Stub);
+}
+
+} // namespace


### PR DESCRIPTION
## Goal

Make in-range (±128MiB) JITLink jumps go **direct** instead of through stubs, for both stub types on AArch64. This is the complete functional set: the branch-stub relaxation mechanism, the gating fix that makes it actually fire on resolved externals, the pointer-jump-stub bypass, and the categorization/diag (a hard dependency of the gating fix's counter rename).

## Commits

1. **`[EJIT] Relax in-range AArch64 JITLink branch stubs`** (ruanchen) — introduces `EJitLinkOptimizationPlugin` with `relaxAArch64BranchStubs`: retargets in-range Branch26PCRel branch stubs directly to the resolved target.
2. **`[EJIT] Categorize branch-stub relaxation skips + print STUBBED audit at INFO`** (Homme) — categorizes skip reasons (chain-mismatch / external / out-of-range / relaxed) and prints an INFO audit. Relaxation logic unchanged (counters only). **Hard dependency of (3)** — (3) renames the `external` counter introduced here.
3. **`[EJIT] Relaxation: gate on resolved address, not isExternal()`** (Homme) — **the fix that makes (1) actually work.** JITLink's `applyLookupResult` resolves external symbols but leaves `isExternal()=true`, so (1)'s `if (Destination->isExternal()) continue` skipped *every* resolved external stub → "external=150, 0 relaxed". Gates on the address instead (skip only when `TargetAddr==0`), so resolved externals proceed to the ±128MiB range check and are retargeted.
4. **`[JITLink][AArch64] Bypass in-range pointer jump stubs`** (ruanchen) — retargets Branch26 calls through standard PLT/GOT pointer-jump stubs directly to resolved targets when within range (independent mechanism, JITLink core).

## Why all four together

(1) alone relaxes 0 AOT calls (all external). (3) fixes that but depends on (2). (4) covers the other stub type. Together they make in-range jumps direct for both branch stubs and pointer-jump stubs.

## Verification

- All four cherry-pick cleanly onto `ejit_dev_spec4` (no conflicts).
- Targeted compile of every relax-touched translation unit (`EJitLinkOptimizationPlugin.cpp`, `EJitLinkDiagPlugin.cpp`, `EJitOrcEngine.cpp`, JITLink `aarch64.cpp`/`ELF_aarch64.cpp`, and the new `EJitLinkOptimizationPluginTest.cpp`) passes in the `ejit_dev_spec4` context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
