### PR TITLE
[WIP][EJIT] Require __attribute__((section(...))) on period-annotated global variables

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13503,6 +13503,10 @@ def err_ejit_entry_recursive : Error<
   "ejit_entry function %0 cannot be recursive">;
 def err_ejit_period_lc_no_index : Error<
   "ejit_period_lc(%0) requires a corresponding ejit_period_arr_ind(%0) parameter">;
+def err_ejit_missing_shared_section : Error<
+  "global variable %0 has %1 but is missing "
+  "'__attribute__((section(\".mc_shared\")))'; "
+  "ejit period variables must reside in cross-core shared memory">;
 def warn_ejit_may_const_modified_without_lc : Warning<
   "modifying ejit_may_const field %0 of %1 without ejit_period_lc attribute">,
   InGroup<EmbeddedJIT>;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -84,6 +84,10 @@ void checkEjitAlwaysInlineConflict(Sema &S, FunctionDecl *FD);
 // Defined in SemaEJIT.cpp.
 void checkEjitMayConstWrites(Sema &S, const FunctionDecl *FD, Stmt *Body);
 
+// Forward declaration for EmbeddedJIT shared-section check.
+// Defined in SemaEJIT.cpp.
+void checkEjitPeriodSharedSection(Sema &S, VarDecl *VD);
+
 Sema::DeclGroupPtrTy Sema::ConvertDeclToDeclGroup(Decl *Ptr, Decl *OwnedType) {
   if (OwnedType) {
     Decl *Group[2] = { OwnedType, Ptr };
@@ -8030,6 +8034,10 @@ NamedDecl *Sema::ActOnVariableDeclarator(
 
   // Handle attributes prior to checking for duplicates in MergeVarDecl
   ProcessDeclAttributes(S, NewVD, D);
+
+  // EmbeddedJIT: global variables with ejit_period / ejit_period_arr must also
+  // have __attribute__((section(...))) for cross-core shared memory.
+  checkEjitPeriodSharedSection(*this, NewVD);
 
   if (getLangOpts().HLSL)
     HLSL().ActOnVariableDeclarator(NewVD);

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -328,6 +328,31 @@ void checkEjitAlwaysInlineConflict(Sema &S, FunctionDecl *FD) {
   }
 }
 
+/// checkEjitPeriodSharedSection - Check that global variables marked with
+/// ejit_period or ejit_period_arr also have __attribute__((section(...)))
+/// placing them in cross-core shared memory.
+/// Called from ActOnVariableDeclarator after ProcessDeclAttributes, so the
+/// check is independent of the source order of the two attributes.
+void checkEjitPeriodSharedSection(Sema &S, VarDecl *VD) {
+  if (!VD)
+    return;
+
+  bool HasPeriod = VD->hasAttr<EjitPeriodAttr>() ||
+                   VD->hasAttr<EjitPeriodArrAttr>();
+  if (!HasPeriod)
+    return;
+
+  if (!VD->hasAttr<SectionAttr>()) {
+    // Try to get the attribute location for a good diagnostic.
+    if (auto *PA = VD->getAttr<EjitPeriodAttr>())
+      S.Diag(PA->getLocation(), diag::err_ejit_missing_shared_section)
+          << VD << "ejit_period";
+    else if (auto *PAA = VD->getAttr<EjitPeriodArrAttr>())
+      S.Diag(PAA->getLocation(), diag::err_ejit_missing_shared_section)
+          << VD << "ejit_period_arr";
+  }
+}
+
 /// If \p E is an lvalue that writes an ejit_may_const field, return that field
 /// and set \p BaseVar to the underlying variable (if any). Strips parentheses
 /// and implicit casts, and walks through array-subscript / member chains to

--- a/clang/test/CodeGen/ejit_lto_inliner_survival.c
+++ b/clang/test/CodeGen/ejit_lto_inliner_survival.c
@@ -18,7 +18,7 @@
 // ejit_deactivate/ejit_activate calls.
 
 struct Cfg { int t; };
-__attribute__((ejit_period_arr("cell"))) struct Cfg g_cell[16];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct Cfg g_cell[16];
 extern void sink(int);
 
 // Small, otherwise-inlineable entry. @caller calls it; the functions are

--- a/clang/test/CodeGen/ejit_may_const_robustness.c
+++ b/clang/test/CodeGen/ejit_may_const_robustness.c
@@ -22,7 +22,7 @@ struct Cfg {
   struct Inner inner;
 };
 
-__attribute__((ejit_period_arr("cell"))) struct Cfg g_cfg[8];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct Cfg g_cfg[8];
 
 extern void barrier(void);
 

--- a/clang/test/CodeGen/ejit_metadata.c
+++ b/clang/test/CodeGen/ejit_metadata.c
@@ -7,10 +7,10 @@ struct CellConfig {
 };
 
 // CHECK-DAG: @g_boardCfg = {{.*}} !ejit.metadata ![[PERIOD_META:[0-9]+]]
-__attribute__((ejit_period("static"))) struct CellConfig g_boardCfg;
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period("static"))) struct CellConfig g_boardCfg;
 
 // CHECK-DAG: @g_cellCfg = {{.*}} !ejit.metadata ![[ARR_META:[0-9]+]]
-__attribute__((ejit_period_arr("cell"))) struct CellConfig g_cellCfg[16];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct CellConfig g_cellCfg[16];
 
 // CHECK: define {{.*}}void @jit_entry({{.*}} !ejit.metadata ![[ENTRY_META:[0-9]+]]
 __attribute__((ejit_entry))

--- a/clang/test/CodeGen/ejit_multi_period_arr.c
+++ b/clang/test/CodeGen/ejit_multi_period_arr.c
@@ -12,13 +12,13 @@ struct CellPhy {
 };
 
 // CHECK-DAG: @cellCfg = {{.*}} !ejit.metadata ![[CELL_META:[0-9]+]]
-__attribute__((ejit_period_arr("cell"))) struct CellConfig cellCfg[16];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct CellConfig cellCfg[16];
 
 // CHECK-DAG: @cellPhy = {{.*}} !ejit.metadata ![[PHY_META:[0-9]+]]
-__attribute__((ejit_period_arr("cell"))) struct CellPhy cellPhy[16];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct CellPhy cellPhy[16];
 
 // CHECK-DAG: @boardCfg = {{.*}} !ejit.metadata ![[BOARD_META:[0-9]+]]
-__attribute__((ejit_period("static"))) int boardCfg;
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period("static"))) int boardCfg;
 
 __attribute__((ejit_entry))
 int process_cell(__attribute__((ejit_period_arr_ind("cell"))) int ci) {

--- a/clang/test/CodeGen/ejit_nested_struct.c
+++ b/clang/test/CodeGen/ejit_nested_struct.c
@@ -12,7 +12,7 @@ struct Outer {
   struct Inner inner;
 };
 
-__attribute__((ejit_period_arr("cell"))) struct Outer g_data[8];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct Outer g_data[8];
 
 // CHECK-DAG: @g_data = {{.*}} !ejit.metadata ![[ARR_META:[0-9]+]]
 

--- a/clang/test/CodeGen/ejit_new_attr_spellings.c
+++ b/clang/test/CodeGen/ejit_new_attr_spellings.c
@@ -7,10 +7,10 @@ struct CellConfig {
 };
 
 // CHECK-DAG: @g_boardCfg = {{.*}} !ejit.metadata
-__attribute__((ejit_in_period("static"))) struct CellConfig g_boardCfg;
+__attribute__((section(".mc_shared"))) __attribute__((ejit_in_period("static"))) struct CellConfig g_boardCfg;
 
 // CHECK-DAG: @g_cellCfg = {{.*}} !ejit.metadata
-__attribute__((ejit_in_period_array("cell"))) struct CellConfig g_cellCfg[16];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_in_period_array("cell"))) struct CellConfig g_cellCfg[16];
 
 // CHECK: define {{.*}} @jit_entry({{.*}} !ejit.metadata
 __attribute__((ejit_entry))

--- a/clang/test/CodeGen/ejit_noinline_attr.c
+++ b/clang/test/CodeGen/ejit_noinline_attr.c
@@ -8,7 +8,7 @@
 // noinline at -O1.
 
 struct Cfg { int t; };
-__attribute__((ejit_period_arr("cell"))) struct Cfg g_cell[16];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct Cfg g_cell[16];
 extern void sink(int);
 
 __attribute__((ejit_entry))

--- a/clang/test/CodeGen/ejit_pipeline.c
+++ b/clang/test/CodeGen/ejit_pipeline.c
@@ -28,7 +28,7 @@
 // CHECK-DAG: declare {{.*}} @ejit_deactivate
 // CHECK-DAG: declare {{.*}} @ejit_activate
 
-int cell_data[16] __attribute__((ejit_period_arr("cell")));
+int cell_data[16] __attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell")));
 
 __attribute__((ejit_entry))
 void process_cell(int __attribute__((ejit_period_arr_ind("cell"))) cell_idx) {

--- a/clang/test/CodeGen/ejit_volatile_field.c
+++ b/clang/test/CodeGen/ejit_volatile_field.c
@@ -7,7 +7,7 @@ struct Config {
   int normalField;
 };
 
-__attribute__((ejit_period_arr("cell"))) struct Config g_cfg[10];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct Config g_cfg[10];
 
 __attribute__((ejit_entry))
 int test_volatile(__attribute__((ejit_period_arr_ind("cell"))) int ci) {

--- a/clang/test/Sema/ejit_shared_section.c
+++ b/clang/test/Sema/ejit_shared_section.c
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -fsyntax-only -verify=expected %s
+// EmbeddedJIT: ejit_period / ejit_period_arr must carry
+// __attribute__((section(".mc_shared")))
+
+// === Correct usage: period + section(".mc_shared") ===
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period("static"))) int g_board;
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) int g_table[64];
+
+struct CellConfig {
+  __attribute__((ejit_may_const)) int cellType;
+};
+
+// === Error: ejit_period without section(".mc_shared") ===
+__attribute__((ejit_period("cell"))) int g_missing_shared;
+// expected-error@-1 {{global variable 'g_missing_shared' has ejit_period but is missing '__attribute__((section(".mc_shared")))'; ejit period variables must reside in cross-core shared memory}}
+
+// === Error: ejit_period_arr without section(".mc_shared") ===
+__attribute__((ejit_period_arr("cell"))) struct CellConfig g_arr_missing[10];
+// expected-error@-1 {{global variable 'g_arr_missing' has ejit_period_arr but is missing '__attribute__((section(".mc_shared")))'; ejit period variables must reside in cross-core shared memory}}
+
+// === Correct: section can be in any order relative to period ===
+__attribute__((ejit_period("late"))) __attribute__((section(".mc_shared"))) int g_late_shared;
+// The deferred check runs after all attributes are processed, so either order works.

--- a/clang/test/Sema/ext_attr_ejit.cpp
+++ b/clang/test/Sema/ext_attr_ejit.cpp
@@ -10,8 +10,8 @@ struct CellConfig {
   int xx;
 };
 
-__attribute__((ejit_period("static"))) int g_board;
-__attribute__((ejit_period_arr("cell"))) struct CellConfig g_cells[16];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period("static"))) int g_board;
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct CellConfig g_cells[16];
 
 __attribute__((ejit_entry))
 void process_task(__attribute__((ejit_period_arr_ind("cell"))) int idx);
@@ -28,6 +28,7 @@ __attribute__((ejit_period_arr("cell"))) int g_not_array;
 // expected-error@-1 {{ejit_period_arr attribute requires an array type; 'g_not_array' is not an array}}
 
 // === Error: duplicate period attributes (only second usage triggers error) ===
+__attribute__((section(".mc_shared")))
 __attribute__((ejit_period("one")))
 __attribute__((ejit_period("two")))
 // expected-error@-1 {{variable 'g_conflict' cannot have multiple ejit_period or ejit_period_arr attributes}}
@@ -61,7 +62,7 @@ struct WarnCfg {
   int plain;
 };
 
-__attribute__((ejit_period_arr("cell"))) struct WarnCfg g_warn[4];
+__attribute__((section(".mc_shared"))) __attribute__((ejit_period_arr("cell"))) struct WarnCfg g_warn[4];
 
 // A plain function (no ejit_period_lc) that writes may_const fields -> warn.
 void bad_writer(int i, int v) {


### PR DESCRIPTION
## Summary

Global variables marked with `ejit_period` or `ejit_period_arr` must reside in cross-core shared memory. This PR adds a deferred Sema check that emits an error when a period-annotated global variable is missing `__attribute__((section(...)))`.

**No new attribute is introduced.** The check uses the existing `SectionAttr` (the standard Clang representation of `__attribute__((section("...")))`). The platform build already configures the shared section name via the CMake `EJIT_SHARED_SECTION_ATTR` variable (e.g., `__attribute__((section(".mc_shared")))`).

## Changes

- **DiagnosticSemaKinds.td**: New `err_ejit_missing_shared_section` error diagnostic
- **SemaEJIT.cpp**: `checkEjitPeriodSharedSection` — deferred check that verifies a period-annotated `VarDecl` has `SectionAttr`
- **SemaDecl.cpp**: Call `checkEjitPeriodSharedSection` in `ActOnVariableDeclarator` after `ProcessDeclAttributes` (handles any source ordering)
- **Tests**: Updated all existing period-annotated test globals to carry `__attribute__((section(".mc_shared")))`; added new lit test `clang/test/Sema/ejit_shared_section.c`

## Error message
```
error: global variable 'g_bad' has ejit_period but is missing '__attribute__((section(".mc_shared")))'; ejit period variables must reside in cross-core shared memory
```

## Testing
- New Sema lit test passes
- All existing Sema and CodeGen lit tests pass
- Verified both `section`/`period` attribute orderings work

🤖 Generated with [Claude Code](https://claude.com/claude-code)