### PR TITLE
Replace hardcoded registry entry type integers with enum constants

### DIFF
--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -36,6 +36,7 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -809,7 +810,7 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
     auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
         GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
     Entries.push_back(ConstantStruct::get(EntryTy, {
-        ConstantInt::get(I32Ty, 0),                          // EJIT_REG_BITCODE
+        ConstantInt::get(I32Ty, EJIT_REG_BITCODE),           // EJIT_REG_BITCODE
         ConstantExpr::getBitCast(NameGV, PtrTy),             // name1 string
         ConstantPointerNull::get(PtrTy),                     // name2 = NULL
         ConstantExpr::getBitCast(BitcodeGV, PtrTy),          // bitcode data ptr
@@ -827,7 +828,7 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
         auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
             GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
         Entries.push_back(ConstantStruct::get(EntryTy, {
-            ConstantInt::get(I32Ty, 3),                      // EJIT_REG_SYMBOL
+            ConstantInt::get(I32Ty, EJIT_REG_SYMBOL),                      // EJIT_REG_SYMBOL
             ConstantExpr::getBitCast(NameGV, PtrTy),         // name1 string
             ConstantPointerNull::get(PtrTy),
             ConstantExpr::getBitCast(const_cast<Function *>(F), PtrTy),
@@ -869,7 +870,7 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
           auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
               GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
           Entries.push_back(ConstantStruct::get(EntryTy, {
-              ConstantInt::get(I32Ty, 3),                // EJIT_REG_SYMBOL
+              ConstantInt::get(I32Ty, EJIT_REG_SYMBOL),                // EJIT_REG_SYMBOL
               ConstantExpr::getBitCast(NameGV, PtrTy),   // name1 string
               ConstantPointerNull::get(PtrTy),
               ConstantExpr::getBitCast(

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterPeriod.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterPeriod.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -156,7 +157,7 @@ generateRegistryTablePeriod(
   // Period array entries
   for (auto &[GV, PeriodName, VarName, Size] : PeriodArrays) {
     Entries.push_back(ConstantStruct::get(EntryTy, {
-        ConstantInt::get(I32Ty, 1),                  // EJIT_REG_PERIOD_ARRAY
+        ConstantInt::get(I32Ty, EJIT_REG_PERIOD_ARRAY),       // EJIT_REG_PERIOD_ARRAY
         makeStrGV(PeriodName),
         makeStrGV(VarName),
         ConstantExpr::getBitCast(GV, PtrTy),         // base address
@@ -167,7 +168,7 @@ generateRegistryTablePeriod(
   // Static var entries
   for (auto &[GV, VarName] : StaticVars) {
     Entries.push_back(ConstantStruct::get(EntryTy, {
-        ConstantInt::get(I32Ty, 2),                  // EJIT_REG_STATIC_VAR
+        ConstantInt::get(I32Ty, EJIT_REG_STATIC_VAR),           // EJIT_REG_STATIC_VAR
         makeStrGV(VarName),
         ConstantPointerNull::get(PtrTy),
         ConstantExpr::getBitCast(GV, PtrTy),

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include <map>
 #include <string>
+#include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -206,7 +207,7 @@ emitLifecycleRegistration(Module &M,
   SmallVector<Constant *, 16> Entries;
   for (auto &KV : LCs) {
     Entries.push_back(ConstantStruct::get(
-        EntryTy, {ConstantInt::get(I32Ty, 5), // EJIT_REG_LIFECYCLE
+        EntryTy, {ConstantInt::get(I32Ty, EJIT_REG_LIFECYCLE),
                   makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
                   ConstantExpr::getBitCast(KV.second, PtrTy),
                   ConstantInt::get(I64Ty, 0)}));
@@ -341,7 +342,7 @@ emitFuncIndexRegistration(Module &M,
   SmallVector<Constant *, 16> Entries;
   for (auto &KV : Fns) {
     Entries.push_back(ConstantStruct::get(
-        EntryTy, {ConstantInt::get(I32Ty, 6), // EJIT_REG_FUNCINDEX
+        EntryTy, {ConstantInt::get(I32Ty, EJIT_REG_FUNCINDEX),
                   makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
                   ConstantExpr::getBitCast(KV.second, PtrTy),
                   ConstantInt::get(I64Ty, 0)}));
@@ -418,7 +419,7 @@ emitIcacheSlotRegistration(Module &M,
   SmallVector<Constant *, 16> Entries;
   for (auto &KV : Fns) {
     Entries.push_back(ConstantStruct::get(
-        EntryTy, {ConstantInt::get(I32Ty, 7), // EJIT_REG_ICACHE_SLOT
+        EntryTy, {ConstantInt::get(I32Ty, EJIT_REG_ICACHE_SLOT),
                   makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
                   ConstantExpr::getBitCast(KV.second.GV, PtrTy),
                   ConstantInt::get(I64Ty, KV.second.NumDims)}));


### PR DESCRIPTION
The AOT passes used magic integers (0,1,2,3,5,6,7) for `ejit_reg_entry_t` types instead of the named enum constants from `EJitRegistryEntry.h`. If the enum order ever changes, the AOT-generated `.ejit_period` entries would carry wrong type tags and the runtime walker would silently misidentify them.

Changes:
- Include `EJitRegistryEntry.h` in `EJitRegisterBitcode.cpp`, `EJitRegisterPeriod.cpp`, `EJitWrapperGen.cpp`
- Replace all magic integers with `EJIT_REG_BITCODE`, `EJIT_REG_PERIOD_ARRAY`, `EJIT_REG_STATIC_VAR`, `EJIT_REG_SYMBOL`, `EJIT_REG_LIFECYCLE`, `EJIT_REG_FUNCINDEX`, `EJIT_REG_ICACHE_SLOT`

The runtime walker (`EJit.cpp`) already uses the enum names, so the two sides now derive from the same source.

Found during a wider audit after fixing the `EJIT_ICACHE_DIM_SIZE` D-value mismatch (PR #128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)