### PR TITLE
[EJIT] icache MissFn: copy F's target attrs to fix A_miss zero-inlining

### DIFF
--- a/jit_design_doc/EJIT_ICACHE_MULTIVERSION.md
+++ b/jit_design_doc/EJIT_ICACHE_MULTIVERSION.md
@@ -99,6 +99,17 @@ touches `sp`. The slow path (funcidx guard + `compile_or_get` + dispatch + AOT
 fallback) is extracted into a per-function `noinline MissFn` (`<name>_miss`),
 which has its own frame. Miss is rare, so the tail-call overhead is irrelevant.
 
+The two tail calls are `musttail` (so they lower to `br` and the wrapper needs
+no frame) **only when `!EJitWrapperTiming`**; under `-ejit-wrapper-timing` the
+hit path inserts `trace_now`/`trace_wrapper` between the call and `ret`, which
+violates the musttail rule, so it becomes a framed plain call + trace + ret
+(the miss path stays musttail). MissFn must inherit F's target attributes
+(`target-cpu`/`target-features`/`tune-cpu`) via `setAttributes(F->getAttributes())`
+-- `Function::Create` only inherits module-default `uwtable`/`frame-pointer`,
+and a bare MissFn fails `TTI::areInlineCompatible`, so the CGSCC InlinerPass
+rejects all helper inlining into MissFn with "conflicting attributes" (zero
+inlining into the AOT fallback).
+
 An `llvm.expect(IHit, true)` hint marks the hit branch likely, so regalloc /
 shrink-wrapping keeps the hit path frame-less for all dims (including 0-dim
 where the arg is idle in the hit path).
@@ -119,7 +130,7 @@ jit_miss:                                      ; miss: tail-call MissFn
   ret
 }
 
-define internal noinline void @funcA_miss(args...) {  ; slow path (own frame)
+define internal noinline void @funcA_miss(args...) {  ; slow path (own frame; inherits F target-cpu/features + section)
   funcidx = load @__ejit_funcidx_funcA
   if funcidx valid: compile_or_get -> dispatch (call spec + release_read) / fallback
   else: fallback (AOT body)
@@ -267,7 +278,10 @@ product picks D + maxDims to fit the per-core BSS budget.
    dispatch + AOT fallback) is extracted into a per-function `noinline
    MissFn` (`<name>_miss`), which owns the frame and the original body.
    The `emitSlowPath` lambda is shared by icache-off (in F) and icache-on
-   (in MissFn).
+   (in MissFn). MissFn is created with `Function::Create` then
+   `setAttributes(F->getAttributes())` (copy `target-cpu`/`target-features`/
+   `tune-cpu` so `TTI::areInlineCompatible` passes and helpers can inline
+   into MissFn) + `addFnAttr(NoInline)` + `setSection(F->getSection())`.
 3. **Hit-path probe**: multi-dim `GEP` (NO bounds check), plain `load` (no
    atomic/acquire -- per-core-private slot), `expect(hit, true)` (hint hit
    likely), null-check -> `jit_miss` (tail-call MissFn). numDims=0 = scalar
@@ -280,7 +294,11 @@ product picks D + maxDims to fit the per-core BSS budget.
    in the entry block, in addition to `@__ejit_funcidx_`.
 7. **Wrapper timing** (`-ejit-wrapper-timing`): the hit path keeps its
    sentinel (`0xFE`) report; the slow path (in MissFn or F) keeps the
-   `trace_now` + `trace_wrapper` sequence.
+   `trace_now` + `trace_wrapper` sequence. Because trace calls are inserted
+   between the call and `ret`, the hit path can no longer be `musttail` and
+   demotes from frame-less to a framed plain call + trace + ret (the miss
+   path stays musttail). The frame-less cycle figures in §11 assume
+   `!EJitWrapperTiming`.
 
 ## 9. Runtime changes
 
@@ -344,6 +362,10 @@ product picks D + maxDims to fit the per-core BSS budget.
   多维索引加的还多）。4 维仅 +1~2 cycle。多版本的代价几乎为零。
 - **Cold**: O(1) per miss (Horner linearize + one `str`). No scan. Miss
   tail-calls `MissFn` (1 `b` instruction).
+
+> 注：本节 frame-less / cycle 数据前提是 `!EJitWrapperTiming`（见 §8 item 7）。
+> 开启 `-ejit-wrapper-timing` 时 hit 路径退化为带帧 plain call + trace + ret，
+> cycle 不适用。
 
 ### 逐维度命中路径汇编（`-Os`，入口 -> `br spec`）
 

--- a/jit_design_doc/PASS3_EJitWrapperGen.md
+++ b/jit_design_doc/PASS3_EJitWrapperGen.md
@@ -531,7 +531,7 @@ jit_miss:                                        ; miss：尾调用 MissFn
   ret
 }
 
-define internal noinline void @funcA_miss(args...) {  ; 慢路径（自带栈帧）
+define internal noinline void @funcA_miss(args...) {  ; 慢路径（自带栈帧；继承 F 的 target-cpu/features/tune-cpu + section）
   ; funcidx 守卫 -> compile_or_get -> dispatch (call spec + release_read) / fallback (AOT body)
 }
 ```
@@ -539,6 +539,8 @@ define internal noinline void @funcA_miss(args...) {  ; 慢路径（自带栈帧
 - `@__ejit_icache_fn_<name>`：每函数私有 `[D]^numDims` 数组（`D = EJIT_ICACHE_DIM_SIZE = 8`，power-of-2），按 `ejit_dim` 参数值索引；numDims=0 退化为标量（= v2 单态）。
 - 命中路径**不调任何 runtime 函数**：直接 GEP + load + null-check + 尾调用。
 - `llvm.expect(hit, true)` 提示命中分支，使 regalloc / shrink-wrapping 对所有维度（含 0 维）保持 frame-less。
+- **musttail 仅在 `!EJitWrapperTiming` 时设置**：hit/miss 两条尾调用标 `TCK_MustTail`，降低成 `br`（复用调用方栈帧），故 wrapper 无栈帧。`-ejit-wrapper-timing` 开启时 hit 路径在 call 与 ret 之间插 `trace_now`/`trace_wrapper`，违反 musttail 规则，改用普通带帧 call + trace + ret（hit 路径不再 frame-less，但 IR 合法、功能不变；miss 路径仍 musttail）。
+- **MissFn 必须继承 F 的 target 属性**：`Function::Create` 新建的 MissFn 只继承 module 默认的 `uwtable`/`frame-pointer`，丢 F 的 `target-cpu`/`target-features`/`tune-cpu`。这会让 `TTI::areInlineCompatible` 判 MissFn 不是 helper 的 subtarget 超集 -> CGSCC InlinerPass 对所有 helper 报 `conflicting attributes` -> MissFn 零内联（AOT fallback 体积异常缩水）。修复：`MissFn->setAttributes(F->getAttributes())` 复制 F 全部属性，再 `addFnAttr(NoInline)`；同时 `setSection(F->getSection())` 让 MissFn 与 F 同段。`!ejit.metadata` 是 metadata（不在 `AttributeList` 里），不会被复制——MissFn 不应被当 ejit_entry 处理。
 - 跨函数 splice 修正：原函数体搬到 MissFn 后，把 `F->getArg(i)` 引用重映射到 `MissFn->getArg(i)`，否则跨函数参数引用会让 SelectionDAG 崩溃。
 - 幂等：`isAlreadyWrapped` 识别 entry 块中对 `@__ejit_icache_fn_<name>` 的 `LoadInst`/`GetElementPtrInst`（以及 `@__ejit_funcidx_<name>`），重复运行不会复制探针。
 
@@ -553,6 +555,8 @@ define internal noinline void @funcA_miss(args...) {  ; 慢路径（自带栈帧
 | 4 | 9 |
 
 命中路径 = 探针（GEP 移位索引 + load + null-check）+ 尾调用 `br`；无栈帧、无 call、无 `release_read`、无跨核 RMW。对比 icache off / 首次 miss 的 taskpool 路径（`compile_or_get` + `readers_` RMW + 桶扫描 + `release_read`），命中路径压到 4–9 cycle。2–4 维的实测 cycle 比指令数（4,5,7,9,11）还少，因为 `sxtw` 与 `adrp` 延迟重叠（ILP）。
+
+> 注：上述 frame-less / cycle 数据前提是 `!EJitWrapperTiming`。开启 `-ejit-wrapper-timing` 时 hit 路径退化为带帧 plain call + trace + ret（见 §10.1 musttail gating），cycle 不适用。
 
 
 

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -782,6 +782,15 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       Function *MissFn = Function::Create(F->getFunctionType(),
                                           GlobalValue::InternalLinkage,
                                           F->getName() + "_miss", &M);
+      // Function::Create only inherits module-default uwtable/frame-pointer from
+      // the context, NOT F's target-cpu/target-features/tune-cpu. Without those,
+      // TTI::areInlineCompatible(Caller=MissFn, Callee=helper) fails the subtarget
+      // feature-bit superset check, so InlinerPass rejects every cost-based
+      // inlining into MissFn with "conflicting attributes" (always_inline still
+      // inlines via the InlineCost.cpp AlwaysInline short-circuit). The AOT
+      // fallback body then loses ~all helper inlining vs the original function.
+      // Copy F's attributes so MissFn matches F's subtarget; re-affirm NoInline.
+      MissFn->setAttributes(F->getAttributes());
       MissFn->addFnAttr(Attribute::NoInline);
       MissFn->setSection(F->getSection());
 

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-missfn-target-attrs.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-missfn-target-attrs.ll
@@ -1,0 +1,25 @@
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s
+;
+; Regression: the icache MissFn (A_miss) must inherit F's target-cpu /
+; target-features. EJitWrapperGen creates MissFn with Function::Create, which
+; only inherits module-default uwtable/frame-pointer -- NOT F's per-function
+; target attributes. A bare MissFn then fails TTI::areInlineCompatible's
+; subtarget feature-bit superset check, so InlinerPass rejects every
+; cost-based inlining into MissFn with "conflicting attributes" (always_inline
+; still inlines via the InlineCost.cpp AlwaysInline short-circuit), and the
+; AOT fallback body loses ~all helper inlining vs the original function.
+; The fix copies F's attributes onto MissFn so it matches F's subtarget.
+
+define i32 @entry_tc(i32 %x) #0 !ejit.metadata !0 {
+  ret i32 %x
+}
+
+; MissFn exists and uses attribute group [[MISS]].
+; CHECK: define internal i32 @entry_tc_miss(i32 %0) #[[MISS:[0-9]+]]
+
+; That same group carries the target-cpu/target-features copied from F
+; (not the bare {noinline} that Function::Create would otherwise produce).
+; CHECK: attributes #[[MISS]] = {{.*}}"target-cpu"="cortex-a57"{{.*}}"target-features"="+crc,+crypto"
+
+attributes #0 = { noinline "target-cpu"="cortex-a57" "target-features"="+crc,+crypto" }
+!0 = !{!{!"ejit_entry"}}


### PR DESCRIPTION
## Problem

With `-ejit-inline-cache`, the icache slow-path `A_miss` (the AOT fallback) was ~half the size of the icache-off wrapper (e.g. 680 vs ~1200 asm lines), losing ~all helper inlining.

## Root cause

`EJitWrapperGen` creates `A_miss` with `Function::Create`, which only inherits module-default `uwtable`/`frame-pointer` from the context — **not** F's per-function `target-cpu`/`target-features`/`tune-cpu`. A bare `A_miss` then fails `TTI::areInlineCompatible`'s subtarget feature-bit superset check, so the CGSCC `InlinerPass` rejects **every** cost-based inlining into `A_miss` with `conflicting attributes` (`always_inline` still inlines via the `InlineCost.cpp` AlwaysInline short-circuit). The AOT fallback body therefore loses ~all helper inlining vs the original function.

Verified end-to-end with `-pass-remarks=inline`: before the fix, `'helper' not inlined into 'A_miss' ... (cost=never): conflicting attributes`; after, `'helper' inlined into 'A_miss' with (cost=N, threshold=337)`.

## Fix

Copy F's attributes onto `A_miss` (then re-affirm `NoInline`) so it matches F's subtarget:

```cpp
Function *MissFn = Function::Create(F->getFunctionType(),
                                    GlobalValue::InternalLinkage,
                                    F->getName() + "_miss", &M);
MissFn->setAttributes(F->getAttributes());
MissFn->addFnAttr(Attribute::NoInline);
MissFn->setSection(F->getSection());
```

`A_miss` is a body-clone of F (same signature), so copying the full `AttributeList` is correct; `!ejit.metadata` is metadata (not in `AttributeList`) and is intentionally not copied (A_miss must not be treated as an ejit_entry).

## Test

`ejit-wrapper-gen-icache-missfn-target-attrs.ll` checks `A_miss` inherits F's `target-cpu`/`target-features` (fails without the fix — `A_miss` reverts to bare `{noinline}` — passes with it). EmbeddedJIT lit: 40 pass + 5 XFAIL, no regressions.

## Note

This restores `A_miss` to ~icache-off size (correct AOT fallback code quality). The 680 was a bug (lost inlining), not an intentional size optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
