### PR TITLE
[EJIT] Harden fixed code-pool ownership and rollback

### DIFF
--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -447,6 +447,11 @@ code pool 与 taskpool 关键路径埋了**默认空展开**的 trace 宏，便�
 可用，~7 个池）。区域耗尽是干净的 `Error`，**不回退动态分配**（特化回退 AOT），保住固定
 地址保证。
 
+该模式强制要求 `EJIT_SRE_SHARED_TASKPOOL=ON`。固定区域是进程级唯一资源，而 bump
+游标 `FixedUsed_` 属于单个 `EJitCodePoolManager`；只有 shared taskpool 选出的唯一
+owner 会创建 ORC/manager 并执行编译。多个独立 manager 会各自从 offset 0 开始切同一
+段内存并覆盖仍在使用的 JIT 代码，因此 CMake 拒绝这种配置。
+
 链接脚本（`ejit_registry.ld` 提供 `INSERT` 片段；段名仅是容器，运行时实际依赖
 `__ejit_code_start`/`__ejit_code_end` 两个符号）：
 
@@ -458,6 +463,24 @@ code pool 与 taskpool 关键路径埋了**默认空展开**的 trace 宏，便�
   __ejit_code_end = .;
 } > CODE        /* 代码段，近 .text（±128MiB 内 bl/adrp 直达 AOT） */
 ```
+
+若不能修改 vendor `SECTIONS`，必须在**最终可执行文件链接**时额外传入 fixed-region
+INSERT 脚本，不能只在 `clang -r` 中间链接使用：
+
+```ld
+SECTIONS
+{
+  .text.ejit : ALIGN(4096)
+  {
+    __ejit_code_start = .;
+    . = __ejit_code_start + 16M;
+    __ejit_code_end = .;
+  }
+} INSERT AFTER .text;
+```
+
+`NOLOAD` 仅适用于确认会为 NOBITS 预留并映射 VMA 的最终加载器。应对最终镜像执行
+`readelf -SW/-lW`，并检查 `__ejit_code_end > __ejit_code_start`。
 
 区域大小由链接脚本（上面的 `+ 16M`）决定，**无 CMake 旋钮**；运行时从
 `__ejit_code_end - __ejit_code_start` 读取实际大小。要改容量就改链接脚本里这一行。
@@ -510,3 +533,6 @@ freestanding strong，类似 `__start_ejit_bitcode`），缺失或对齐后太�
 - **部分失败回滚**：`enableRwRange` 中途某页 `enable_rw` 失败时，把已成功 RX->RW 的页
   用 `Seal_` 封回 RX（避免代码段永久可写 W^X 违规）；被 carve 的 slab 留作废弃孔洞
   （不回收，保简单），下次编译从下一位置切。
+- **后续失败回滚**：slab 已经 RX->RW 后，若 layout、JITLink finalize action、seal 或
+  abandon 失败，`restoreRxRange` 会尝试把整个废弃 slab 恢复为 RX，并合并报告回滚错误；
+  只有 finalize actions 全部成功后才记录可供 peer 查询的 finalized range。

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -826,6 +826,14 @@ if(EJIT_SRE_TASKPOOL_NO_RECLAIM AND NOT EJIT_SRE_SHARED_TASKPOOL)
     "EJIT_SRE_TASKPOOL_NO_RECLAIM requires EJIT_SRE_SHARED_TASKPOOL=ON")
 endif()
 
+# The fixed region is process-global, but its bump cursor belongs to one
+# EJitCodePoolManager. Require the shared taskpool's elected single owner so
+# independent managers cannot allocate the same fixed addresses.
+if(EJIT_FIXED_CODE_POOL AND NOT EJIT_SRE_SHARED_TASKPOOL)
+  message(FATAL_ERROR
+    "EJIT_FIXED_CODE_POOL requires EJIT_SRE_SHARED_TASKPOOL=ON so exactly one owner manages the fixed-region bump cursor")
+endif()
+
 set(LLVM_TARGETS_TO_BUILD "all"
     CACHE STRING "Semicolon-separated list of targets to build, or \"all\".")
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -215,6 +215,13 @@ public:
   /// any enable_rw fails (in which case the slab must not be written).
   Error enableRwRange(const void *Start, size_t Size);
 
+  /// Code-segment mode failure cleanup: seal every page covering
+  /// [Start, Start + Size) back to RX. This is used when an allocation was
+  /// made writable but JITLink abandons it or fails before publication. No-op
+  /// when needsEnableRw is false. All pages are attempted and failures are
+  /// joined so a partial W^X restoration cannot be hidden.
+  Error restoreRxRange(const void *Start, size_t Size);
+
   /// True if this manager seals execute permission per 4KiB page (rather than
   /// per whole 2MiB pool).
   bool usesPageSeal() const { return Opts_.fourKSeal; }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -29,6 +29,15 @@ inline uintptr_t addr(const void *P) {
   return reinterpret_cast<uintptr_t>(P);
 }
 
+bool rangeFitsPool(const CodePool &P, const void *Start, size_t Size) {
+  uintptr_t A = addr(Start);
+  uintptr_t B = addr(P.base);
+  if (A < B)
+    return false;
+  uintptr_t Offset = A - B;
+  return Offset <= P.size && Size <= P.size - Offset;
+}
+
 } // namespace
 
 EJitCodePoolManager::EJitCodePoolManager(Options Opts, RawAllocFn Alloc,
@@ -357,6 +366,13 @@ Error EJitCodePoolManager::sealCodeRange(const void *Start, size_t Size) {
             " is not owned by any code pool",
         inconvertibleErrorCode());
   }
+  if (!rangeFitsPool(*P, Start, Size)) {
+    EJIT_DIAG("sealCodeRange FAIL: range start=%p size=%zu crosses pool end",
+              Start, Size);
+    return make_error<StringError>(
+        "EJitCodePool: seal range crosses code-pool boundary",
+        inconvertibleErrorCode());
+  }
 
   // Seal every 4KiB page the written code overlaps: page-align the start down
   // and the end up, then enable_ex(1, pageVA) per page.
@@ -404,6 +420,13 @@ Error EJitCodePoolManager::enableRwRange(const void *Start, size_t Size) {
             " is not owned by any code pool",
         inconvertibleErrorCode());
   }
+  if (!rangeFitsPool(*P, Start, Size)) {
+    EJIT_DIAG("enableRwRange FAIL: range start=%p size=%zu crosses pool end",
+              Start, Size);
+    return make_error<StringError>(
+        "EJitCodePool: writable range crosses code-pool boundary",
+        inconvertibleErrorCode());
+  }
   // Make every 4KiB page the slab overlaps writable, mirroring sealCodeRange.
   size_t Page = Opts_.sealPageSize;
   uintptr_t PageStart = alignDownAddr(addr(Start), Page);
@@ -421,29 +444,68 @@ Error EJitCodePoolManager::enableRwRange(const void *Start, size_t Size) {
       // writable (W^X violation). Sealing (RW->RX) is security-benign (more
       // restrictive). The carved slab itself is left unused (a bounded hole in
       // the fixed region) rather than reclaimed, to keep this path simple.
-      for (uintptr_t RollVA = PageStart; RollVA < VA; RollVA += Page) {
-        if (Seal_) {
-          unsigned SealRc = Seal_(reinterpret_cast<void *>(RollVA));
-          // Best-effort rollback: a seal (RW->RX) failure here leaves this
-          // page writable in the code segment (a W^X leak) that we could not
-          // restore. Surface it so the leak is observable rather than silent;
-          // we still return the original enable_rw error below.
-          if (SealRc != 0)
-            EJIT_DIAG("enableRwRange rollback: seal (RW->RX) FAILED page=0x%llx "
-                      "rc=%u (page left RW - W^X leak)",
-                      static_cast<unsigned long long>(RollVA), SealRc);
-        }
-      }
-      return make_error<StringError>(
+      Error Err = make_error<StringError>(
           "EJitCodePool: enable_rw failed (rc=" + Twine(Rc) + ") for page " +
               Twine(VA),
           inconvertibleErrorCode());
+      for (uintptr_t RollVA = PageStart; RollVA < VA; RollVA += Page) {
+        unsigned SealRc = Seal_ ? Seal_(reinterpret_cast<void *>(RollVA)) : 1;
+        if (SealRc == 0) {
+          ++SealInvocations_;
+          continue;
+        }
+        EJIT_DIAG("enableRwRange rollback: seal (RW->RX) FAILED page=0x%llx "
+                  "rc=%u (page left RW - W^X leak)",
+                  static_cast<unsigned long long>(RollVA), SealRc);
+        Err = joinErrors(std::move(Err),
+                         make_error<StringError>(
+                             "EJitCodePool: rollback enable_ex failed (rc=" +
+                                 Twine(SealRc) + ") for page " + Twine(RollVA),
+                             inconvertibleErrorCode()));
+      }
+      return Err;
     }
     ++RwEnableInvocations_;
   }
   EJIT_DIAG("enableRwRange OK: start=%p size=%zu (invocations=%zu)", Start, Size,
             RwEnableInvocations_);
   return Error::success();
+}
+
+Error EJitCodePoolManager::restoreRxRange(const void *Start, size_t Size) {
+  if (!Opts_.needsEnableRw || Size == 0)
+    return Error::success();
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  CodePool *P = findPoolLocked(Start);
+  if (!P || !rangeFitsPool(*P, Start, Size)) {
+    EJIT_DIAG("restoreRxRange FAIL: range start=%p size=%zu not owned", Start,
+              Size);
+    return make_error<StringError>(
+        "EJitCodePool: restore range is not contained in one code pool",
+        inconvertibleErrorCode());
+  }
+
+  size_t Page = Opts_.sealPageSize;
+  uintptr_t PageStart = alignDownAddr(addr(Start), Page);
+  uintptr_t PageEnd = alignUpAddr(addr(Start) + Size, Page);
+  Error Err = Error::success();
+  for (uintptr_t VA = PageStart; VA < PageEnd; VA += Page) {
+    unsigned Rc = Seal_ ? Seal_(reinterpret_cast<void *>(VA)) : 1;
+    if (Rc == 0) {
+      ++SealInvocations_;
+      continue;
+    }
+    EJIT_DIAG("restoreRxRange FAIL: enable_ex page=0x%llx rc=%u",
+              static_cast<unsigned long long>(VA), Rc);
+    Err = joinErrors(
+        std::move(Err),
+        make_error<StringError>("EJitCodePool: restore enable_ex failed (rc=" +
+                                    Twine(Rc) + ") for page " + Twine(VA),
+                                inconvertibleErrorCode()));
+  }
+  return Err;
 }
 
 bool EJitCodePoolManager::contains(const void *Ptr) const {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -44,8 +44,9 @@ class EJitCodePoolMemoryManager::InFlightAllocImpl
     : public JITLinkMemoryManager::InFlightAlloc {
 public:
   InFlightAllocImpl(EJitCodePoolMemoryManager &MM, LinkGraph &G, BasicLayout BL,
-                    void *Base, std::vector<ExecSegRange> ExecRanges)
-      : Pool(&MM.getPool()), G(&G), BL(std::move(BL)), Base(Base),
+                    void *Base, size_t Size,
+                    std::vector<ExecSegRange> ExecRanges)
+      : Pool(&MM.getPool()), G(&G), BL(std::move(BL)), Base(Base), Size(Size),
         ExecRanges(std::move(ExecRanges)) {}
 
   void finalize(OnFinalizedFunction OnFinalized) override {
@@ -68,27 +69,26 @@ public:
           EJIT_DIAG("finalize FAIL: sealCodeRange addr=0x%llx size=%llu",
                     static_cast<unsigned long long>(R.Addr),
                     static_cast<unsigned long long>(R.Size));
-          OnFinalized(std::move(Err));
+          OnFinalized(
+              joinErrors(std::move(Err), Pool->restoreRxRange(Base, Size)));
           return;
         }
     }
-    // Record the real, fully-written/relocated (and, in 4K mode, RX-sealed)
-    // executable extent so a later function-pointer lookup can recover the
-    // exact [codeStart, codeSize) a peer core must seal in its own translation
-    // context. This is the only source of the cross-core code range — it is
-    // never estimated or recovered by scanning machine code.
-    for (const ExecSegRange &R : ExecRanges)
-      Pool->recordFinalizedRange(reinterpret_cast<void *>(R.Addr),
-                                 static_cast<size_t>(R.Size));
     runFinalizeActions(
         G->allocActions(),
         [this, OnFinalized = std::move(OnFinalized)](
             Expected<std::vector<WrapperFunctionCall>> DeallocActions) mutable {
           if (!DeallocActions) {
             EJIT_DIAG("finalize FAIL: runFinalizeActions error base=%p", Base);
-            OnFinalized(DeallocActions.takeError());
+            OnFinalized(joinErrors(DeallocActions.takeError(),
+                                   Pool->restoreRxRange(Base, Size)));
             return;
           }
+          // Publish executable ranges only after every finalize action has
+          // succeeded. Failed allocations must never look callable to peers.
+          for (const ExecSegRange &R : ExecRanges)
+            Pool->recordFinalizedRange(reinterpret_cast<void *>(R.Addr),
+                                       static_cast<size_t>(R.Size));
           auto *Info = new FinalizedInfo();
           Info->Base = Base;
           Info->DeallocActions = std::move(*DeallocActions);
@@ -100,11 +100,12 @@ public:
   }
 
   void abandon(OnAbandonedFunction OnAbandoned) override {
-    // v1 does not reclaim pool memory; just drop the in-flight state.
+    // Pool bytes are not reclaimed, but fixed code-segment pages must not stay
+    // writable after an abandoned link.
 #ifndef NDEBUG
     G = nullptr;
 #endif
-    OnAbandoned(Error::success());
+    OnAbandoned(Pool->restoreRxRange(Base, Size));
   }
 
 private:
@@ -112,6 +113,7 @@ private:
   LinkGraph *G;
   BasicLayout BL;
   void *Base;
+  size_t Size;
   std::vector<ExecSegRange> ExecRanges;
 };
 
@@ -195,13 +197,16 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   if (auto Err = BL.apply()) {
     EJIT_DIAG("allocate FAIL: BasicLayout apply error graph=%s",
               G.getName().c_str());
-    OnAllocated(std::move(Err));
+    OnAllocated(
+        joinErrors(std::move(Err),
+                   Pool_.restoreRxRange(Slab, static_cast<size_t>(Total))));
     return;
   }
 
   EJIT_DIAG("allocate OK: slab=%p total=%llu execRanges=%zu", Slab,
             static_cast<unsigned long long>(Total), ExecRanges.size());
   OnAllocated(std::make_unique<InFlightAllocImpl>(*this, G, std::move(BL), Slab,
+                                                  static_cast<size_t>(Total),
                                                   std::move(ExecRanges)));
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -18,6 +18,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if defined(EJIT_FIXED_CODE_POOL) && !defined(EJIT_SRE_SHARED_TASKPOOL)
+#error "EJIT_FIXED_CODE_POOL requires the shared taskpool"
+#endif
+
 #ifdef EJIT_SRE_CODE_POOL
 
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"

--- a/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
+++ b/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
@@ -92,9 +92,11 @@ SECTIONS
    * [__ejit_code_start, aligned start) are wasted slack (at most ~2MiB), so size
    * the region with that headroom (16M -> ~14M usable, ~7 pools). If the aligned
    * region is smaller than one pool (2MiB) the runtime falls back to
-   * SRE_MemDbgAlloc with a diagnostic. Add (NOLOAD) before the colon to reserve
-   * the VMA range without 16M of flash load data (the runtime zero-fills each
-   * slab on first use). Under EJIT_FREESTANDING these symbols are strong, so a
+   * SRE_MemDbgAlloc with a diagnostic. Use (NOLOAD) only when the final platform
+   * loader reserves/maps NOBITS ranges. Do not rely on NOLOAD in a relocatable
+   * (`clang -r`) intermediate: some product link pipelines discard its VMA
+   * reservation. The runtime zero-fills each slab on first use. Under
+   * EJIT_FREESTANDING these symbols are strong, so a
    * bare-metal link REQUIRES this block; a missing definition is a hard link
    * error (not silent).
    *
@@ -144,4 +146,21 @@ SECTIONS
  * With the INSERT form the linker still places .ejit_registry next to .rodata
  * in the same loadable segment, so it does not become a "custom segment" — it
  * rides in the normal data/rodata program header.
+ *
+ * EJIT_FIXED_CODE_POOL also needs a fixed-region INSERT fragment at the FINAL
+ * executable link (not merely at an intermediate `clang -r` link):
+ *
+ *   SECTIONS
+ *   {
+ *     .text.ejit : ALIGN(4096)
+ *     {
+ *       __ejit_code_start = .;
+ *       . = __ejit_code_start + 16M;
+ *       __ejit_code_end = .;
+ *     }
+ *   } INSERT AFTER .text;
+ *
+ * Use (NOLOAD) only if the target loader is known to map/reserve the resulting
+ * NOBITS range. Verify the final image with readelf -SW/-lW and confirm
+ * __ejit_code_end > __ejit_code_start.
  */

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -635,3 +635,44 @@ TEST(EJitCodePoolMemMgr4K, FixedCodeSegmentEnablesRwThenSealsExecOnly) {
 
   cantFail(MM.deallocate(std::move(FA)));
 }
+
+// Once allocate() has made a fixed code-segment slab writable, abandoning the
+// JITLink allocation must restore every slab page to RX. The bump allocation is
+// intentionally not reclaimed, but no writable hole may remain in .text.ejit.
+TEST(EJitCodePoolMemMgr4K, AbandonRestoresWholeSlabToRx) {
+  constexpr size_t kRegion = kTwoMiB;
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kTwoMiB, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  MockSre4K M;
+  auto O = fourKMemMgrOpts();
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+  O.needsEnableRw = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); },
+      [&M](void *V) { return M.enableRw(V); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeTextAndDataGraph(0x1000, 0x2000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  ASSERT_GT(M.RwEnabledPages.size(), 0u);
+  size_t WritablePages = M.RwEnabledPages.size();
+
+  bool CallbackCalled = false;
+  bool AbandonFailed = false;
+  IFA->abandon([&](Error Err) {
+    CallbackCalled = true;
+    if (Err) {
+      AbandonFailed = true;
+      consumeError(std::move(Err));
+    }
+  });
+  EXPECT_TRUE(CallbackCalled);
+  EXPECT_FALSE(AbandonFailed);
+  EXPECT_EQ(M.SealCalls, WritablePages);
+  EXPECT_EQ(M.SealedPages.size(), WritablePages);
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
@@ -934,3 +934,38 @@ TEST(EJitCodePoolFixed, EnableRwRangeFailsOnRc) {
   EXPECT_TRUE(bool(E)) << "enable_rw failure must propagate as an Error";
   consumeError(std::move(E));
 }
+
+// A range whose first byte is owned but whose end crosses the pool boundary
+// must be rejected before any platform permission callback runs.
+TEST(EJitCodePoolFixed, PermissionRangeCannotCrossPoolBoundary) {
+  constexpr size_t kAlign = 256;
+  constexpr size_t kPool = 256;
+  constexpr size_t kRegion = 512;
+  void *Region = nullptr;
+  ASSERT_EQ(posix_memalign(&Region, kAlign, kRegion), 0);
+  std::unique_ptr<void, void (*)(void *)> Guard(Region, std::free);
+
+  EJitCodePoolManager::Options O;
+  O.poolSize = kPool;
+  O.poolAlign = kAlign;
+  O.minCodeAlign = 64;
+  O.fourKSeal = true;
+  O.sealPageSize = kAlign;
+  O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+  O.fixedSize = kRegion;
+  O.needsEnableRw = true;
+
+  MockSre4K M;
+  auto Mgr = makeManager4K(M, O);
+  void *P = cantFail(Mgr.allocateCode(128, 64));
+
+  Error RwErr = Mgr.enableRwRange(P, kPool + 1);
+  EXPECT_TRUE(bool(RwErr));
+  consumeError(std::move(RwErr));
+  EXPECT_EQ(M.RwEnableCalls, 0u);
+
+  Error SealErr = Mgr.sealCodeRange(P, kPool + 1);
+  EXPECT_TRUE(bool(SealErr));
+  consumeError(std::move(SealErr));
+  EXPECT_EQ(M.SealCalls, 0u);
+}


### PR DESCRIPTION
## 中文说明

### 背景

PR #116 引入固定 code pool 后，固定区是进程级共享资源，但分配游标属于单个 `EJitCodePoolManager`。如果未启用 shared taskpool，多实例可能从相同固定地址重复分配。此外，link/finalize 失败或 allocation abandon 后，已经切成 RW 的页面可能没有恢复为 RX。

### 修改

- 要求 `EJIT_FIXED_CODE_POOL` 必须与 `EJIT_SRE_SHARED_TASKPOOL=ON` 配合，CMake 和源码编译入口均有防护。
- 对 seal/RW 操作增加完整区间边界检查，拒绝跨 code-pool 边界的范围。
- 在 `BL.apply`、seal、finalize action 和 abandon 失败路径中，将废弃 slab 的全部页面恢复为 RX，并聚合报告 rollback 错误。
- 仅在所有 finalize actions 成功后发布 finalized executable ranges，避免 peer 看到不可调用的失败 allocation。
- 补充最终链接脚本示例，并说明 `NOLOAD`/relocatable link 的限制。
- 新增跨池边界和 abandon 恢复 RX 的单元测试。

正常成功路径和 cache-hit 热路径不变；无共享 ABI 变化。

## English Summary

PR #116 introduced a process-global fixed code region while each `EJitCodePoolManager` owns its own bump cursor. This patch requires the shared taskpool's elected single owner whenever the fixed pool is enabled, preventing independent managers from allocating overlapping fixed addresses.

It also hardens discarded-allocation handling: ranges are boundary-checked, failed or abandoned slabs are restored to RX, rollback errors are preserved, and finalized executable ranges are published only after all finalize actions succeed. The linker-script documentation now clarifies final-link placement and the `NOLOAD` caveat.

## Validation

- `EJITCodePoolTests`: **54/54 passed**
- Fixed code pool + shared taskpool source compile: passed
- Fixed code pool without shared taskpool: rejected by the intended source guard
- `git diff --check`: clean
- `clang-format`: clean