### PR TITLE
[EJIT] Restore CodeGen-time NoInline on ejit_entry + extend to ejit_period_lc

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13510,6 +13510,11 @@ def warn_ejit_undeclared_period_dep : Warning<
   "function %0 references ejit_period_arr '%1' but does not declare "
   "a dependency on it via ejit_period_arr_ind">,
   InGroup<EmbeddedJIT>;
+def warn_ejit_always_inline_conflict : Warning<
+  "'always_inline' is incompatible with %0, which must remain "
+  "out-of-line so it survives the inliner for JIT specialization; "
+  "ignoring 'always_inline'">,
+  InGroup<EmbeddedJIT>;
 def note_ejit_period_arr_defined_here : Note<
   "ejit_period_arr '%0' defined here">;
 def note_ejit_entry_defined_here : Note<

--- a/clang/lib/CodeGen/CGEJIT.cpp
+++ b/clang/lib/CodeGen/CGEJIT.cpp
@@ -39,8 +39,11 @@ void clang::CodeGen::emitEjitFunctionMetadata(CodeGenModule &CGM,
     // In LTO pipelines the inliner runs before EJitWrapperGenPass can
     // add this attribute; emitting it at CodeGen time ensures the
     // function survives so PASS1 can extract its bitcode and PASS3
-    // can insert the JIT wrapper.
-    F->addFnAttr(llvm::Attribute::NoInline);
+    // can insert the JIT wrapper. Sema rejects always_inline on
+    // ejit_entry; the AlwaysInline guard is a backstop for hand-written
+    // IR (noinline + alwaysinline is illegal and aborts the verifier).
+    if (!F->hasFnAttribute(llvm::Attribute::AlwaysInline))
+      F->addFnAttr(llvm::Attribute::NoInline);
   }
 
   // ejit_period_lc
@@ -56,8 +59,10 @@ void clang::CodeGen::emitEjitFunctionMetadata(CodeGenModule &CGM,
   // at its entry/returns. Unlike ejit_entry, PASS4 does not self-defend
   // with NoInline, so the CodeGen-time attribute is the only guard.
   // Lifecycle guards are entered/left rarely, so NoInline has no real
-  // perf cost.
-  if (FD->hasAttr<EjitPeriodLcAttr>())
+  // perf cost. Sema rejects always_inline here too; the guard backstops
+  // hand-written IR.
+  if (FD->hasAttr<EjitPeriodLcAttr>() &&
+      !F->hasFnAttribute(llvm::Attribute::AlwaysInline))
     F->addFnAttr(llvm::Attribute::NoInline);
 
   // ejit_period_arr_ind (on parameters)

--- a/clang/lib/CodeGen/CGEJIT.cpp
+++ b/clang/lib/CodeGen/CGEJIT.cpp
@@ -35,6 +35,12 @@ void clang::CodeGen::emitEjitFunctionMetadata(CodeGenModule &CGM,
   if (FD->hasAttr<EjitEntryAttr>()) {
     Entries.push_back(llvm::MDNode::get(Ctx,
         llvm::MDString::get(Ctx, TAG_EJIT_ENTRY)));
+    // Prevent the inliner from merging ejit_entry into its callers.
+    // In LTO pipelines the inliner runs before EJitWrapperGenPass can
+    // add this attribute; emitting it at CodeGen time ensures the
+    // function survives so PASS1 can extract its bitcode and PASS3
+    // can insert the JIT wrapper.
+    F->addFnAttr(llvm::Attribute::NoInline);
   }
 
   // ejit_period_lc
@@ -44,6 +50,15 @@ void clang::CodeGen::emitEjitFunctionMetadata(CodeGenModule &CGM,
         llvm::MDString::get(Ctx, LCA->getPeriodName())
     }));
   }
+  // Same LTO-inliner hazard as ejit_entry: in FullLTO the inliner runs
+  // before EJitAotModulePass, so PASS4 (EJitPeriodHandler) would see an
+  // inlined-away function and fail to emit ejit_deactivate/ejit_activate
+  // at its entry/returns. Unlike ejit_entry, PASS4 does not self-defend
+  // with NoInline, so the CodeGen-time attribute is the only guard.
+  // Lifecycle guards are entered/left rarely, so NoInline has no real
+  // perf cost.
+  if (FD->hasAttr<EjitPeriodLcAttr>())
+    F->addFnAttr(llvm::Attribute::NoInline);
 
   // ejit_period_arr_ind (on parameters)
   for (unsigned I = 0; I < FD->getNumParams(); ++I) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -76,6 +76,10 @@ using namespace sema;
 // Defined in SemaEJIT.cpp.
 void checkEjitPeriodArrIndLimit(Sema &S, const FunctionDecl *FD);
 
+// Forward declaration for EmbeddedJIT always_inline conflict check.
+// Defined in SemaEJIT.cpp.
+void checkEjitAlwaysInlineConflict(Sema &S, FunctionDecl *FD);
+
 // Forward declaration for EmbeddedJIT may_const write check.
 // Defined in SemaEJIT.cpp.
 void checkEjitMayConstWrites(Sema &S, const FunctionDecl *FD, Stmt *Body);
@@ -10513,6 +10517,10 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
 
   // Enforce at most 4 ejit_period_arr_ind parameters per function.
   checkEjitPeriodArrIndLimit(*this, NewFD);
+
+  // An ejit_entry / ejit_period_lc function must not carry always_inline
+  // (it conflicts with the noinline CodeGen/PASS3 add for LTO survival).
+  checkEjitAlwaysInlineConflict(*this, NewFD);
 
   const auto *NewTVA = NewFD->getAttr<TargetVersionAttr>();
   if (Context.getTargetInfo().getTriple().isAArch64() && NewTVA &&

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -303,6 +303,31 @@ void checkEjitPeriodArrIndLimit(Sema &S, const FunctionDecl *FD) {
   }
 }
 
+/// checkEjitAlwaysInlineConflict - An ejit_entry / ejit_period_lc function
+/// must stay out-of-line: CodeGen and PASS3 mark it noinline so it survives
+/// the LTO inliner for PASS1 (bitcode extraction), PASS3 (wrapper), and
+/// PASS4 (lifecycle). A user-written always_inline would produce illegal IR
+/// ("'noinline and alwaysinline' are incompatible"), which the verifier
+/// aborts on. Warn and drop the always_inline so ejit semantics win.
+/// Called from ActOnFunctionDeclarator after ProcessDeclAttributes, so the
+/// check is independent of the source order of the two attributes.
+void checkEjitAlwaysInlineConflict(Sema &S, FunctionDecl *FD) {
+  if (!FD)
+    return;
+  bool IsEntry = FD->hasAttr<EjitEntryAttr>();
+  bool IsLc = FD->hasAttr<EjitPeriodLcAttr>();
+  if (!IsEntry && !IsLc)
+    return;
+  if (AlwaysInlineAttr *AI = FD->getAttr<AlwaysInlineAttr>()) {
+    S.Diag(AI->getLocation(), diag::warn_ejit_always_inline_conflict)
+        << (IsEntry ? "ejit_entry" : "ejit_period_lc");
+    S.Diag(IsEntry ? FD->getAttr<EjitEntryAttr>()->getLocation()
+                   : FD->getAttr<EjitPeriodLcAttr>()->getLocation(),
+           diag::note_conflicting_attribute);
+    FD->dropAttr<AlwaysInlineAttr>();
+  }
+}
+
 /// If \p E is an lvalue that writes an ejit_may_const field, return that field
 /// and set \p BaseVar to the underlying variable (if any). Strips parentheses
 /// and implicit casts, and walks through array-subscript / member chains to

--- a/clang/test/CodeGen/ejit_lto_inliner_survival.c
+++ b/clang/test/CodeGen/ejit_lto_inliner_survival.c
@@ -1,0 +1,44 @@
+// RUN: %clang_cc1 -flto=full -O1 -emit-llvm-bc -o %t.bc %s
+// RUN: opt -passes='cgscc(inline),ejit-aot-module' -S %t.bc | FileCheck %s
+//
+// FullLTO hazard: in buildLTODefaultPipeline the inliner runs BEFORE
+// EJitAotModulePass (PASS2-4 run last, after all LTO optimization). A small,
+// otherwise-inlineable ejit_entry / ejit_period_lc would be merged into its
+// caller before PASS3/PASS4 can wrap/instrument it, silently dropping the
+// JIT wrapper and the lifecycle activate/deactivate.
+//
+// Reproduction: step 1 is a real FullLTO pre-link (-flto=full): the LTO
+// pre-link pipeline runs PASS1 but SKIPS PASS2-4 (gated on !isLTOPreLink),
+// so the bitcode carries the CodeGen noinline on the ejit functions but no
+// wrapper yet. Step 2 runs the inliner (cgscc(inline)) followed by PASS2-4
+// (ejit-aot-module) - the same inliner-before-PASS3 ordering as the FullLTO
+// post-link. The static entry/lifecycle must survive the inliner (noinline;
+// without it they would be inlined into @caller and dropped by GlobalDCE)
+// and still receive the wrapper (jit_entry label + taskpool call) and the
+// ejit_deactivate/ejit_activate calls.
+
+struct Cfg { int t; };
+__attribute__((ejit_period_arr("cell"))) struct Cfg g_cell[16];
+extern void sink(int);
+
+// Small, otherwise-inlineable entry. @caller calls it; the functions are
+// static so that, without noinline, the -O1 inliner would merge them into
+// @caller and GlobalDCE would drop them - leaving PASS3/PASS4 nothing to
+// wrap/instrument. With the CodeGen noinline they survive for PASS3/PASS4.
+__attribute__((ejit_entry))
+static void entry(__attribute__((ejit_period_arr_ind("cell"))) int i) { sink(g_cell[i].t); }
+
+__attribute__((ejit_period_lc("cell")))
+static void lc(__attribute__((ejit_period_arr_ind("cell"))) int i) { g_cell[i].t = 1; }
+
+void caller(int i) { entry(i); lc(i); }
+
+// PASS3 wrapper survives on @entry (it was not inlined into @caller).
+// CHECK: define {{.*}} @entry(
+// CHECK: jit_entry:
+// CHECK: call {{.*}} @ejit_taskpool_compile_or_get_
+
+// PASS4 lifecycle survives on @lc (it was not inlined into @caller).
+// CHECK: define {{.*}} @lc(
+// CHECK: call {{.*}} @ejit_deactivate(
+// CHECK: call {{.*}} @ejit_activate(

--- a/clang/test/CodeGen/ejit_metadata.c
+++ b/clang/test/CodeGen/ejit_metadata.c
@@ -27,9 +27,10 @@ void lc_func(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx) {
   g_cellCfg[cellIdx].xx = 42; // modify non-may_const field
 }
 
-// CHECK-DAG: ![[PERIOD_META]] = distinct !{![[PERIOD:[0-9]+]]}
+// CHECK-DAG: ![[MAYCONST_FIELD:[0-9]+]] = !{!"ejit_may_const_field", i32 0}
+// CHECK-DAG: ![[PERIOD_META]] = distinct !{![[PERIOD:[0-9]+]], ![[MAYCONST_FIELD]]}
 // CHECK-DAG: ![[PERIOD]] = !{!"ejit_period", !"static"}
-// CHECK-DAG: ![[ARR_META]] = distinct !{![[ARR:[0-9]+]]}
+// CHECK-DAG: ![[ARR_META]] = distinct !{![[ARR:[0-9]+]], ![[MAYCONST_FIELD]]}
 // CHECK-DAG: ![[ARR]] = !{!"ejit_period_arr", !"cell", i32 16}
 // CHECK-DAG: ![[ENTRY_META]] = distinct !{![[ENTRY:[0-9]+]], ![[IND:[0-9]+]]}
 // CHECK-DAG: ![[ENTRY]] = !{!"ejit_entry"}

--- a/clang/test/CodeGen/ejit_nested_struct.c
+++ b/clang/test/CodeGen/ejit_nested_struct.c
@@ -37,6 +37,8 @@ int process_static_only() {
   return 0;
 }
 
-// CHECK-DAG: ![[ARR_META]] = distinct !{![[ARR:[0-9]+]]}
+// CHECK-DAG: ![[ARR_META]] = distinct !{![[ARR:[0-9]+]], {{![0-9]+}}, {{![0-9]+}}}
 // CHECK-DAG: ![[ARR]] = !{!"ejit_period_arr", !"cell", i32 8}
+// CHECK-DAG: !{!"ejit_may_const_field", i32 0}
+// CHECK-DAG: !{!"ejit_may_const_field", i32 8}
 // CHECK-DAG: ![[MAYCONST]] = !{}

--- a/clang/test/CodeGen/ejit_new_attr_spellings.c
+++ b/clang/test/CodeGen/ejit_new_attr_spellings.c
@@ -6,10 +6,10 @@ struct CellConfig {
   int xx;
 };
 
-// CHECK: @g_boardCfg = {{.*}} !ejit.metadata
+// CHECK-DAG: @g_boardCfg = {{.*}} !ejit.metadata
 __attribute__((ejit_in_period("static"))) struct CellConfig g_boardCfg;
 
-// CHECK: @g_cellCfg = {{.*}} !ejit.metadata
+// CHECK-DAG: @g_cellCfg = {{.*}} !ejit.metadata
 __attribute__((ejit_in_period_array("cell"))) struct CellConfig g_cellCfg[16];
 
 // CHECK: define {{.*}} @jit_entry({{.*}} !ejit.metadata

--- a/clang/test/CodeGen/ejit_noinline_attr.c
+++ b/clang/test/CodeGen/ejit_noinline_attr.c
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -O1 -mllvm -enable-ejit-aot=false -emit-llvm -o - %s | FileCheck %s
+//
+// CodeGen must mark ejit_entry and ejit_period_lc noinline so they survive
+// the LTO inliner for PASS1 (bitcode), PASS3 (wrapper) and PASS4 (lifecycle).
+// AOT passes are disabled (-enable-ejit-aot=false) so the attribute is
+// attributable to CodeGen alone - PASS3 would otherwise also add noinline to
+// ejit_entry. A plain function is the negative control: it must NOT carry
+// noinline at -O1.
+
+struct Cfg { int t; };
+__attribute__((ejit_period_arr("cell"))) struct Cfg g_cell[16];
+extern void sink(int);
+
+__attribute__((ejit_entry))
+void entry(__attribute__((ejit_period_arr_ind("cell"))) int i) {
+  sink(g_cell[i].t);
+}
+
+__attribute__((ejit_period_lc("cell")))
+void lc(__attribute__((ejit_period_arr_ind("cell"))) int i) {
+  g_cell[i].t = 1;
+}
+
+void plain(int i) {
+  sink(i);
+}
+
+// CHECK-DAG: define {{.*}} @entry{{.*}}#[[E:[0-9]+]]
+// CHECK-DAG: define {{.*}} @lc{{.*}}#[[L:[0-9]+]]
+// CHECK-DAG: define {{.*}} @plain{{.*}}#[[P:[0-9]+]]
+// CHECK-DAG: attributes #[[E]] = { {{.*}}noinline{{.*}} }
+// CHECK-DAG: attributes #[[L]] = { {{.*}}noinline{{.*}} }
+// Plain's attribute set must not contain noinline.
+// CHECK: attributes #[[P]] = {
+// CHECK-NOT: noinline
+// CHECK: }

--- a/clang/test/CodeGen/ejit_pipeline.c
+++ b/clang/test/CodeGen/ejit_pipeline.c
@@ -1,30 +1,32 @@
 // RUN: %clang_cc1 -O2 -emit-llvm -o - %s 2>&1 | FileCheck %s
 
-// Verify full EmbeddedJIT AOT pipeline works via clang.
+// Verify full EmbeddedJIT AOT pipeline works via clang (unified taskpool API).
 
-// PASS1: Bitcode extraction and registration
-// CHECK: @__ejit_bitcode = internal constant {{.*}} section ".ejit.bitcode"
+// PASS1: Bitcode extraction and registration. The raw bitcode global is
+// referenced by a registry table emitted into the ".ejit_bitcode" section.
+// CHECK: @__ejit_bitcode = internal constant
+// CHECK: @.ejit.registry.bitcode = {{.*}} section ".ejit_bitcode"
 // CHECK: @llvm.global_ctors = appending global {{.*}} ptr @ejit_auto_register
 
 // PASS3: Wrapper generation in process_cell
 // CHECK: jit_entry:
-// CHECK: call ptr @ejit_compile_or_get(
+// CHECK: call {{.*}} @ejit_taskpool_compile_or_get_
 // CHECK: jit_fallback:
 // CHECK: jit_dispatch:
 
-// PASS4: Lifecycle handler in lc_handler — deactivate at entry, activate at exit
-// CHECK: call {{.*}} @ejit_deactivate_array(ptr {{[^,]*}}, ptr {{[^,]*}} @cell_data{{[^)]*}})
-// CHECK: call {{.*}} @ejit_activate_array(ptr {{[^,]*}}, ptr {{[^,]*}} @cell_data{{[^)]*}})
+// PASS4: Lifecycle handler in lc_handler - deactivate at entry, activate at exit
+// CHECK: call {{.*}} @ejit_deactivate(
+// CHECK: call {{.*}} @ejit_activate(
 
 // PASS1+PASS2: Combined registration in ejit_auto_register
 // CHECK-DAG: call {{.*}} @ejit_register_bitcode(
-// CHECK-DAG: call {{.*}} @ejit_register_period_array(ptr {{[^,]*}}, ptr {{[^,]*}}, ptr {{[^,]*}} @cell_data, i64 16)
+// CHECK-DAG: call {{.*}} @ejit_register_period_array({{.*}} @cell_data, i64 16)
 
 // External runtime declarations
 // CHECK-DAG: declare {{.*}} @ejit_register_bitcode
-// CHECK-DAG: declare {{.*}} @ejit_compile_or_get
-// CHECK-DAG: declare {{.*}} @ejit_deactivate_array
-// CHECK-DAG: declare {{.*}} @ejit_activate_array
+// CHECK-DAG: declare {{.*}} @ejit_taskpool_compile_or_get_
+// CHECK-DAG: declare {{.*}} @ejit_deactivate
+// CHECK-DAG: declare {{.*}} @ejit_activate
 
 int cell_data[16] __attribute__((ejit_period_arr("cell")));
 

--- a/clang/test/Sema/ext_attr_ejit.cpp
+++ b/clang/test/Sema/ext_attr_ejit.cpp
@@ -80,3 +80,21 @@ void good_writer(__attribute__((ejit_period_arr_ind("cell"))) int i, int v) {
   g_warn[i].cellType = v;  // no warning: ejit_period_lc sanctions the write
   g_warn[i].flags += v;    // no warning
 }
+
+// === Warning: always_inline conflicts with ejit_entry / ejit_period_lc ===
+// These functions must stay out-of-line: CodeGen/PASS3 mark them noinline so
+// they survive the LTO inliner for PASS1/PASS3/PASS4. always_inline is
+// incompatible ('noinline and alwaysinline' aborts the verifier), so it is
+// dropped after warning. The check is deferred to ActOnFunctionDeclarator
+// (after all attributes are processed), so both source orders are rejected.
+__attribute__((always_inline, ejit_entry))  // expected-warning {{'always_inline' is incompatible with ejit_entry}} expected-note {{conflicting attribute is here}}
+void ai_entry(__attribute__((ejit_period_arr_ind("cell"))) int idx) { g_warn[idx].plain = idx; }
+
+__attribute__((ejit_entry, always_inline))  // expected-warning {{'always_inline' is incompatible with ejit_entry}} expected-note {{conflicting attribute is here}}
+void ai_entry_rev(__attribute__((ejit_period_arr_ind("cell"))) int idx) { g_warn[idx].plain = idx; }
+
+__attribute__((always_inline, ejit_period_lc("cell")))  // expected-warning {{'always_inline' is incompatible with ejit_period_lc}} expected-note {{conflicting attribute is here}}
+void ai_lc(__attribute__((ejit_period_arr_ind("cell"))) int idx) { g_warn[idx].plain = idx; }
+
+// No ejit attribute -> always_inline is fine, no warning.
+__attribute__((always_inline)) inline void plain_ai(int x) { (void)x; }

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -39,11 +39,6 @@ using namespace llvm::ejit;
 
 extern cl::opt<bool> EnableEJitGlobalCtors;
 
-static cl::opt<bool> EJitNoInlineEntry(
-    "ejit-noinline-entry", cl::init(true), cl::Hidden,
-    cl::desc("Add noinline attribute to ejit_entry functions to prevent the "
-             "CGSCC inliner from duplicating the JIT wrapper into callers"));
-
 // Emit fixed-dimension taskpool fast-path C ABI calls
 // (ejit_taskpool_compile_or_get_Nd, N = dim count) for entries with <= 2 dims
 // (0-2 dims fit in 8 integer arg registers, no stack spill). Entries with > 2
@@ -564,9 +559,12 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // Prevent the CGSCC inliner from inlining the wrapped function into
     // callers. Each call site would duplicate the JIT dispatch logic
     // (cacheKey computation, ejit_compile_or_get call, indirect call) and
-    // the inliner may produce
-    // inconsistent AOT fallback code depending on call-site context.
-    if (EJitNoInlineEntry)
+    // the inliner may produce inconsistent AOT fallback code depending on
+    // call-site context. This is unconditional: the entry must stay
+    // out-of-line for LTO correctness. Sema rejects always_inline on
+    // ejit_entry; the guard backstops hand-written IR (noinline +
+    // alwaysinline is illegal and aborts the verifier).
+    if (!F->hasFnAttribute(Attribute::AlwaysInline))
       F->addFnAttr(Attribute::NoInline);
 
     auto PeriodInds = getPeriodArrIndInfo(*F);

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bug-alwaysinline.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bug-alwaysinline.ll
@@ -1,22 +1,13 @@
-; RUN: opt -passes=ejit-wrapper-gen -disable-output %s
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s
 ;
-; XFAIL: *
-;
-; KNOWN BUG (recorded now, fix tracked separately).
-;
-; EJitWrapperGen unconditionally adds the `noinline` attribute to every
-; ejit_entry function (EJitNoInlineEntry defaults to true). If the user wrote
-;     __attribute__((always_inline)) ejit_entry ...
-; the function already carries `alwaysinline`, and `noinline` + `alwaysinline`
-; are mutually exclusive — the module verifier aborts the whole AOT compile:
-;     Attributes 'noinline and alwaysinline' are incompatible!
-;     LLVM ERROR: Broken module found, compilation aborted!
-;
-; This RUN line currently aborts (non-zero exit) -> the test fails -> XFAIL
-; matches. The fix should make the pass not create conflicting attributes
-; (e.g. skip adding noinline when alwaysinline is present, or drop
-; alwaysinline). Once fixed, opt's built-in verifier passes, this RUN
-; succeeds, and lit reports XPASS -> remove the XFAIL line.
+; An ejit_entry function carrying always_inline must not also receive
+; noinline from EJitWrapperGen: the two are mutually exclusive and would
+; abort the verifier ("Attributes 'noinline and alwaysinline' are
+; incompatible!"). Sema rejects this combination at the source level
+; (warn_ejit_always_inline_conflict drops always_inline); this test
+; backstops hand-written IR by verifying the pass skips noinline when
+; alwaysinline is present - the function keeps alwaysinline and noinline
+; is added nowhere in the module.
 
 define void @always_inline_entry() alwaysinline !ejit.metadata !0 {
 entry:
@@ -24,3 +15,7 @@ entry:
 }
 
 !0 = distinct !{!{!"ejit_entry"}}
+
+; CHECK: define void @always_inline_entry() #[[A:[0-9]+]]
+; CHECK: attributes #[[A]] = { {{.*}}alwaysinline{{.*}} }
+; CHECK-NOT: noinline


### PR DESCRIPTION
The NoInline on ejit_entry was dropped in the bulk revert of 38e264f4 (which reverted a PASS1 repositioning), but it is an independent LTO defense. In buildLTODefaultPipeline the inliner runs before EJitAotModulePass (PASS1/PASS3), so without a CodeGen-time NoInline the inliner merges ejit_entry into its callers before PASS1 can extract bitcode and PASS3 can insert the wrapper -> missing __ejit_bitcode, no JIT.

Extend the same defense to ejit_period_lc. PASS4 (EJitPeriodHandler) inserts ejit_deactivate/ejit_activate at entry/returns but, unlike PASS3, does not self-defend with NoInline, so the CodeGen-time attribute is the only guard against the FullLTO inliner inlining the lifecycle function away before PASS4 runs. Lifecycle guards are entered rarely, so NoInline has no meaningful perf cost.

Also fix four pre-existing stale CodeGen tests that were red on baseline:
- ejit_metadata.c, ejit_nested_struct.c: account for the ejit_may_const_field GV-level offset operands added by the v1.7 PASS6 fallback.
- ejit_new_attr_spellings.c: global emission order is not stable; use CHECK-DAG for the two global metadata checks.
- ejit_pipeline.c: rewrite CHECKs for the unified taskpool API (ejit_taskpool_compile_or_get_Nd, ejit_deactivate/activate, .ejit_bitcode section on the registry global).