### PR TITLE
[EJIT] Warn on &ejit_may_const without const qualifier

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13506,6 +13506,11 @@ def err_ejit_period_lc_no_index : Error<
 def warn_ejit_may_const_modified_without_lc : Warning<
   "modifying ejit_may_const field %0 of %1 without ejit_period_lc attribute">,
   InGroup<EmbeddedJIT>;
+def warn_ejit_may_const_addr_without_const : Warning<
+  "taking address of ejit_may_const field %0 of %1 without const qualifier; "
+  "a non-const pointer allows the field to be written outside "
+  "ejit_period_lc, breaking the JIT's time-window constancy assumption">,
+  InGroup<EmbeddedJIT>;
 def warn_ejit_undeclared_period_dep : Warning<
   "function %0 references ejit_period_arr '%1' but does not declare "
   "a dependency on it via ejit_period_arr_ind">,

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -407,6 +407,12 @@ private:
   /// If taking the address of an ejit_may_const field without const on the
   /// pointee type, warn: a non-const pointer can escape and write the field
   /// outside ejit_period_lc.
+  ///
+  /// Walks up the parent chain through transparent/semi-transparent nodes
+  /// (ParenExpr, CastExpr, UnaryOperator*, ConditionalOperator) to reach
+  /// the context that determines whether the pointer is const-protected or
+  /// directly written through.  Stops at terminals: VarDecl, CallExpr,
+  /// ReturnStmt, BinaryOperator (assignment), UnaryOperator (inc/dec).
   void checkAddrOf(UnaryOperator *UO) {
     const VarDecl *BaseVar = nullptr;
     const FieldDecl *FD =
@@ -414,34 +420,115 @@ private:
     if (!FD)
       return;
 
-    // Walk up the parent chain skipping transparent nodes (ParenExpr) to
-    // check whether the address-of result lands in a const-qualified pointer
-    // context.  The & operator always yields T*; const is added by an
-    // implicit or explicit cast.
+    // Track whether the pointer result is const-protected at any layer.
+    // A non-pointer cast (bool, intptr_t) terminates the walk: no writable
+    // pointer escapes.
+    bool ConstProtected = false;
     DynTypedNode CurNode = DynTypedNode::create(*UO);
+
     for (;;) {
       auto Parents = S.getASTContext().getParents(CurNode);
       if (Parents.empty())
-        break;
+        break; // no parent → conservative: warn
       const DynTypedNode &Parent = Parents[0];
 
-      if (Parent.get<ParenExpr>()) {
+      // Transparent nodes: skip and continue.
+      if (isa<ParenExpr>(Parent.get<Stmt>())) {
         CurNode = Parent;
         continue;
       }
-      if (const auto *UOInner = Parent.get<UnaryOperator>())
-        if (UOInner->getOpcode() == UO_Deref)
-          return; // *&field — no persistent writable pointer escapes
-      if (const auto *CE = Parent.get<CastExpr>()) {
-        QualType QT = CE->getType();
-        if (!QT->isPointerType())
-          return; // converted to non-pointer (e.g. bool, intptr_t) — no
-                  // writable pointer escapes
-        if (QT->getPointeeType().isConstQualified())
-          return; // cast to const T* — safe, cannot write through this pointer
+      if (isa<AbstractConditionalOperator>(Parent.get<Stmt>())) {
+        CurNode = Parent;
+        continue; // type flows through the branches
       }
-      break; // stop at first non-transparent parent
+
+      // Cast: track whether const qualification was added or stripped.
+      if (const auto *CE =
+              dyn_cast_or_null<CastExpr>(Parent.get<Stmt>())) {
+        QualType CastTy = CE->getType();
+        if (!CastTy->isPointerType())
+          return; // converted to non-pointer — no writable pointer escapes
+        const Expr *Sub = CE->getSubExpr();
+        if (Sub && Sub->getType()->isPointerType()) {
+          const auto *CastPT = dyn_cast<PointerType>(CastTy.getTypePtr());
+          const auto *SubPT =
+              dyn_cast<PointerType>(Sub->getType().getTypePtr());
+          bool CastConst = CastPT &&
+                           CastPT->getPointeeType().isConstQualified();
+          bool SubConst =
+              SubPT && SubPT->getPointeeType().isConstQualified();
+          if (CastConst && !SubConst)
+            ConstProtected = true;  // cast added const to pointee
+          else if (!CastConst && SubConst)
+            ConstProtected = false; // cast stripped const from pointee
+        }
+        CurNode = Parent;
+        continue;
+      }
+
+      // *&field: the pointer is consumed by the deref.  Walk past it — the
+      // deref result is the field's value (or an lvalue that may be written).
+      // Mark ConstProtected so non-write terminals (value copy, function arg)
+      // do not false-positive; write terminals will reset it below.
+      if (const auto *UOInner =
+              dyn_cast_or_null<UnaryOperator>(Parent.get<Stmt>()))
+        if (UOInner->getOpcode() == UO_Deref) {
+          ConstProtected = true; // pointer consumed — no writable pointer exists
+          CurNode = Parent;
+          continue;
+        }
+
+      // --- Terminal nodes: the walk ends, decide below ---
+
+      // Declaration: the declared type may add const protection.
+      // Check the pointee directly through PointerType to avoid
+      // QualType::getPointeeType's fast-qualifier merging.
+      if (const auto *VD =
+              dyn_cast_or_null<VarDecl>(Parent.get<Decl>())) {
+        if (!ConstProtected) {
+          if (const auto *PT =
+                  dyn_cast<PointerType>(VD->getType().getTypePtr()))
+            if (PT->getPointeeType().isConstQualified())
+              return; // const T* → safe
+        }
+        break;
+      }
+
+      // Call argument: the pointer escapes through a function parameter.
+      if (isa<CallExpr>(Parent.get<Stmt>())) {
+        break; // warn unless const-protected
+      }
+
+      // Return: the pointer escapes to the caller.
+      if (isa<ReturnStmt>(Parent.get<Stmt>())) {
+        break;
+      }
+
+      // Assignment or inc/dec on the dereferenced result: a write through
+      // the address — always warn, even if the pointer was const-cast.
+      if (const auto *BO =
+              dyn_cast_or_null<BinaryOperator>(Parent.get<Stmt>())) {
+        if (BO->isAssignmentOp() || BO->isCompoundAssignmentOp()) {
+          ConstProtected = false; // being written → warn
+          break;
+        }
+        break; // other binary op — check ConstProtected
+      }
+      if (const auto *UO2 =
+              dyn_cast_or_null<UnaryOperator>(Parent.get<Stmt>())) {
+        if (UO2->isIncrementDecrementOp()) {
+          ConstProtected = false; // being written → warn
+          break;
+        }
+        break;
+      }
+
+      // Any other parent we cannot classify: conservative, warn.
+      break;
     }
+
+    if (ConstProtected)
+      return;
 
     if (BaseVar)
       S.Diag(UO->getOperatorLoc(),

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/ParentMapContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/RecursiveASTVisitor.h"
@@ -363,6 +364,18 @@ static const FieldDecl *findMayConstWriteTarget(Expr *E,
     if (auto *VD = dyn_cast<VarDecl>(DRE->getDecl()))
       BaseVar = VD;
 
+  // The EjitMayConstAttr lives on the FieldDecl and applies to every struct
+  // instance.  Suppress the warning when the base is a local struct copy
+  // (value type, not pointer/reference), which does not alias period data.
+  // Pointers and references are kept because they may point to period data
+  // even though the variable itself lacks a period annotation.
+  if (BaseVar &&
+      !BaseVar->hasAttr<EjitPeriodArrAttr>() &&
+      !BaseVar->hasAttr<EjitPeriodAttr>() &&
+      !BaseVar->getType()->isPointerType() &&
+      !BaseVar->getType()->isReferenceType())
+    return nullptr;
+
   return FD;
 }
 
@@ -385,10 +398,61 @@ public:
   bool VisitUnaryOperator(UnaryOperator *UO) {
     if (UO->isIncrementDecrementOp())
       checkWrite(UO->getSubExpr(), UO->getOperatorLoc());
+    else if (UO->getOpcode() == UO_AddrOf)
+      checkAddrOf(UO);
     return true;
   }
 
 private:
+  /// If taking the address of an ejit_may_const field without const on the
+  /// pointee type, warn: a non-const pointer can escape and write the field
+  /// outside ejit_period_lc.
+  void checkAddrOf(UnaryOperator *UO) {
+    const VarDecl *BaseVar = nullptr;
+    const FieldDecl *FD =
+        findMayConstWriteTarget(UO->getSubExpr(), BaseVar);
+    if (!FD)
+      return;
+
+    // Walk up the parent chain skipping transparent nodes (ParenExpr) to
+    // check whether the address-of result lands in a const-qualified pointer
+    // context.  The & operator always yields T*; const is added by an
+    // implicit or explicit cast.
+    DynTypedNode CurNode = DynTypedNode::create(*UO);
+    for (;;) {
+      auto Parents = S.getASTContext().getParents(CurNode);
+      if (Parents.empty())
+        break;
+      const DynTypedNode &Parent = Parents[0];
+
+      if (Parent.get<ParenExpr>()) {
+        CurNode = Parent;
+        continue;
+      }
+      if (const auto *UOInner = Parent.get<UnaryOperator>())
+        if (UOInner->getOpcode() == UO_Deref)
+          return; // *&field — no persistent writable pointer escapes
+      if (const auto *CE = Parent.get<CastExpr>()) {
+        QualType QT = CE->getType();
+        if (!QT->isPointerType())
+          return; // converted to non-pointer (e.g. bool, intptr_t) — no
+                  // writable pointer escapes
+        if (QT->getPointeeType().isConstQualified())
+          return; // cast to const T* — safe, cannot write through this pointer
+      }
+      break; // stop at first non-transparent parent
+    }
+
+    if (BaseVar)
+      S.Diag(UO->getOperatorLoc(),
+             diag::warn_ejit_may_const_addr_without_const)
+          << FD << BaseVar;
+    else
+      S.Diag(UO->getOperatorLoc(),
+             diag::warn_ejit_may_const_addr_without_const)
+          << FD << FD->getParent();
+  }
+
   /// If \p Target designates an ejit_may_const field, emit the warning.
   void checkWrite(Expr *Target, SourceLocation Loc) {
     const VarDecl *BaseVar = nullptr;
@@ -422,10 +486,13 @@ void checkEjitMayConstWrites(Sema &S, const FunctionDecl *FD, Stmt *Body) {
   if (FD->hasAttr<EjitPeriodLcAttr>())
     return;
 
-  // Skip the traversal entirely when the warning is disabled
+  // Skip the traversal entirely when BOTH diagnostics are disabled
   // (e.g. -Wno-embedded-jit), matching the AnalysisBasedWarnings pattern.
+  // If either warning is enabled the visitor must run — it emits both.
   if (S.getDiagnostics().isIgnored(
-          diag::warn_ejit_may_const_modified_without_lc, FD->getLocation()))
+          diag::warn_ejit_may_const_modified_without_lc, FD->getLocation()) &&
+      S.getDiagnostics().isIgnored(
+          diag::warn_ejit_may_const_addr_without_const, FD->getLocation()))
     return;
 
   EjitMayConstWriteVisitor Visitor(S);

--- a/clang/test/Sema/ejit_may_const_warn_toggle.cpp
+++ b/clang/test/Sema/ejit_may_const_warn_toggle.cpp
@@ -18,6 +18,8 @@ __attribute__((ejit_period_arr("cell"))) struct S g_s[2];
 void write_without_lc(int i) {
   g_s[i].a = 1; // on-warning {{modifying ejit_may_const field 'a' of 'g_s' without ejit_period_lc attribute}} explicit-warning {{modifying ejit_may_const field 'a' of 'g_s' without ejit_period_lc attribute}}
   g_s[i].b = 1; // no warning: 'b' is not ejit_may_const
+  int *p1 = &g_s[i].a;        // on-warning {{taking address of ejit_may_const field 'a' of 'g_s' without const qualifier}} explicit-warning {{taking address of ejit_may_const field 'a' of 'g_s' without const qualifier}}
+  const int *p2 = &g_s[i].a;  // no warning: const qualified
 }
 
 // ejit_period_lc sanctions the write -> never warns, under any toggle.

--- a/clang/test/Sema/ext_attr_ejit.cpp
+++ b/clang/test/Sema/ext_attr_ejit.cpp
@@ -74,6 +74,19 @@ void bad_writer(int i, int v) {
   (void)r;
   int *p1 = &g_warn[i].cellType;        // expected-warning {{taking address of ejit_may_const field 'cellType' of 'g_warn' without const qualifier}}
   const int *p2 = &g_warn[i].cellType;  // no warning: const qualifier on pointee
+  *&g_warn[i].cellType = v;             // expected-warning {{taking address of ejit_may_const field 'cellType' of 'g_warn' without const qualifier}}
+  (*&g_warn[i].cellType)++;             // expected-warning {{taking address of ejit_may_const field 'cellType' of 'g_warn' without const qualifier}}
+  (void)(*&g_warn[i].cellType);         // no warning: deref consumed pointer, no writable pointer escapes
+}
+
+// Pointer-based access: p may alias period data -> warn.
+void via_pointer(struct WarnCfg *p) {
+  p->cellType = 5;  // expected-warning {{modifying ejit_may_const field 'cellType' of 'p' without ejit_period_lc attribute}}
+}
+
+// Nested cast: outer (int*) strips const added by inner (const int*) -> warn.
+void nested_const_cast(int i) {
+  int *p = (int *)(const int *)&g_warn[i].cellType;  // expected-warning {{taking address of ejit_may_const field 'cellType' of 'g_warn' without const qualifier}}
 }
 
 // An ejit_period_lc function is sanctioned to modify may_const fields -> no warning.

--- a/clang/test/Sema/ext_attr_ejit.cpp
+++ b/clang/test/Sema/ext_attr_ejit.cpp
@@ -72,6 +72,8 @@ void bad_writer(int i, int v) {
   g_warn[i].plain = v;     // no warning: 'plain' is not ejit_may_const
   int r = g_warn[i].cellType; // no warning: read, not a write
   (void)r;
+  int *p1 = &g_warn[i].cellType;        // expected-warning {{taking address of ejit_may_const field 'cellType' of 'g_warn' without const qualifier}}
+  const int *p2 = &g_warn[i].cellType;  // no warning: const qualifier on pointee
 }
 
 // An ejit_period_lc function is sanctioned to modify may_const fields -> no warning.
@@ -79,6 +81,7 @@ __attribute__((ejit_period_lc("cell")))
 void good_writer(__attribute__((ejit_period_arr_ind("cell"))) int i, int v) {
   g_warn[i].cellType = v;  // no warning: ejit_period_lc sanctions the write
   g_warn[i].flags += v;    // no warning
+  int *p1 = &g_warn[i].cellType;        // no warning: lc is exempt
 }
 
 // === Warning: always_inline conflicts with ejit_entry / ejit_period_lc ===


### PR DESCRIPTION
Add Sema warning when taking the address of an ejit_may_const field without a const qualifier on the pointee type. A non-const pointer can escape and write the field outside ejit_period_lc, breaking the JIT's time-window constancy assumption.

- DiagnosticSemaKinds.td: add warn_ejit_may_const_addr_without_const
- SemaEJIT.cpp: EjitMayConstWriteVisitor gains checkAddrOf with parent-chain walk (skips ParenExpr, detects const CastExpr and *& cancellation).  findMayConstWriteTarget now suppresses for local struct copies (value types without period attr).
- isIgnored guard now checks both diagnostics so suppressing one does not silently disable the other.
- Tests: ext_attr_ejit.cpp (write + addr-of), toggle (on/off/explicit)