### PR TITLE
[EJIT] Add -ejit-warn-few-mayconst diagnostic for PASS1

### DIFF
--- a/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
@@ -44,3 +44,15 @@ cl::opt<bool> EJitReportMayConst(
     cl::desc("Report per-ejit_entry ejit_may_const read counts (total and "
              "in-loop) in the specialization closure, for manual "
              "specialization-value assessment."));
+
+// Optional warning (off by default): warn when an ejit_entry's specialization
+// closure has fewer than N ejit_may_const reads. N=0 disables the check,
+// N>0 enables it with that threshold. A low load count means the JIT has
+// little to specialize against, but the significance depends on whether those
+// few loads gate branches or sit in hot loops — this warning flags low counts
+// for manual review rather than asserting a defect.
+cl::opt<unsigned> EJitWarnFewMayConst(
+    "ejit-warn-few-mayconst", cl::init(0), cl::Hidden,
+    cl::desc("Warn when an ejit_entry's specialization closure has fewer than "
+             "N ejit_may_const reads (0 = off). Example: "
+             "-ejit-warn-few-mayconst=4 warns on 0..3 may-const reads."));

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -45,6 +45,7 @@ extern cl::opt<std::string> EJitDumpBitcodeDir;
 extern cl::opt<bool> EJitWarnNoSpecialization;
 extern cl::opt<bool> EJitWarnUnusedDim;
 extern cl::opt<bool> EJitReportMayConst;
+extern cl::opt<unsigned> EJitWarnFewMayConst;
 
 #define DEBUG_TYPE "ejit-register-bitcode"
 
@@ -431,7 +432,8 @@ computeEjitFuncDiagInfo(Function &F, EjitFuncDiagInfo &Info, unsigned MayConstKi
 static void
 runSpecializationDiagnostic(Module &Extracted,
                             const SmallVectorImpl<Function *> &EntryFuncs) {
-  if (!EJitWarnNoSpecialization && !EJitWarnUnusedDim && !EJitReportMayConst)
+  if (!EJitWarnNoSpecialization && !EJitWarnUnusedDim && !EJitReportMayConst &&
+      !EJitWarnFewMayConst)
     return;
 
   SmallVector<EjitEntryDiag, 4> Entries;
@@ -525,9 +527,10 @@ runSpecializationDiagnostic(Module &Extracted,
                         "removing it\n";
   }
 
-  // Optional info report: per-entry ejit_may_const read counts (total /
-  // in-loop) over the specialization closure. Report-only; it does not gate.
-  if (EJitReportMayConst) {
+  // Per-entry may_const read counts over the specialization closure (BFS).
+  // Used by the info report and the few-may-const warning; both share the
+  // same closure walk so they share one gated loop.
+  if (EJitReportMayConst || EJitWarnFewMayConst > 0) {
     for (const EjitEntryDiag &ED : Entries) {
       const Function *EF = Extracted.getFunction(ED.Name);
       if (!EF || EF->isDeclaration())
@@ -548,9 +551,24 @@ runSpecializationDiagnostic(Module &Extracted,
         for (const Function *Callee : It->second.Callees)
           WL.push_back(Callee);
       }
-      errs() << "EJit info: ejit_entry function '" << EF->getName() << "': "
-             << K << " ejit_may_const read" << (K == 1 ? "" : "s") << " ("
-             << J << " in loops)\n";
+
+      // Info report (not a warning): summary of all may-const reads.
+      if (EJitReportMayConst)
+        errs() << "EJit info: ejit_entry function '" << EF->getName() << "': "
+               << K << " ejit_may_const read" << (K == 1 ? "" : "s") << " ("
+               << J << " in loops)\n";
+
+      // Warning #3: too few may-const reads for meaningful specialization.
+      // A low count means the JIT has little to fold, but doesn't mean the
+      // entry is misconfigured — the significance depends on what those loads
+      // gate.  This only flags the count for manual review.
+      if (EJitWarnFewMayConst > 0 && K < EJitWarnFewMayConst)
+        errs() << "EJit warning: ejit_entry function '" << EF->getName()
+               << "' has only " << K << " ejit_may_const read"
+               << (K == 1 ? "" : "s") << " in its specialization closure"
+               << " (threshold: " << EJitWarnFewMayConst
+               << "); low specialization surface, consider adding more"
+                  " may-const fields\n";
     }
   }
 }

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-few-mayconst.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-few-mayconst.ll
@@ -1,0 +1,96 @@
+; RUN: opt -passes=ejit-register-bitcode -ejit-warn-few-mayconst=4 \
+; RUN:     -ejit-warn-no-specialization=false -ejit-warn-unused-dim=false \
+; RUN:     -S %s 2>&1 | FileCheck %s
+; RUN: opt -passes=ejit-register-bitcode -ejit-warn-few-mayconst=0 -S %s 2>&1 \
+; RUN:     | FileCheck %s --check-prefix=OFF
+
+; #3: warn when the specialization closure has fewer than N ejit_may_const
+; reads. N=4 means 0..3 reads trigger the warning.
+
+; 1 read → warn (below threshold 4).
+; CHECK: EJit warning: ejit_entry function 'entry_one' has only 1 ejit_may_const read
+
+; 3 reads in the closure (direct + callee) → warn.
+; CHECK: EJit warning: ejit_entry function 'entry_three_via_helper' has only 3 ejit_may_const reads
+
+; 0 reads → warn (below threshold 4).
+; CHECK: EJit warning: ejit_entry function 'entry_zero' has only 0 ejit_may_const reads
+
+; 4 reads → at threshold → no warning.
+; CHECK-NOT: EJit warning: ejit_entry function 'entry_four'
+
+; 5 reads → above threshold → no warning.
+; CHECK-NOT: EJit warning: ejit_entry function 'entry_five'
+
+; OFF threshold (0) → no warning at all.
+; OFF-NOT: has only {{[0-9]+}} ejit_may_const read
+
+@cell_data = global [16 x i32] zeroinitializer, !ejit.metadata !10
+
+; ── 1 read: below threshold 4 → warn ──
+define i32 @entry_one(i32 %c) !ejit.metadata !20 {
+  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %c
+  %v = load i32, ptr %p, !ejit.may_const !{}
+  ret i32 %v
+}
+
+; ── 0 reads: below threshold → warn ──
+define i32 @entry_zero(i32 %c) !ejit.metadata !20 {
+  %x = add i32 %c, 1
+  ret i32 %x
+}
+
+; ── 4 reads: at threshold → no warn ──
+define i32 @entry_four(i32 %c) !ejit.metadata !20 {
+  %p0 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 0
+  %v0 = load i32, ptr %p0, !ejit.may_const !{}
+  %p1 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 1
+  %v1 = load i32, ptr %p1, !ejit.may_const !{}
+  %p2 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 2
+  %v2 = load i32, ptr %p2, !ejit.may_const !{}
+  %p3 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 3
+  %v3 = load i32, ptr %p3, !ejit.may_const !{}
+  %sum = add i32 %v0, %v1
+  %sum2 = add i32 %sum, %v2
+  %sum3 = add i32 %sum2, %v3
+  ret i32 %sum3
+}
+
+; ── 5 reads: above threshold → no warn ──
+define i32 @entry_five(i32 %c) !ejit.metadata !20 {
+  %p0 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 0
+  %v0 = load i32, ptr %p0, !ejit.may_const !{}
+  %p1 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 1
+  %v1 = load i32, ptr %p1, !ejit.may_const !{}
+  %p2 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 2
+  %v2 = load i32, ptr %p2, !ejit.may_const !{}
+  %p3 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 3
+  %v3 = load i32, ptr %p3, !ejit.may_const !{}
+  %p4 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 4
+  %v4 = load i32, ptr %p4, !ejit.may_const !{}
+  %s0 = add i32 %v0, %v1
+  %s1 = add i32 %s0, %v2
+  %s2 = add i32 %s1, %v3
+  %s3 = add i32 %s2, %v4
+  ret i32 %s3
+}
+
+; ── 3 reads in closure (1 direct + 2 in callee) → below threshold → warn ──
+define i32 @entry_three_via_helper(i32 %c) !ejit.metadata !20 {
+  %v = call i32 @helper_two(i32 %c)
+  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %c
+  %direct = load i32, ptr %p, !ejit.may_const !{}
+  %sum = add i32 %v, %direct
+  ret i32 %sum
+}
+define internal i32 @helper_two(i32 %c) {
+  %p0 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 0
+  %v0 = load i32, ptr %p0, !ejit.may_const !{}
+  %p1 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 1
+  %v1 = load i32, ptr %p1, !ejit.may_const !{}
+  %sum = add i32 %v0, %v1
+  ret i32 %sum
+}
+
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}, !{!"ejit_may_const_field", i32 0}}
+!20 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}


### PR DESCRIPTION
Add optional warning when an ejit_entry's specialization closure has fewer than N ejit_may_const reads. N=0 disables (default), N>0 enables with that threshold. Shares the BFS closure walk with the existing -ejit-report-mayconst info report.

- EJitPassOptions.cpp: add cl::opt<unsigned> EJitWarnFewMayConst
- EJitRegisterBitcode.cpp: extend guard + BFS gate, emit warning #3
- test: ejit-diag-few-mayconst.ll