### PR TITLE
[EJIT] Pin JIT code pool to a fixed code-segment region via enable_rw

### DIFF
--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -4,6 +4,7 @@
 **开关**:
 - `-DEJIT_SRE_CODE_POOL=ON`（默认 OFF，上游默认行为不变）
 - `-DEJIT_CODE_POOL_4K_SEAL=ON`（默认 ON，仅在 `EJIT_SRE_CODE_POOL=ON` 时生效；OFF 回退到旧的整 2MiB 池封固）
+- `-DEJIT_FIXED_CODE_POOL=ON`（默认 OFF）：代码池改用链接脚本固定区域 `[__ejit_code_start, __ejit_code_end)`（段名 `.text.ejit`，**代码段**），替代动态 `SRE_MemDbgAlloc`，给 JIT 稳定地址（±128MiB 内可直 `bl`/`adrp` 到 AOT）。写前 `enable_rw`（RX->RW）、finalize `enable_ex`（RW->RX）。需平台提供 `enable_rw`。详见 [§14](#14-固定代码池区域ejit_fixed_code_pool)。
 
 **关联代码**:
 - `llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h` / `llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp`
@@ -191,6 +192,7 @@ cmake -S llvm -B build-ejit-sre-pool \
 | `EJIT_SRE_CODE_POOL_SIZE` | 2097152 (2MiB) | 每个池的可用字节数；4K 模式下向上取整为 2MiB 整数倍 |
 | `EJIT_SRE_CODE_POOL_PTNO` | 8 | 传给 `SRE_MemDbgAlloc` 的分区号 ptNo |
 | `EJIT_SRE_ENABLE_EX` | 随 `EJIT_SRE_CODE_POOL` | 关闭后代码仍走池，但不做权限翻转（bring-up/测量用） |
+| `EJIT_FIXED_CODE_POOL` | OFF | 固定区域代码池（**代码段**）：用链接脚本 `[__ejit_code_start, __ejit_code_end)`（段名 `.text.ejit`）替代 `SRE_MemDbgAlloc`，给 JIT 稳定地址（±128MiB 内直 `bl`/`adrp`）。写前 `enable_rw`（RX->RW）、finalize `enable_ex`（RW->RX）。需平台 `enable_rw`。仅在 `EJIT_SRE_CODE_POOL=ON` 时生效。详见 §14 |
 
 平台接口（在 `EJitSrePlatform.cpp` 内**仅声明、不定义**，避免污染通用命名空间）：
 
@@ -209,7 +211,8 @@ extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
 
 - `enable_ex`
 - `split_2m_to_4k`
-- `SRE_MemDbgAlloc`
+- `SRE_MemDbgAlloc`（未用固定区域时；固定区域模式不调它）
+- `enable_rw`（`EJIT_FIXED_CODE_POOL=ON` 时；签名 `unsigned enable_rw(unsigned level, unsigned long long va)`，与 `enable_ex` 对称）
 - 若启用平台 taskpool 队列（`EJIT_SRE_TASKPOOL_PLATFORM_QUEUE`），还必须提供
   `QueueCreate` / `QueueWrite` / `QueueRead`（见 `EJitSreQueue.cpp`）。
 
@@ -430,3 +433,78 @@ code pool 与 taskpool 关键路径埋了**默认空展开**的 trace 宏，便�
   `allocateCode`（req / res）、`sealCodeRange`（范围 / 每页 rc）、`sealPoolContaining` 的
   4K 误用；taskpool 的 `compileOrGet`（enter / cacheHit / dedup / queuePush）、`runCompile`
   （begin / compiled / published）、`pollOne`（empty / dequeued）、`freeCode`（cancel/free）。
+
+---
+
+## 14. 固定代码池区域（EJIT_FIXED_CODE_POOL / 代码段放置 enable_rw）
+
+`EJIT_FIXED_CODE_POOL=ON` 时，代码池改用**链接脚本定义的固定区域**
+`[__ejit_code_start, __ejit_code_end)`（段名 `.text.ejit`），替代动态 `SRE_MemDbgAlloc`。
+`EJitCodePoolManager` 进入固定区域模式（`Options::fixedBase`/`fixedSize` + `FixedUsed_`
+游标），`newActivePoolLocked` 从该区域切出 2MiB 对齐的池，**不调 `RawAllocFn`**。运行时
+把 `__ejit_code_start` 向上对齐到 2MiB（链接脚本只需 `ALIGN(4096)`），
+`[__ejit_code_start, 对齐基)` 是浪费的 slack（最多 ~2MiB），区域要留余量（16M -> ~14M
+可用，~7 个池）。区域耗尽是干净的 `Error`，**不回退动态分配**（特化回退 AOT），保住固定
+地址保证。
+
+链接脚本（`ejit_registry.ld` 提供 `INSERT` 片段；段名仅是容器，运行时实际依赖
+`__ejit_code_start`/`__ejit_code_end` 两个符号）：
+
+```ld
+.text.ejit : ALIGN(4096)
+{
+  __ejit_code_start = .;
+  . = __ejit_code_start + 16M;
+  __ejit_code_end = .;
+} > CODE        /* 代码段，近 .text（±128MiB 内 bl/adrp 直达 AOT） */
+```
+
+区域大小由链接脚本（上面的 `+ 16M`）决定，**无 CMake 旋钮**；运行时从
+`__ejit_code_end - __ejit_code_start` 读取实际大小。要改容量就改链接脚本里这一行。
+
+`makeSreCodePoolManager` 自动探测 `__ejit_code_start`/`__ejit_code_end`（host weak /
+freestanding strong，类似 `__start_ejit_bitcode`），缺失或对齐后太小则回退
+`SRE_MemDbgAlloc` 并打诊断。`EJIT_FREESTANDING` 下这两个符号是 strong，裸核链接**必须**
+定义该块，缺失即硬链接错误。
+
+### 14.1 代码段放置
+
+固定区域放在**代码段**（近 `.text`），装载即 RX，给 JIT 稳定地址且 ±128MiB 内可直
+`bl`/`adrp` 到 AOT 代码。链接脚本用 `> CODE`（或代码段中 `.text` 之后）：
+
+```ld
+.text.ejit : ALIGN(4096)
+{
+  __ejit_code_start = .;
+  . = __ejit_code_start + 16M;
+  __ejit_code_end = .;
+} > CODE        /* 代码段，近 .text（±128MiB 内 bl/adrp 直达 AOT） */
+```
+
+| 阶段 | 权限 | 操作 |
+|---|---|---|
+| 装载 | RX | 链接脚本 `> CODE` |
+| 写前（每次 slab） | RX->RW | `enableRwRange`（逐 4K 页 `enable_rw`），在 `memset` 前 |
+| finalize | RW->RX | `sealCodeRange`（逐 4K 页 `enable_ex`）；.data/.got 页保持 RW 供 GOT 写 |
+| `enable_rw` | 必须平台提供 | 强 extern，缺失即硬链接错误 |
+| per-core | 编译核 `enable_rw`+`enable_ex`；peer 核只 `enable_ex` | 只读执行已写好的代码 |
+
+> **W^X 取舍**：为拿到 `bl` 直达，slab 整段（含 .data/.got 页）写前都被 `enable_rw` 成
+> RW，finalize 只把可执行页封回 RX，.data/.got 页保持 RW（供 GOT 写）。即代码段里非可执行
+> 数据页是可写的--这是"代码池放代码段换 bl 直达"的固有取舍。
+
+生产 preset `ejit-minimal-aarch64_be` 用 `EJIT_FIXED_CODE_POOL=ON`（代码段 + enable_rw）。
+
+### 14.2 enable_rw 机制
+
+- `EnableRwFn` callback + `enableRwRange(Start, Size)`：按页对齐、逐页翻转，与
+  `sealCodeRange` 对称。`EJitCodePoolMemoryManager::allocate` 在 `memset` **之前**调
+  `enableRwRange(slab, total)`。
+- 平台签名：`unsigned enable_rw(unsigned level, unsigned long long va)`，`level=1`（与
+  `enable_ex` 的 `startLevel` 对称）。翻转 PTE AP 位 + TLB flush。
+- `enable_rw` 是**强 extern**（platform-supplied，无 weak 兜底）--缺失即**硬链接错误**，
+  不会静默不可写。
+- per-core：编译核 `enable_rw`+`enable_ex`；peer 核只 `enable_ex`（只读执行已写好的代码）。
+- **部分失败回滚**：`enableRwRange` 中途某页 `enable_rw` 失败时，把已成功 RX->RW 的页
+  用 `Seal_` 封回 RX（避免代码段永久可写 W^X 违规）；被 carve 的 slab 留作废弃孔洞
+  （不回收，保简单），下次编译从下一位置切。

--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -501,7 +501,9 @@ freestanding strong，类似 `__start_ejit_bitcode`），缺失或对齐后太�
   `sealCodeRange` 对称。`EJitCodePoolMemoryManager::allocate` 在 `memset` **之前**调
   `enableRwRange(slab, total)`。
 - 平台签名：`unsigned enable_rw(unsigned level, unsigned long long va)`，`level=1`（与
-  `enable_ex` 的 `startLevel` 对称）。翻转 PTE AP 位 + TLB flush。
+  `enable_ex` 的 `startLevel` 对称）。**必须**同时置写权限（AP 位）**并清执行权限**
+  （UXN/PXN）+ TLB flush，即 RX->RW（非 RWX），保 W^X；只翻 AP 位会留下 RWX 写窗口。
+  `enable_ex` 是对称逆操作（RW->RX：清写、置执行 + I-cache sync）。
 - `enable_rw` 是**强 extern**（platform-supplied，无 weak 兜底）--缺失即**硬链接错误**，
   不会静默不可写。
 - per-core：编译核 `enable_rw`+`enable_ex`；peer 核只 `enable_ex`（只读执行已写好的代码）。

--- a/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
+++ b/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
@@ -222,8 +222,11 @@ EJitOrcEngine::Create(const EJitConfig& config) {
   code-pool 内存，pool lifetime 与 engine 一致。
 
 平台 adapter 只声明 `enable_ex`、`split_2m_to_4k` 和
-`SRE_MemDbgAlloc`。目标最终链接必须提供强定义；这些平台依赖不能由
-`ejit_register_symbol` 补齐。
+`SRE_MemDbgAlloc`（固定代码池模式 `EJIT_FIXED_CODE_POOL=ON` 下不调 `SRE_MemDbgAlloc`，
+改用链接脚本区域 `[__ejit_code_start, __ejit_code_end)`，并需 `enable_rw`，签名
+`unsigned enable_rw(unsigned level, unsigned long long va)`，与 `enable_ex` 对称）。目标
+最终链接必须提供强定义；这些平台依赖不能由 `ejit_register_symbol` 补齐。固定代码池区域
+详见 `EJIT_SRE_CODE_POOL.md` §14。
 
 <details>
 <summary>历史设计：固定 slab EJitJITLinkMemoryManager（已删除）</summary>

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -661,6 +661,26 @@ if(EJIT_SRE_CODE_POOL AND EJIT_CODE_POOL_4K_SEAL)
   message(STATUS "EmbeddedJIT: SRE code pool uses 4K-granular page sealing")
 endif()
 
+# Pin the JIT code pool to a fixed, linker-script-defined region
+# [__ejit_code_start, __ejit_code_end) (the .text.ejit output section) in the
+# executable CODE segment, instead of dynamic SRE_MemDbgAlloc. A fixed region
+# gives a stable JIT address range and, placed within +-128MiB of .text, lets
+# codegen use direct bl/adrp with no GOT/stubs. The code segment is RX by
+# default, so the runtime enable_rw's each slab (RX->RW) before writing and
+# enable_ex's it (RW->RX) at finalize. REQUIRES the platform to supply
+# enable_rw (symmetric to enable_ex); a missing enable_rw is a hard link error.
+# When the linker script does NOT define the symbols, the runtime falls back to
+# SRE_MemDbgAlloc, so this is backward-compatible.
+# Default OFF: existing dynamic-allocation behavior is unchanged.
+# Authoritative size is __ejit_code_end - __ejit_code_start from the .text.ejit
+# linker-script block (no CMake size knob).
+option(EJIT_FIXED_CODE_POOL
+  "Pin the JIT code pool to a fixed linker-script region in the RX code segment (enable_rw write / enable_ex seal) instead of dynamic SRE_MemDbgAlloc. Needs platform enable_rw." OFF)
+if(EJIT_SRE_CODE_POOL AND EJIT_FIXED_CODE_POOL)
+  message(STATUS "EmbeddedJIT: fixed code-pool region enabled (code segment, enable_rw) "
+                 "(size is __ejit_code_end - __ejit_code_start from the linker script's .text.ejit block)")
+endif()
+
 #===-- EmbeddedJIT per-function inline cache (multi-version) -------------===#
 # EJIT_ICACHE_DIM_SIZE: the per-dimension bound D of the per-function
 # @__ejit_icache_fn_<name> [D]^numDims inline-cache array. MUST be a power of 2

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -78,6 +78,7 @@
         "EJIT_CODE_POOL_4K_SEAL": "ON",
         "EJIT_SRE_CODE_POOL": "ON",
         "EJIT_SRE_CODE_POOL_PTNO": "8",
+        "EJIT_FIXED_CODE_POOL": "ON",
         "EJIT_SRE_TASKPOOL": "ON",
         "EJIT_SRE_SHARED_TASKPOOL": "ON",
         "EJIT_SRE_TASKPOOL_NO_RECLAIM": "ON",

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -106,6 +106,12 @@ public:
   /// default). Returns 0 on success, non-zero on failure. On the target this
   /// calls enable_rw(va); in tests, a mock. Only used when
   /// Options::needsEnableRw is set (code-segment fixed-pool placement).
+  ///
+  /// W^X contract: the platform enable_rw MUST clear execute permission
+  /// (set UXN/PXN on AArch64) as well as set write permission, so the page
+  /// transitions RX -> RW (writable, NOT executable) during the write window.
+  /// Flipping only the write/AP bit would leave the page RWX, violating W^X.
+  /// enable_ex (seal, RW -> RX) is the symmetric inverse.
   using EnableRwFn = std::function<unsigned(void *va)>;
 
   struct Options {

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -101,6 +101,13 @@ public:
   /// Options::fourKSeal is set.
   using SplitFn = std::function<unsigned(void *base, size_t size)>;
 
+  /// Make one 4KiB page writable (RX -> RW) so JIT code can be written into a
+  /// fixed region placed in the executable code segment (which is RX by
+  /// default). Returns 0 on success, non-zero on failure. On the target this
+  /// calls enable_rw(va); in tests, a mock. Only used when
+  /// Options::needsEnableRw is set (code-segment fixed-pool placement).
+  using EnableRwFn = std::function<unsigned(void *va)>;
+
   struct Options {
     /// Usable bytes per pool (EJIT_SRE_CODE_POOL_SIZE). Default 2MiB. In 4K
     /// seal mode this is rounded up to a multiple of poolAlign.
@@ -116,6 +123,25 @@ public:
     bool fourKSeal = false;
     /// Execute-permission seal granularity in 4K mode. Platform constant 4KiB.
     size_t sealPageSize = 4096;
+    /// When fixedSize > 0, new pools are carved sequentially from the fixed
+    /// pre-reserved region [fixedBase, fixedBase + fixedSize) (e.g. a
+    /// linker-script .text.ejit bounded by __ejit_code_start/__ejit_code_end)
+    /// instead of calling RawAllocFn. The region MUST be poolAlign-aligned
+    /// (2MiB); Split_/Seal_ still apply. Two placement modes:
+    ///   * data-region (default, needsEnableRw=false): region is RW at load,
+    ///     writable directly; enable_ex seals .text pages to RX.
+    ///   * code-segment (needsEnableRw=true): region is RX at load (placed in
+    ///     the code segment for bl/adrp reach to AOT .text); each slab must be
+    ///     enable_rw'd (RX->RW) before writing, then enable_ex'd (RW->RX) at
+    ///     finalize. Requires an EnableRwFn.
+    /// Exhausting the region is a clean Error (no fallback to RawAllocFn, which
+    /// would break the fixed-address guarantee). Default 0 = dynamic allocation.
+    uintptr_t fixedBase = 0;
+    size_t fixedSize = 0;
+    /// When true, the fixed region starts read-only (code segment, RX) and each
+    /// slab is enable_rw'd before writing. Ignored unless fixedSize > 0.
+    /// Default false (data-region placement, RW).
+    bool needsEnableRw = false;
   };
 
   struct Stats {
@@ -129,12 +155,14 @@ public:
                                 ///< (per 4K page in 4K seal mode)
     size_t splitInvocations = 0; ///< number of successful split_2m_to_4k calls
                                  ///< (one per pool in 4K seal mode)
+    size_t rwEnableInvocations = 0; ///< number of successful enable_rw calls
+                                    ///< (per 4K page, code-segment mode only)
     size_t finalizedRangeCount = 0; ///< distinct executable ranges recorded
                                     ///< (duplicates are not double-counted)
   };
 
   EJitCodePoolManager(Options Opts, RawAllocFn Alloc, SealFn Seal,
-                      SplitFn Split = nullptr);
+                      SplitFn Split = nullptr, EnableRwFn EnableRw = nullptr);
   ~EJitCodePoolManager();
 
   EJitCodePoolManager(const EJitCodePoolManager &) = delete;
@@ -171,6 +199,15 @@ public:
   /// Returns an Error if `Start` is not owned by any pool or if any page seal
   /// fails (in which case no callable pointer must be handed back).
   Error sealCodeRange(const void *Start, size_t Size);
+
+  /// Code-segment mode (Options::needsEnableRw): make the 4KiB pages covering
+  /// [Start, Start + Size) writable (RX -> RW) so JITLink can write code into
+  /// the fixed region placed in the executable code segment. Called by the
+  /// code-pool memory manager at allocate, BEFORE memset/JITLink writes.
+  /// No-op (returns success) when needsEnableRw is false (data-region placement
+  /// is already RW). Returns an Error if `Start` is not owned by any pool or if
+  /// any enable_rw fails (in which case the slab must not be written).
+  Error enableRwRange(const void *Start, size_t Size);
 
   /// True if this manager seals execute permission per 4KiB page (rather than
   /// per whole 2MiB pool).
@@ -209,12 +246,17 @@ private:
   RawAllocFn Alloc_;
   SealFn Seal_;
   SplitFn Split_;
+  EnableRwFn EnableRw_;
 
   // Pool descriptors (ordinary host bookkeeping; never holds code bytes).
   std::vector<std::unique_ptr<CodePool>> Pools_;
   CodePool *Active_ = nullptr;
   size_t SealInvocations_ = 0;
   size_t SplitInvocations_ = 0;
+  size_t RwEnableInvocations_ = 0;
+  /// Bump cursor (bytes consumed) over the fixed region [fixedBase, fixedBase +
+  /// fixedSize) when Options::fixedSize > 0; unused in dynamic-allocation mode.
+  size_t FixedUsed_ = 0;
 
   /// Finalized executable allocation extents (ordinary host bookkeeping; never
   /// holds code bytes). Recorded at finalize, queried by findRange(). Append

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -150,6 +150,15 @@ if(EJIT_SRE_CODE_POOL AND EJIT_CODE_POOL_4K_SEAL)
   target_compile_definitions(LLVMEJIT PRIVATE EJIT_CODE_POOL_4K_SEAL)
 endif()
 
+# Pin the JIT code pool to a fixed linker-script region [__ejit_code_start,
+# __ejit_code_end) in the RX code segment (enable_rw write / enable_ex seal)
+# instead of dynamic SRE_MemDbgAlloc. The only user of this macro is the SRE
+# adapter (EJitSrePlatform.cpp), so scope it to LLVMEJIT like
+# EJIT_CODE_POOL_4K_SEAL above. Effective only when the SRE code pool is on.
+if(EJIT_SRE_CODE_POOL AND EJIT_FIXED_CODE_POOL)
+  target_compile_definitions(LLVMEJIT PRIVATE EJIT_FIXED_CODE_POOL)
+endif()
+
 # EJIT_ICACHE_DIM_SIZE: per-dim bound D of the multi-version inline cache.
 # Used by icacheFill/icacheTry linearization in EJitSharedTaskPool. Must match
 # the AOT -mllvm -ejit-icache-dim-size value (both from the top-level CMake

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -21,6 +21,10 @@ inline uintptr_t alignDownAddr(uintptr_t V, size_t A) {
   return V & ~(static_cast<uintptr_t>(A) - 1);
 }
 
+inline uintptr_t alignUpAddr(uintptr_t V, size_t A) {
+  return (V + (static_cast<uintptr_t>(A) - 1)) & ~(static_cast<uintptr_t>(A) - 1);
+}
+
 inline uintptr_t addr(const void *P) {
   return reinterpret_cast<uintptr_t>(P);
 }
@@ -28,23 +32,29 @@ inline uintptr_t addr(const void *P) {
 } // namespace
 
 EJitCodePoolManager::EJitCodePoolManager(Options Opts, RawAllocFn Alloc,
-                                         SealFn Seal, SplitFn Split)
+                                         SealFn Seal, SplitFn Split,
+                                         EnableRwFn EnableRw)
     : Opts_(Opts), Alloc_(std::move(Alloc)), Seal_(std::move(Seal)),
-      Split_(std::move(Split)) {
+      Split_(std::move(Split)), EnableRw_(std::move(EnableRw)) {
   // minCodeAlign and poolAlign must be powers of two for the masking math.
   if (Opts_.minCodeAlign == 0 || !isPowerOf2_64(Opts_.minCodeAlign))
     Opts_.minCodeAlign = 64;
   if (Opts_.poolAlign == 0 || !isPowerOf2_64(Opts_.poolAlign))
     Opts_.poolAlign = static_cast<size_t>(2) * 1024 * 1024;
   if (Opts_.fourKSeal) {
-    // 4K seal granularity must be a power of two.
-    if (Opts_.sealPageSize == 0 || !isPowerOf2_64(Opts_.sealPageSize))
-      Opts_.sealPageSize = 4096;
     // The pool size must be a whole multiple of the large-page / split
     // granularity (poolAlign); round up if a configured size is not.
     Opts_.poolSize = alignUp(Opts_.poolSize, Opts_.poolAlign);
     if (Opts_.poolSize == 0)
       Opts_.poolSize = Opts_.poolAlign;
+  }
+  // sealPageSize is the per-page granularity for BOTH 4K sealing and enable_rw
+  // (RX->RW). Validate it whenever either is active - enableRwRange uses it
+  // regardless of fourKSeal, and a 0 / non-power-of-2 value would cause
+  // alignDownAddr(addr, 0) UB in the per-page loop.
+  if (Opts_.fourKSeal || Opts_.needsEnableRw) {
+    if (Opts_.sealPageSize == 0 || !isPowerOf2_64(Opts_.sealPageSize))
+      Opts_.sealPageSize = 4096;
   }
   EJIT_DIAG_VERBOSE("code pool ctor: poolSize=%zu poolAlign=%zu minCodeAlign=%zu "
                     "fourKSeal=%u sealPage=%zu",
@@ -64,41 +74,78 @@ bool EJitCodePoolManager::poolHasRoomLocked(const CodePool &P, size_t Size,
 }
 
 Error EJitCodePoolManager::newActivePoolLocked() {
-  // Reserve alignment slack so the base can be rounded up to poolAlign while
-  // still leaving poolSize usable bytes. In 4K seal mode the platform contract
-  // wants a full large-page (poolAlign) of slack; legacy mode needs only
-  // poolAlign - 1.
-  size_t RawSize = Opts_.fourKSeal ? (Opts_.poolSize + Opts_.poolAlign)
-                                   : (Opts_.poolSize + Opts_.poolAlign - 1);
-  EJIT_DIAG("newActivePool: poolSize=%zu fourKSeal=%u rawSize=%zu",
-            Opts_.poolSize, static_cast<unsigned>(Opts_.fourKSeal), RawSize);
-  void *Raw = Alloc_ ? Alloc_(RawSize) : nullptr;
-  if (!Raw) {
-    EJIT_DIAG("newActivePool FAIL: raw alloc %zu bytes returned null (hasAlloc=%u)",
-              RawSize, static_cast<unsigned>(static_cast<bool>(Alloc_)));
-    return make_error<StringError>(
-        "EJitCodePool: raw allocation of " + Twine(RawSize) + " bytes failed",
-        inconvertibleErrorCode());
-  }
-  EJIT_DIAG("newActivePool: rawAlloc=%p size=%zu", Raw, RawSize);
+  uint8_t *RawBytes = nullptr;
+  uint8_t *Base = nullptr;
 
-  auto *RawBytes = static_cast<uint8_t *>(Raw);
-  auto *Base = reinterpret_cast<uint8_t *>(
-      alignUp(addr(RawBytes), Opts_.poolAlign));
-  EJIT_DIAG("newActivePool: alignedBase=%p", static_cast<void *>(Base));
-
-  if (Opts_.fourKSeal) {
-    // The 2MiB-aligned usable window must stay inside the raw allocation.
-    if (addr(Base) + Opts_.poolSize > addr(RawBytes) + RawSize) {
-      EJIT_DIAG("newActivePool FAIL: aligned window base=%p +%zu > raw %p +%zu",
-                static_cast<void *>(Base), Opts_.poolSize,
-                static_cast<void *>(RawBytes), RawSize);
+  if (Opts_.fixedSize > 0) {
+    // Fixed-region mode: carve the next poolAlign-aligned pool from the
+    // pre-reserved region [fixedBase, fixedBase + fixedSize) (e.g. a
+    // linker-script .text.ejit bounded by __ejit_code_start/__ejit_code_end).
+    // No Alloc_ call - the region is owned by the image. Split_/Seal_ still
+    // apply: the region is RX, enable_rw'd to RW before writing, sealed RX at
+    // finalize. Exhaustion is a clean Error:
+    // there is intentionally NO fallback to RawAllocFn, which would break the
+    // fixed-address guarantee (the specialization falls back to AOT instead).
+    uintptr_t RegionEnd = Opts_.fixedBase + Opts_.fixedSize;
+    uintptr_t Next =
+        alignUpAddr(Opts_.fixedBase + FixedUsed_, Opts_.poolAlign);
+    if (Next + Opts_.poolSize > RegionEnd) {
+      EJIT_DIAG("newActivePool FAIL: fixed region exhausted next=0x%llx +%zu > "
+                "end=0x%llx (used=%zu of %zu)",
+                static_cast<unsigned long long>(Next), Opts_.poolSize,
+                static_cast<unsigned long long>(RegionEnd), FixedUsed_,
+                Opts_.fixedSize);
       return make_error<StringError>(
-          "EJitCodePool: aligned pool window exceeds raw allocation",
+          "EJitCodePool: fixed code-pool region exhausted (used " +
+              Twine(FixedUsed_) + " of " + Twine(Opts_.fixedSize) +
+              " bytes; no fallback to dynamic allocation)",
           inconvertibleErrorCode());
     }
+    RawBytes = reinterpret_cast<uint8_t *>(Next);
+    Base = RawBytes; // already poolAlign-aligned by the carve
+    FixedUsed_ = (Next + Opts_.poolSize) - Opts_.fixedBase;
+    EJIT_DIAG("newActivePool: fixed region base=%p size=%zu used=%zu/%zu",
+              static_cast<void *>(Base), Opts_.poolSize, FixedUsed_,
+              Opts_.fixedSize);
+  } else {
+    // Dynamic mode: reserve alignment slack so the base can be rounded up to
+    // poolAlign while still leaving poolSize usable bytes. In 4K seal mode the
+    // platform contract wants a full large-page (poolAlign) of slack; legacy
+    // mode needs only poolAlign - 1.
+    size_t RawSize = Opts_.fourKSeal ? (Opts_.poolSize + Opts_.poolAlign)
+                                     : (Opts_.poolSize + Opts_.poolAlign - 1);
+    EJIT_DIAG("newActivePool: poolSize=%zu fourKSeal=%u rawSize=%zu",
+              Opts_.poolSize, static_cast<unsigned>(Opts_.fourKSeal), RawSize);
+    void *Raw = Alloc_ ? Alloc_(RawSize) : nullptr;
+    if (!Raw) {
+      EJIT_DIAG("newActivePool FAIL: raw alloc %zu bytes returned null (hasAlloc=%u)",
+                RawSize, static_cast<unsigned>(static_cast<bool>(Alloc_)));
+      return make_error<StringError>(
+          "EJitCodePool: raw allocation of " + Twine(RawSize) + " bytes failed",
+          inconvertibleErrorCode());
+    }
+    EJIT_DIAG("newActivePool: rawAlloc=%p size=%zu", Raw, RawSize);
+    RawBytes = static_cast<uint8_t *>(Raw);
+    Base = reinterpret_cast<uint8_t *>(
+        alignUp(addr(RawBytes), Opts_.poolAlign));
+    EJIT_DIAG("newActivePool: alignedBase=%p", static_cast<void *>(Base));
+    if (Opts_.fourKSeal) {
+      // The 2MiB-aligned usable window must stay inside the raw allocation.
+      if (addr(Base) + Opts_.poolSize > addr(RawBytes) + RawSize) {
+        EJIT_DIAG("newActivePool FAIL: aligned window base=%p +%zu > raw %p +%zu",
+                  static_cast<void *>(Base), Opts_.poolSize,
+                  static_cast<void *>(RawBytes), RawSize);
+        return make_error<StringError>(
+            "EJitCodePool: aligned pool window exceeds raw allocation",
+            inconvertibleErrorCode());
+      }
+    }
+  }
+
+  if (Opts_.fourKSeal) {
     // Split the 2MiB-aligned region into 4K mappings before any enable_ex. One
-    // split per pool; per-page enable_ex happens later at seal time.
+    // split per pool; per-page enable_ex happens later at seal time. Applies in
+    // both modes (fixed region is RW until sealed too).
     unsigned Rc = Split_ ? Split_(Base, Opts_.poolSize) : 1;
     if (Rc != 0) {
       EJIT_DIAG("newActivePool FAIL: split_2m_to_4k base=%p size=%zu rc=%u",
@@ -326,6 +373,57 @@ Error EJitCodePoolManager::sealCodeRange(const void *Start, size_t Size) {
   return Error::success();
 }
 
+Error EJitCodePoolManager::enableRwRange(const void *Start, size_t Size) {
+  // No-op in data-region placement (region is already RW at load). Only the
+  // code-segment placement (needsEnableRw) must flip pages RX -> RW before any
+  // write. Also a clean no-op for a zero-size range.
+  if (!Opts_.needsEnableRw || Size == 0)
+    return Error::success();
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  CodePool *P = findPoolLocked(Start);
+  if (!P) {
+    EJIT_DIAG("enableRwRange FAIL: start=%p size=%zu not owned by any pool",
+              Start, Size);
+    return make_error<StringError>(
+        "EJitCodePool: address " + Twine(addr(Start)) +
+            " is not owned by any code pool",
+        inconvertibleErrorCode());
+  }
+  // Make every 4KiB page the slab overlaps writable, mirroring sealCodeRange.
+  size_t Page = Opts_.sealPageSize;
+  uintptr_t PageStart = alignDownAddr(addr(Start), Page);
+  uintptr_t PageEnd = alignUp(addr(Start) + Size, Page);
+  EJIT_DIAG("enableRwRange: start=%p size=%zu pageStart=0x%llx pageEnd=0x%llx",
+            Start, Size, static_cast<unsigned long long>(PageStart),
+            static_cast<unsigned long long>(PageEnd));
+  for (uintptr_t VA = PageStart; VA < PageEnd; VA += Page) {
+    unsigned Rc = EnableRw_ ? EnableRw_(reinterpret_cast<void *>(VA)) : 1;
+    if (Rc != 0) {
+      EJIT_DIAG("enableRwRange FAIL: enable_rw page=0x%llx rc=%u",
+                static_cast<unsigned long long>(VA), Rc);
+      // Roll back: seal the pages we already made writable (RX->RW) back to RX
+      // so a partial failure does not leave code-segment pages permanently
+      // writable (W^X violation). Sealing (RW->RX) is security-benign (more
+      // restrictive). The carved slab itself is left unused (a bounded hole in
+      // the fixed region) rather than reclaimed, to keep this path simple.
+      for (uintptr_t RollVA = PageStart; RollVA < VA; RollVA += Page) {
+        if (Seal_)
+          Seal_(reinterpret_cast<void *>(RollVA));
+      }
+      return make_error<StringError>(
+          "EJitCodePool: enable_rw failed (rc=" + Twine(Rc) + ") for page " +
+              Twine(VA),
+          inconvertibleErrorCode());
+    }
+    ++RwEnableInvocations_;
+  }
+  EJIT_DIAG("enableRwRange OK: start=%p size=%zu (invocations=%zu)", Start, Size,
+            RwEnableInvocations_);
+  return Error::success();
+}
+
 bool EJitCodePoolManager::contains(const void *Ptr) const {
 #ifndef EJIT_FREESTANDING
   std::lock_guard<std::mutex> Lock(Mutex_);
@@ -428,6 +526,7 @@ EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
   S.poolCount = Pools_.size();
   S.sealInvocations = SealInvocations_;
   S.splitInvocations = SplitInvocations_;
+  S.rwEnableInvocations = RwEnableInvocations_;
   S.finalizedRangeCount = FinalizedRanges_.size();
   for (auto &P : Pools_) {
     S.reservedBytes += P->size;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -56,6 +56,19 @@ EJitCodePoolManager::EJitCodePoolManager(Options Opts, RawAllocFn Alloc,
     if (Opts_.sealPageSize == 0 || !isPowerOf2_64(Opts_.sealPageSize))
       Opts_.sealPageSize = 4096;
   }
+  // Code-segment placement (needsEnableRw) is designed for 4K page-seal mode:
+  // finalize seals only the executable pages (RW->RX) and leaves .data/.got
+  // pages RW (the per-page W^X semantics in EJIT_SRE_CODE_POOL.md S14).
+  // Without fourKSeal, finalize does not seal (the whole pool is sealed RX
+  // later, at lookup, including data pages), so that per-page W^X behavior
+  // does not hold. Warn so the misconfiguration is observable rather than
+  // silent; the factory (makeSreCodePoolManager) always couples the two via
+  // the EJIT_FIXED_CODE_POOL + EJIT_CODE_POOL_4K_SEAL presets.
+  if (Opts_.needsEnableRw && !Opts_.fourKSeal) {
+    EJIT_DIAG("code pool ctor WARNING: needsEnableRw=1 without fourKSeal: "
+              "per-page W^X (data pages stay RW) requires 4K seal mode; "
+              "legacy mode seals the whole pool RX at lookup");
+  }
   EJIT_DIAG_VERBOSE("code pool ctor: poolSize=%zu poolAlign=%zu minCodeAlign=%zu "
                     "fourKSeal=%u sealPage=%zu",
                     Opts_.poolSize, Opts_.poolAlign, Opts_.minCodeAlign,
@@ -409,8 +422,17 @@ Error EJitCodePoolManager::enableRwRange(const void *Start, size_t Size) {
       // restrictive). The carved slab itself is left unused (a bounded hole in
       // the fixed region) rather than reclaimed, to keep this path simple.
       for (uintptr_t RollVA = PageStart; RollVA < VA; RollVA += Page) {
-        if (Seal_)
-          Seal_(reinterpret_cast<void *>(RollVA));
+        if (Seal_) {
+          unsigned SealRc = Seal_(reinterpret_cast<void *>(RollVA));
+          // Best-effort rollback: a seal (RW->RX) failure here leaves this
+          // page writable in the code segment (a W^X leak) that we could not
+          // restore. Surface it so the leak is observable rather than silent;
+          // we still return the original enable_rw error below.
+          if (SealRc != 0)
+            EJIT_DIAG("enableRwRange rollback: seal (RW->RX) FAILED page=0x%llx "
+                      "rc=%u (page left RW - W^X leak)",
+                      static_cast<unsigned long long>(RollVA), SealRc);
+        }
       }
       return make_error<StringError>(
           "EJitCodePool: enable_rw failed (rc=" + Twine(Rc) + ") for page " +

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -146,6 +146,16 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
       return;
     }
     Slab = *MemOrErr;
+    // Code-segment fixed-pool placement: the slab sits in the RX code segment,
+    // so make its pages writable (RX -> RW via enable_rw) BEFORE any write. In
+    // data-region placement this is a no-op (already RW). Failure means the slab
+    // is not writable - do not hand it back for JITLink to write into.
+    if (auto Err = Pool_.enableRwRange(Slab, static_cast<size_t>(Total))) {
+      EJIT_DIAG("allocate FAIL: enableRwRange total=%llu",
+                static_cast<unsigned long long>(Total));
+      OnAllocated(std::move(Err));
+      return;
+    }
     // Zero-fill the whole slab up-front (covers zero-fill segments and any
     // inter-segment page padding).
     std::memset(Slab, 0, static_cast<size_t>(Total));

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -79,6 +79,12 @@ ejit_sre_split_2m_to_4k(unsigned long long va,
 // enable_rw surfaces as a hard link error rather than silent non-writability.
 // Platform signature: unsigned enable_rw(unsigned level, unsigned long long va)
 // (level mirrors enable_ex's startLevel; the EnableRw lambda below passes 1).
+//
+// W^X contract: enable_rw MUST clear execute permission (set UXN/PXN on
+// AArch64) as well as set write permission (AP bit), so the page transitions
+// RX -> RW (writable, NOT executable) during the write window. Flipping only
+// the AP/write bit would leave the page RWX, violating W^X. enable_ex is the
+// symmetric inverse (RW -> RX: clear write, set executable + I-cache sync).
 #if defined(EJIT_FIXED_CODE_POOL)
 extern "C" unsigned
 ejit_sre_enable_rw(unsigned level, unsigned long long va) __asm__("enable_rw");
@@ -269,9 +275,13 @@ llvm::ejit::makeSreCodePoolManager() {
   auto EnableRw = [](void *Va) -> unsigned {
 #ifdef EJIT_FIXED_CODE_POOL
     // Make one 4KiB page writable (RX -> RW) so JITLink can write code into the
-    // code-segment fixed region. enable_rw flips the PTE AP bit + TLB flush
-    // (no I-cache sync needed - we are about to WRITE, not execute). Per-core:
-    // only the compiling core calls this; peer cores only enable_ex to execute.
+    // code-segment fixed region. enable_rw must set write permission (AP bit)
+    // AND clear execute permission (UXN/PXN) + TLB flush, so the page is
+    // RW-but-not-X (true W^X) during the write window - flipping only the AP
+    // bit would leave it RWX. No I-cache sync is needed here: we are about to
+    // WRITE, not execute (enable_ex / sealAndSyncCache syncs caches later, at
+    // RW -> RX). Per-core: only the compiling core calls this; peer cores only
+    // enable_ex to execute.
     return ejit_sre_enable_rw(
         /*level=*/1u,
         static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(Va)));

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -70,9 +70,44 @@ extern "C" unsigned
 ejit_sre_split_2m_to_4k(unsigned long long va,
                         unsigned long long size) __asm__("split_2m_to_4k");
 
+// Make a 4KiB page writable (RX -> RW) so JIT code can be written into a fixed
+// region placed in the executable code segment. Symmetric to enable_ex (which
+// makes a page executable, RW -> RX). Returns 0 on success. Only declared when
+// the fixed code pool is placed in the code segment
+// (EJIT_FIXED_CODE_POOL); the platform MUST supply the strong
+// definition - there is intentionally no weak no-op fallback, so a missing
+// enable_rw surfaces as a hard link error rather than silent non-writability.
+// Platform signature: unsigned enable_rw(unsigned level, unsigned long long va)
+// (level mirrors enable_ex's startLevel; the EnableRw lambda below passes 1).
+#if defined(EJIT_FIXED_CODE_POOL)
+extern "C" unsigned
+ejit_sre_enable_rw(unsigned level, unsigned long long va) __asm__("enable_rw");
+#endif
+
 extern "C" void *SRE_MemDbgAlloc(unsigned int mid, unsigned char ptNo,
                                  unsigned long size, const char *func,
                                  unsigned int line);
+
+// Fixed code-pool region bounds, defined by the linker script (a .text.ejit
+// output section bracketed by these two symbols). When EJIT_FIXED_CODE_POOL is
+// on, makeSreCodePoolManager() prefers this fixed region over dynamic
+// SRE_MemDbgAlloc so JIT code lands at a stable, predictable address (enabling
+// direct bl/adrp reach to AOT code). Declared weak on the host (absent -> null
+// -> dynamic fallback, so host tests link without a linker script) and strong
+// under EJIT_FREESTANDING, exactly like __start_ejit_bitcode in EJit.cpp: a
+// bare-metal link MUST define them via the linker script, and a missing
+// definition is a hard link error rather than a silent no-op.
+#if defined(EJIT_FIXED_CODE_POOL)
+extern "C" {
+#ifndef EJIT_FREESTANDING
+extern const unsigned char __ejit_code_start[] __attribute__((weak));
+extern const unsigned char __ejit_code_end[] __attribute__((weak));
+#else
+extern const unsigned char __ejit_code_start[];
+extern const unsigned char __ejit_code_end[];
+#endif
+}
+#endif
 
 namespace {
 /// Make newly-written JIT code in [Va, Va + Size) observable to instruction
@@ -141,6 +176,62 @@ llvm::ejit::makeSreCodePoolManager() {
   Opts.sealPageSize = k4KiB;
 #endif
 
+#ifdef EJIT_FIXED_CODE_POOL
+  // The linker script reserves [.text.ejit] = [__ejit_code_start, __ejit_code_end)
+  // with only page (4KiB) alignment. Align the start UP to the 2MiB large-page
+  // granularity here: split_2m_to_4k / enable_ex require 2MiB-aligned bases, so
+  // the runtime (not the linker script) owns the 2MiB alignment. The bytes
+  // [__ejit_code_start, AlignedBase) are wasted alignment slack (at most ~2MiB),
+  // so size the region with that headroom in mind (16M -> ~14M usable). Engage
+  // fixed mode only if the aligned region can hold at least one pool; otherwise
+  // fall back to SRE_MemDbgAlloc (a too-small fixed region would exhaust on
+  // every compile). A fixed region gives a stable JIT address range and, when
+  // placed within +-128MiB of .text, lets codegen use direct bl/adrp.
+  {
+    uintptr_t FBase = reinterpret_cast<uintptr_t>(__ejit_code_start);
+    uintptr_t FEnd = reinterpret_cast<uintptr_t>(__ejit_code_end);
+    uintptr_t AlignedBase =
+        (FBase + (static_cast<uintptr_t>(k2MiB) - 1)) &
+        ~(static_cast<uintptr_t>(k2MiB) - 1);
+    if (FEnd > AlignedBase && (FEnd - AlignedBase) >= kSrePoolSize) {
+      Opts.fixedBase = AlignedBase;
+      Opts.fixedSize = FEnd - AlignedBase;
+      EJIT_DIAG("makeSreCodePoolManager: FIXED region sym=[0x%llx,0x%llx) "
+                "alignedBase=0x%llx usable=%llu (~%llu pools of %lluB)",
+                static_cast<unsigned long long>(FBase),
+                static_cast<unsigned long long>(FEnd),
+                static_cast<unsigned long long>(AlignedBase),
+                static_cast<unsigned long long>(FEnd - AlignedBase),
+                static_cast<unsigned long long>((FEnd - AlignedBase) / kSrePoolSize),
+                static_cast<unsigned long long>(kSrePoolSize));
+    } else {
+      EJIT_DIAG("makeSreCodePoolManager: fixed region absent or too small after "
+                "2MiB alignment (sym=[0x%llx,0x%llx) alignedBase=0x%llx "
+                "usable=%llu < poolSize=%llu), falling back to SRE_MemDbgAlloc "
+                "ptNo=%u",
+                static_cast<unsigned long long>(FBase),
+                static_cast<unsigned long long>(FEnd),
+                static_cast<unsigned long long>(AlignedBase),
+                static_cast<unsigned long long>(FEnd > AlignedBase
+                                                    ? FEnd - AlignedBase
+                                                    : 0),
+                static_cast<unsigned long long>(kSrePoolSize),
+                static_cast<unsigned>(kSrePtNo));
+    }
+  }
+#endif
+
+#ifdef EJIT_FIXED_CODE_POOL
+  // Code-segment placement: the fixed region is RX by default, so each slab
+  // must be enable_rw'd (RX -> RW) before writing. needsEnableRw makes
+  // EJitCodePoolMemoryManager::allocate call enableRwRange before memset. Only
+  // meaningful when the fixed region is actually engaged (fixedSize > 0).
+  if (Opts.fixedSize > 0) {
+    Opts.needsEnableRw = true;
+    EJIT_DIAG("makeSreCodePoolManager: code-segment placement -> needsEnableRw=1");
+  }
+#endif
+
   auto RawAlloc = [](size_t Bytes) -> void * {
     return SRE_MemDbgAlloc(kSreMid, kSrePtNo, static_cast<unsigned long>(Bytes),
                            __func__, __LINE__);
@@ -175,7 +266,23 @@ llvm::ejit::makeSreCodePoolManager() {
 #endif
   };
 
-  return std::make_unique<EJitCodePoolManager>(Opts, RawAlloc, Seal, Split);
+  auto EnableRw = [](void *Va) -> unsigned {
+#ifdef EJIT_FIXED_CODE_POOL
+    // Make one 4KiB page writable (RX -> RW) so JITLink can write code into the
+    // code-segment fixed region. enable_rw flips the PTE AP bit + TLB flush
+    // (no I-cache sync needed - we are about to WRITE, not execute). Per-core:
+    // only the compiling core calls this; peer cores only enable_ex to execute.
+    return ejit_sre_enable_rw(
+        /*level=*/1u,
+        static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(Va)));
+#else
+    (void)Va;
+    return 0;
+#endif
+  };
+
+  return std::make_unique<EJitCodePoolManager>(Opts, RawAlloc, Seal, Split,
+                                                EnableRw);
 }
 
 bool llvm::ejit::prepareSreCodeForCurrentCore(const void *FnPtr) {

--- a/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
+++ b/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
@@ -83,7 +83,37 @@ SECTIONS
     . = ALIGN(8);
   } > FLASH      /* or your rodata memory region; use > RAM AT> FLASH for .data */
 
-  /* ... your existing .data / .bss / etc. ... */
+  /* --- EmbeddedJIT fixed JIT code-pool region (enable: EJIT_FIXED_CODE_POOL) --- */
+  /* The runtime reads __ejit_code_start / __ejit_code_end, aligns the start UP to
+   * 2MiB, and carves 2MiB-aligned pools from [aligned start, __ejit_code_end)
+   * instead of dynamic SRE_MemDbgAlloc - giving a stable JIT address range.
+   * The section only needs page (4KiB) alignment: the runtime owns the 2MiB
+   * alignment (enable_ex / split_2m_to_4k require 2MiB-aligned bases). The bytes
+   * [__ejit_code_start, aligned start) are wasted slack (at most ~2MiB), so size
+   * the region with that headroom (16M -> ~14M usable, ~7 pools). If the aligned
+   * region is smaller than one pool (2MiB) the runtime falls back to
+   * SRE_MemDbgAlloc with a diagnostic. Add (NOLOAD) before the colon to reserve
+   * the VMA range without 16M of flash load data (the runtime zero-fills each
+   * slab on first use). Under EJIT_FREESTANDING these symbols are strong, so a
+   * bare-metal link REQUIRES this block; a missing definition is a hard link
+   * error (not silent).
+   *
+   * Code-segment placement (EJIT_FIXED_CODE_POOL=ON): place in the CODE region,
+   * within +-128MiB of .text ("> CODE" below, or after .text in the code
+   * segment). The region is RX at load; the runtime enable_rw's each slab
+   * (RX->RW) before writing and enable_ex's .text pages (RW->RX) at finalize
+   * (.data/.got pages stay RW for GOT writes). Gives direct bl+adrp reach to
+   * AOT code. REQUIRES the platform to supply enable_rw (symmetric to
+   * enable_ex); a missing enable_rw is a hard link error.
+   */
+  .text.ejit : ALIGN(4096)
+  {
+    __ejit_code_start = .;
+    . = __ejit_code_start + 16M;
+    __ejit_code_end = .;
+  } > CODE       /* code segment, near .text (±128MiB bl/adrp reach to AOT) */
+
+  /* ... your existing .bss / etc. ... */
 }
 
 /*

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -233,6 +233,10 @@ struct MockSre4K {
   size_t SealCalls = 0;
   int FailSealOnCall = -1; // 1-based seal index to fail; -1 = never
   unsigned SealFailRc = 7;
+  std::vector<uintptr_t> RwEnabledPages;
+  size_t RwEnableCalls = 0;
+  unsigned RwEnableRc = 0;     // 0 = success; non-zero simulates enable_rw failure
+  int FailRwOnCall = -1;       // 1-based enable_rw index to fail; -1 = never
 
   ~MockSre4K() {
     for (void *P : Origs)
@@ -255,6 +259,15 @@ struct MockSre4K {
     SealedPages.push_back(reinterpret_cast<uintptr_t>(P));
     if (FailSealOnCall > 0 && static_cast<int>(SealCalls) == FailSealOnCall)
       return SealFailRc;
+    return 0;
+  }
+  unsigned enableRw(void *Va) {
+    ++RwEnableCalls;
+    if (RwEnableRc != 0)
+      return RwEnableRc;
+    if (FailRwOnCall > 0 && static_cast<int>(RwEnableCalls) == FailRwOnCall)
+      return 1; // simulate a mid-range enable_rw failure
+    RwEnabledPages.push_back(reinterpret_cast<uintptr_t>(Va));
     return 0;
   }
 };
@@ -550,5 +563,75 @@ TEST(EJitCodePoolMemMgr, NoEnableRwWhenNotNeeded) {
   EXPECT_EQ(M.RwEnableCalls, 0u); // data-region: no enable_rw
 
   auto FA = cantFail(IFA->finalize());
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// Production config (EJIT_FIXED_CODE_POOL preset): 4K page-seal + fixed
+// code-segment region (needsEnableRw). allocate enable_rw's the slab pages
+// (RX->RW) before memset - covering BOTH the executable __text page and the
+// writable __data page (the whole slab is writable during the write). finalize
+// then seals ONLY the executable page (RW->RX), leaving the __data page
+// unsealed (RW) - the per-page W^X toggle order and granularity the
+// code-segment placement relies on. The raw allocator is never consulted
+// (the fixed region supplies the memory).
+TEST(EJitCodePoolMemMgr4K, FixedCodeSegmentEnablesRwThenSealsExecOnly) {
+  // A 2MiB-aligned 2MiB region stands in for the linker-script .text.ejit block
+  // [__ejit_code_start, __ejit_code_end). Exactly one pool is carved from it.
+  constexpr size_t kRegion = kTwoMiB;
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kTwoMiB, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  MockSre4K M;
+  auto O = fourKMemMgrOpts();
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+  O.needsEnableRw = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); },
+      [&M](void *V) { return M.enableRw(V); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeTextAndDataGraph(0x1000, 0x2000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *TextAddr = blockAddrByExec(*G, /*WantExec=*/true);
+  void *DataAddr = blockAddrByExec(*G, /*WantExec=*/false);
+  ASSERT_NE(TextAddr, nullptr);
+  ASSERT_NE(DataAddr, nullptr);
+
+  auto pageOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) &
+           ~static_cast<uintptr_t>(kFourKiB - 1);
+  };
+  ASSERT_NE(pageOf(TextAddr), pageOf(DataAddr)); // distinct pages
+
+  // allocate enable_rw'd the slab's pages (RX->RW) before the write - both the
+  // executable and the data page, since the whole slab is written. Seal has
+  // not run yet, and the raw allocator was never consulted (fixed region).
+  EXPECT_GT(M.RwEnableCalls, 0u);
+  EXPECT_EQ(M.SealCalls, 0u);
+  EXPECT_TRUE(M.Origs.empty());
+  bool TextRw = false, DataRw = false;
+  for (uintptr_t P : M.RwEnabledPages) {
+    if (P == pageOf(TextAddr))
+      TextRw = true;
+    if (P == pageOf(DataAddr))
+      DataRw = true;
+  }
+  EXPECT_TRUE(TextRw); // exec page RW'd (sealed RX at finalize)
+  EXPECT_TRUE(DataRw); // data page RW'd (stays RW - the W^X tradeoff)
+
+  auto FA = cantFail(IFA->finalize());
+
+  // finalize seals ONLY the executable page (RW->RX); the data page is NOT
+  // sealed (left RW for data/GOT writes) - the per-page W^X guarantee.
+  EXPECT_EQ(M.SealCalls, 1u);
+  ASSERT_EQ(M.SealedPages.size(), 1u);
+  EXPECT_EQ(M.SealedPages[0], pageOf(TextAddr));
+  for (uintptr_t Sealed : M.SealedPages)
+    EXPECT_NE(Sealed, pageOf(DataAddr));
+
   cantFail(MM.deallocate(std::move(FA)));
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -38,6 +38,10 @@ struct MockSre {
   std::vector<void *> Raws;
   size_t SealCalls = 0;
   unsigned SealRc = 0;
+  std::vector<uintptr_t> RwEnabledPages;
+  size_t RwEnableCalls = 0;
+  unsigned RwEnableRc = 0;
+  int FailRwOnCall = -1; // 1-based enable_rw index to fail; -1 = never
 
   ~MockSre() {
     for (void *P : Raws)
@@ -52,6 +56,15 @@ struct MockSre {
   unsigned seal(void *) {
     ++SealCalls;
     return SealRc;
+  }
+  unsigned enableRw(void *Va) {
+    ++RwEnableCalls;
+    if (RwEnableRc != 0)
+      return RwEnableRc;
+    if (FailRwOnCall > 0 && static_cast<int>(RwEnableCalls) == FailRwOnCall)
+      return 1; // simulate a mid-range enable_rw failure
+    RwEnabledPages.push_back(reinterpret_cast<uintptr_t>(Va));
+    return 0;
   }
 };
 
@@ -448,5 +461,94 @@ TEST(EJitCodePoolMemMgr4K, SealsAndRecordsOnlyExecutableSegment) {
   EXPECT_EQ(Info.fnPtr, TextAddr);
   EXPECT_FALSE(Pool.findRange(DataAddr, Info));
 
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// Code-segment placement (needsEnableRw): allocate must enable_rw the slab's
+// pages (RX -> RW) BEFORE memset/JITLink writes, so the RX code-segment pages
+// are writable. enable_rw happens at allocate; enable_ex (seal) only later at
+// finalize/lookup - confirming the RW-then-RX toggle order.
+TEST(EJitCodePoolMemMgr, AllocateEnablesRwBeforeWrite) {
+  MockSre M;
+  auto O = poolOpts(256 * 1024);
+  O.needsEnableRw = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); }, nullptr, // no split (legacy mode)
+      [&M](void *V) { return M.enableRw(V); });
+  EJitCodePoolMemoryManager MM(Pool, 4096);
+
+  auto G = makeCodeGraph(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+
+  // allocate enable_rw'd the slab's pages before the write; seal not yet.
+  EXPECT_GT(M.RwEnableCalls, 0u);
+  EXPECT_EQ(M.SealCalls, 0u);
+
+  auto FA = cantFail(IFA->finalize());
+  // finalize in legacy mode does not seal either (seal is at lookup).
+  EXPECT_EQ(M.SealCalls, 0u);
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// enable_rw failure (every page fails): allocate must return an Error and not
+// reach memset. No rollback (0 pages were successfully RW'd).
+TEST(EJitCodePoolMemMgr, AllocateFailsWhenEnableRwFails) {
+  MockSre M;
+  M.RwEnableRc = 7; // every enable_rw call fails
+  auto O = poolOpts(256 * 1024);
+  O.needsEnableRw = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); }, nullptr,
+      [&M](void *V) { return M.enableRw(V); });
+  EJitCodePoolMemoryManager MM(Pool, 4096);
+
+  auto G = makeCodeGraph(64, 0x1000);
+  auto Res = MM.allocate(nullptr, *G);
+  ASSERT_FALSE((bool)Res) << "allocate must fail when enable_rw fails";
+  EXPECT_GT(M.RwEnableCalls, 0u); // enable_rw was attempted
+  EXPECT_EQ(M.SealCalls, 0u);     // 0 pages RW'd -> no rollback seal
+  consumeError(Res.takeError());
+}
+
+// Partial enable_rw failure (2nd page fails on a multi-page slab): allocate
+// must return an Error AND roll back the page that was successfully made
+// writable (seal it back to RX), so the code segment is not left with a
+// permanently-RW page (W^X).
+TEST(EJitCodePoolMemMgr, AllocateRollsBackOnPartialEnableRwFailure) {
+  MockSre M;
+  M.FailRwOnCall = 2; // page 0 succeeds, page 1 fails
+  auto O = poolOpts(256 * 1024);
+  O.needsEnableRw = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); }, nullptr,
+      [&M](void *V) { return M.enableRw(V); });
+  EJitCodePoolMemoryManager MM(Pool, 4096);
+
+  auto G = makeCodeGraph(8192, 0x1000); // spans >= 2 pages
+  auto Res = MM.allocate(nullptr, *G);
+  ASSERT_FALSE((bool)Res) << "allocate must fail on partial enable_rw failure";
+  EXPECT_EQ(M.RwEnabledPages.size(), 1u); // only page 0 was RW'd
+  EXPECT_EQ(M.SealCalls, 1u);             // rollback sealed page 0 back to RX
+  consumeError(Res.takeError());
+}
+
+// needsEnableRw=false (data-region placement): allocate must NOT call
+// enable_rw (the region is already RW). Regression guard for the no-op path.
+TEST(EJitCodePoolMemMgr, NoEnableRwWhenNotNeeded) {
+  MockSre M;
+  EJitCodePoolManager Pool(
+      poolOpts(256 * 1024), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); }, nullptr,
+      [&M](void *V) { return M.enableRw(V); });
+  EJitCodePoolMemoryManager MM(Pool, 4096);
+
+  auto G = makeCodeGraph(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  EXPECT_EQ(M.RwEnableCalls, 0u); // data-region: no enable_rw
+
+  auto FA = cantFail(IFA->finalize());
   cantFail(MM.deallocate(std::move(FA)));
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
@@ -318,6 +318,10 @@ struct MockSre4K {
   int FailSealOnCall = -1; // 1-based seal call index to fail; -1 = never
   unsigned SealFailRc = 7;
 
+  std::vector<uintptr_t> RwEnabledPages;
+  size_t RwEnableCalls = 0;
+  unsigned RwEnableRc = 0; // 0 = success; non-zero simulates enable_rw failure
+
   ~MockSre4K() {
     for (void *P : Origs)
       std::free(P);
@@ -349,6 +353,14 @@ struct MockSre4K {
     SealedPages.push_back(reinterpret_cast<uintptr_t>(PageVA));
     return 0;
   }
+
+  unsigned enableRw(void *PageVA) {
+    ++RwEnableCalls;
+    if (RwEnableRc != 0)
+      return RwEnableRc;
+    RwEnabledPages.push_back(reinterpret_cast<uintptr_t>(PageVA));
+    return 0;
+  }
 };
 
 EJitCodePoolManager::Options fourKOpts() {
@@ -366,7 +378,8 @@ EJitCodePoolManager makeManager4K(MockSre4K &M,
   return EJitCodePoolManager(
       Opts, [&M](size_t N) { return M.rawAlloc(N); },
       [&M](void *V) { return M.seal(V); },
-      [&M](void *B, size_t S) { return M.split(B, S); });
+      [&M](void *B, size_t S) { return M.split(B, S); },
+      [&M](void *V) { return M.enableRw(V); });
 }
 
 } // namespace
@@ -678,4 +691,246 @@ TEST(EJitCodePoolRange, OverlappingRangesResolveDeterministically) {
   // First (append order) containing range wins.
   EXPECT_EQ(Info.codeStart, A(P));
   EXPECT_EQ(Info.codeSize, 400u);
+}
+
+// ---- Fixed-region mode (EJIT_FIXED_CODE_POOL) ----
+// When Options::fixedSize > 0, pools are carved from the pre-reserved
+// [fixedBase, fixedBase+fixedSize) region instead of calling RawAllocFn. These
+// tests use tiny geometry (poolAlign=poolSize=256) so they run fast and never
+// touch real 2MiB pages; the carve math is identical at any scale.
+
+// Fixed-region mode carves poolAlign-aligned pools from the region WITHOUT ever
+// calling the raw allocator (dynamic SRE_MemDbgAlloc is the fallback only when
+// fixedSize == 0).
+TEST(EJitCodePoolFixed, CarvesAlignedPoolsWithoutAlloc) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 256;
+  constexpr size_t kRegion = 1024; // 4 pools
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kAlign, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+
+  MockSre M;
+  auto Mgr = makeManager(M, O);
+
+  uintptr_t RegionBase = reinterpret_cast<uintptr_t>(Region);
+  uintptr_t Prev = 0;
+  for (int i = 0; i < 4; ++i) {
+    void *P = cantFail(Mgr.allocateCode(kPool, 64));
+    uintptr_t AP = A(P);
+    EXPECT_GE(AP, RegionBase);
+    EXPECT_LT(AP, RegionBase + kRegion);
+    EXPECT_EQ(AP % kAlign, 0u);
+    EXPECT_NE(AP, Prev);
+    Prev = AP;
+  }
+  // The raw allocator is never consulted in fixed-region mode.
+  EXPECT_EQ(M.AllocCalls, 0u);
+}
+
+// Exhausting the fixed region is a clean Error (no crash, no silent fallback
+// to dynamic allocation), and pools already carved remain valid.
+TEST(EJitCodePoolFixed, ExhaustsCleanly) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 256;
+  constexpr size_t kRegion = 512; // 2 pools
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kAlign, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+
+  MockSre M;
+  auto Mgr = makeManager(M, O);
+
+  void *P0 = cantFail(Mgr.allocateCode(kPool, 64));
+  void *P1 = cantFail(Mgr.allocateCode(kPool, 64));
+  EXPECT_NE(A(P0), A(P1));
+  Expected<void *> E = Mgr.allocateCode(kPool, 64);
+  ASSERT_FALSE(E) << "fixed region must exhaust cleanly, not fall back";
+  consumeError(E.takeError());
+}
+
+// 4K page-seal mode still splits the fixed-region pool at creation and seals
+// the covering pages at finalize - the fixed region is RW until sealed, exactly
+// like a dynamically allocated pool.
+TEST(EJitCodePoolFixed, StillSplitsAndSealsIn4KMode) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 256;
+  constexpr size_t kPage = 256;
+  constexpr size_t kRegion = 512; // 2 pools
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kAlign, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fourKSeal = true;
+  O.sealPageSize = kPage;
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, O);
+
+  void *P = cantFail(Mgr.allocateCode(128, 64));
+  // Pool creation in 4K mode still split the fixed-region pool.
+  ASSERT_EQ(M.Splits.size(), 1u);
+  EXPECT_EQ(M.Splits[0].first, reinterpret_cast<uintptr_t>(Region));
+  EXPECT_EQ(M.Splits[0].second, kPool);
+  // Raw allocator never consulted.
+  EXPECT_EQ(M.AllocCalls, 0u);
+
+  // Sealing the carved code range flips the covering page. P is page-aligned
+  // (EffAlign >= sealPageSize in 4K mode), so exactly one page is sealed.
+  cantFail(Mgr.sealCodeRange(P, 128));
+  EXPECT_EQ(M.SealCalls, 1u);
+  ASSERT_EQ(M.SealedPages.size(), 1u);
+  EXPECT_EQ(M.SealedPages[0], A(P));
+}
+
+// A non-poolAlign-aligned fixedBase is aligned UP by the manager. The factory
+// (makeSreCodePoolManager) does this alignment itself; this test pins that the
+// manager stays robust to a misaligned base from any direct Options caller
+// (defense in depth): the first pool lands at alignUp(fixedBase, poolAlign),
+// inside the region, and the raw allocator is still never consulted.
+TEST(EJitCodePoolFixed, AlignsMisalignedBase) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 256;
+  // 256-aligned buffer; start the region at +100 so it is NOT 256-aligned, with
+  // enough headroom that the align-up still leaves room for a pool.
+  void *Buf = nullptr;
+  ASSERT_EQ(posix_memalign(&Buf, kAlign, kAlign + 1024), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Buf, std::free);
+  uintptr_t MisalignedBase = reinterpret_cast<uintptr_t>(Buf) + 100;
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fixedBase = MisalignedBase;
+  O.fixedSize = 1024;
+
+  MockSre M;
+  auto Mgr = makeManager(M, O);
+
+  uintptr_t ExpectedFirst =
+      (MisalignedBase + (kAlign - 1)) & ~(static_cast<uintptr_t>(kAlign) - 1);
+  void *P = cantFail(Mgr.allocateCode(kPool, 64));
+  EXPECT_EQ(A(P), ExpectedFirst);
+  EXPECT_GE(A(P), MisalignedBase);
+  EXPECT_LT(A(P), MisalignedBase + 1024);
+  EXPECT_EQ(A(P) % kAlign, 0u);
+  EXPECT_EQ(M.AllocCalls, 0u);
+}
+
+// ---- Code-segment placement (enable_rw) ----
+
+// enableRwRange makes the slab's 4K pages writable (RX -> RW) when
+// needsEnableRw is set (code-segment placement). Page-aligned like
+// sealCodeRange; one enable_rw per covered page.
+TEST(EJitCodePoolFixed, EnableRwRangeFlipsCoveredPages) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 1024; // >= the 384-byte request
+  constexpr size_t kPage = 256;
+  constexpr size_t kRegion = 2048; // 2 pools
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kAlign, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fourKSeal = true;
+  O.sealPageSize = kPage;
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+  O.needsEnableRw = true;
+
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, O);
+
+  // A 384-byte request spans 2 pages ([P, P+384) -> [P, P+512)).
+  void *P = cantFail(Mgr.allocateCode(384, 64));
+  cantFail(Mgr.enableRwRange(P, 384));
+  EXPECT_EQ(M.RwEnableCalls, 2u);
+  ASSERT_EQ(M.RwEnabledPages.size(), 2u);
+  EXPECT_EQ(M.RwEnabledPages[0], A(P));
+  EXPECT_EQ(M.RwEnabledPages[1], A(P) + kPage);
+}
+
+// enableRwRange is a clean no-op when needsEnableRw is false (data-region
+// placement is already RW) - enable_rw is never called.
+TEST(EJitCodePoolFixed, EnableRwRangeNoOpWhenNotNeeded) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 256;
+  constexpr size_t kPage = 256;
+  constexpr size_t kRegion = 512;
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kAlign, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fourKSeal = true;
+  O.sealPageSize = kPage;
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+  O.needsEnableRw = false; // data-region placement: no enable_rw
+
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, O);
+
+  void *P = cantFail(Mgr.allocateCode(128, 64));
+  cantFail(Mgr.enableRwRange(P, 128));
+  EXPECT_EQ(M.RwEnableCalls, 0u);
+  EXPECT_TRUE(M.RwEnabledPages.empty());
+}
+
+// enableRwRange propagates an enable_rw failure as an Error (the slab must not
+// be written if a page cannot be made writable).
+TEST(EJitCodePoolFixed, EnableRwRangeFailsOnRc) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 256;
+  constexpr size_t kPage = 256;
+  constexpr size_t kRegion = 512;
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kAlign, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fourKSeal = true;
+  O.sealPageSize = kPage;
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+  O.needsEnableRw = true;
+
+  MockSre4K M;
+  M.RwEnableRc = 5; // simulate enable_rw failure
+  auto Mgr = makeManager4K(M, O);
+
+  void *P = cantFail(Mgr.allocateCode(128, 64));
+  Error E = Mgr.enableRwRange(P, 128);
+  EXPECT_TRUE(bool(E)) << "enable_rw failure must propagate as an Error";
+  consumeError(std::move(E));
 }


### PR DESCRIPTION
## What

Back the JIT code pool with a fixed, linker-script-defined region `[__ejit_code_start, __ejit_code_end)` (section `.text.ejit`) in the executable **CODE segment**, instead of dynamic `SRE_MemDbgAlloc`. A fixed region gives a stable JIT address range and, within +-128MiB of `.text`, lets codegen use direct `bl`/`adrp` with no GOT/stubs.

## Code-segment placement (the only supported mode)

The region is RX at load. The runtime `enable_rw`'s each slab (RX->RW) before writing and `enable_ex`'s it (RW->RX) at finalize (`.data`/`.got` pages stay RW for GOT writes). Requires the platform to supply `enable_rw` (symmetric to `enable_ex`); a missing `enable_rw` is a hard link error.

## Runtime

- **`EJitCodePoolManager` fixed-region mode**: `Options::fixedBase`/`fixedSize` + `FixedUsed_` cursor; `newActivePoolLocked` carves 2MiB-aligned pools from the region WITHOUT calling `RawAllocFn`. Runtime aligns `__ejit_code_start` UP to 2MiB (linker script only needs `ALIGN(4096)`). Region exhaustion is a clean `Error` with no fallback to dynamic allocation (specialization falls back to AOT).
- **`enable_rw`**: `EnableRwFn` callback + `enableRwRange(Start,Size)` (page-aligned, per-page, mirrors `sealCodeRange`). `allocate` calls `enableRwRange(slab, total)` BEFORE `memset`. Per-core: compiling core `enable_rw`+`enable_ex`; peer cores only `enable_ex`.
- **Partial-failure rollback**: on a mid-range `enable_rw` failure, seal the already-RW'd pages back to RX so the code segment is not left permanently writable (W^X). The carved slab is left as a bounded hole.
- **`sealPageSize` validation**: validated whenever `fourKSeal` OR `needsEnableRw` is set (`enableRwRange` uses it regardless of `fourKSeal`; a 0/non-power-of-2 value caused `alignDownAddr(addr,0)` UB).

## CMake

Single bool `EJIT_FIXED_CODE_POOL` (ON = code segment + `enable_rw`, OFF = dynamic). No separate `IN_CODESEG` option (code-segment-only) and no size knob (authoritative size is `__ejit_code_end - __ejit_code_start` from the linker script). `ejit-minimal-aarch64_be` preset turns it ON.

## Linker script

`ejit_registry.ld`: `.text.ejit` output section (`ALIGN(4096)`) bracketed by `__ejit_code_start`/`__ejit_code_end`; `INSERT` form provided.

## Tests

`EJitCodePoolTest` / `EJitCodePoolMemoryManagerTest` cover fixed-region carve/exhaustion/misaligned-base/4K-seal + `enableRwRange` flips/no-op/fail + allocate-enables-rw-before-write + allocate-failure-on-`enable_rw`-fail + partial-failure rollback (`FailRwOnCall` mock).

## Docs

`EJIT_SRE_CODE_POOL.md` S14 (fixed code-pool region: code-segment placement, `enable_rw` mechanism, W^X tradeoff, rollback), S9 CMake table; `PASS7` platform-symbol note; linker-script comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
