### PR TITLE
[EJIT] Build the ORC engine only on the elected owner core

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -57,9 +57,22 @@ public:
   void invalidateAllByPeriod(const std::string &periodName);
 
   // Configuration
-  /// Change compile mode. In a taskpool build, switching to Async requires a
-  /// ready ORC engine and a successfully started worker; on failure the current
-  /// mode is preserved and false is returned.
+  /// Change compile mode. On failure the current mode is preserved and false
+  /// is returned.
+  ///
+  /// Private taskpool: Async requires a ready ORC engine on this instance and a
+  /// successfully started worker.
+  ///
+  /// Shared taskpool: Async instead requires the SHARED pool to be serviceable
+  /// (Ready, owner elected, worker running) -- peers have no engine of their
+  /// own, the elected owner compiles for every core. The switch is rejected if
+  /// the owner shuts down while it is in flight.
+  ///
+  /// Shared SYNC compiles on the CALLING core, and only the owner has an
+  /// engine, so a non-owner core in Sync mode does not JIT: its calls resolve
+  /// to nullptr and the wrapper cleanly runs the AOT body. Sync is therefore a
+  /// single-core debugging mode under the shared taskpool, not a way for every
+  /// core to compile.
   bool setCompileMode(CompileMode mode);
   CompileMode getCompileMode() const;
   void setOptimizationLevel(OptimizationLevel level);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -20,6 +20,8 @@
 #endif
 #include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace llvm {
 namespace ejit {
@@ -103,6 +105,18 @@ public:
 #endif
 
   void setJitEngine(std::unique_ptr<EJitOrcEngine> engine);
+
+  /// Build the ORC engine on THIS core if one is not already installed.
+  /// Idempotent, and never replaces a live engine (published code is reached
+  /// through it). Under the shared taskpool this is the owner-elected hook:
+  /// ownership is won by CAS and released by ownerShutdown, so the engine must
+  /// follow whoever wins, whenever they win. Hence a member of a lifetime-
+  /// stable object rather than a lambda over a caller's stack.
+  bool ensureJitEngine();
+
+  /// Stage a user symbol for the engine. The list is durable because the engine
+  /// may not exist yet: a peer elected owner after a re-election builds its
+  /// engine long after registration is over and must still see every symbol.
   void registerSymbol(const std::string &name, void *addr);
 
 private:
@@ -114,6 +128,9 @@ private:
 #endif
 
   std::unique_ptr<EJitOrcEngine> jitEngine_;
+  /// Durable record of every user symbol, replayed into whichever engine this
+  /// driver ends up building (see ensureJitEngine).
+  std::vector<std::pair<std::string, void *>> userSymbols_;
 #ifdef EJIT_SRE_TASKPOOL
   std::unique_ptr<EJitTaskPool> taskPool_;
 #endif
@@ -130,6 +147,9 @@ private:
   /// Worker idle/yield hook: defers to the platform task abstraction
   /// (EJitSreTask::yield) so the shared worker never busy-spins.
   static void sharedWorkerIdle(void *ctx);
+  /// Owner-elected hook: builds the engine on whichever core wins the election.
+  /// ctx is the driver, which owns sharedPool_ and so always outlives it.
+  static bool sharedOwnerElected(void *ctx);
 #endif
   // Async compiler will be added in EJitAsyncCompiler phase
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -114,6 +114,12 @@ public:
   /// stable object rather than a lambda over a caller's stack.
   bool ensureJitEngine();
 
+  /// Drop this core's ORC engine. Called when ownership is given up, so a
+  /// handoff does not leave one engine per former owner. Safe for already
+  /// published code: the code pool never recycles memory, so specializations
+  /// peers are still running outlive the compiler that produced them.
+  void releaseJitEngine();
+
   /// Stage a user symbol for the engine. The list is durable because the engine
   /// may not exist yet: a peer elected owner after a re-election builds its
   /// engine long after registration is over and must still see every symbol.
@@ -150,6 +156,8 @@ private:
   /// Owner-elected hook: builds the engine on whichever core wins the election.
   /// ctx is the driver, which owns sharedPool_ and so always outlives it.
   static bool sharedOwnerElected(void *ctx);
+  /// Owner-release hook: the counterpart of sharedOwnerElected.
+  static void sharedOwnerReleased(void *ctx);
 #endif
   // Async compiler will be added in EJitAsyncCompiler phase
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -244,6 +244,9 @@ public:
   /// Owner-only setup hook (see setOwnerElectedCallback). Return false to fail
   /// init. Runs on the elected owner, inside init(), before the worker starts.
   using OwnerElectedFn = bool (*)(void *ctx);
+  /// Owner-only teardown hook (see setOwnerReleasedCallback). Runs on the core
+  /// giving up ownership, inside ownerShutdown().
+  using OwnerReleasedFn = void (*)(void *ctx);
 
   enum class InitResult : uint32_t {
     BecameOwner =
@@ -399,6 +402,20 @@ public:
     ownerElected_ = fn;
     ownerElectedCtx_ = ctx;
   }
+  /// The counterpart of setOwnerElectedCallback: release whatever that hook
+  /// built. Runs inside ownerShutdown() AFTER the worker is joined and BEFORE
+  /// the blob returns to Uninitialized, so no compile can be in flight and no
+  /// peer can have been elected yet.
+  ///
+  /// Quiescence: what this releases is the COMPILER, not the code. Code-pool
+  /// memory is never recycled (sealed RX pages are not reused), so
+  /// specializations already published stay executable for peers still running
+  /// them after the engine is gone. Same lifetime rules as the elected hook:
+  /// stable ctx, armed for the pool's lifetime.
+  void setOwnerReleasedCallback(OwnerReleasedFn fn, void *ctx) {
+    ownerReleased_ = fn;
+    ownerReleasedCtx_ = ctx;
+  }
   /// Inject the worker idle/yield hook (see WorkerIdleFn). When unset the loop
   /// falls back to a compiler reordering barrier only (used by step tests).
   void setWorkerIdleHook(WorkerIdleFn fn, void *ctx) {
@@ -440,6 +457,27 @@ public:
             static_cast<uint32_t>(EJitSharedInitState::Ready))
       state_->mode.storeRelease(static_cast<uint32_t>(mode));
   }
+  /// Publish \p mode only if the blob is still Ready at generation \p gen --
+  /// the one asyncServiceAvailable() validated. An ownerShutdown that lands in
+  /// between bumps the generation, so the stale mode is never committed and the
+  /// caller learns the switch did not take. Returns false without writing then.
+  bool publishSharedMode(EJitCompileMode mode, uint32_t gen) {
+    if (!state_)
+      return false;
+    if (state_->initState.loadAcquire() !=
+            static_cast<uint32_t>(EJitSharedInitState::Ready) ||
+        state_->generation.loadAcquire() != gen)
+      return false;
+    configuredMode_ = mode;
+    state_->mode.storeRelease(static_cast<uint32_t>(mode));
+    // Re-check: if the owner went Stopping between the gate and the store, the
+    // write is stale. Producers gate on Ready before enqueuing so nothing can
+    // act on it, but report the failure rather than claim the switch took.
+    return state_->initState.loadAcquire() ==
+               static_cast<uint32_t>(EJitSharedInitState::Ready) &&
+           state_->generation.loadAcquire() == gen;
+  }
+
   /// The current cross-core compile mode: the shared state's mode (acquire
   /// load) once the blob is Ready, otherwise the staged configuredMode_.
   EJitCompileMode getSharedMode() const {
@@ -458,9 +496,16 @@ public:
   /// when the blob is Ready, an owner is elected, and that owner's single
   /// worker started. Says nothing about a LOCAL engine: peers have none by
   /// design and the owner compiles for every core (see EJit::setCompileMode).
-  bool asyncServiceAvailable() const {
+  ///
+  /// The fields are re-read after the check and the whole thing is rejected if
+  /// the generation or state moved, so the answer describes ONE generation
+  /// rather than a mix of before- and after-shutdown reads. \p outGeneration
+  /// receives that generation; pass it to publishSharedMode() so the mode can
+  /// only commit against the same one.
+  bool asyncServiceAvailable(uint32_t *outGeneration = nullptr) const {
     if (!state_)
       return false;
+    const uint32_t gen = state_->generation.loadAcquire();
     if (state_->initState.loadAcquire() !=
         static_cast<uint32_t>(EJitSharedInitState::Ready))
       return false;
@@ -469,7 +514,17 @@ public:
     // Published only after a successful worker start, cleared by
     // ownerShutdown: the one field separating "a worker is running" from "the
     // blob merely looks Ready".
-    return state_->workerTaskId.loadAcquire() != 0;
+    if (state_->workerTaskId.loadAcquire() == 0)
+      return false;
+    // Re-validate: an ownerShutdown concurrent with the reads above moves the
+    // state to Stopping and bumps the generation.
+    if (state_->initState.loadAcquire() !=
+            static_cast<uint32_t>(EJitSharedInitState::Ready) ||
+        state_->generation.loadAcquire() != gen)
+      return false;
+    if (outGeneration)
+      *outGeneration = gen;
+    return true;
   }
 
   /// Owner-only orderly shutdown: stop+join the worker, then return the state
@@ -800,6 +855,8 @@ private:
   void *workerIdleCtx_ = nullptr;
   OwnerElectedFn ownerElected_ = nullptr;
   void *ownerElectedCtx_ = nullptr;
+  OwnerReleasedFn ownerReleased_ = nullptr;
+  void *ownerReleasedCtx_ = nullptr;
   uint64_t regFingerprint_ = 0;
   EJitCompileMode configuredMode_ = EJitCompileMode::Async;
   bool codeSharingEnabled_ = false;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -388,6 +388,13 @@ public:
   /// Placement is load-bearing: the worker may compile the instant it starts,
   /// and peers may enqueue the instant Ready is published, so the engine must
   /// exist before both.
+  ///
+  /// LIFETIME: \p fn and \p ctx MUST stay valid for the pool's whole lifetime,
+  /// and \p fn MUST be idempotent. An election is not a one-shot event:
+  /// ownerShutdown() returns the blob to Uninitialized precisely so a later
+  /// init() can elect a different existing peer, which runs this hook on ITS
+  /// pool object. So ctx must be a lifetime-stable object, never a caller's
+  /// stack, and the hook must not be cleared after the first election.
   void setOwnerElectedCallback(OwnerElectedFn fn, void *ctx) {
     ownerElected_ = fn;
     ownerElectedCtx_ = ctx;
@@ -446,6 +453,24 @@ public:
   /// Run owner election + bind. Idempotent: re-observes the same outcome.
   InitResult init();
   bool isOwner() const { return isOwner_; }
+
+  /// Can an async request submitted from THIS core actually be compiled? True
+  /// when the blob is Ready, an owner is elected, and that owner's single
+  /// worker started. Says nothing about a LOCAL engine: peers have none by
+  /// design and the owner compiles for every core (see EJit::setCompileMode).
+  bool asyncServiceAvailable() const {
+    if (!state_)
+      return false;
+    if (state_->initState.loadAcquire() !=
+        static_cast<uint32_t>(EJitSharedInitState::Ready))
+      return false;
+    if (state_->ownerCoreId.loadAcquire() == kEJitInvalidCoreId)
+      return false;
+    // Published only after a successful worker start, cleared by
+    // ownerShutdown: the one field separating "a worker is running" from "the
+    // blob merely looks Ready".
+    return state_->workerTaskId.loadAcquire() != 0;
+  }
 
   /// Owner-only orderly shutdown: stop+join the worker, then return the state
   /// to Uninitialized so a later init() can re-elect. No-op for a non-owner.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -241,6 +241,9 @@ public:
   /// never busy-spins and starves the core trying to publish Ready. MUST NOT be
   /// called while holding a bucket lock / queue slot / dedup critical state.
   using WorkerIdleFn = void (*)(void *ctx);
+  /// Owner-only setup hook (see setOwnerElectedCallback). Return false to fail
+  /// init. Runs on the elected owner, inside init(), before the worker starts.
+  using OwnerElectedFn = bool (*)(void *ctx);
 
   enum class InitResult : uint32_t {
     BecameOwner =
@@ -369,6 +372,25 @@ public:
     workerStart_ = start;
     workerStop_ = stop;
     workerCtx_ = ctx;
+  }
+  /// Owner-only setup, run inside init() by the core that WINS the election,
+  /// after the blob is built but before the worker is started and before Ready
+  /// is published. Returning false is a clean init failure (Failed +
+  /// OwnerSetupFailed), exactly like a failed worker start.
+  ///
+  /// This exists so the JIT engine is built only on the core that will actually
+  /// compile. Only the owner's worker ever invokes the compile callback, so
+  /// constructing an LLJIT on every core wastes one per non-owner. Ownership is
+  /// won by CAS and is not permanent (see ownerShutdown), so the engine cannot
+  /// be assigned to a fixed core -- it has to follow whoever wins, which is
+  /// what this hook expresses.
+  ///
+  /// Placement is load-bearing: the worker may compile the instant it starts,
+  /// and peers may enqueue the instant Ready is published, so the engine must
+  /// exist before both.
+  void setOwnerElectedCallback(OwnerElectedFn fn, void *ctx) {
+    ownerElected_ = fn;
+    ownerElectedCtx_ = ctx;
   }
   /// Inject the worker idle/yield hook (see WorkerIdleFn). When unset the loop
   /// falls back to a compiler reordering barrier only (used by step tests).
@@ -751,6 +773,8 @@ private:
   void *workerCtx_ = nullptr;
   WorkerIdleFn workerIdle_ = nullptr;
   void *workerIdleCtx_ = nullptr;
+  OwnerElectedFn ownerElected_ = nullptr;
+  void *ownerElectedCtx_ = nullptr;
   uint64_t regFingerprint_ = 0;
   EJitCompileMode configuredMode_ = EJitCompileMode::Async;
   bool codeSharingEnabled_ = false;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -124,6 +124,11 @@ enum class EJitSharedInitState : uint32_t {
 enum class EJitSharedInitError : uint32_t {
   None = 0,
   WorkerStartFailed = 1,
+  /// Owner-only setup (building the JIT engine) failed after the election was
+  /// won. Only the owner compiles, so the engine is built inside init() once
+  /// the CAS succeeds; a failure there is an init failure exactly like a failed
+  /// worker start, not a silently degraded pool.
+  OwnerSetupFailed = 2,
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -597,6 +597,11 @@ bool EJit::setCompileMode(CompileMode mode) {
   EJitTaskPool *tp = taskPool();
   if (!tp)
     return false;
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  // The generation asyncServiceAvailable() validated, so the publish below can
+  // only commit against the same one.
+  uint32_t serviceGen = 0;
+#endif
 
   if (mode == CompileMode::Async) {
     // Do not expose Async until a compiler and a consumer exist. Failure
@@ -609,7 +614,7 @@ bool EJit::setCompileMode(CompileMode mode) {
     // setCompileMode(Async) and any switch back after a flip to Sync. A Ready
     // blob with an elected owner running the single worker is exactly the
     // condition under which a request enqueued from here gets compiled.
-    if (!compileDriver_->sharedTaskPool()->asyncServiceAvailable()) {
+    if (!compileDriver_->sharedTaskPool()->asyncServiceAvailable(&serviceGen)) {
       EJIT_DIAG("compile mode switch rejected: shared pool cannot service "
                 "async (not Ready / no owner / no worker)");
       return false;
@@ -650,10 +655,31 @@ bool EJit::setCompileMode(CompileMode mode) {
   // blob with release semantics so every core's compileOrGet() observes the new
   // mode; engine/worker ownership stays owner-controlled (a mode flip never
   // starts/stops the shared worker or re-runs owner election).
-  if (EJitSharedTaskPool *sp = sharedTaskPool())
-    sp->setSharedMode(mode == CompileMode::Async   ? EJitCompileMode::Async
-                     : mode == CompileMode::Sync   ? EJitCompileMode::Sync
-                                                   : EJitCompileMode::Off);
+  //
+  // Async commits only against the generation the availability check ran on: an
+  // ownerShutdown landing in between bumps it, and the switch reports failure
+  // rather than leaving Async live over a stopped worker. Sync/Off need no
+  // gate -- neither asks the worker for anything.
+  if (EJitSharedTaskPool *sp = sharedTaskPool()) {
+    const EJitCompileMode shared =
+        mode == CompileMode::Async  ? EJitCompileMode::Async
+        : mode == CompileMode::Sync ? EJitCompileMode::Sync
+                                    : EJitCompileMode::Off;
+    if (mode == CompileMode::Async) {
+      if (!sp->publishSharedMode(shared, serviceGen)) {
+        EJIT_DIAG("compile mode switch rejected: owner shut down during the "
+                  "switch (generation moved)");
+        tp->switchController().setMode(
+            config_.compileMode == CompileMode::Async ? EJitCompileMode::Async
+            : config_.compileMode == CompileMode::Sync
+                ? EJitCompileMode::Sync
+                : EJitCompileMode::Off);
+        return false;
+      }
+    } else {
+      sp->setSharedMode(shared);
+    }
+  }
 #endif
   config_.compileMode = mode;
   return true;

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -260,30 +260,50 @@ EJit::EJit(const Config &config) : config_(config) {
       "registered: bitcodes=%zu periodArrays=%zu staticVars=%zu symbols=%zu",
       data.bitcodes.size(), data.periodArrays.size(), data.staticVars.size(),
       data.userSymbols.size());
-  auto engine = EJitOrcEngine::Create(config, runtimeState_->getRegistry(),
-                                      *runtimeState_);
+  // Build the ORC engine. On the shared-taskpool async path this is DEFERRED to
+  // the core that wins the owner election: only the owner's worker ever invokes
+  // the compile callback, so every other core would construct an LLJIT
+  // (ExecutionSession, object/IR layers, LLVMContext, memory manager) and never
+  // use it. Ownership is decided by a CAS inside init() and is not permanent
+  // (see ownerShutdown), so the engine has to follow whoever wins rather than
+  // being assigned to a fixed core.
   bool engineReady = false;
-  if (engine) {
+  auto createJitEngine = [&]() -> bool {
+    auto engine = EJitOrcEngine::Create(config, runtimeState_->getRegistry(),
+                                        *runtimeState_);
+    if (!engine) {
+      EJIT_DIAG("FAILED to create OrcJIT engine");
+#ifndef EJIT_FREESTANDING
+      std::string errStr;
+      llvm::handleAllErrors(
+          engine.takeError(),
+          [&](const llvm::ErrorInfoBase &E) { errStr = E.message(); });
+      if (logger_)
+        logger_->log(EJIT_ERR_COMPILE_FAILED,
+                     "Failed to create OrcJIT engine: " + errStr, "", "");
+#else
+      consumeError(engine.takeError());
+#endif
+      return false;
+    }
     // Forward auto-registered user symbols to the engine.
     for (auto &sym : data.userSymbols)
       (*engine)->addUserSymbol(sym.name, sym.addr);
     compileDriver_->setJitEngine(std::move(*engine));
     engineReady = true;
     EJIT_DIAG("OrcJIT engine created successfully");
-  } else {
-    EJIT_DIAG("FAILED to create OrcJIT engine");
-#ifndef EJIT_FREESTANDING
-    std::string errStr;
-    llvm::handleAllErrors(
-        engine.takeError(),
-        [&](const llvm::ErrorInfoBase &E) { errStr = E.message(); });
-    if (logger_)
-      logger_->log(EJIT_ERR_COMPILE_FAILED,
-                   "Failed to create OrcJIT engine: " + errStr, "", "");
-#else
-    consumeError(engine.takeError());
+    return true;
+  };
+
+  // Sync mode compiles on the CALLING core, so there every core genuinely needs
+  // its own engine; only the async shared path funnels all compiles through the
+  // elected owner. Anything else builds it eagerly, exactly as before.
+  bool deferEngineToOwner = false;
+#if defined(EJIT_SRE_TASKPOOL) && defined(EJIT_SRE_SHARED_TASKPOOL)
+  deferEngineToOwner = (config_.compileMode == CompileMode::Async);
 #endif
-  }
+  if (!deferEngineToOwner)
+    createJitEngine();
 
 #ifdef EJIT_SRE_TASKPOOL
   // Deferred worker start (spec §3.4 single async worker): the taskpool worker
@@ -297,19 +317,52 @@ EJit::EJit(const Config &config) : config_(config) {
   if (!initFailed_) {
     regPhase_ = RegistrationPhase::Frozen;
     if (config_.compileMode == CompileMode::Async) {
-      EJIT_DIAG_VERBOSE("taskpool async init: engineReady=%u",
-                        static_cast<unsigned>(engineReady));
+      EJIT_DIAG_VERBOSE("taskpool async init: engineReady=%u deferred=%u",
+                        static_cast<unsigned>(engineReady),
+                        static_cast<unsigned>(deferEngineToOwner));
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+      // Cross-core shared taskpool: run owner election and (if elected) build
+      // the engine and start the ONE shared worker. engineReady is still false
+      // on EVERY core here -- the engine is created inside init() by the
+      // callback below, and only on the winner. A clean failure (engine build /
+      // worker start / ABI mismatch) fails init rather than accepting requests
+      // no worker consumes.
+      // The unary + forces the captureless thunk to a plain function pointer;
+      // the captured lambda travels as the ctx argument.
+      compileDriver_->sharedTaskPool()->setOwnerElectedCallback(
+          +[](void *ctx) -> bool {
+            return (*static_cast<decltype(createJitEngine) *>(ctx))();
+          },
+          &createJitEngine);
+      bool poolOk = compileDriver_->startSharedTaskPool();
+      // The callback closes over this constructor's stack; drop it before those
+      // locals die so a later init() can never call through a dangling pointer.
+      compileDriver_->sharedTaskPool()->setOwnerElectedCallback(nullptr,
+                                                                nullptr);
+      if (!poolOk) {
+        // Distinguish "the engine failed to build on the winner" from a genuine
+        // election/ABI failure -- the pool records which in lastInitError, and
+        // reporting "election failed" for an engine failure sends the next
+        // person debugging this to the wrong place.
+        EJitSharedDiagnostics d{};
+        compileDriver_->sharedTaskPool()->getDiagnostics(d);
+        recordInitError(EJIT_ERR_COMPILE_FAILED,
+                        d.lastInitError ==
+                                static_cast<uint32_t>(
+                                    EJitSharedInitError::OwnerSetupFailed)
+                            ? "owner elected but ORC engine creation failed"
+                            : "shared taskpool init/election failed",
+                        "");
+      } else if (!engineReady) {
+        // Attached as a peer: no engine here by design. Stated explicitly so
+        // the absence of "OrcJIT engine created" in a log is a recorded fact
+        // rather than something to infer.
+        EJIT_DIAG("ORC engine skipped: not the compile owner");
+      }
+#else
       if (!engineReady)
         recordInitError(EJIT_ERR_COMPILE_FAILED,
                         "Async mode requires a ready ORC engine", "");
-#ifdef EJIT_SRE_SHARED_TASKPOOL
-      // Cross-core shared taskpool: run owner election and (if elected) start
-      // the ONE shared worker. A clean failure (owner worker-start failed / ABI
-      // mismatch) fails init rather than accepting requests no worker consumes.
-      else if (!compileDriver_->startSharedTaskPool())
-        recordInitError(EJIT_ERR_COMPILE_FAILED,
-                        "shared taskpool init/election failed", "");
-#else
       else if (!compileDriver_->startTaskPoolWorker())
         recordInitError(EJIT_ERR_COMPILE_FAILED,
                         "taskpool worker failed to start", "");

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -260,41 +260,19 @@ EJit::EJit(const Config &config) : config_(config) {
       "registered: bitcodes=%zu periodArrays=%zu staticVars=%zu symbols=%zu",
       data.bitcodes.size(), data.periodArrays.size(), data.staticVars.size(),
       data.userSymbols.size());
+  // Stage the auto-registered user symbols on the DRIVER, not on an engine.
+  // Whichever core ends up building one replays this list, including a peer
+  // elected owner long after this constructor (and `data`) is gone.
+  for (auto &sym : data.userSymbols)
+    compileDriver_->registerSymbol(sym.name, sym.addr);
+
   // Build the ORC engine. On the shared-taskpool async path this is DEFERRED to
   // the core that wins the owner election: only the owner's worker ever invokes
   // the compile callback, so every other core would construct an LLJIT
   // (ExecutionSession, object/IR layers, LLVMContext, memory manager) and never
-  // use it. Ownership is decided by a CAS inside init() and is not permanent
-  // (see ownerShutdown), so the engine has to follow whoever wins rather than
-  // being assigned to a fixed core.
-  bool engineReady = false;
-  auto createJitEngine = [&]() -> bool {
-    auto engine = EJitOrcEngine::Create(config, runtimeState_->getRegistry(),
-                                        *runtimeState_);
-    if (!engine) {
-      EJIT_DIAG("FAILED to create OrcJIT engine");
-#ifndef EJIT_FREESTANDING
-      std::string errStr;
-      llvm::handleAllErrors(
-          engine.takeError(),
-          [&](const llvm::ErrorInfoBase &E) { errStr = E.message(); });
-      if (logger_)
-        logger_->log(EJIT_ERR_COMPILE_FAILED,
-                     "Failed to create OrcJIT engine: " + errStr, "", "");
-#else
-      consumeError(engine.takeError());
-#endif
-      return false;
-    }
-    // Forward auto-registered user symbols to the engine.
-    for (auto &sym : data.userSymbols)
-      (*engine)->addUserSymbol(sym.name, sym.addr);
-    compileDriver_->setJitEngine(std::move(*engine));
-    engineReady = true;
-    EJIT_DIAG("OrcJIT engine created successfully");
-    return true;
-  };
-
+  // use it. The driver's owner-elected hook, armed for the pool's lifetime, is
+  // what lets the engine follow whoever wins, whenever they win.
+  //
   // Sync mode compiles on the CALLING core, so there every core genuinely needs
   // its own engine; only the async shared path funnels all compiles through the
   // elected owner. Anything else builds it eagerly, exactly as before.
@@ -302,8 +280,8 @@ EJit::EJit(const Config &config) : config_(config) {
 #if defined(EJIT_SRE_TASKPOOL) && defined(EJIT_SRE_SHARED_TASKPOOL)
   deferEngineToOwner = (config_.compileMode == CompileMode::Async);
 #endif
-  if (!deferEngineToOwner)
-    createJitEngine();
+  bool engineReady =
+      deferEngineToOwner ? false : compileDriver_->ensureJitEngine();
 
 #ifdef EJIT_SRE_TASKPOOL
   // Deferred worker start (spec §3.4 single async worker): the taskpool worker
@@ -324,21 +302,11 @@ EJit::EJit(const Config &config) : config_(config) {
       // Cross-core shared taskpool: run owner election and (if elected) build
       // the engine and start the ONE shared worker. engineReady is still false
       // on EVERY core here -- the engine is created inside init() by the
-      // callback below, and only on the winner. A clean failure (engine build /
-      // worker start / ABI mismatch) fails init rather than accepting requests
-      // no worker consumes.
-      // The unary + forces the captureless thunk to a plain function pointer;
-      // the captured lambda travels as the ctx argument.
-      compileDriver_->sharedTaskPool()->setOwnerElectedCallback(
-          +[](void *ctx) -> bool {
-            return (*static_cast<decltype(createJitEngine) *>(ctx))();
-          },
-          &createJitEngine);
+      // driver's owner-elected hook, and only on the winner. A clean failure
+      // (engine build / worker start / ABI mismatch) fails init rather than
+      // accepting requests no worker consumes.
       bool poolOk = compileDriver_->startSharedTaskPool();
-      // The callback closes over this constructor's stack; drop it before those
-      // locals die so a later init() can never call through a dangling pointer.
-      compileDriver_->sharedTaskPool()->setOwnerElectedCallback(nullptr,
-                                                                nullptr);
+      engineReady = compileDriver_->hasJitEngine();
       if (!poolOk) {
         // Distinguish "the engine failed to build on the winner" from a genuine
         // election/ABI failure -- the pool records which in lastInitError, and
@@ -631,14 +599,26 @@ bool EJit::setCompileMode(CompileMode mode) {
     return false;
 
   if (mode == CompileMode::Async) {
-    // Do not expose Async until both the compiler engine and consumer exist.
-    // Failure preserves the old mode, so callers cannot enqueue permanent
-    // pending work into a worker-less taskpool.
+    // Do not expose Async until a compiler and a consumer exist. Failure
+    // preserves the old mode, so callers cannot enqueue permanent pending work
+    // into a taskpool nothing drains.
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+    // A peer has NO local engine by design -- the elected owner compiles for
+    // every core -- so gating on the private engine would make Async
+    // unreachable on every non-owner core, including an idempotent
+    // setCompileMode(Async) and any switch back after a flip to Sync. A Ready
+    // blob with an elected owner running the single worker is exactly the
+    // condition under which a request enqueued from here gets compiled.
+    if (!compileDriver_->sharedTaskPool()->asyncServiceAvailable()) {
+      EJIT_DIAG("compile mode switch rejected: shared pool cannot service "
+                "async (not Ready / no owner / no worker)");
+      return false;
+    }
+#else
     if (!compileDriver_->hasJitEngine()) {
       EJIT_DIAG("compile mode switch rejected: async without engine");
       return false;
     }
-#ifndef EJIT_SRE_SHARED_TASKPOOL
     // Private taskpool: the worker is local to this instance, so a runtime
     // switch to Async must start it here. In a shared build the single worker
     // is cross-core and owner-controlled (started by owner election during

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -172,6 +172,12 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
   // Ready or on an empty queue (spec §11): a high-priority worker that spun
   // could starve the owner core trying to publish Ready / a producer enqueuing.
   sharedPool_.setWorkerIdleHook(&EJitCompileDriver::sharedWorkerIdle, this);
+  // Owner-only setup, armed for the pool's WHOLE lifetime with a stable ctx.
+  // It must stay armed after the first election: ownerShutdown() returns the
+  // blob to Uninitialized, so a later init() can elect a DIFFERENT peer, and a
+  // peer that won with no hook would publish Ready with no engine.
+  sharedPool_.setOwnerElectedCallback(&EJitCompileDriver::sharedOwnerElected,
+                                      this);
   sharedPool_.setMode(config_.compileMode == CompileMode::Async   ? EJitCompileMode::Async
                           : config_.compileMode == CompileMode::Sync ? EJitCompileMode::Sync
                                                                      : EJitCompileMode::Off);
@@ -243,6 +249,10 @@ void EJitCompileDriver::sharedWorkerIdle(void * /*ctx*/) {
   EJitSreTask::yield();
 }
 
+bool EJitCompileDriver::sharedOwnerElected(void *ctx) {
+  return static_cast<EJitCompileDriver *>(ctx)->ensureJitEngine();
+}
+
 bool EJitCompileDriver::startSharedTaskPool() {
   // Publish this core's funcIndex/dimType registration digest so a peer with a
   // divergent mapping is cleanly rejected at attach (spec §11), never silently
@@ -284,7 +294,40 @@ void EJitCompileDriver::setJitEngine(std::unique_ptr<EJitOrcEngine> engine) {
   jitEngine_ = std::move(engine);
 }
 
+bool EJitCompileDriver::ensureJitEngine() {
+  // Ownership can be won more than once by the same core, and a live engine is
+  // how already-published code is reached, so never rebuild.
+  if (jitEngine_)
+    return true;
+
+  auto engine =
+      EJitOrcEngine::Create(config_, runtimeState_.getRegistry(), runtimeState_);
+  if (!engine) {
+    EJIT_DIAG("FAILED to create OrcJIT engine");
+#ifndef EJIT_FREESTANDING
+    std::string errStr;
+    llvm::handleAllErrors(
+        engine.takeError(),
+        [&](const llvm::ErrorInfoBase &E) { errStr = E.message(); });
+    if (logger_)
+      logger_->log(EJIT_ERR_COMPILE_FAILED,
+                   "Failed to create OrcJIT engine: " + errStr, "", "");
+#else
+    consumeError(engine.takeError());
+#endif
+    return false;
+  }
+  jitEngine_ = std::move(*engine);
+  // Replay the staged symbols: on a re-elected owner this engine is built long
+  // after registration ran, so the list is the only record of them left.
+  for (auto &sym : userSymbols_)
+    jitEngine_->addUserSymbol(sym.first, sym.second);
+  EJIT_DIAG("OrcJIT engine created successfully");
+  return true;
+}
+
 void EJitCompileDriver::registerSymbol(const std::string &name, void *addr) {
+  userSymbols_.emplace_back(name, addr);
   if (jitEngine_)
     jitEngine_->addUserSymbol(name, addr);
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -178,6 +178,8 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
   // peer that won with no hook would publish Ready with no engine.
   sharedPool_.setOwnerElectedCallback(&EJitCompileDriver::sharedOwnerElected,
                                       this);
+  sharedPool_.setOwnerReleasedCallback(&EJitCompileDriver::sharedOwnerReleased,
+                                       this);
   sharedPool_.setMode(config_.compileMode == CompileMode::Async   ? EJitCompileMode::Async
                           : config_.compileMode == CompileMode::Sync ? EJitCompileMode::Sync
                                                                      : EJitCompileMode::Off);
@@ -253,6 +255,10 @@ bool EJitCompileDriver::sharedOwnerElected(void *ctx) {
   return static_cast<EJitCompileDriver *>(ctx)->ensureJitEngine();
 }
 
+void EJitCompileDriver::sharedOwnerReleased(void *ctx) {
+  static_cast<EJitCompileDriver *>(ctx)->releaseJitEngine();
+}
+
 bool EJitCompileDriver::startSharedTaskPool() {
   // Publish this core's funcIndex/dimType registration digest so a peer with a
   // divergent mapping is cleanly rejected at attach (spec §11), never silently
@@ -324,6 +330,13 @@ bool EJitCompileDriver::ensureJitEngine() {
     jitEngine_->addUserSymbol(sym.first, sym.second);
   EJIT_DIAG("OrcJIT engine created successfully");
   return true;
+}
+
+void EJitCompileDriver::releaseJitEngine() {
+  if (!jitEngine_)
+    return;
+  EJIT_DIAG("OrcJIT engine released: ownership given up");
+  jitEngine_.reset();
 }
 
 void EJitCompileDriver::registerSymbol(const std::string &name, void *addr) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -1679,6 +1679,12 @@ void EJitSharedTaskPool::ownerShutdown() {
       static_cast<uint32_t>(EJitSharedInitState::Stopping));
   if (workerStop_)
     workerStop_(workerCtx_); // soft-stop + JOIN (no use-after-free).
+  // Release what the election built, between the join and Uninitialized: no
+  // compile can be in flight, and no peer can be elected yet. Without this the
+  // former owner keeps its engine while a new owner builds another, so the
+  // system accumulates one per handoff.
+  if (ownerReleased_)
+    ownerReleased_(ownerReleasedCtx_);
   state_->ownerCoreId.storeRelease(kEJitInvalidCoreId);
   state_->workerTaskId.storeRelease(0);
   state_->generation.storeRelease(state_->generation.loadRelaxed() + 1);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -1578,6 +1578,20 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       state_->structSize =
           static_cast<uint32_t>(sizeof(EJitSharedTaskPoolState));
 
+      // Owner-only setup (building the JIT engine) runs HERE: after the blob is
+      // built, before the worker exists, and before Ready is published. Both
+      // orderings matter -- the worker can compile the instant it starts, and a
+      // peer can enqueue the instant it observes Ready. A failure is a clean
+      // init failure, exactly like a failed worker start.
+      if (ownerElected_ && !ownerElected_(ownerElectedCtx_)) {
+        state_->lastInitError.storeRelease(
+            static_cast<uint32_t>(EJitSharedInitError::OwnerSetupFailed));
+        state_->initState.storeRelease(
+            static_cast<uint32_t>(EJitSharedInitState::Failed));
+        EJIT_DIAG("shared taskpool owner=%u setup FAILED (engine)", self);
+        return InitResult::OwnerFailed;
+      }
+
       // Start the ONE worker (if a starter was injected). A failure here is a
       // clean init failure: record it, publish Failed, and DO NOT pretend JIT
       // is up.

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -158,6 +158,43 @@ bool mockWorkerStart(void *ctx, EJitSharedTaskPool::WorkerEntryFn /*entry*/,
 }
 void mockWorkerStop(void *ctx) { ++static_cast<WorkerHooks *>(ctx)->stops; }
 
+// Stands in for building/releasing the owner's ORC engine, and records what the
+// blob looked like WHILE it ran -- the ordering against the worker start and the
+// Ready publish is the contract, not just that it ran.
+struct OwnerEngineLog {
+  int built = 0;
+  int released = 0;
+  bool failBuild = false;
+  uint32_t coreAtBuild = kEJitInvalidCoreId;
+  uint32_t stateAtBuild = 0xFFFFFFFFu;
+  uint64_t taskIdAtBuild = ~0ull;
+  int workerStartsAtBuild = -1;
+  uint32_t stateAtRelease = 0xFFFFFFFFu;
+  int workerStopsAtRelease = -1;
+  EJitSharedTaskPoolState *state = nullptr;
+  const WorkerHooks *hooks = nullptr;
+};
+bool mockOwnerElected(void *ctx) {
+  auto *l = static_cast<OwnerEngineLog *>(ctx);
+  ++l->built;
+  l->coreAtBuild = EJitCoreId::current();
+  if (l->state) {
+    l->stateAtBuild = l->state->initState.loadAcquire();
+    l->taskIdAtBuild = l->state->workerTaskId.loadAcquire();
+  }
+  if (l->hooks)
+    l->workerStartsAtBuild = l->hooks->starts;
+  return !l->failBuild;
+}
+void mockOwnerReleased(void *ctx) {
+  auto *l = static_cast<OwnerEngineLog *>(ctx);
+  ++l->released;
+  if (l->state)
+    l->stateAtRelease = l->state->initState.loadAcquire();
+  if (l->hooks)
+    l->workerStopsAtRelease = l->hooks->stops;
+}
+
 // A worker start hook that ignores its ctx (returns success), so a test can
 // share a non-WorkerHooks ctx between start and stop hooks.
 bool startOkIgnoreCtx(void * /*ctx*/,
@@ -3036,6 +3073,196 @@ TEST_F(SharedTaskPoolTest, L0CollidingIdentitiesNeverCrossServe) {
   pool.l0Fill(31, codeFor(37), c, 1);
   if (pool.l0Try(30, c, 1, &out))
     EXPECT_NE(out, codeFor(37)) << "funcIndex 30 served funcIndex 31's entry";
+}
+
+//===----------------------------------------------------------------------===//
+// Owner-only engine lifecycle. Only the elected owner builds an ORC engine, and
+// it releases it when it gives ownership up, so a handoff never leaves two.
+//===----------------------------------------------------------------------===//
+
+// Winner-only, and BEFORE the worker exists and before Ready is published: the
+// worker can compile the instant it starts and a peer can enqueue the instant
+// it sees Ready, so an engine built after either would be too late.
+TEST_F(SharedTaskPoolTest, OwnerSetupRunsOnTheWinnerBeforeWorkerAndReady) {
+  WorkerHooks hooks;
+  OwnerEngineLog winner, loser;
+  winner.state = state_.get();
+  winner.hooks = &hooks;
+  loser.state = state_.get();
+
+  EJitSharedTaskPool c0, c1;
+  for (auto *pool : {&c0, &c1}) {
+    pool->bind(state_.get());
+    pool->setCompiler(&mockCompile, nullptr);
+    pool->setMode(EJitCompileMode::Async);
+  }
+  c0.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &hooks);
+  c0.setOwnerElectedCallback(&mockOwnerElected, &winner);
+  c1.setOwnerElectedCallback(&mockOwnerElected, &loser);
+
+  EJitCoreId::setCurrentForTest(3);
+  ASSERT_EQ(c0.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  EJitCoreId::setCurrentForTest(4);
+  ASSERT_EQ(c1.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+
+  EXPECT_EQ(winner.built, 1);
+  EXPECT_EQ(winner.coreAtBuild, 3u);
+  EXPECT_EQ(loser.built, 0) << "a peer built an LLJIT it can never use";
+
+  EXPECT_EQ(winner.stateAtBuild,
+            static_cast<uint32_t>(EJitSharedInitState::Initializing));
+  EXPECT_EQ(winner.workerStartsAtBuild, 0);
+  EXPECT_EQ(winner.taskIdAtBuild, 0ull);
+  EXPECT_EQ(hooks.starts, 1);
+  EXPECT_EQ(state_->initState.loadAcquire(),
+            static_cast<uint32_t>(EJitSharedInitState::Ready));
+}
+
+// A failed engine build is a clean init failure: OwnerSetupFailed, no worker.
+TEST_F(SharedTaskPoolTest, OwnerSetupFailureStartsNoWorker) {
+  WorkerHooks hooks;
+  OwnerEngineLog log;
+  log.failBuild = true;
+
+  EJitSharedTaskPool owner;
+  EJitCoreId::setCurrentForTest(0);
+  owner.bind(state_.get());
+  owner.setCompiler(&mockCompile, nullptr);
+  owner.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &hooks);
+  owner.setOwnerElectedCallback(&mockOwnerElected, &log);
+  owner.setMode(EJitCompileMode::Async);
+
+  EXPECT_EQ(owner.init(), EJitSharedTaskPool::InitResult::OwnerFailed);
+  EXPECT_EQ(log.built, 1);
+  EXPECT_EQ(hooks.starts, 0) << "a worker with no compiler behind it";
+  EXPECT_EQ(state_->lastInitError.loadAcquire(),
+            static_cast<uint32_t>(EJitSharedInitError::OwnerSetupFailed));
+  EXPECT_FALSE(owner.isOwner());
+  EXPECT_FALSE(owner.asyncServiceAvailable());
+}
+
+// The handoff: the old owner releases its engine and the new one builds its
+// own, so the system never holds two. Release lands after the worker join and
+// before the blob is up for election again.
+TEST_F(SharedTaskPoolTest, ReElectionReleasesTheOldEngineAndBuildsTheNew) {
+  WorkerHooks ownerHooks, peerHooks;
+  OwnerEngineLog ownerLog, peerLog;
+  ownerLog.state = peerLog.state = state_.get();
+  ownerLog.hooks = &ownerHooks;
+  peerLog.hooks = &peerHooks;
+
+  EJitSharedTaskPool owner, peer;
+  for (auto *pool : {&owner, &peer}) {
+    pool->bind(state_.get());
+    pool->setCompiler(&mockCompile, nullptr);
+    pool->setMode(EJitCompileMode::Async);
+  }
+  owner.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &ownerHooks);
+  owner.setOwnerElectedCallback(&mockOwnerElected, &ownerLog);
+  owner.setOwnerReleasedCallback(&mockOwnerReleased, &ownerLog);
+  peer.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &peerHooks);
+  peer.setOwnerElectedCallback(&mockOwnerElected, &peerLog);
+  peer.setOwnerReleasedCallback(&mockOwnerReleased, &peerLog);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_EQ(peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+  ASSERT_EQ(ownerLog.built, 1);
+  ASSERT_EQ(peerLog.built, 0) << "the peer built an engine while attaching";
+
+  EJitCoreId::setCurrentForTest(0);
+  owner.ownerShutdown();
+  EXPECT_EQ(ownerLog.released, 1) << "the former owner kept its engine";
+  EXPECT_EQ(ownerLog.workerStopsAtRelease, 1)
+      << "released before the worker was joined";
+  EXPECT_EQ(ownerLog.stateAtRelease,
+            static_cast<uint32_t>(EJitSharedInitState::Stopping))
+      << "released after the blob was already up for re-election";
+
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_EQ(peer.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  EXPECT_EQ(peerLog.built, 1) << "the new owner must build its own engine";
+  EXPECT_EQ(ownerLog.built, 1) << "the old owner was rebuilt";
+  EXPECT_EQ(ownerLog.released, 1);
+  EXPECT_TRUE(peer.asyncServiceAvailable());
+}
+
+// A peer with no engine of its own can still flip the shared mode in both
+// directions, because the elected owner compiles for every core.
+TEST_F(SharedTaskPoolTest, PeerSwitchesSharedModeBothWays) {
+  WorkerHooks hooks;
+  EJitSharedTaskPool owner, peer;
+  for (auto *pool : {&owner, &peer}) {
+    pool->bind(state_.get());
+    pool->setCompiler(&mockCompile, nullptr);
+    pool->setMode(EJitCompileMode::Async);
+  }
+  owner.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &hooks);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_EQ(peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+
+  uint32_t gen = 0;
+  ASSERT_TRUE(peer.asyncServiceAvailable(&gen));
+  peer.setSharedMode(EJitCompileMode::Sync);
+  EXPECT_EQ(owner.getSharedMode(), EJitCompileMode::Sync)
+      << "the owner never saw the peer's flip";
+
+  ASSERT_TRUE(peer.asyncServiceAvailable(&gen));
+  EXPECT_TRUE(peer.publishSharedMode(EJitCompileMode::Async, gen))
+      << "Sync -> Async is unreachable for a peer";
+  EXPECT_EQ(owner.getSharedMode(), EJitCompileMode::Async);
+}
+
+// The shutdown race: a peer that validated the pool, then had the owner shut
+// down underneath it, must NOT commit Async against a stopped worker.
+TEST_F(SharedTaskPoolTest, ShutdownDuringModeSwitchRejectsTheAsyncPublish) {
+  WorkerHooks hooks;
+  EJitSharedTaskPool owner, peer;
+  for (auto *pool : {&owner, &peer}) {
+    pool->bind(state_.get());
+    pool->setCompiler(&mockCompile, nullptr);
+    pool->setMode(EJitCompileMode::Sync);
+  }
+  owner.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &hooks);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_EQ(peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+
+  // The peer checks and is told yes.
+  uint32_t gen = 0;
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_TRUE(peer.asyncServiceAvailable(&gen));
+
+  // The owner shuts down before the peer gets to publish.
+  EJitCoreId::setCurrentForTest(0);
+  owner.ownerShutdown();
+  ASSERT_EQ(hooks.stops, 1);
+
+  EJitCoreId::setCurrentForTest(1);
+  EXPECT_FALSE(peer.publishSharedMode(EJitCompileMode::Async, gen))
+      << "published Async over a stopped worker";
+  EXPECT_FALSE(peer.asyncServiceAvailable())
+      << "still claims the pool can service async";
+  // And nothing can be enqueued anyway: every producer path gates on Ready.
+  const EJitDimPair d[1] = {{0, 0}};
+  EXPECT_EQ(peer.compileOrGet(1, d, 1, codeFor(1)).status,
+            EJitCompileOrGetStatus::OffMode);
+}
+
+// A Ready blob whose worker never started is not serviceable: a request
+// enqueued there would sit pending forever.
+TEST_F(SharedTaskPoolTest, AsyncServiceUnavailableWithoutAWorker) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner); // no worker hooks injected: tests drive pollOne()
+  ASSERT_EQ(state_->initState.loadAcquire(),
+            static_cast<uint32_t>(EJitSharedInitState::Ready));
+  EXPECT_FALSE(owner.asyncServiceAvailable());
 }
 
 } // namespace


### PR DESCRIPTION
Only the owner's worker invokes the compile callback, so every other core was constructing an LLJIT it never used. 

This patch defers engine creation to a new owner-elected hook that `init()` runs after winning the CAS, before the worker starts and before Ready is published.

Sync mode compiles on the calling core and still builds eagerly.