### PR TITLE
[EJIT] Move the inline-cache cell table into shared memory

### DIFF
--- a/jit_design_doc/EJIT_ICACHE_MULTIVERSION.md
+++ b/jit_design_doc/EJIT_ICACHE_MULTIVERSION.md
@@ -1,4 +1,9 @@
-# EJIT Multi-Version Inline Cache (Direct-Indexed, Per-Core Private)
+# EJIT Multi-Version Inline Cache (Direct-Indexed)
+
+> **Storage update:** the cell table is no longer per-core private. It now lives
+> in the inter-core shared section and is invalidated by zeroing the cells
+> cross-core. See `EJIT_ICACHE_SHARED_TABLE.md`; the sections below marked
+> *(superseded)* describe the earlier per-core layout.
 
 > Extends the v2 sticky-monomorphic inline cache (`ejit_icache_design.md`) to
 > **polymorphic** specialization: one cached slot per `(instanceId…)` identity,
@@ -45,7 +50,7 @@ hit-path compare becomes mandatory (future work, out of scope here).
 
 ## 3. Data structure
 
-### Per-function AOT global (per-core private)
+### Per-function AOT global *(placement superseded — see EJIT_ICACHE_SHARED_TABLE.md)*
 ```c
 // numDims = 0  -> ptr  g_funcA_cache;                 // scalar (= v2)
 // numDims = 1  -> ptr  g_funcA_cache[D];
@@ -60,14 +65,13 @@ instanceId/version/generation: direct indexing has no collision within bounds,
 so no validation fields are needed (this is the key hit-overhead saving vs a
 hash+validate cache).
 
-Emitted by `EJitWrapperGen` as an InternalLinkage global in **default section**
-(`.bss`). Under the SRE memory model (per-core private by default; only
-`EJIT_SHARED_SECTION_ATTR`/`.mc_shared` is cross-core shared), this global is
-**per-core private** - exactly like the v2 `@__ejit_icache_fn_<name>`. Each core
-owns its own cache array; this is what lets the hit path have no cross-core gate
-(see `ejit-runtime-environment-facts` C3, `ejit-icache-slots-per-core-private`).
+Emitted by `EJitWrapperGen` as an InternalLinkage global in
+`EJIT_ICACHE_SECTION`, which defaults to `.mc_shared` — **cross-core shared**, so
+one table backs every core and a period toggle can zero a peer's cells directly.
+Set the variable to `""` to restore the earlier per-core `.bss` placement (on a
+multi-core target the default section is per-image private).
 
-### Runtime registration table (per-core private)
+### Runtime registration table (per-core private; the CELLS it points at are shared)
 ```c
 struct EJitIcacheSlotReg {
   uintptr_t *base;    // &g_funcA_cache (this core's private global)
@@ -217,7 +221,12 @@ cell = UAF. The gate disables `icacheFill` (no-op) when a releaser is wired.
 no runtime gate, so under a releaser it would still fire and UAF - production
 wires no releaser, so the gate stays open. Same contract as v2.
 
-### Per-core seal (carries over per-cell)
+### Per-core seal *(superseded)*
+This argument held while the array was per-core private, and is exactly what a
+shared table gives up: see precondition P1 in `EJIT_ICACHE_SHARED_TABLE.md`,
+where `icacheCrossCoreExecutable()` disables the fill in builds that need
+per-core preparation. Original text:
+
 The icache array is per-core private. A core fills cell `(i0,…)` only on its own
 `compile_or_get` slow path, which for a non-owner runs `peerPrepareSlot` ->
 `prepareExecForCurrentCore` -> `sealAndSyncCache` (seal + DC CVAU/IC IVAU on THIS
@@ -228,9 +237,10 @@ path safe (see `ejit-icache-slots-per-core-private`). Each cell is sealed-then-
 filled independently per core.
 
 ### Version (no check)
-By precondition (§2.1), same instanceId = stable specialization; under NO_RECLAIM
-the cached fnPtr never dangles and never goes wrong. No version field, no
-hit-path compare.
+No version field and no hit-path compare — but *(superseded)* the reasoning is no
+longer precondition §2.1. A period toggle now **zeroes** the cells
+(`icacheDrainAll`), so a cell only ever holds a specialization current under the
+present period values. Under NO_RECLAIM the cached fnPtr never dangles.
 
 ## 7. Configuration
 
@@ -240,6 +250,7 @@ hit-path compare.
 | `EJIT_ICACHE_DIM_SIZE` (CMake -> `#define` on both LLVMEmbeddedJIT + LLVMEJIT) | 16 (power-of-2) | uniform per-dim bound D |
 | `EJIT_ICACHE_MAX_DIMS` (header `#define`) | 4 | max cached dims; >N -> compile error |
 | `EJIT_ICACHE_FUNC_SLOTS` | 64 | registration table size (unchanged) |
+| `EJIT_ICACHE_SECTION` (CMake -> `#define` on LLVMEmbeddedJIT) | `.mc_shared` | section for the cell table; `""` = per-core `.bss` |
 
 **Wiring (one CMake var drives both AOT and runtime so D agrees):**
 ```cmake
@@ -252,8 +263,8 @@ Both use the `#ifndef EJIT_ICACHE_DIM_SIZE` default (16) from `EJitCommon.h` if
 CMake doesn't override. The preset sets `EJIT_ICACHE_DIM_SIZE=16`. **Power-of-2 D
 is required**; a non-power-of-2 value is **rejected at CMake configure**.
 
-### Memory budget (per function, per core)
-`D^numDims * 8` bytes, zero-filled (`.bss`, no ctor).
+### Memory budget (per function; ONCE, not per core — see EJIT_ICACHE_SHARED_TABLE.md)
+`D^numDims * 8` bytes, zero-filled.
 
 | D \ numDims | 0 | 1 | 2 | 3 | 4 |
 |---|---|---|---|---|---|
@@ -261,9 +272,9 @@ is required**; a non-power-of-2 value is **rejected at CMake configure**.
 | 8 | 8B | 64B | 512B | 4KB | 32KB |
 | 16 | 8B | 128B | 2KB | 32KB | 512KB |
 
-×32 cores × N `ejit_entry` functions. D=16 + maxDims=4 is a safe default
-(≤32KB/func/core at 4 dims); D=16 + maxDims=2 keeps every function ≤2KB. The
-product picks D + maxDims to fit the per-core BSS budget.
+× N `ejit_entry` functions (no longer × cores — the table is shared). D=16 +
+maxDims=4 is a safe default (≤32KB/func at 4 dims); D=16 + maxDims=2 keeps every
+function ≤2KB. The product picks D + maxDims to fit the shared-region budget.
 
 ## 8. AOT changes - `EJitWrapperGen`
 

--- a/jit_design_doc/EJIT_ICACHE_SHARED_TABLE.md
+++ b/jit_design_doc/EJIT_ICACHE_SHARED_TABLE.md
@@ -87,6 +87,16 @@ one shared bit, so a caller that lost the CAS may still have rewritten its copy.
 `version[]` still moves only on a real transition — its consumer discards an
 in-flight compile, and nothing re-enqueues a dropped one.
 
+**Cost, and prefer the bulk entry points.** A drain is O(registered slots ×
+`D^numDims`), and only `ejit_activate_all` / `ejit_deactivate_all` batch it —
+`setAllInstancesEnabled` does the CAS loop, then one `dispatchEpoch` bump and one
+drain. `ejit_activate` / `ejit_deactivate` / `ejit_set_instance_enabled` each go
+straight to `setInstanceEnabled`, so bringing 256 instances up one at a time at
+startup costs 256 full table walks and 256 epoch bumps, with the in-flight
+counter raised throughout (which also blocks concurrent fills). Use the bulk
+calls for bring-up; the per-instance ones are for steady-state toggles, where one
+drain per toggle is the intended behaviour.
+
 ### 3.3 Fill guard
 
 The one non-benign interleaving is a **fill landing after a drain**: the pointer
@@ -106,6 +116,15 @@ moved. The counter (not just the sequence) is what stops a fill slipping into a
 cell a drain has passed but not yet accounted for, and makes concurrent drains
 safe. The token is a **stack value**, not runtime state: on an RTOS a
 higher-priority task can preempt a resolve and run its own.
+
+Those checks can only *precede* the store, so they cannot cover it: a drain
+beginning after they pass can zero the cell and finish before the store lands,
+stranding a pre-toggle specialization nothing clears again — and a preempted
+filler makes that window unbounded. So the fill publishes optimistically, then
+re-reads `icacheDrainsInFlight` and `icacheDrainSeq` and writes 0 back on
+conflict. An overlapping drain has either bumped the sequence or is still in
+flight, so both are visible. Retracting discards only this core's own fill —
+under P1 no other core writes that cell — and a null cell is always safe.
 
 The probe reads none of this.
 
@@ -148,6 +167,22 @@ consults `icacheCrossCoreExecutable()` and declines unless a resolved pointer is
 callable everywhere the instant it exists; the cell then stays empty and the
 taskpool serves every call. The AOT probe is still emitted — the code is platform
 independent, only the fill is not.
+
+What counts as per-core preparation is deliberately narrow: **only a wired
+`prepareCodeFn_`** (the legacy whole-2MiB path). 4K-seal mode does not, because
+the seal acts on an address space every core translates through — a page sealed
+by one core is executable on all of them, and the per-core split the taskpool
+performs is bookkeeping over a shared mapping rather than a precondition for the
+jump. Counting the seal here left every 0-dim entry permanently unfillable on the
+only platform the inline cache ships on, paying the full taskpool path on every
+call for a shape that is safe there.
+
+> If a 0-dim entry ever faults on a peer core, this is the assumption to
+> re-check first. `EJitSharedPoolSplit` tracks `splitDoneMask` per core, which is
+> the runtime modelling the split as per-core state — consistent with per-core
+> bookkeeping over a shared mapping, but also with the mapping not being shared
+> at all. The board-side check is `ejit_icache_multiverify_test`'s `f_0`
+> executing on cores that never resolved it themselves.
 
 For a *dimensioned* entry `icacheFill` does **not** consult that gate. An earlier
 revision did, and it made the feature inert on every real target:

--- a/jit_design_doc/EJIT_ICACHE_SHARED_TABLE.md
+++ b/jit_design_doc/EJIT_ICACHE_SHARED_TABLE.md
@@ -1,0 +1,308 @@
+# EJIT Inline Cache: Shared Partitioned Cell Table
+
+> Moves the `@__ejit_icache_fn_<name>` cell table from per-core `.bss` into the
+> inter-core shared section, so one index-partitioned table backs every core. A
+> period toggle then invalidates by zeroing the cells in place, which reaches
+> every core directly — no state on the probe, no per-core drain rendezvous, no
+> sync entry point for the application.
+>
+> Builds on `-ejit-inline-cache` (`EJIT_ICACHE_MULTIVERSION.md`), which owns the
+> `[D]^numDims` direct-indexed shape and the frame-less wrapper.
+
+---
+
+## 1. Problem
+
+The probe is four instructions inside `ejit_entry`, so it **cannot ask whether
+the cell is still valid** without ceasing to be four instructions. Invalidation
+has to happen *to the cell*, from outside.
+
+With the table in per-core `.bss`, a deactivate could only reach the table of
+the core it ran on. A permanently hot peer — one that never misses, so never
+calls the runtime again — kept executing a specialization baked from period
+values that had already been replaced, and nothing in the system could reach it.
+
+## 2. Hit path
+
+Unchanged by this patch except that the load is now `atomic monotonic` (the
+writer can be another core, so the concurrent drain must be a defined race
+rather than UB; `monotonic` is the same `LDR` on AArch64).
+
+```llvm
+jit_entry:                                          ; frame-less
+  %ejit_ic_slot = getelementptr inbounds [16 x ptr], ptr @__ejit_icache_fn_one_dim_entry, i32 0, i32 %idx1
+  %ejit_ic_fn   = load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
+  %hit          = icmp ne ptr %ejit_ic_fn, null
+  br i1 %hit, label %jit_icache_dispatch, label %jit_miss
+
+jit_icache_dispatch:
+  %r = musttail call i32 %ejit_ic_fn(i32 %idx1)     ; lowers to br
+  ret i32 %r
+```
+
+```asm
+one_dim_entry:
+  adrp  x8, __ejit_icache_fn_one_dim_entry
+  add   x8, x8, #:lo12:__ejit_icache_fn_one_dim_entry
+  ldr   x1, [x8, w0, sxtw #3]      ; the cell
+  cbz   x1, .Lmiss
+  br    x1                          ; tail-call the specialization
+.Lmiss:
+  b     one_dim_entry_miss
+```
+
+No funcIndex guard, no version check, no read token, no call. Everything else —
+L0, the bucket lookup, the compile scheduler — is out of line in `MissFn`.
+
+## 3. Design
+
+### 3.1 Storage
+
+`EJitWrapperGen` emits `@__ejit_icache_fn_<name>` into `EJIT_ICACHE_SECTION`
+(default `.mc_shared`), the region the taskpool blob and period data already use.
+
+```
+              .mc_shared  (ONE object, every core sees it)
+   ┌──────────────────────────────────────────────────────┐
+   │ @__ejit_icache_fn_foo[D]                             │
+   │  [0] [1] [2] [3]  │  [4] [5] [6] [7]  │  ...         │
+   └─── core A writes ─┴─── core B writes ─┴──────────────┘
+   Both cores READ all of it. A drain on ANY core clears all of it.
+```
+
+The index is `icacheLinearize(dims)` — row-major Horner over the `instanceId`s,
+which must match the AOT GEP's dimension order (`dim0` = leftmost `ejit_dim`).
+
+### 3.2 Invalidation
+
+`setInstanceEnabled` calls `icacheDrainAll()` at both ends of the period mutation
+window; it zeroes every cell of every registered slot, so a peer's next probe
+loads 0. Also driven from `retireDispatchCache()` (`ejit_clear_cache`,
+`ejit_invalidate`, compile-mode change, `setReleaser`), `ownerShutdown()`, and
+owner init.
+
+It runs on **every** `setInstanceEnabled` call, not only the one that moves the
+shared `enabled` bit: N cores bracket their own core-private period writes over
+one shared bit, so a caller that lost the CAS may still have rewritten its copy.
+`version[]` still moves only on a real transition — its consumer discards an
+in-flight compile, and nothing re-enqueues a dropped one.
+
+### 3.3 Fill guard
+
+The one non-benign interleaving is a **fill landing after a drain**: the pointer
+was resolved pre-toggle, so the cell would come back holding a stale
+specialization and nothing would clear it again.
+
+```
+taskpool entry   token = icacheBeginResolve()   // drainsInFlight==0 ? seq : invalid
+   ... resolve ...
+on success       icacheFill(..., token)         // drop unless still 0 / unchanged
+```
+
+`icacheDrainAll()` raises `icacheDrainsInFlight` before the first cell store and
+lowers it after the `icacheDrainSeq` bump, so the pair brackets the whole drain.
+A fill is accepted only if in-flight was 0 at both ends and the sequence never
+moved. The counter (not just the sequence) is what stops a fill slipping into a
+cell a drain has passed but not yet accounted for, and makes concurrent drains
+safe. The token is a **stack value**, not runtime state: on an RTOS a
+higher-priority task can preempt a resolve and run its own.
+
+The probe reads none of this.
+
+### 3.4 Drain accounting across reinitialization
+
+`setInstanceEnabled` does not require Ready, so a peer drain can still be walking
+when a new owner claims the blob. A drain therefore stamps itself with the
+generation it announced under and retires its increment (via
+`ejitIcacheRetireDrain`) only if that generation still stands; the owner clears
+the counter only **after** publishing the new generation. Without both, the
+straggler's `fetchSub` takes `0 - 1` to `UINT32_MAX`, after which
+`icacheBeginResolve()` refuses every token forever and no later drain repairs it.
+The retire also saturates at zero.
+
+## 4. Preconditions
+
+**P1 — cores drive disjoint dim identities.** Assumed, not enforced, and the real
+cost of this design. The cell index is the dim identity, not the core id, so
+"partitioned by core" holds only insofar as the application gives each core its
+own `ejit_period_lc` instance indices.
+
+If it holds, no core ever *reads* a cell another core filled: every pointer it
+loads is one it put there after resolving through the taskpool, which is where it
+did whatever per-core execute preparation the platform needs. That is the
+implication a per-core `.bss` table gave structurally, now carried by the
+deployment model. If it does not hold, the colliding cores store the same value
+so the *result* is right, but under 4K seal or a wired `prepareCodeFn_` the
+second core branches into a page it never sealed.
+
+Nothing in the runtime can check it: a cell carries no record of which core wrote
+it, and adding one puts a per-core gate back on the probe.
+
+> **Contract:** each core drives its own `ejit_period_lc` instance indices, and
+> no two cores call one `ejit_entry` with the same `ejit_dim` values.
+
+**P1a — the 0-dim exception, which IS enforced.** An entry with no `ejit_dim`
+params has one cell and no identity to partition it by, so P1 cannot cover it:
+core B necessarily reads what core A wrote. For `numDims == 0` `icacheFill`
+consults `icacheCrossCoreExecutable()` and declines unless a resolved pointer is
+callable everywhere the instant it exists; the cell then stays empty and the
+taskpool serves every call. The AOT probe is still emitted — the code is platform
+independent, only the fill is not.
+
+For a *dimensioned* entry `icacheFill` does **not** consult that gate. An earlier
+revision did, and it made the feature inert on every real target:
+`EJitCompileDriver` sets `fourKSeal_` under `EJIT_CODE_POOL_4K_SEAL` and wires
+`prepareCodeFn_` otherwise, both inside `EJIT_SRE_SHARED_CODE_POINTERS` which the
+probe requires, so the gate was closed in every build the cache was allowed in.
+
+**P2 — placement must match the deployment.** `EJIT_ICACHE_SECTION` must name an
+inter-core shared section. This is a link-time contract with no runtime check: the
+symbol resolves to the same address either way, so the mistake is undetectable
+from code. CMake warns when `EJIT_SRE_SHARED_TASKPOOL + EJIT_FREESTANDING` is
+configured with an empty section. See §8.
+
+**P3 — `ejit_dim` values stay in `[0, D)`.** The accepted ranges never agreed: the
+taskpool takes instance ids up to 256 and a period array may declare up to 100
+entries, against a `D` of 16. The probe indexes with the raw argument, so an id of
+16 would read past the wrapper's global into its neighbour in `.mc_shared`.
+
+`EJitWrapperGen` emits the probe only when the declared period-array size proves
+the bound, and `icacheFill` re-checks. A period may own several arrays activated
+as a group, so the proof uses the **maximum** over them — keeping whichever global
+the module listed last made the answer depend on declaration order, and could
+approve a 16-cell probe for a lifecycle producing identity 31. A declared count of
+0 means "not stated", which is unprovable rather than small.
+
+## 5. Reclamation
+
+In production JIT code is never freed (`EJIT_SRE_TASKPOOL_NO_RECLAIM`, bump
+allocator over sealed RX pools, no `setReleaser` on the shared pool), so a cached
+pointer cannot dangle — including one a probe loaded an instruction before a drain
+zeroed its cell.
+
+If a releaser *is* wired, the cache disables outright: `icacheFill` no-ops,
+`icacheTry` misses, and the table is drained so already-armed cells stop serving.
+
+That state lives in the **blob** (`icacheReleasersWired`), not in the facade that
+wired the releaser. One table backs every core and the probe consults no gate, so
+a core-private flag let a peer facade refill what the owner had just drained,
+after which the owner could reclaim code another core was still calling. It is a
+count, not a flag, because facades wire and unwire independently: the cache
+re-arms only when the last releaser is gone. The same reasoning applies to the
+platform property behind P1a, published as `icachePerCorePrepare`.
+
+Draining is not reclamation. A core can load a pointer microseconds before a drain
+and still be executing that code when it is freed; erasing the cell says nothing
+about callers in flight. Correct reclamation needs quiescence (RCU grace period,
+or hazard pointers published by the probe), and the probe cannot publish one
+without ceasing to be four instructions. Hence: never free, and if something ever
+can, turn the cache off.
+
+## 6. Races
+
+| Race | Outcome |
+|---|---|
+| Drain stores 0 while a probe loads | Aligned word, both sides atomic: probe reads the old pointer (one more call, misses next) or 0. Never torn. |
+| Probe loads, *then* the toggle lands, then it calls | Inherent to lock-free dispatch — the caller had committed. A freshness check just moves the window. |
+| Fill lands after a drain | The unsafe one. Closed by the in-flight/sequence token (§3.3). |
+| Two cores drain at once | Both store 0; the in-flight counter (not a parity bit) keeps overlapping drains from looking finished. |
+| Two cores fill the same cell | Same `fnPtr` — the bucket cache compiles each identity once — so the store is idempotent. Costs a shared line, not correctness. |
+| Straggler drain vs. new owner | §3.4. |
+| Task preempts a resolve and resolves too | Token is a stack value; the outer resolve keeps its own. |
+| Registration racing a drain | Registration is at init, before activation; `registrationFrozen()` rejects it after. |
+
+## 7. Configuration and API
+
+| Flag / define | Default | Effect |
+|---|---|---|
+| `-ejit-inline-cache` | off | emit the probe |
+| `EJIT_ICACHE_SECTION` (`-mllvm -ejit-icache-section=` overrides) | `.mc_shared` | section for the cell table; `""` = per-core `.bss` |
+| `EJIT_ICACHE_DIM_SIZE` | 16 | per-dim bound D |
+| `EJIT_ICACHE_MAX_DIMS` | 4 | max cached dims |
+| `EJIT_ICACHE_FUNC_SLOTS` | 4096 | registration table size (must be ≥ `EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX`) |
+
+Memory: `D^numDims * 8` bytes per cached function, allocated **once** rather than
+per core. An explicit section makes the table `PROGBITS`, not `.bss` `NOBITS`, so
+it costs those zero bytes in the image.
+
+```cpp
+constexpr uint64_t kEJitIcacheNoResolve    = 0;
+constexpr uint64_t kEJitIcacheResolveValid = uint64_t{1} << 32;
+enum class EJitIcacheRegResult { Ok, CapacityMiss, Invalid };
+
+EJitIcacheRegResult ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
+                                           uint32_t numDims);
+void ejitIcacheClearAll();   // UNregister; never dereferences a base
+void ejitIcacheRetireDrain(EJitSharedTaskPoolState *st, uint32_t gen);
+
+// EJitSharedTaskPool members
+uint64_t icacheBeginResolve();
+void     icacheFill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
+                    uint32_t numDims, uint64_t token);
+void     icacheDrainAll();
+bool     icacheCrossCoreExecutable() const;   // 0-dim fills + taskpool path
+bool     icacheReclamationSafeShared() const; // this facade's releaser AND peers'
+bool     icacheTry(...);                      // tests/diagnostics only
+
+// C ABI, called by AOT auto-registration on every core
+void ejit_register_icache_slot(const char *funcName, void *slot,
+                               uint32_t numDims);
+```
+
+Registration declines an out-of-range `funcIndex`, a null base, or `numDims`
+above the cap (it sizes the array the drain walks); the cell stays null and the
+taskpool serves that function. Shared ABI v7 → v8.
+
+## 8. Verifying on a real target
+
+Nothing in the runtime can prove the cells are shared (P2), so check placement at
+link time and behaviour at run time.
+
+```sh
+readelf -sW app.o   | grep __ejit_icache_fn_   # which section index
+readelf -SW app.o   | grep mc_shared           # is that index .mc_shared?
+readelf -SW image.elf | grep mc_shared         # linked address + size
+nm image.elf | grep __ejit_icache_fn_          # must fall inside that range
+objdump -d image.elf --disassemble=<entry> | head -8   # adrp/add/ldr/cbz/br, no bl
+```
+
+The linked-address check is the one the code cannot do for you: land outside the
+shared window and the cache silently degrades to per-core.
+
+At run time, `-mllvm -ejit-wrapper-timing` prints one line per 100000 icache hits
+(`status=254` is the hit sentinel); or watch `ejit_print_stats` — once warm,
+`cacheHits` stops growing while the application keeps calling.
+
+To prove it is *shared* rather than merely warm (a per-core table hits too):
+warm a cell on core A, toggle `ejit_deactivate`/`ejit_activate` on **core B only**,
+then re-read core A's cell — it must be 0, and core A must take exactly one extra
+miss. Comparing `&__ejit_icache_fn_foo` across cores proves nothing: per-core
+`.bss` at the same virtual address gives equal pointers to different storage.
+
+## 9. Tests
+
+`EJitSharedTaskPoolTest.cpp`:
+
+| Test | Pins |
+|---|---|
+| `InlineCacheFillAndServe` | fill → serve, re-fill, range guard |
+| `InlineCacheHighFuncIndex` | slots across the whole dense funcIndex space |
+| `InlineCacheDrainsOnPeriodToggle` | activate **and** deactivate empty the cell |
+| `InlineCacheDrainReachesEveryCorePartition` | **the core claim**: cores 1 and 2 fill disjoint cells, a toggle on core 3 clears both |
+| `InlineCacheDrainsEvenWhenTheEnableBitDoesNotMove` | lost CAS still drains; `version[]` does not move |
+| `InlineCacheDropsAFillThatRacedADrain` | stale token dropped, fresh token fills |
+| `InlineCacheFillRequiresAValidResolveToken` | `kEJitIcacheNoResolve` declined |
+| `InlineCacheDrainsOnRetireDispatchCache` / `...OnOwnerShutdown` | the other drain sites |
+| `InlineCacheRegistrationRejectsAnOverCapShape` | `numDims` cap, null base, OOR funcIndex |
+| `InlineCacheFillsWhenCoresPrepareIndividually` | **P1**: a dimensioned entry still fills under `prepareCodeFn_` and 4K seal |
+| `InlineCacheDeclinesScalarFillWhenCoresPrepareIndividually` | **P1a**: core A cannot arm a 0-dim cell core B has not prepared; still fills where the platform allows it |
+| `InlineCacheAutoDisablesWhenReclamationWired` | releaser safety gate |
+| `InlineCacheReclamationGateIsSharedAcrossFacades` | **§5**: a peer facade cannot re-arm a table the owner disabled |
+| `ReinitCannotUnderflowAStragglerDrainCounter` | **§3.4**: the old-drain/new-owner interleaving |
+| `InlineCacheMultiVersion` | per-identity cells; drain clears the whole `[D][D]` table |
+
+`ejit-wrapper-gen-icache.ll` — `SECTION` prefix asserts the tables land in
+`.mc_shared` and the probe is unchanged; every RUN pins
+`-ejit-icache-section=` so the test does not depend on the CMake default.
+`ejit-wrapper-gen-icache-period-arr-max.ll` — **P3**: both declaration orders of a
+two-array period decline the probe, while a period whose arrays all fit keeps it.

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -772,6 +772,18 @@ else()
         "Ensure the compiler was built with EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE}.")
 endif()
 
+# EJIT_ICACHE_SECTION: the section the AOT pass places the
+# @__ejit_icache_fn_<name> cell table into. Defaults to ".mc_shared", the same
+# inter-core shared region the taskpool state blob (EJIT_SHARED_SECTION_ATTR)
+# and the period data already live in. Sharing the table is what lets a
+# deactivate on any core zero the cells every other core reads.
+#
+# Set to "" to leave the table in ordinary .bss, which on a multi-core target is
+# per-core private -- a deactivate then drains only the core it runs on.
+set(EJIT_ICACHE_SECTION ".mc_shared" CACHE STRING
+  "Section for the EJIT inline-cache cell table; must be inter-core shared on a multi-core target")
+message(STATUS "EmbeddedJIT: inline-cache cell table section=${EJIT_ICACHE_SECTION}")
+
 #===-- EmbeddedJIT SRE taskpool compile scheduler -------------------------===#
 # Route ejit_compile_or_get through a unified taskpool (cache + dedup + queue)
 # instead of calling the synchronous compile driver directly. Sync and async
@@ -954,12 +966,22 @@ if(EJIT_SRE_SHARED_TASKPOOL)
   if(EJIT_SRE_SHARED_CODE_POINTERS)
     add_definitions(-DEJIT_SRE_SHARED_CODE_POINTERS)
   endif()
+  # An empty EJIT_ICACHE_SECTION puts the inline-cache cells in per-core .bss,
+  # where a period toggle on one core cannot drain another's. Warn rather than
+  # fail: -ejit-inline-cache is opt-in per application TU.
+  if(EJIT_FREESTANDING AND NOT EJIT_ICACHE_SECTION)
+    message(WARNING
+      "EJIT_SRE_SHARED_TASKPOOL + EJIT_FREESTANDING with an empty "
+      "EJIT_ICACHE_SECTION: TUs built with -ejit-inline-cache get a PER-CORE "
+      "cell table, which a period toggle on another core cannot drain.")
+  endif()
   message(STATUS "EmbeddedJIT: cross-core shared taskpool enabled "
                  "(cacheSlots=${EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS}, "
                  "workerStack=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE}, "
                  "platformCoreId=${EJIT_FREESTANDING}, "
                  "codePointers=${EJIT_SRE_SHARED_CODE_POINTERS}, "
-                 "sharedSection=${_ejit_shared_section})")
+                 "sharedSection=${_ejit_shared_section}, "
+                 "icacheSection=${EJIT_ICACHE_SECTION})")
 endif()
 
 if(EJIT_SRE_TASKPOOL_NO_RECLAIM AND NOT EJIT_SRE_SHARED_TASKPOOL)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -161,15 +161,18 @@ void ejit_register_lifecycle(const char *lifecycleName, uint32_t *slotOut);
 // funcIndex global; a capacity failure is recorded so ejit_init can fail.
 void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 
-// Register the wrapper's per-function inline-cache slot (@__ejit_icache_fn_<name>
-// global address) by name, with its dimensionality (number of ejit_dim params).
-// The runtime writes the frozen specialization pointer through the [D]^numDims
-// cell at [i0][i1]... on a successful resolve (icacheFill); the wrapper reads
-// the cell directly on the hit path (GEP + one atomic load + null-check +
-// indirect call, no ejit_icache_try call). Keys the slot by the SAME registry
-// funcIndex assigned by ejit_register_funcindex. Called by AOT auto-registration.
-// A null slot or capacity exhaustion is recorded; the base stays null and the
-// probe misses.
+// Register the wrapper's per-function inline-cache cell table
+// (@__ejit_icache_fn_<name> global address) by name, with its dimensionality
+// (number of ejit_dim params). The runtime writes the specialization pointer
+// through the [D]^numDims cell at [i0][i1]... on a successful resolve
+// (icacheFill) and zeroes every cell on a period toggle (icacheDrainAll); the
+// wrapper reads the cell directly on the hit path (GEP + one load + null-check
+// + indirect call, no ejit_icache_try call). Keys the slot by the SAME registry
+// funcIndex assigned by ejit_register_funcindex. Called by AOT auto-registration
+// on EVERY core: the table is one shared object, so each core records the same
+// base and a drain on any of them clears the cells all of them read. A null
+// slot, capacity exhaustion, or a numDims above the cap is recorded; the base
+// stays null and the probe misses.
 void ejit_register_icache_slot(const char *funcName, void *slot,
                                uint32_t numDims);
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -71,7 +71,10 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// the optional EJIT_SRE_TASKPOOL_NO_RECLAIM seqlock reader.
 /// v7: full IR/ASM payloads are worker-local again; shared dump state contains
 /// only a bounded filter and latest-capture metadata. publishSeq is unchanged.
-constexpr uint32_t kEJitSharedAbiVersion = 7u;
+/// v8: the SwitchController line gains icacheDrainSeq, bumped by every
+/// inline-cache drain so a resolve that raced the drain drops its fill rather
+/// than refilling a cell the drain just cleared.
+constexpr uint32_t kEJitSharedAbiVersion = 8u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -74,7 +74,7 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// v8: the SwitchController line gains icacheDrainSeq, bumped by every
 /// inline-cache drain so a resolve that raced the drain drops its fill rather
 /// than refilling a cell the drain just cleared.
-constexpr uint32_t kEJitSharedAbiVersion = 8u;
+constexpr uint32_t kEJitSharedAbiVersion = 9u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -104,19 +104,39 @@ enum class EJitWorkerStep : uint32_t {
 //    its next call, with no invalidation epoch on the probe, no per-core drain
 //    rendezvous, and no sync entry point for the application to call.
 //
-// PREREQUISITE 1: the partitioning must be real -- each core drives its OWN
-// ejit_period_lc instance indices. Two cores calling one ejit_entry with the
-// SAME identity share a cell; the pointer they race to store is the same
-// specialization, so the write is benign, but "disjoint by construction"
-// weakens to "identical by construction".
+// PREREQUISITE, and it is a CORRECTNESS one: the partitioning must be real --
+// each core drives its OWN ejit_period_lc instance indices, so no two cores
+// call one ejit_entry with the same ejit_dim values.
 //
-// PREREQUISITE 2, enforced rather than assumed: a resolved fnPtr must be
-// callable on EVERY core with no per-core work. A shared cell publishes the
-// pointer to all cores at once, so where the platform needs per-core execute
-// preparation (4K-seal mode, or a wired prepareCodeFn_) a peer could jump to an
-// address it has not sealed. The private table ruled that out for free -- a
-// non-null cell meant THIS core had resolved, hence prepared. See
-// icacheCrossCoreExecutable(), which disables the fill in those builds.
+// Disjointness is what makes a cell safe to jump to. A core only ever reads
+// cells it filled itself, and it filled them after resolving through the
+// taskpool, which is where per-core execute preparation happens (4K seal /
+// prepareCodeFn_). So the pointer it loads is always code it has already
+// prepared -- exactly the guarantee a per-core .bss table gave for free.
+//
+// If two cores DO share an identity they share a cell, and the second one loads
+// a pointer the first one prepared. The value is the same specialization, so
+// the result is right, but the translation is not: under per-core sealing that
+// core branches into a page it never sealed. So a collision is NOT benign here,
+// and this is the one thing about the design that cannot be checked from the
+// runtime side: the cell carries no record of which core wrote it, and adding
+// one would put a per-core gate back on a probe whose whole point is not having
+// any. It is a deployment contract, and it is on the application to hold it.
+//
+// (icacheCrossCoreExecutable() is NOT consulted for a DIMENSIONED entry. It
+// would decline every fill in every build the probe is allowed in, since
+// EJIT_SRE_SHARED_CODE_POINTERS always wires either fourKSeal_ or
+// prepareCodeFn_. The taskpool's own cross-core path still uses it.)
+//
+// THE 0-DIM EXCEPTION. An entry with no ejit_dim params has ONE cell and no
+// identity to partition it by, so everything above simply does not apply to it:
+// every core reads and writes that same scalar however well behaved the
+// deployment is. It is not a contract violation, it is the shape. So for
+// numDims == 0 icacheFill DOES consult icacheCrossCoreExecutable() and declines
+// unless a resolved pointer is callable on every core the instant it exists.
+// Where it declines the cell stays empty, the probe keeps missing, and the
+// taskpool -- which prepares -- serves every call. The AOT pass still emits the
+// 0D probe: the code is platform independent, only the fill is not.
 //
 // THE RACE, and why it is bounded: core A's drain stores 0 while core B's probe
 // loads the cell. Both are naturally-aligned word accesses, so B reads the old
@@ -192,12 +212,18 @@ void ejitIcacheClearAll();
 // one shared object, which is what lets a drain on any core clear the cells
 // every other core reads.
 //
-// Returns false, registering nothing, for an out-of-range funcIndex, a null
-// base, or numDims above EJIT_ICACHE_MAX_DIMS (numDims sizes the array the
-// drain walks, so an over-cap value would write past the wrapper's global).
-// Declining is the safe degradation: the cell stays null, the taskpool serves
-// every call.
-bool ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
+// Outcome of a slot registration. The two failure kinds must NOT be conflated:
+//
+//   CapacityMiss  past EJIT_ICACHE_FUNC_SLOTS (4096) while the function registry
+//                 holds 4096. Normal in a large application: the cell stays
+//                 null and the taskpool serves the function. Callers must
+//                 degrade, never error, or the 65th ejit_entry stops ejit_init.
+//   Invalid       null base, or numDims above the cap (it sizes the array the
+//                 drain walks). A real defect, and reported.
+enum class EJitIcacheRegResult { Ok, CapacityMiss, Invalid };
+
+EJitIcacheRegResult ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
+                                           uint32_t numDims);
 
 /// Diagnostic: dump every registered icache slot to the diagnostic log.
 /// Shows funcIndex, base pointer, numDims, and cell[0] (the scalar or
@@ -206,6 +232,20 @@ bool ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
 /// NOTE: dereferences base[0] of every registered slot — bases must be
 /// module-lifetime storage, never stack locals (see ejitIcacheClearAll).
 void ejitDumpIcacheSlots();
+
+/// Retire one in-flight drain that was announced under generation \p gen.
+///
+/// Split out of icacheDrainAll() because it is the half of the drain protocol
+/// that has to survive a (re)initialization landing in the middle of a walk,
+/// and that interleaving is only reachable deterministically by calling this
+/// directly. Two rules:
+///
+///  * If the blob's generation has moved on, do nothing. A re-init discards the
+///    whole in-flight count, so this drain's increment is already gone and
+///    subtracting again would wrap the counter.
+///  * Never go below zero regardless, so no ordering anywhere can leave
+///    icacheBeginResolve() permanently refusing tokens.
+void ejitIcacheRetireDrain(EJitSharedTaskPoolState *st, uint32_t gen);
 
 /// One L0 slot, sized to a cache line. The identity is stored in full and
 /// re-checked on every hit, because the index hash is not injective: it selects
@@ -372,7 +412,13 @@ public:
   EJitSharedTaskPool &operator=(const EJitSharedTaskPool &) = delete;
 
   /// Bind to the shared blob (not owned). Call before init().
-  void bind(EJitSharedTaskPoolState *state) { state_ = state; }
+  void bind(EJitSharedTaskPoolState *state) {
+    state_ = state;
+    // Seal mode / prepareCode may have been configured before the blob existed.
+    publishIcachePrepareMode();
+    // Likewise a releaser wired pre-bind must count against the shared table.
+    syncIcacheReleaserCount();
+  }
   EJitSharedTaskPoolState *state() const { return state_; }
 
   /// Callback type for forEachCompiled: receives the funcIndex, its dim
@@ -395,16 +441,28 @@ public:
     compileCtx_ = ctx;
   }
   void setReleaser(ReleaseCallback fn, void *ctx) {
+    const bool had = (releaseFn_ != nullptr);
     releaseFn_ = fn;
     releaseCtx_ = ctx;
     // v2 inline cache never reclaims (no HP-scan retire, ever). A wired
     // releaser means code may be freed while a cached fnPtr still pins it ->
     // UAF. Auto-disable the cache while a releaser is wired. Production wires
     // no releaser, so the gate stays open and the cache is unconditionally safe.
+    //
+    // The disable state is SHARED, not just this facade's: the cells are one
+    // table backing every core, so a peer facade with its own flag still clear
+    // would happily refill what this one just drained, and the probe consults
+    // no gate at all. Track the transition as a count in the blob so the cache
+    // re-arms only when the LAST releaser goes away.
+    (void)had;
     icacheReclamationSafe_ = (fn == nullptr);
+    syncIcacheReleaserCount();
     if (fn) {
       // The gate is evaluated at fill, so blocking new fills is not enough:
       // entries armed earlier would keep serving code the releaser may free.
+      // retireDispatchCache() drains the cell table as part of retiring the L0,
+      // so this needs no second icacheDrainAll(): that would walk the whole
+      // table twice and bump icacheDrainSeq twice for one event.
       gEJitL0State = nullptr;
       retireDispatchCache();
     }
@@ -412,6 +470,7 @@ public:
   void setPrepareCodeCallback(PrepareCodeCallback fn, void *ctx) {
     prepareCodeFn_ = fn;
     prepareCodeCtx_ = ctx;
+    publishIcachePrepareMode();
   }
   /// Whether a resolved fnPtr is callable on EVERY core the instant it exists,
   /// with no per-core work. False when the platform wires per-core execute
@@ -424,8 +483,39 @@ public:
   /// probe has no per-core gate to restore the implication -- so when per-core
   /// preparation is required icacheFill declines and the taskpool, which
   /// prepares, serves every call.
+  /// The reclamation gate as every core sees it: this facade's own releaser
+  /// AND any peer's. The cells are shared, so a peer wiring a releaser must
+  /// stop THIS core filling and serving them too.
+  bool icacheReclamationSafeShared() const {
+    return icacheReclamationSafe_ &&
+           (!state_ || state_->icacheReleasersWired.loadAcquire() == 0);
+  }
   bool icacheCrossCoreExecutable() const {
-    return !fourKSeal_ && prepareCodeFn_ == nullptr;
+    // The shared answer wins. A facade that was never handed the seal mode has
+    // fourKSeal_ == false and no prepareCodeFn_, and would otherwise conclude
+    // "callable everywhere" for a platform on which it is not -- see
+    // icachePerCorePrepare.
+    if (state_ && state_->icachePerCorePrepare.loadAcquire())
+      return false;
+    // 4K-seal mode is NOT counted as per-core preparation. On the target this
+    // runs on, the seal is an operation on an address space every core
+    // translates through, so a page sealed by one core is executable on all of
+    // them; the per-core split the taskpool still performs is bookkeeping, not
+    // a precondition for the jump. Counting it here left the 0-dim shared
+    // scalar permanently unfillable on the only platform the inline cache ships
+    // on, which costs every 0-dim entry the full taskpool path on every call.
+    //
+    // A wired prepareCodeFn_ (the legacy whole-2MiB path) IS per-core work and
+    // still closes the gate.
+    //
+    // NOTE, and it is the assumption to re-check if a 0-dim entry ever faults:
+    // EJitSharedPoolSplit tracks splitDoneMask per core, which is the runtime
+    // modelling the split as per-core state. That is consistent with the split
+    // being per-core bookkeeping over a shared mapping, but it is also what you
+    // would see if the mapping were NOT shared. Verified on the board by
+    // ejit_icache_multiverify_test's 0-dim entry (f_0) executing on cores that
+    // never resolved it themselves.
+    return prepareCodeFn_ == nullptr;
   }
   /// Owner: provide the finalized code-range resolver (see CodeRangeCallback).
   void setCodeRangeProvider(CodeRangeCallback fn, void *ctx) {
@@ -445,7 +535,10 @@ public:
   /// true = 4KiB page seal (split the pool once per core, then enable_ex every
   /// page the code covers), false = legacy whole-2MiB-pool seal. Must match the
   /// owner's code pool. Default false.
-  void setSealMode(bool fourKSeal) { fourKSeal_ = fourKSeal; }
+  void setSealMode(bool fourKSeal) {
+    fourKSeal_ = fourKSeal;
+    publishIcachePrepareMode();
+  }
   /// 4K mode: per-core split primitive (see SplitPoolCallback).
   void setSplitPoolCallback(SplitPoolCallback fn, void *ctx) {
     splitPoolFn_ = fn;
@@ -679,6 +772,16 @@ public:
   ///
   /// \returns whether the enabled BIT flipped. The invalidations run either way.
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
+
+  /// Toggle EVERY instance of \p dimType, draining ONCE at the end.
+  ///
+  /// setInstanceEnabled drains the whole table per call, so looping it cost
+  /// MAX_INSTANCES full drains (256 x 256 cells per function for a 2-dim entry)
+  /// with the in-flight counter raised throughout, blocking concurrent fills.
+  /// The drain is global, not per instance, so one covers the batch.
+  ///
+  /// \returns the number of instances whose enabled bit actually flipped.
+  uint32_t setAllInstancesEnabled(uint32_t dimType, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read
   /// counterpart of setInstanceEnabled, and the single cross-core source of
   /// truth the compile gate (compileCold) and ejit_is_active consult. Returns
@@ -1011,6 +1114,50 @@ private:
   // releaser (code may be freed) + the cache = UAF; the gate then auto-disables
   // the cache. See setReleaser().
   bool icacheReclamationSafe_ = true;
+  /// Whether THIS facade currently contributes 1 to icacheReleasersWired.
+  /// Without it, bind() and setReleaser() each add on their own and a facade
+  /// that is bound twice, or wired then re-bound, counts itself more than once
+  /// and the gate never re-opens.
+  bool icacheReleaserCounted_ = false;
+  /// Make the shared count agree with this facade's releaser, exactly once.
+  ///
+  /// LIMIT, and it is why production must keep to ONE facade per blob
+  /// (EJitCompileDriver::sharedPool_): a (re)initialization zeroes the count
+  /// while this flag stays set, so after a re-init this facade believes it is
+  /// counted when it is not. Only init() re-publishes, and only for the owner's
+  /// own releaseFn_ -- a peer facade that wired a releaser before the re-init
+  /// is not restored, and its later unwire would decrement a count it no longer
+  /// owns. The decrement saturates at zero so the worst case is re-opening the
+  /// gate early, never wrapping it shut forever; closing it properly would need
+  /// the same generation stamp the drain protocol uses.
+  void syncIcacheReleaserCount() {
+    const bool want = (state_ != nullptr) && (releaseFn_ != nullptr);
+    if (want == icacheReleaserCounted_)
+      return;
+    if (want) {
+      state_->icacheReleasersWired.fetchAdd(1);
+      icacheReleaserCounted_ = true;
+      return;
+    }
+    if (state_) {
+      uint32_t cur = state_->icacheReleasersWired.loadAcquire();
+      while (cur != 0 &&
+             !state_->icacheReleasersWired.compareExchange(cur, cur - 1))
+        ;
+    }
+    icacheReleaserCounted_ = false;
+  }
+  /// Publish this facade's local "needs per-core execute preparation" answer
+  /// into the blob, so every other facade -- including ones never handed the
+  /// seal mode -- gates the 0-dim shared scalar on it. Set-only: see
+  /// icachePerCorePrepare for why the monotone direction is the safe one.
+  void publishIcachePrepareMode() {
+    // Only a wired prepareCodeFn_ counts. 4K-seal mode is deliberately NOT
+    // per-core preparation here -- see icacheCrossCoreExecutable() for why, and
+    // for the assumption to re-check if a 0-dim entry ever faults.
+    if (state_ && prepareCodeFn_ != nullptr)
+      state_->icachePerCorePrepare.storeRelease(1);
+  }
 
   // Worker observability + startup-wait bound (owner-local).
   EJitAtomicU64 workerConsumeLoops_{0};

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -82,29 +82,61 @@ enum class EJitWorkerStep : uint32_t {
 };
 
 //===----------------------------------------------------------------------===//
-// Per-function inline cache (v2: sticky monomorphic).
+// Per-function inline cache: SHARED PARTITIONED CELL TABLE.
 //
-// A single global slot per funcIndex holding a FROZEN specialization pointer:
-// written once (first resolution, one-shot CAS) and read forever. No version /
-// dims / generation re-validation, no refill, and no release_read on the hit
-// path - the probe is a single acquire load + null check.
+// One cell per (funcIndex, dim identity) holding a specialization pointer, read
+// with no version / dims / generation re-validation and no release_read: the
+// probe is one load + null check + indirect call.
 //
-// Correctness rests on a hard precondition: every ejit_entry's specialization
-// is invariant for process lifetime (period toggles do not change the baked
-// code; each entry is monomorphic - always called with one dim identity). If
-// that ever fails the cache silently runs a stale specialization; the safety
-// gate below does NOT cover that, only UAF.
+// Where the cells LIVE is the design. The wrapper's @__ejit_icache_fn_<name>
+// array is emitted into the inter-core shared section (EJIT_ICACHE_SECTION,
+// .mc_shared) rather than per-core .bss, so ONE table backs every core:
+//
+//  * PARTITIONED, so no locking. A cell's index is icacheLinearize(dims), the
+//    ejit_dim argument values (the ejit_period_lc instance indices). Cores drive
+//    disjoint instance ranges, so they write disjoint cells and the hit path is
+//    what it was when the table was private: no gate, no contention, one load.
+//
+//  * DRAINABLE ACROSS CORES, which a private table is not. activate/deactivate
+//    zeroes every registered cell in place (icacheDrainAll), reaching a peer's
+//    partition directly. A permanently-hot core -- one that never misses and
+//    never calls the runtime again -- stops running the stale specialization on
+//    its next call, with no invalidation epoch on the probe, no per-core drain
+//    rendezvous, and no sync entry point for the application to call.
+//
+// PREREQUISITE 1: the partitioning must be real -- each core drives its OWN
+// ejit_period_lc instance indices. Two cores calling one ejit_entry with the
+// SAME identity share a cell; the pointer they race to store is the same
+// specialization, so the write is benign, but "disjoint by construction"
+// weakens to "identical by construction".
+//
+// PREREQUISITE 2, enforced rather than assumed: a resolved fnPtr must be
+// callable on EVERY core with no per-core work. A shared cell publishes the
+// pointer to all cores at once, so where the platform needs per-core execute
+// preparation (4K-seal mode, or a wired prepareCodeFn_) a peer could jump to an
+// address it has not sealed. The private table ruled that out for free -- a
+// non-null cell meant THIS core had resolved, hence prepared. See
+// icacheCrossCoreExecutable(), which disables the fill in those builds.
+//
+// THE RACE, and why it is bounded: core A's drain stores 0 while core B's probe
+// loads the cell. Both are naturally-aligned word accesses, so B reads the old
+// pointer (calls the previous specialization once more, misses next call) or 0
+// (misses now) -- never a torn value.
+//
+// The one race that is NOT benign is a fill landing AFTER a drain: the pointer
+// was resolved pre-toggle, so the cell would come back holding a specialization
+// baked from the old period values and nothing would clear it. icacheDrainSeq
+// closes exactly that -- icacheBeginResolve() snapshots it at the taskpool entry
+// point and icacheFill drops the fill if it moved.
 //
 // Lifetime safety: JIT code is never physically freed in production (NO_RECLAIM
-// + no releaseFn_ wired), so a cached pointer can never dangle. v2 does NO
-// hazard-pointer retire and never will: if a releaser IS wired (code may be
-// freed) the safety gate (icacheReclamationSafe_) auto-disables the cache
-// (icacheTry always misses, icacheFill no-ops) to avoid UAF.
+// + no releaser wired), so a cached pointer can never dangle -- including one a
+// probe loaded an instruction before the drain zeroed its cell. There is no
+// hazard-pointer retire: if a releaser IS wired the safety gate
+// (icacheReclamationSafe_) disables the cache outright to avoid UAF.
 //
 // The code-sharing gate is retained: a non-owner core may only read a cached
-// pointer when EJIT_SRE_SHARED_CODE_POINTERS is platform-validated; otherwise it
-// misses and falls back to ejit_taskpool_compile_or_get. Under sharing=OFF only
-// the owner core uses the cache, so one global slot suffices.
+// pointer when EJIT_SRE_SHARED_CODE_POINTERS is platform-validated.
 //===----------------------------------------------------------------------===//
 #ifndef EJIT_ICACHE_FUNC_SLOTS
 // Fallback ONLY for a non-CMake compile. The default must cover the full
@@ -134,20 +166,38 @@ enum class EJitWorkerStep : uint32_t {
 #define EJIT_ICACHE_MAX_DIMS 4u
 #endif
 
-// Test/diagnostic: clear every icache slot. The slot-pointer table is
-// process-static storage shared across pool instances, so tests clear it
-// between cases to avoid stale cross-test leakage.
+/// Resolve token (see EJitSharedTaskPool::icacheBeginResolve): bit 32 marks a
+/// usable token, the low 32 bits carry the drain sequence it was taken at. A
+/// plain integer so the taskpool C ABI can hold one in a local without dragging
+/// this header into non-shared builds.
+constexpr uint64_t kEJitIcacheNoResolve = 0;
+constexpr uint64_t kEJitIcacheResolveValid = uint64_t{1} << 32;
+
+// Test/diagnostic: UNREGISTER every icache slot, WITHOUT touching the cells the
+// bases point at (a test-local base may already be gone). The slot table is
+// process-static, so tests clear it between cases. To empty the cells of slots
+// that stay registered, use EJitSharedTaskPool::icacheDrainAll().
 void ejitIcacheClearAll();
 
 // Register a per-function icache slot: \p base is the address of the wrapper's
-// @__ejit_icache_fn_<name> global (an EJitAtomicUPtr, or a [D]^numDims array of
+// @__ejit_icache_fn_<name> global (a uintptr_t cell, or a [D]^numDims array of
 // them for a multi-version entry), and \p numDims is its dimensionality. The
-// runtime writes the frozen specialization pointer through the cell at
-// [i0][i1]... (linearized from dims) on a successful resolve (icacheFill); the
-// wrapper reads the cell directly. Called from ejit_register_icache_slot
-// (name->funcIndex resolution) at ejit_auto_register / .ejit_period time.
-// No-op for an out-of-range funcIndex or null base.
-void ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
+// runtime writes the specialization pointer through the cell at [i0][i1]...
+// (linearized from dims) on a successful resolve (icacheFill), and zeroes the
+// whole array on a period toggle (icacheDrainAll); the wrapper reads the cell
+// directly. Called from ejit_register_icache_slot (name->funcIndex resolution)
+// at ejit_auto_register / .ejit_period time.
+//
+// Every core registers the SAME base: with EJIT_ICACHE_SECTION set the array is
+// one shared object, which is what lets a drain on any core clear the cells
+// every other core reads.
+//
+// Returns false, registering nothing, for an out-of-range funcIndex, a null
+// base, or numDims above EJIT_ICACHE_MAX_DIMS (numDims sizes the array the
+// drain walks, so an over-cap value would write past the wrapper's global).
+// Declining is the safe degradation: the cell stays null, the taskpool serves
+// every call.
+bool ejitIcacheRegisterSlot(uint32_t funcIndex, void *base, uint32_t numDims);
 
 /// Diagnostic: dump every registered icache slot to the diagnostic log.
 /// Shows funcIndex, base pointer, numDims, and cell[0] (the scalar or
@@ -362,6 +412,20 @@ public:
   void setPrepareCodeCallback(PrepareCodeCallback fn, void *ctx) {
     prepareCodeFn_ = fn;
     prepareCodeCtx_ = ctx;
+  }
+  /// Whether a resolved fnPtr is callable on EVERY core the instant it exists,
+  /// with no per-core work. False when the platform wires per-core execute
+  /// preparation (legacy 2M `prepareCodeFn_`, or 4K-seal mode, where a core must
+  /// split its pool and seal the code's pages before executing a peer's code).
+  ///
+  /// This is the precondition of a SHARED cell table, and what the per-core
+  /// table gave for free: a non-null cell there implied THIS core had resolved,
+  /// hence prepared. A shared fill publishes to every core at once, and the
+  /// probe has no per-core gate to restore the implication -- so when per-core
+  /// preparation is required icacheFill declines and the taskpool, which
+  /// prepares, serves every call.
+  bool icacheCrossCoreExecutable() const {
+    return !fourKSeal_ && prepareCodeFn_ == nullptr;
   }
   /// Owner: provide the finalized code-range resolver (see CodeRangeCallback).
   void setCodeRangeProvider(CodeRangeCallback fn, void *ctx) {
@@ -597,6 +661,23 @@ public:
                                    uint32_t inst2, uint32_t dim3,
                                    uint32_t inst3);
   void releaseRead(uint32_t bucketIndex);
+  /// Drive one end of a period-value mutation window for a lifecycle instance.
+  ///
+  /// The shared `enabled` bit is the JIT compile gate and is CAS'd, so only the
+  /// first caller in each direction moves it.
+  ///
+  /// The INVALIDATIONS (icache drain + L0 dispatchEpoch bump) run on EVERY call.
+  /// Period data is core-private while the specialization is SHARED, so N cores
+  /// each bracket their own writes over one shared bit: a caller that LOST the
+  /// CAS may still have rewritten its own copy, and neither cache stores a
+  /// version.
+  ///
+  /// version[] moves ONLY on a real transition. Its consumer is runCompile's
+  /// checkpoints, which DISCARD a finished compile when it changes, and nothing
+  /// re-enqueues a dropped compile -- so an unconditional bump would let N cores
+  /// activating the same instance at startup stall the JIT permanently.
+  ///
+  /// \returns whether the enabled BIT flipped. The invalidations run either way.
   bool setInstanceEnabled(uint32_t dimType, uint32_t instanceId, bool enabled);
   /// Query the shared activation bit for a lifecycle instance — the read
   /// counterpart of setInstanceEnabled, and the single cross-core source of
@@ -608,9 +689,9 @@ public:
   // NOTE: the production hit path does NOT use icacheTry. With -ejit-inline-cache
   // the ejit_entry wrapper reads its per-function @__ejit_icache_fn_<name> slot
   // directly - a GEP into the [D]^numDims array by the ejit_dim arg values, one
-  // acquire load + null-check + indirect call, NO ejit_icache_try call, NO
+  // load + null-check + indirect call, NO ejit_icache_try call, NO
   // per-call guards. icacheTry is retained for unit tests / diagnostics: on a
-  // hit it sets *outFn to the frozen specialization for the given dims (call
+  // hit it sets *outFn to the cached specialization for the given dims (call
   // with NO releaseRead) and returns true; on a miss returns false. It keeps
   // the reclamation-safety, pool-Ready, range, and cross-core code-sharing gates
   // (the latter matters in non-shared test builds; the wrapper's inline probe is
@@ -667,14 +748,53 @@ public:
   void l0Fill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
               uint32_t numDims);
 
-  /// Retire every core's L0. Must be called from every path that can
-  /// invalidate an (identity -> fnPtr) mapping from OUTSIDE the taskpool --
-  /// ejit_clear_cache(), ejit_invalidate(), a compile-mode change -- since
-  /// those bypass cachePublish() and setInstanceEnabled().
+  /// Retire every core's L0 AND drain the shared inline cache. Must be called
+  /// from every path that can invalidate an (identity -> fnPtr) mapping from
+  /// OUTSIDE the taskpool -- ejit_clear_cache(), ejit_invalidate(), a
+  /// compile-mode change -- since those bypass cachePublish() and
+  /// setInstanceEnabled(). Both caches answer the same question and neither
+  /// re-validates on read, so they are retired together or not at all.
   void retireDispatchCache();
 
+  /// Open a resolve window: returns a token pinning the shared drain state, to
+  /// be handed back to icacheFill(). Called at every taskpool entry point that
+  /// can end in a fill, BEFORE the resolve and before any bucket read token.
+  /// kEJitIcacheNoResolve when a drain is already in flight (its reach is
+  /// unknown, so no fill from this resolve may be trusted).
+  ///
+  /// The token is a VALUE the caller keeps on its stack, not runtime state: on
+  /// an RTOS a higher-priority task can preempt this core mid-resolve and run
+  /// its own resolve, which would clobber any core-private snapshot.
+  uint64_t icacheBeginResolve();
+
+  /// Publish \p fnPtr into the cell for \p dims. Dropped unless \p token, from
+  /// the icacheBeginResolve() that opened this resolve, shows no drain
+  /// overlapped it.
   void icacheFill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
-                  uint32_t numDims);
+                  uint32_t numDims, uint64_t token);
+
+  /// Zero every cell of every registered icache slot, bracketed by
+  /// icacheDrainsInFlight and closed by an icacheDrainSeq bump, so any resolve
+  /// this overlaps drops its fill. This is THE cross-core
+  /// invalidation: the cells are shared, so clearing them here clears them for
+  /// every core, including one that is permanently hot and would never reach a
+  /// runtime entry point of its own.
+  ///
+  /// Cost is O(cells registered) -- proportional to the table the build chose to
+  /// allocate. Toggles are rare; paying the refill once per toggle is what buys
+  /// a probe with no freshness check.
+  ///
+  /// Safe against a concurrent probe on any core: it reads the old pointer (and
+  /// calls it once more; the code is never freed under the gate this cache
+  /// requires) or 0 (and misses).
+  /// Zero every registered cell. \p reason names the event that triggered it
+  /// and appears in the EJIT_DIAG line, which is what makes a drain visible on
+  /// an SRE board -- the probe never enters the runtime on a hit, so a sudden
+  /// burst of misses is otherwise unexplained.
+  void icacheDrainAll(const char *reason = "unspecified");
+
+  /// Number of drains this shared state has performed. Diagnostic / test hook.
+  uint32_t icacheDrainSeq() const;
 
   //--- consumer path (worker / test) -----------------------------------------
   bool pollOne();

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -357,6 +357,40 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
   /// but not yet bumped the sequence would otherwise let a fill slip in behind
   /// it, and because several cores can drain at once.
   EJitAtomicU32 icacheDrainsInFlight;
+  /// 1 => at least one cell has been armed since the last drain emptied the
+  /// table. A drain reads this first and skips the whole walk when it is clear,
+  /// which is what makes bring-up affordable: N cores each calling ejit_activate
+  /// per instance produce N x instances drains, and until something is actually
+  /// cached every one of them writes 0 over 0 across every cell of every
+  /// registered slot (5 slots at dims 0..4 is ~70k cells per drain).
+  ///
+  /// Safety does NOT rest on this flag -- the in-flight/sequence bracket and the
+  /// post-store retract already guarantee no cell survives a drain. The flag
+  /// only removes work, and it errs on the side of doing it: icacheFill sets it
+  /// with release BEFORE storing the cell, so any drain that could observe a
+  /// non-null cell observes the flag first. A retracted fill leaves it set,
+  /// which costs one redundant walk and nothing else.
+  EJitAtomicU32 icacheArmed;
+  /// 1 => at least one core needs per-core execute preparation (4K seal, or a
+  /// wired prepareCode callback) before it may run JIT code.
+  ///
+  /// Must be SHARED, not per-facade: the property gates the 0-dim inline-cache
+  /// fill, and a peer facade that was never handed the seal mode would evaluate
+  /// its private copy as "no preparation needed" and arm the one shared scalar
+  /// that every core reads. Published by any facade that observes it locally and
+  /// never cleared except by (re)initialization -- "set" is the conservative
+  /// direction, and being monotone means no core can race another into a weaker
+  /// answer.
+  EJitAtomicU32 icachePerCorePrepare;
+  /// Number of bound facades that currently have a physical-code releaser wired.
+  /// Non-zero disables the inline cache for EVERY core: code may then be freed
+  /// and the probe does no HP-scan retire, so any cell still holding a pointer
+  /// can dangle.
+  ///
+  /// Must be SHARED for the same reason, and it is a count rather than a flag
+  /// because facades wire and unwire independently: the cache may only re-arm
+  /// once the LAST releaser is gone.
+  EJitAtomicU32 icacheReleasersWired;
   EJitAtomicU32 anyInstanceActivated; ///< 1 once any instance first
                                       ///< setInstanceEnabled(true); gates the
                                       ///< instanceDisabledPreActivate counter.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -343,6 +343,20 @@ struct alignas(kEJitSharedCacheLine) EJitSharedTaskPoolState {
       EJitAtomicU8 enabled[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 version[kEJitSharedDimTypes][kEJitSharedInstances];
   EJitAtomicU32 mode; ///< EJitCompileMode (Off=0, Async=1)
+  /// Counts inline-cache drains. Bumped by icacheDrainAll() AFTER it zeroes the
+  /// shared cell table, so a resolve that started before the drain can tell its
+  /// fnPtr may be specialized for period values that have since changed, and
+  /// drop the fill rather than re-populate a cell the drain just cleared. The
+  /// hit path never reads it: the cells are shared, so the drain reaches every
+  /// core directly. Bumped, never reset.
+  EJitAtomicU32 icacheDrainSeq;
+  /// Drains currently zeroing the table. Raised before the first cell store and
+  /// lowered after the sequence bump, so the pair brackets the whole drain: a
+  /// fill that sees 0 at both ends of its resolve and an unchanged sequence
+  /// provably did not overlap one. Needed because a drain that has passed a cell
+  /// but not yet bumped the sequence would otherwise let a fill slip in behind
+  /// it, and because several cores can drain at once.
+  EJitAtomicU32 icacheDrainsInFlight;
   EJitAtomicU32 anyInstanceActivated; ///< 1 once any instance first
                                       ///< setInstanceEnabled(true); gates the
                                       ///< instanceDisabledPreActivate counter.

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -218,12 +218,21 @@ EJit::EJit(const Config &config) : config_(config) {
           }
           uint32_t numDims = static_cast<uint32_t>(e->size);
           uint32_t idx = EJitFuncRegistry::instance().resolveAssign(e->name1);
-          if (idx != kEJitInvalidFuncIndex)
-            ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr), numDims);
-          else
+          if (idx == kEJitInvalidFuncIndex) {
             recordInitError(EJIT_ERR_CACHE_FULL,
                             "funcIndex capacity exhausted for icache slot",
                             e->name1);
+            break;
+          }
+          if (!ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr),
+                                      numDims)) {
+            // Declined (numDims above the cap): the cell stays null and every
+            // call to this function resolves through the taskpool. Correct,
+            // just without the fast path.
+            recordInitError(EJIT_ERR_INVALID_PARAM,
+                            "icache slot declined: numDims above the cap",
+                            e->name1);
+          }
           break;
         }
         default:

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -224,14 +224,26 @@ EJit::EJit(const Config &config) : config_(config) {
                             e->name1);
             break;
           }
-          if (!ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr),
-                                      numDims)) {
-            // Declined (numDims above the cap): the cell stays null and every
-            // call to this function resolves through the taskpool. Correct,
-            // just without the fast path.
+          switch (ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr),
+                                         numDims)) {
+          case EJitIcacheRegResult::Ok:
+            break;
+          case EJitIcacheRegResult::CapacityMiss:
+            // NOT an error. The inline cache holds EJIT_ICACHE_FUNC_SLOTS
+            // functions while the registry holds thousands, so a large
+            // application legitimately runs out. The cell stays null and the
+            // taskpool serves every call to this function. Recording an init
+            // error here would stop EJIT from starting at all.
+            EJIT_DIAG("register_icache_slot name=%s: no free inline-cache slot "
+                      "(idx=%u >= %u), continuing without the fast path",
+                      e->name1, idx, EJIT_ICACHE_FUNC_SLOTS);
+            break;
+          case EJitIcacheRegResult::Invalid:
             recordInitError(EJIT_ERR_INVALID_PARAM,
-                            "icache slot declined: numDims above the cap",
+                            "icache slot invalid: null base or numDims above "
+                            "the cap",
                             e->name1);
+            break;
           }
           break;
         }
@@ -481,9 +493,10 @@ bool EJit::activateAll(const std::string &periodName) {
   uint32_t dt = EJitLifecycleRegistry::instance().lookup(periodName);
   if (dt != kEJitInvalidDimType) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
+    // One batched call: the per-instance entry point drains the whole cell
+    // table each time, so looping it here cost MAX_INSTANCES full drains.
     if (EJitSharedTaskPool *sp = sharedTaskPool())
-      for (uint32_t i = 0; i < EJitSwitchController::MAX_INSTANCES; ++i)
-        sp->setInstanceEnabled(dt, i, /*enabled=*/true);
+      sp->setAllInstancesEnabled(dt, /*enabled=*/true);
 #else
     runtimeState_->activateAll(periodName);
     if (EJitTaskPool *tp = taskPool())
@@ -510,8 +523,7 @@ bool EJit::deactivateAll(const std::string &periodName) {
   if (dt != kEJitInvalidDimType) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
     if (EJitSharedTaskPool *sp = sharedTaskPool())
-      for (uint32_t i = 0; i < EJitSwitchController::MAX_INSTANCES; ++i)
-        sp->setInstanceEnabled(dt, i, /*enabled=*/false);
+      sp->setAllInstancesEnabled(dt, /*enabled=*/false);
 #else
     runtimeState_->deactivateAll(periodName);
     if (EJitTaskPool *tp = taskPool())

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -482,16 +482,28 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
               funcName);
     return;
   }
-  if (!ejitIcacheRegisterSlot(idx, slot, numDims)) {
+  switch (ejitIcacheRegisterSlot(idx, slot, numDims)) {
+  case EJitIcacheRegResult::Ok:
+    EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
+                      funcName, idx, numDims);
+    break;
+  case EJitIcacheRegResult::CapacityMiss:
+    // Expected in a large application: more ejit_entry functions than
+    // EJIT_ICACHE_FUNC_SLOTS. Not recorded as an error -- a registration error
+    // during construction fails ejit_init, and losing an optional fast path on
+    // one function must never do that.
+    EJIT_DIAG("register_icache_slot name=%s: no free inline-cache slot "
+              "(idx=%u >= %u), continuing without the fast path",
+              funcName, idx, EJIT_ICACHE_FUNC_SLOTS);
+    break;
+  case EJitIcacheRegResult::Invalid:
     EJitRegistrationStore::instance().recordError(
-        EJIT_ERR_INVALID_PARAM, "icache slot declined: numDims above the cap",
-        funcName);
+        EJIT_ERR_INVALID_PARAM,
+        "icache slot invalid: null base or numDims above the cap", funcName);
     EJIT_DIAG("register_icache_slot FAIL name=%s: numDims=%u above the cap %u",
               funcName, numDims, EJIT_ICACHE_MAX_DIMS);
-    return;
+    break;
   }
-  EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
-                    funcName, idx, numDims);
 }
 
 ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -448,13 +448,14 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
 
 void ejit_register_icache_slot(const char *funcName, void *slot,
                                uint32_t numDims) {
-  // Wire the wrapper's per-function @__ejit_icache_fn_<name> slot into the
-  // runtime slot registry, keyed by the SAME registry funcIndex
+  // Wire the wrapper's per-function @__ejit_icache_fn_<name> cell table into
+  // the runtime slot registry, keyed by the SAME registry funcIndex
   // ejit_register_funcindex assigns by name. numDims is the [D]^numDims shape
-  // so icacheFill can linearize. The wrapper reads the cell directly on the
-  // icache hit path; icacheFill writes the frozen specialization pointer through
-  // it on resolve. Idempotent by name (resolveAssign is). A null slot or
-  // unresolvable name is recorded; the base stays null and the wrapper's probe
+  // so icacheFill can linearize and icacheDrainAll knows how far to walk. The
+  // wrapper reads a cell directly on the icache hit path. Idempotent by name
+  // (resolveAssign is), and every core registering the same shared table
+  // records the same base. A null slot, an unresolvable name, or a numDims
+  // above the cap is recorded; the base stays null and the wrapper's probe
   // cleanly misses -> taskpool fallback.
   if (!funcName || !slot) {
     EJIT_DIAG("register_icache_slot reject: name=%p slot=%p",
@@ -481,7 +482,14 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
               funcName);
     return;
   }
-  ejitIcacheRegisterSlot(idx, slot, numDims);
+  if (!ejitIcacheRegisterSlot(idx, slot, numDims)) {
+    EJitRegistrationStore::instance().recordError(
+        EJIT_ERR_INVALID_PARAM, "icache slot declined: numDims above the cap",
+        funcName);
+    EJIT_DIAG("register_icache_slot FAIL name=%s: numDims=%u above the cap %u",
+              funcName, numDims, EJIT_ICACHE_MAX_DIMS);
+    return;
+  }
   EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
                     funcName, idx, numDims);
 }
@@ -682,33 +690,57 @@ inline EJitTaskPool *activeTaskPool() {
 }
 #endif
 
-// Fill the calling core's icache slot on a successful taskpool resolve (cache
-// hit or fresh compile), so a cold icache is filled on the first taskpool hit,
-// not only on a fresh compile. Multi-version: one-shot per cell (the
-// specialization is invariant per identity - no version snapshot); dims selects
-// the [D]^numDims cell. No-op without the shared pool or a null fnPtr. Always
-// defined (a no-op without the shared taskpool) so call sites need no #ifdef
-// guards.
-inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
-                                    const EJitDimPair *dims,
-                                    uint32_t numDims) {
+// Open a resolve window and return the token icacheFill needs to prove no drain
+// overlapped it. Runs at the taskpool entry point, BEFORE any bucket read token.
+// The token lives in the caller's LOCAL, so a higher-priority task preempting
+// this core mid-resolve cannot clobber it. 0 without the shared pool, so call
+// sites need no #ifdef guards.
+inline uint64_t ejitIcacheBeginResolve() {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
-  if (!fnPtr) {
-    EJIT_DIAG("icacheFillOnSuccess SKIP func=%u: fnPtr is null", funcIndex);
+  if (EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr)
+    return sp->icacheBeginResolve();
+#endif
+  return 0;
+}
+
+// Fill the icache cell on a successful taskpool resolve (cache hit or fresh
+// compile), so a cold icache is filled on the first taskpool hit, not only on a
+// fresh compile. dims selects the [D]^numDims cell. No-op without the shared
+// pool or a null fnPtr. Always defined (a no-op without the shared taskpool) so
+// call sites need no #ifdef guards.
+inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
+                                    const EJitDimPair *dims, uint32_t numDims,
+                                    uint64_t token) {
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  // Deliberately silent. A null fnPtr is the NORMAL outcome of a resolve while
+  // a compile is still pending, so every call to every entry takes this path
+  // until the JIT warms up -- logging it drowned the board's log in lines that
+  // report nothing wrong. The decline reasons that ARE worth seeing live in
+  // icacheFill(), one-shot per reason.
+  if (!fnPtr)
     return;
-  }
   EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr;
   if (!sp) {
-    EJIT_DIAG("icacheFillOnSuccess SKIP func=%u: no shared pool (gEJIT=%p)",
-              funcIndex, (void *)gEJIT);
+    // Unlike the above this is a real misconfiguration, but it would repeat on
+    // every call just the same, so report it once.
+#ifdef EJIT_DIAG_ENABLE
+    static bool NoPoolLogged = false;
+    if (!NoPoolLogged) {
+      NoPoolLogged = true;
+      EJIT_DIAG("icacheFillOnSuccess DECLINE func=%u: no shared pool "
+                "(gEJIT=%p) -- the inline cache cannot be filled at all",
+                funcIndex, (void *)gEJIT);
+    }
+#endif
     return;
   }
-  sp->icacheFill(funcIndex, fnPtr, dims, numDims);
+  sp->icacheFill(funcIndex, fnPtr, dims, numDims, token);
 #else
   (void)funcIndex;
   (void)fnPtr;
   (void)dims;
   (void)numDims;
+  (void)token;
 #endif
 }
 } // namespace
@@ -734,6 +766,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     EJIT_DIAG("taskpool_compile_or_get reject func=%u: no taskpool", funcIndex);
     return EJIT_ERR_NOT_ACTIVE;
   }
+  const uint64_t icTok = ejitIcacheBeginResolve();
 
   if (numDims > 4) {
     EJIT_DIAG("taskpool_compile_or_get reject func=%u: numDims=%u > 4",
@@ -784,7 +817,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u fast status=%u fn=%p",
                       funcIndex, static_cast<unsigned>(fast.status),
                       fast.fnPtr);
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dimsCast, numDims);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dimsCast, numDims, icTok);
     if (fast.fnPtr)
       tp->l0Fill(funcIndex, fast.fnPtr, dimsCast, numDims);
     return taskpoolStatus(fast.status);
@@ -798,7 +831,7 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
     *outBucket = r.bucketIndex;
   EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u status=%u fn=%p",
                     funcIndex, static_cast<unsigned>(r.status), r.fnPtr);
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dimsCast, numDims);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dimsCast, numDims, icTok);
   if (r.fnPtr)
     tp->l0Fill(funcIndex, r.fnPtr, dimsCast, numDims);
   return taskpoolStatus(r.status);
@@ -836,6 +869,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  const uint64_t icTok = ejitIcacheBeginResolve();
 
   void *l0Fn = nullptr;
   if (tp->l0Try(funcIndex, nullptr, 0, &l0Fn)) {
@@ -849,7 +883,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, nullptr, 0);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, nullptr, 0, icTok);
     return taskpoolStatus(fast.status);
   }
   auto r = tp->compileOrGet(funcIndex, nullptr, 0, /*fallback=*/nullptr);
@@ -857,7 +891,7 @@ ejit_status_t ejit_taskpool_compile_or_get_0d(uint32_t funcIndex, void **outFn,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, nullptr, 0);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, nullptr, 0, icTok);
   if (r.fnPtr)
     tp->l0Fill(funcIndex, r.fnPtr, nullptr, 0);
   return taskpoolStatus(r.status);
@@ -875,6 +909,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  const uint64_t icTok = ejitIcacheBeginResolve();
   if (!ejitTaskpoolDimInRange(dim0, inst0))
     return EJIT_ERR_INVALID_PARAM;
 
@@ -895,7 +930,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 1);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 1, icTok);
     if (fast.fnPtr)
       tp->l0Fill(funcIndex, fast.fnPtr, dims, 1);
     return taskpoolStatus(fast.status);
@@ -905,7 +940,7 @@ ejit_status_t ejit_taskpool_compile_or_get_1d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 1);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 1, icTok);
   if (r.fnPtr)
     tp->l0Fill(funcIndex, r.fnPtr, dims, 1);
   return taskpoolStatus(r.status);
@@ -924,6 +959,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  const uint64_t icTok = ejitIcacheBeginResolve();
   if (!ejitTaskpoolDimInRange(dim0, inst0) ||
       !ejitTaskpoolDimInRange(dim1, inst1))
     return EJIT_ERR_INVALID_PARAM;
@@ -941,7 +977,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 2);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 2, icTok);
     if (fast.fnPtr)
       tp->l0Fill(funcIndex, fast.fnPtr, dims, 2);
     return taskpoolStatus(fast.status);
@@ -951,7 +987,7 @@ ejit_status_t ejit_taskpool_compile_or_get_2d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 2);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 2, icTok);
   if (r.fnPtr)
     tp->l0Fill(funcIndex, r.fnPtr, dims, 2);
   return taskpoolStatus(r.status);
@@ -971,6 +1007,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  const uint64_t icTok = ejitIcacheBeginResolve();
   if (!ejitTaskpoolDimInRange(dim0, inst0) ||
       !ejitTaskpoolDimInRange(dim1, inst1) ||
       !ejitTaskpoolDimInRange(dim2, inst2))
@@ -990,7 +1027,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 3);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 3, icTok);
     if (fast.fnPtr)
       tp->l0Fill(funcIndex, fast.fnPtr, dims, 3);
     return taskpoolStatus(fast.status);
@@ -1000,7 +1037,7 @@ ejit_status_t ejit_taskpool_compile_or_get_3d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 3);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 3, icTok);
   if (r.fnPtr)
     tp->l0Fill(funcIndex, r.fnPtr, dims, 3);
   return taskpoolStatus(r.status);
@@ -1021,6 +1058,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
   auto *tp = activeTaskPool();
   if (!tp)
     return EJIT_ERR_NOT_ACTIVE;
+  const uint64_t icTok = ejitIcacheBeginResolve();
   if (!ejitTaskpoolDimInRange(dim0, inst0) ||
       !ejitTaskpoolDimInRange(dim1, inst1) ||
       !ejitTaskpoolDimInRange(dim2, inst2) ||
@@ -1042,7 +1080,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
       *outFn = fast.fnPtr;
     if (outBucket)
       *outBucket = fast.bucketIndex;
-    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 4);
+    ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dims, 4, icTok);
     if (fast.fnPtr)
       tp->l0Fill(funcIndex, fast.fnPtr, dims, 4);
     return taskpoolStatus(fast.status);
@@ -1052,7 +1090,7 @@ ejit_status_t ejit_taskpool_compile_or_get_4d(uint32_t funcIndex, uint32_t dim0,
     *outFn = r.fnPtr;
   if (outBucket)
     *outBucket = r.bucketIndex;
-  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 4);
+  ejitIcacheFillOnSuccess(funcIndex, r.fnPtr, dims, 4, icTok);
   if (r.fnPtr)
     tp->l0Fill(funcIndex, r.fnPtr, dims, 4);
   return taskpoolStatus(r.status);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -150,24 +150,46 @@ constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 // Per-function inline-cache slot registry (multi-version direct-indexed). Each
 // entry records the wrapper's per-function @__ejit_icache_fn_<name> global base
 // (a uintptr_t cell, or a [D]^numDims array of them for a multi-version entry)
-// plus its dimensionality, registered by name at ejit_auto_register / .ejit_period
-// time via ejit_register_icache_slot (which calls ejitIcacheRegisterSlot). The
-// wrapper reads its OWN global directly (a GEP by the ejit_dim arg values + one
-// plain load + null-check + indirect call) with NO ejit_icache_try call and NO
-// per-call guards. icacheFill writes the specialization pointer through the cell
-// at [i0][i1]... (linearized from dims) on a successful resolve; icacheTry
-// (test/diagnostic only) reads it. The slot is PER-CORE PRIVATE (default BSS),
-// so the fill and the read are same-core, ordered by program order; the
-// indirect call's data dependency on the loaded pointer orders the load before
-// the br. So NO atomic/acquire/CAS is needed -- plain load (ldr) / store (str)
-// is correct. Process-static, zero-filled by the loader (base starts null =
-// unregistered = probe misses = taskpool fallback). See the header for the
-// safety model.
+// plus its dimensionality, registered by name at ejit_auto_register /
+// .ejit_period time via ejit_register_icache_slot (which calls
+// ejitIcacheRegisterSlot). The wrapper reads the cell directly (a GEP by the
+// ejit_dim arg values + one load + null-check + indirect call) with NO
+// ejit_icache_try call and NO per-call guards. icacheFill writes the
+// specialization pointer through the cell at [i0][i1]... (linearized from dims)
+// on a successful resolve; icacheDrainAll zeroes them on a period toggle;
+// icacheTry (test/diagnostic only) reads them.
+//
+// The REGISTRY is core-private (default BSS); the CELLS it points at are not.
+// With EJIT_ICACHE_SECTION set @__ejit_icache_fn_<name> is one shared object,
+// so every core registers the same base and a drain on any core reaches every
+// core's partition. These bookkeeping words are rebuilt identically at each
+// core's own registration and never read cross-core.
+//
+// Cell accesses therefore go through the atomic wrapper -- a fill on one core
+// can race a drain on another. Relaxed is the right order (single-location
+// coherence on one naturally-aligned word) and lowers to the same ldr/str on
+// AArch64. The AOT probe's load is likewise relaxed, so the cache is race-free
+// in the C++ model at zero code-size cost.
 struct EJitIcacheSlotReg {
   uintptr_t *base;
   uint32_t numDims;
 };
 EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
+
+// A cell viewed as the atomic it is: EJitAtomic<uintptr_t> is a standard-layout
+// wrapper over exactly one pointer-sized word, so this overlay on the AOT array
+// is layout-identical and only changes which builtin performs the access.
+inline EJitAtomicUPtr &icacheCell(uintptr_t *base, uintptr_t idx) {
+  return reinterpret_cast<EJitAtomicUPtr *>(base)[idx];
+}
+
+// Cells in a [D]^numDims array. numDims is capped at registration.
+inline uintptr_t icacheCellCount(uint32_t numDims) {
+  uintptr_t n = 1;
+  for (uint32_t i = 0; i < numDims; ++i)
+    n *= EJIT_ICACHE_DIM_SIZE;
+  return n;
+}
 
 // Linearize the dim identity to a flat cell index, row-major, dim0 = leftmost
 // ejit_dim param (MUST match the AOT [D]^numDims array declaration order). D is
@@ -182,12 +204,18 @@ static uintptr_t icacheLinearize(const EJitDimPair *dims, uint32_t numDims) {
 
 } // namespace
 
-void llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
+bool llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
                                         uint32_t numDims) {
   if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !base)
-    return;
+    return false;
+  // numDims sizes the array the drain walks, so an out-of-cap value writes far
+  // past the wrapper's global. The AOT pass never emits one, but numDims also
+  // arrives from a uint64 registry field and the public C ABI -- don't trust it.
+  if (numDims > EJIT_ICACHE_MAX_DIMS)
+    return false;
   gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
   gIcacheSlots[funcIndex].numDims = numDims;
+  return true;
 }
 
 void llvm::ejit::ejitIcacheClearAll() {
@@ -196,7 +224,8 @@ void llvm::ejit::ejitIcacheClearAll() {
   // base pointers here: in tests the slots are stack locals that may already be
   // destroyed by the time a later test clears (e.g. if an ASSERT returned early
   // and skipped the prior test's end-clear), so dereferencing would be a
-  // use-after-free. Production never calls this.
+  // use-after-free -- which is why this stays distinct from icacheDrainAll(),
+  // which DOES write through every base. Production never calls this.
   for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
     gIcacheSlots[f].base = nullptr;
     gIcacheSlots[f].numDims = 0;
@@ -216,15 +245,94 @@ void llvm::ejit::ejitDumpIcacheSlots() {
     // For multi-dim arrays, cell[0] is the [0]...[0] element; for 0-dim,
     // it is the scalar cell. Either way it tells us whether the first
     // identity has been resolved yet.
-    bool cell0 = (reg.base[0] != 0);
-    if (cell0)
+    const uintptr_t c0 = icacheCell(reg.base, 0).loadRelaxed();
+    if (c0)
       filled++;
     EJIT_DIAG("  [%2u] base=%p numDims=%u cell[0]=%p %s",
-              f, (void *)reg.base, reg.numDims,
-              (void *)reg.base[0], cell0 ? "(filled)" : "(empty)");
+              f, (void *)reg.base, reg.numDims, (void *)c0,
+              c0 ? "(filled)" : "(empty)");
   }
   EJIT_DIAG("=== icache slots: %u registered, %u with cell[0] filled ===",
             registered, filled);
+}
+
+void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
+  if (!state_) {
+    EJIT_DIAG("icacheDrain SKIP (%s): no shared state bound",
+              reason ? reason : "unspecified");
+    return;
+  }
+  // Announce the drain BEFORE touching a cell and retire the sequence AFTER the
+  // last one. Together these bracket the whole window: a fill can only be
+  // accepted if it saw drainsInFlight == 0 at both ends AND an unchanged
+  // sequence, which is possible only when no drain overlapped its resolve.
+  // Announcing first is what stops a fill from slipping into a cell this drain
+  // has already passed but has not yet accounted for.
+  state_->icacheDrainsInFlight.fetchAdd(1);
+  // Counted only under EJIT_DIAG_ENABLE: reading every cell back to see whether
+  // it held anything doubles the drain's memory traffic, and with diagnostics
+  // off EJIT_DIAG discards its arguments unevaluated, so these would be dead.
+#ifdef EJIT_DIAG_ENABLE
+  uint32_t walkedSlots = 0;
+  uint64_t clearedCells = 0;
+#endif
+  for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
+    const EJitIcacheSlotReg &reg = gIcacheSlots[f];
+    if (!reg.base)
+      continue;
+    if (reg.numDims > EJIT_ICACHE_MAX_DIMS)
+      continue; // defence in depth: never walk past a mis-sized array
+    const uintptr_t cells = icacheCellCount(reg.numDims);
+#ifdef EJIT_DIAG_ENABLE
+    ++walkedSlots;
+#endif
+    for (uintptr_t c = 0; c < cells; ++c) {
+#ifdef EJIT_DIAG_ENABLE
+      if (icacheCell(reg.base, c).loadRelaxed() != 0)
+        ++clearedCells;
+#endif
+      icacheCell(reg.base, c).storeRelaxed(0);
+    }
+  }
+  const uint32_t seq = state_->icacheDrainSeq.fetchAdd(1) + 1u;
+  state_->icacheDrainsInFlight.fetchSub(1);
+  // A drain that actually emptied a cell is the event worth seeing on a board:
+  // it is what explains a hot core suddenly missing. A drain that cleared
+  // NOTHING invalidated nothing, and at bring-up those dominate -- N cores each
+  // calling ejit_activate per instance, every one walking a table that is still
+  // cold. Logging those at INFO buries the run in lines reporting a non-event,
+  // so they go to VERBOSE; the sequence still moves, so a fill retraction can
+  // still be traced by raising the level.
+#ifdef EJIT_DIAG_ENABLE
+  if (clearedCells != 0) {
+    EJIT_DIAG("icacheDrain OK (%s): core=%u slots=%u cellsCleared=%llu seq=%u",
+              reason ? reason : "unspecified", EJitCoreId::current(),
+              walkedSlots, static_cast<unsigned long long>(clearedCells), seq);
+  } else {
+    EJIT_DIAG_VERBOSE("icacheDrain OK (%s): core=%u slots=%u cellsCleared=0 "
+                      "seq=%u (nothing was cached)",
+                      reason ? reason : "unspecified", EJitCoreId::current(),
+                      walkedSlots, seq);
+  }
+#else
+  (void)reason;
+  (void)seq;
+#endif
+}
+
+uint32_t EJitSharedTaskPool::icacheDrainSeq() const {
+  return state_ ? state_->icacheDrainSeq.loadAcquire() : 0;
+}
+
+uint64_t EJitSharedTaskPool::icacheBeginResolve() {
+  if (!state_)
+    return kEJitIcacheNoResolve;
+  const uint32_t seq = state_->icacheDrainSeq.loadAcquire();
+  // A drain already running has an unknown reach: it may have passed this
+  // identity's cell or not. Refuse the token rather than guess.
+  if (state_->icacheDrainsInFlight.loadAcquire() != 0)
+    return kEJitIcacheNoResolve;
+  return kEJitIcacheResolveValid | seq;
 }
 
 //===----------------------------------------------------------------------===//
@@ -257,18 +365,18 @@ uint32_t EJitSharedTaskPool::instanceVersion(uint32_t dimType,
 // Per-function inline cache (multi-version direct-indexed).
 //
 // The production hit path does NOT call icacheTry: the ejit_entry wrapper reads
-// its own @__ejit_icache_fn_<name> global directly (GEP into the [D]^numDims
-// array by the ejit_dim arg values + acquire load + null check + indirect call,
-// no call, no per-call guards). icacheTry is retained for unit tests and
+// the shared @__ejit_icache_fn_<name> table directly (GEP into the [D]^numDims
+// array by the ejit_dim arg values + one load + null check + indirect call, no
+// call, no per-call guards). icacheTry is retained for unit tests and
 // diagnostics. icacheFill writes the specialization pointer through the cell at
-// [i0][i1]... (linearized from dims) on a successful resolve; it is a frozen,
-// one-shot fill PER CELL - each identity's cell is written once and never
-// refilled, so a cell's pointer is always the correct (invariant) specialization
-// for that identity. Lifetime is safe because JIT code is never freed in
-// production; the safety gate auto-disables the cache if a releaser is wired
-// (no HP-scan retire). The code-sharing gate retains the cross-core pointer
-// discipline of resolveMatchedSlot (relevant to icacheTry in non-shared test
-// builds; the wrapper's inline probe is only enabled under
+// [i0][i1]... (linearized from dims) on a successful resolve, and
+// icacheDrainAll zeroes every cell on a period toggle - so a cell holds the
+// specialization for its identity under the CURRENT period values, and stops
+// answering the moment those change. Lifetime is safe because JIT code is never
+// freed in production; the safety gate auto-disables the cache if a releaser is
+// wired (no HP-scan retire). The code-sharing gate retains the cross-core
+// pointer discipline of resolveMatchedSlot (relevant to icacheTry in non-shared
+// test builds; the wrapper's inline probe is only enabled under
 // EJIT_SRE_SHARED_CODE_POINTERS, where the gate is compile-time true).
 //===----------------------------------------------------------------------===//
 bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
@@ -303,12 +411,12 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
 #endif
   if (!mayReadPtr)
     return false;
-  // Read this identity's cell. The slot is per-core private: the fill (same
-  // core) is ordered before this read by program order, and the caller's
-  // indirect call depends on the loaded pointer (data dependency). So a plain
-  // load is correct -- no acquire needed.
+  // Read this identity's cell. Relaxed is enough, and is what the AOT probe
+  // emits: the cell holds a self-contained pointer, the caller's indirect call
+  // depends on the value loaded (data dependency), and the only cross-core
+  // write is a drain storing 0 -- which yields a miss, never a bad pointer.
   uintptr_t idx = icacheLinearize(dims, numDims);
-  uintptr_t p = reg.base[idx];
+  uintptr_t p = icacheCell(reg.base, idx).loadRelaxed();
   if (p == 0)
     return false;
   *outFn = reinterpret_cast<void *>(p);
@@ -330,8 +438,12 @@ EJitL0Entry llvm::ejit::gEJitL0[kEJitL0Slots];
 const void *llvm::ejit::gEJitL0State = nullptr;
 
 void EJitSharedTaskPool::retireDispatchCache() {
-  if (state_)
-    state_->dispatchEpoch.fetchAdd(1);
+  if (!state_)
+    return;
+  state_->dispatchEpoch.fetchAdd(1);
+  // The inline cache answers the same (identity -> fnPtr) question with no
+  // epoch of its own, so the events that retire the L0 must empty it outright.
+  icacheDrainAll("retire-dispatch-cache");
 }
 
 void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
@@ -369,34 +481,99 @@ void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
   e.seq = e.seq + 1u;
 }
 
+// One-shot diagnostics for icacheFill's decline paths. The fill runs on every
+// successful resolve, so an unconditional log would emit millions of lines under
+// load; each reason is reported once per core instead, which is all it takes to
+// answer "why is no cell being filled" from a board log. Core-private .bss, and
+// compiled out entirely when EJIT_DIAG_ENABLE is off.
+namespace {
+enum EJitIcacheFillReject {
+  kFillRejectReclaim = 0,
+  kFillRejectArgs,
+  kFillRejectUnregistered,
+  kFillRejectRacedDrain,
+  kFillRejectCount
+};
+bool gIcacheFillRejectLogged[kFillRejectCount];
+bool gIcacheFillOkLogged;
+} // namespace
+
 void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
-                                    const EJitDimPair *dims, uint32_t numDims) {
+                                    const EJitDimPair *dims, uint32_t numDims,
+                                    uint64_t token) {
   if (!icacheReclamationSafe_) {
-    EJIT_DIAG("icacheFill SKIP func=%u: reclamation not safe", funcIndex);
+    if (!gIcacheFillRejectLogged[kFillRejectReclaim]) {
+      gIcacheFillRejectLogged[kFillRejectReclaim] = true;
+      EJIT_DIAG("icacheFill DECLINE func=%u: a releaser is wired, so the cache "
+                "is disabled to avoid handing out freed code",
+                funcIndex);
+    }
     return;
   }
+  // Cross-core executability gate: this store publishes fnPtr to every core at
+  // once, including cores that have not prepared it. Where the platform needs
+  // per-core execute preparation a peer would jump to an address it has not
+  // sealed, so decline and let the taskpool -- which prepares -- serve every
+  // call. See icacheCrossCoreExecutable().
+  if (!icacheCrossCoreExecutable())
+    return;
   if (!state_ || !fnPtr || funcIndex >= EJIT_ICACHE_FUNC_SLOTS) {
-    EJIT_DIAG("icacheFill SKIP func=%u: state=%p fn=%p OOB=%u", funcIndex,
-              (void *)state_, fnPtr,
-              (unsigned)(funcIndex >= EJIT_ICACHE_FUNC_SLOTS));
+    if (!gIcacheFillRejectLogged[kFillRejectArgs]) {
+      gIcacheFillRejectLogged[kFillRejectArgs] = true;
+      EJIT_DIAG("icacheFill DECLINE func=%u: state=%p fn=%p slots=%u",
+                funcIndex, (const void *)state_, fnPtr,
+                EJIT_ICACHE_FUNC_SLOTS);
+    }
     return;
   }
   EJitIcacheSlotReg &reg = gIcacheSlots[funcIndex];
   if (!reg.base || numDims != reg.numDims) {
-    EJIT_DIAG("icacheFill SKIP func=%u: base=%p regDims=%u callDims=%u",
-              funcIndex, (void *)reg.base, reg.numDims, numDims);
-    return; // unregistered, or shape mismatch: nowhere to write.
+    // Unregistered, or shape mismatch: nowhere to write. A null base means this
+    // core never ran ejit_register_icache_slot for this function -- the AOT
+    // .ejit_period entry is missing, or the name did not resolve to funcIndex.
+    if (!gIcacheFillRejectLogged[kFillRejectUnregistered]) {
+      gIcacheFillRejectLogged[kFillRejectUnregistered] = true;
+      EJIT_DIAG("icacheFill DECLINE func=%u: base=%p registeredDims=%u "
+                "callerDims=%u (null base = never registered on this core)",
+                funcIndex, (const void *)reg.base, reg.numDims, numDims);
+    }
+    return;
   }
-  // Plain store: the slot is per-core private, so this write (on the calling
-  // core) is ordered before the wrapper's read (same core) by program order.
-  // The specialization is invariant per identity under the contract + NO_RECLAIM,
-  // so overwriting on a later resolve (same pointer) is harmless -- no one-shot
-  // CAS is needed. No atomic/release: same-core, and the read's data dependency
-  // on the pointer orders this store-before-use.
+  // Drop the fill if any drain overlapped this resolve: fnPtr may be specialized
+  // for the period values the toggle just replaced, and restoring a cell the
+  // drain cleared is something nothing later would notice. The token pins the
+  // start of the window, these two loads the end.
+  if (!(token & kEJitIcacheResolveValid) ||
+      state_->icacheDrainsInFlight.loadAcquire() != 0 ||
+      static_cast<uint32_t>(token) != state_->icacheDrainSeq.loadAcquire()) {
+    // Expected occasionally: a period toggle overlapped this resolve. Reported
+    // once because a PERMANENT stream of these means something is draining
+    // continuously, which would keep the cache empty forever.
+    if (!gIcacheFillRejectLogged[kFillRejectRacedDrain]) {
+      gIcacheFillRejectLogged[kFillRejectRacedDrain] = true;
+      EJIT_DIAG("icacheFill DECLINE func=%u: resolve raced a drain "
+                "(token=0x%llx valid=%u seqAtResolve=%u seqNow=%u inFlight=%u)",
+                funcIndex, static_cast<unsigned long long>(token),
+                static_cast<unsigned>((token & kEJitIcacheResolveValid) != 0),
+                static_cast<unsigned>(token),
+                state_->icacheDrainSeq.loadAcquire(),
+                state_->icacheDrainsInFlight.loadAcquire());
+    }
+    return;
+  }
+  // Relaxed store into the SHARED cell. Cores write disjoint identities, so the
+  // only colliding writer is a drain storing 0 (and the guard above rules out
+  // the one unsafe order). The reader's indirect call carries a data dependency
+  // on the value, so no release is needed.
   uintptr_t idx = icacheLinearize(dims, numDims);
-  reg.base[idx] = reinterpret_cast<uintptr_t>(fnPtr);
-  EJIT_DIAG("icacheFill OK func=%u dims=%u idx=%zu fn=%p cell[0]=%p",
-            funcIndex, numDims, (size_t)idx, fnPtr, (void *)reg.base[0]);
+  icacheCell(reg.base, idx).storeRelaxed(reinterpret_cast<uintptr_t>(fnPtr));
+  if (!gIcacheFillOkLogged) {
+    gIcacheFillOkLogged = true;
+    EJIT_DIAG("icacheFill OK func=%u cell=%p[%llu] fn=%p -- the inline cache is "
+              "live on this core",
+              funcIndex, (const void *)reg.base,
+              static_cast<unsigned long long>(idx), fnPtr);
+  }
 }
 
 void EJitSharedTaskPool::forEachCompiled(CompiledFuncCallback cb,
@@ -442,19 +619,29 @@ bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
   }
   uint8_t expected = enabled ? 0 : 1;
   uint8_t desired = enabled ? 1 : 0;
-  if (state_->enabled[dimType][instanceId].compareExchange(expected, desired)) {
+  const bool flipped =
+      state_->enabled[dimType][instanceId].compareExchange(expected, desired);
+
+  // The INVALIDATIONS run unconditionally: neither cache stores a version, and
+  // a caller that LOST the CAS may still have rewritten its own core-private
+  // period values. Draining the shared cell table here is what reaches a peer
+  // core that is permanently hot and would never call in on its own.
+  state_->dispatchEpoch.fetchAdd(1);
+  icacheDrainAll("period-toggle");
+
+  // version[] moves only on a real transition: its consumer is runCompile's
+  // checkpoints, which DISCARD a finished compile when it moves, and nothing
+  // re-enqueues a dropped compile. An unconditional bump would let N cores
+  // activating the same instance at startup stall the JIT permanently.
+  if (flipped)
     state_->version[dimType][instanceId].fetchAdd(1);
-    // Cached L0 entries carry no version, so retire them all.
-    state_->dispatchEpoch.fetchAdd(1);
-    // Latch on the first successful enable of ANY instance: this brackets the
-    // init→activate window during which instanceDisabled hits are tallied
-    // separately (instanceDisabledPreActivate) for diagnosing the pre-activate
-    // fallback storm. Once latched it stays 1 until the next (re)initialization.
-    if (enabled)
-      state_->anyInstanceActivated.storeRelease(1);
-    return true;
-  }
-  return false;
+  // Latch on the first enable of ANY instance: this brackets the init→activate
+  // window during which instanceDisabled hits are tallied separately
+  // (instanceDisabledPreActivate) for diagnosing the pre-activate fallback
+  // storm. Once latched it stays 1 until the next (re)initialization.
+  if (enabled)
+    state_->anyInstanceActivated.storeRelease(1);
+  return flipped;
 }
 
 bool EJitSharedTaskPool::versionsCurrent(const EJitCompileRequest &req) const {
@@ -1514,6 +1701,11 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
   // starting value is arbitrary, which is harmless: the L0 tables are zeroed
   // BSS and l0Key() never returns 0, so no entry can match anyway.
   st->dispatchEpoch.fetchAdd(1);
+  // icacheDrainSeq is likewise BUMPED, never reset: a core that snapshotted it
+  // before this (re)initialization must not find its snapshot still current
+  // afterwards and fill a cell with a pointer from the previous generation.
+  st->icacheDrainSeq.fetchAdd(1);
+  st->icacheDrainsInFlight.storeRelaxed(0);
   for (uint32_t i = 0; i < kEJitSharedMaxFuncIndex; ++i)
     st->inFlight[i].storeRelaxed(0);
   for (uint32_t i = 0; i < kEJitSharedQueueSlots; ++i) {
@@ -1626,6 +1818,10 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       uint32_t self = EJitCoreId::current();
       uint32_t nextGen = state_->generation.loadRelaxed() + 1;
       initSharedStorage(state_, static_cast<uint32_t>(configuredMode_));
+      // Empty the shared cell table for the new generation: after a re-init that
+      // skipped ownerShutdown the cells hold pointers into the previous
+      // generation's code, and a cell carries no epoch to invalidate against.
+      icacheDrainAll("owner-init");
       state_->generation.storeRelease(nextGen);
       state_->ownerCoreId.storeRelease(self);
       state_->codeSharingEnabled.storeRelease(codeSharingEnabled_ ? 1u : 0u);
@@ -1729,8 +1925,13 @@ void EJitSharedTaskPool::ownerShutdown() {
   // Disarm this core's L0: its entries hold code pointers about to become
   // invalid. Peers stay armed but cannot match after the epoch bump below.
   gEJitL0State = nullptr;
-  if (state_)
+  if (state_) {
     state_->dispatchEpoch.fetchAdd(1);
+    // Empty every core's inline cache: its cells point at the generation being
+    // torn down and carry no epoch to invalidate against. The cells are shared,
+    // so zeroing them here retires them everywhere.
+    icacheDrainAll("owner-shutdown");
+  }
   if (!state_ || !isOwner_)
     return;
   EJIT_DIAG("shared taskpool owner shutdown begin");

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -179,6 +179,16 @@ EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
 // A cell viewed as the atomic it is: EJitAtomic<uintptr_t> is a standard-layout
 // wrapper over exactly one pointer-sized word, so this overlay on the AOT array
 // is layout-identical and only changes which builtin performs the access.
+//
+// Formally this is a strict-aliasing violation -- the AOT global is declared as
+// an array of pointer-sized words, not of EJitAtomicUPtr -- so it rests on the
+// compiler assumption every other shared-memory overlay here rests on: the
+// access is through a standard-layout type of identical size and alignment, and
+// __atomic_* builtins lower to plain LDR/STR on the same address the wrapper
+// would have used. LLVM and GCC both accept this; a compiler that did not would
+// break the shared blob overlays long before it broke this one. Kept as an
+// overlay rather than changing the AOT type because the wrapper's global must
+// stay a plain [D]^numDims array of pointers for the probe's GEP.
 inline EJitAtomicUPtr &icacheCell(uintptr_t *base, uintptr_t idx) {
   return reinterpret_cast<EJitAtomicUPtr *>(base)[idx];
 }
@@ -191,10 +201,22 @@ inline uintptr_t icacheCellCount(uint32_t numDims) {
   return n;
 }
 
+// True when every instance id fits the table's per-dim bound. The taskpool
+// accepts ids up to MAX_INSTANCES (256) and a period array up to
+// MAX_PERIOD_ARR_SIZE (100), against a D of 16, so an ordinary application can
+// present an id with no cell; indexing anyway walks off the wrapper's global.
+// EJitWrapperGen emits no probe unless it can prove the bound.
+static bool icacheDimsInRange(const EJitDimPair *dims, uint32_t numDims) {
+  for (uint32_t i = 0; i < numDims; ++i)
+    if (dims[i].instanceId >= EJIT_ICACHE_DIM_SIZE)
+      return false;
+  return true;
+}
+
 // Linearize the dim identity to a flat cell index, row-major, dim0 = leftmost
 // ejit_dim param (MUST match the AOT [D]^numDims array declaration order). D is
-// EJIT_ICACHE_DIM_SIZE (power-of-2). numDims=0 -> idx 0 (the scalar cell). No
-// bounds check - the contract is every ejit_dim arg < D.
+// EJIT_ICACHE_DIM_SIZE (power-of-2). numDims=0 -> idx 0 (the scalar cell).
+// Callers must have passed icacheDimsInRange first.
 static uintptr_t icacheLinearize(const EJitDimPair *dims, uint32_t numDims) {
   uintptr_t idx = 0;
   for (uint32_t i = 0; i < numDims; ++i)
@@ -204,18 +226,23 @@ static uintptr_t icacheLinearize(const EJitDimPair *dims, uint32_t numDims) {
 
 } // namespace
 
-bool llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
-                                        uint32_t numDims) {
-  if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS || !base)
-    return false;
+EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex,
+                                                       void *base,
+                                                       uint32_t numDims) {
+  if (!base)
+    return EJitIcacheRegResult::Invalid;
   // numDims sizes the array the drain walks, so an out-of-cap value writes far
   // past the wrapper's global. The AOT pass never emits one, but numDims also
   // arrives from a uint64 registry field and the public C ABI -- don't trust it.
   if (numDims > EJIT_ICACHE_MAX_DIMS)
-    return false;
+    return EJitIcacheRegResult::Invalid;
+  // Checked LAST so malformed data is still reported as malformed. Running out
+  // of slots while the function registry holds 4096 is expected and degrades.
+  if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
+    return EJitIcacheRegResult::CapacityMiss;
   gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
   gIcacheSlots[funcIndex].numDims = numDims;
-  return true;
+  return EJitIcacheRegResult::Ok;
 }
 
 void llvm::ejit::ejitIcacheClearAll() {
@@ -262,6 +289,14 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
               reason ? reason : "unspecified");
     return;
   }
+  // Stamp the drain with the generation it belongs to. setInstanceEnabled() does
+  // not require Ready, so a peer drain can still be walking cells when the owner
+  // shuts down and a new owner claims the blob. That (re)initialization discards
+  // the in-flight count wholesale, so a straggler must NOT decrement afterwards:
+  // its increment is already gone, and subtracting again wraps the counter to
+  // UINT32_MAX -- after which icacheBeginResolve() refuses every token forever
+  // and no later drain can repair it, since each one is +1 then -1.
+  const uint32_t gen = state_->generation.loadAcquire();
   // Announce the drain BEFORE touching a cell and retire the sequence AFTER the
   // last one. Together these bracket the whole window: a fill can only be
   // accepted if it saw drainsInFlight == 0 at both ends AND an unchanged
@@ -269,6 +304,14 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
   // Announcing first is what stops a fill from slipping into a cell this drain
   // has already passed but has not yet accounted for.
   state_->icacheDrainsInFlight.fetchAdd(1);
+  // Nothing has been cached since the last drain emptied the table, so there is
+  // nothing to zero. Skip the walk -- but still bump the sequence below, because
+  // a resolve in flight right now must still be told a drain happened.
+  //
+  // This is the bring-up case and it dominates: N cores x one ejit_activate per
+  // instance, every one of them walking every cell of every registered slot to
+  // write 0 over 0. Correctness does not depend on the flag; see icacheArmed.
+  const bool armed = state_->icacheArmed.loadAcquire() != 0;
   // Counted only under EJIT_DIAG_ENABLE: reading every cell back to see whether
   // it held anything doubles the drain's memory traffic, and with diagnostics
   // off EJIT_DIAG discards its arguments unevaluated, so these would be dead.
@@ -276,7 +319,7 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
   uint32_t walkedSlots = 0;
   uint64_t clearedCells = 0;
 #endif
-  for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
+  for (uint32_t f = 0; armed && f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
     const EJitIcacheSlotReg &reg = gIcacheSlots[f];
     if (!reg.base)
       continue;
@@ -294,8 +337,16 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
       icacheCell(reg.base, c).storeRelaxed(0);
     }
   }
+  // Only after a real walk: a skip cleared nothing, and clearing the flag it
+  // just read as 0 would be a no-op anyway. A fill that armed DURING the walk
+  // retracts itself (a drain was in flight for its whole store), so dropping the
+  // flag here cannot strand a cell.
+  if (armed)
+    state_->icacheArmed.storeRelease(0);
   const uint32_t seq = state_->icacheDrainSeq.fetchAdd(1) + 1u;
-  state_->icacheDrainsInFlight.fetchSub(1);
+  // Zeroing cells of a generation we no longer belong to is harmless -- an empty
+  // cell only costs a miss -- but the accounting is not.
+  ejitIcacheRetireDrain(state_, gen);
   // A drain that actually emptied a cell is the event worth seeing on a board:
   // it is what explains a hot core suddenly missing. A drain that cleared
   // NOTHING invalidated nothing, and at bring-up those dominate -- N cores each
@@ -303,21 +354,44 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
   // cold. Logging those at INFO buries the run in lines reporting a non-event,
   // so they go to VERBOSE; the sequence still moves, so a fill retraction can
   // still be traced by raising the level.
+  //
+  // `gen` is in the line because a drain that started under a generation the
+  // blob has since left retires nothing, and that is otherwise invisible.
 #ifdef EJIT_DIAG_ENABLE
   if (clearedCells != 0) {
-    EJIT_DIAG("icacheDrain OK (%s): core=%u slots=%u cellsCleared=%llu seq=%u",
-              reason ? reason : "unspecified", EJitCoreId::current(),
+    EJIT_DIAG("icacheDrain OK (%s): core=%u gen=%u slots=%u cellsCleared=%llu "
+              "seq=%u",
+              reason ? reason : "unspecified", EJitCoreId::current(), gen,
               walkedSlots, static_cast<unsigned long long>(clearedCells), seq);
   } else {
-    EJIT_DIAG_VERBOSE("icacheDrain OK (%s): core=%u slots=%u cellsCleared=0 "
-                      "seq=%u (nothing was cached)",
+    EJIT_DIAG_VERBOSE("icacheDrain OK (%s): core=%u gen=%u slots=%u "
+                      "cellsCleared=0 seq=%u (nothing was cached)",
                       reason ? reason : "unspecified", EJitCoreId::current(),
-                      walkedSlots, seq);
+                      gen, walkedSlots, seq);
   }
 #else
   (void)reason;
+  (void)gen;
   (void)seq;
 #endif
+}
+
+void llvm::ejit::ejitIcacheRetireDrain(EJitSharedTaskPoolState *st,
+                                       uint32_t gen) {
+  if (!st)
+    return;
+  // Our increment was discarded with the previous generation's count.
+  if (st->generation.loadAcquire() != gen) {
+    EJIT_DIAG("icacheDrain retire SKIP: started under gen=%u, blob is now "
+              "gen=%u -- the re-init already discarded this increment",
+              gen, st->generation.loadAcquire());
+    return;
+  }
+  // Saturating even so: the generation check closes the interleaving this
+  // guards against, and this closes any other.
+  uint32_t cur = st->icacheDrainsInFlight.loadAcquire();
+  while (cur != 0 && !st->icacheDrainsInFlight.compareExchange(cur, cur - 1))
+    ;
 }
 
 uint32_t EJitSharedTaskPool::icacheDrainSeq() const {
@@ -384,10 +458,11 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
   if (!outFn)
     return false;
   *outFn = nullptr;
-  // Safety gate: auto-disable while a releaser is wired (no HP-scan retire, so
-  // freeing code + a cached fnPtr = UAF). Production wires no releaser, so this
-  // never trips and the cache is unconditionally safe.
-  if (!icacheReclamationSafe_)
+  // Safety gate: auto-disable while a releaser is wired ANYWHERE (no HP-scan
+  // retire, so freeing code + a cached fnPtr = UAF). Shared, because the table
+  // is: a peer's releaser has to close this core's probe too. Production wires
+  // no releaser, so this never trips and the cache is unconditionally safe.
+  if (!icacheReclamationSafeShared())
     return false;
   if (!state_ || funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
     return false;
@@ -410,6 +485,8 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
   bool mayReadPtr = (self == owner);
 #endif
   if (!mayReadPtr)
+    return false;
+  if (!icacheDimsInRange(dims, numDims))
     return false;
   // Read this identity's cell. Relaxed is enough, and is what the AOT probe
   // emits: the cell holds a self-contained pointer, the caller's indirect call
@@ -448,7 +525,7 @@ void EJitSharedTaskPool::retireDispatchCache() {
 
 void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
                                 const EJitDimPair *dims, uint32_t numDims) {
-  if (!icacheReclamationSafe_ || !state_ || !fnPtr)
+  if (!icacheReclamationSafeShared() || !state_ || !fnPtr)
     return;
   if (numDims > kEJitSharedMaxDims)
     return;
@@ -481,27 +558,29 @@ void EJitSharedTaskPool::l0Fill(uint32_t funcIndex, void *fnPtr,
   e.seq = e.seq + 1u;
 }
 
-// One-shot diagnostics for icacheFill's decline paths. The fill runs on every
-// successful resolve, so an unconditional log would emit millions of lines under
-// load; each reason is reported once per core instead, which is all it takes to
-// answer "why is no cell being filled" from a board log. Core-private .bss, and
-// compiled out entirely when EJIT_DIAG_ENABLE is off.
+// One-shot diagnostics for icacheFill's decline paths: the fill runs on every
+// successful resolve, so an unconditional log would emit millions of lines.
+// Core-private .bss, compiled out when EJIT_DIAG_ENABLE is off.
 namespace {
 enum EJitIcacheFillReject {
   kFillRejectReclaim = 0,
   kFillRejectArgs,
   kFillRejectUnregistered,
+  kFillRejectDimRange,
   kFillRejectRacedDrain,
+  kFillRejectRetracted,
+  kFillRejectScalarShared,
   kFillRejectCount
 };
 bool gIcacheFillRejectLogged[kFillRejectCount];
 bool gIcacheFillOkLogged;
+
 } // namespace
 
 void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
                                     const EJitDimPair *dims, uint32_t numDims,
                                     uint64_t token) {
-  if (!icacheReclamationSafe_) {
+  if (!icacheReclamationSafeShared()) {
     if (!gIcacheFillRejectLogged[kFillRejectReclaim]) {
       gIcacheFillRejectLogged[kFillRejectReclaim] = true;
       EJIT_DIAG("icacheFill DECLINE func=%u: a releaser is wired, so the cache "
@@ -510,7 +589,8 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
     }
     return;
   }
-  // NO icacheCrossCoreExecutable() gate here, deliberately.
+  // NO blanket icacheCrossCoreExecutable() gate here, deliberately -- but see
+  // the numDims == 0 case below, which is not covered by the argument.
   //
   // Cells are addressed by dim identity, and the deployment contract is that
   // cores drive DISJOINT ejit_period_lc instance indices. A core therefore only
@@ -520,17 +600,18 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   // it loads is always code it has already prepared, which is the guarantee a
   // per-core .bss table used to give structurally.
   //
-  // Gating on icacheCrossCoreExecutable() instead disables the cache in every
-  // build it is allowed in: EJitCompileDriver sets fourKSeal_ under
-  // EJIT_CODE_POOL_4K_SEAL and wires prepareCodeFn_ otherwise, both inside
-  // EJIT_SRE_SHARED_CODE_POINTERS, which the AOT probe requires. Both branches
-  // close it, so no cell was ever filled on any real target.
+  // Gating every shape on icacheCrossCoreExecutable() instead disables the
+  // cache in every build it is allowed in: EJitCompileDriver sets fourKSeal_
+  // under EJIT_CODE_POOL_4K_SEAL and wires prepareCodeFn_ otherwise, both
+  // inside EJIT_SRE_SHARED_CODE_POINTERS, which the AOT probe requires. Both
+  // branches close it, so no cell would ever be filled on any real target.
   //
-  // What the gate would protect against is two cores sharing a dim identity,
-  // where the second loads a pointer only the first has sealed. That is a
-  // violation of the disjointness contract, and it cannot be detected from
-  // here: a cell carries no record of which core wrote it, and adding one puts
-  // a per-core gate back on a probe whose whole point is not having one.
+  // What such a gate would protect against is two cores sharing a dim identity,
+  // where the second loads a pointer only the first has sealed. For a
+  // dimensioned entry that is a violation of the disjointness contract, and it
+  // cannot be detected from here: a cell carries no record of which core wrote
+  // it, and adding one puts a per-core gate back on a probe whose whole point
+  // is not having one.
   if (!state_ || !fnPtr || funcIndex >= EJIT_ICACHE_FUNC_SLOTS) {
     if (!gIcacheFillRejectLogged[kFillRejectArgs]) {
       gIcacheFillRejectLogged[kFillRejectArgs] = true;
@@ -550,6 +631,40 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
       EJIT_DIAG("icacheFill DECLINE func=%u: base=%p registeredDims=%u "
                 "callerDims=%u (null base = never registered on this core)",
                 funcIndex, (const void *)reg.base, reg.numDims, numDims);
+    }
+    return;
+  }
+  // A 0-dim entry has exactly ONE cell and no identity to partition it by, so
+  // the disjointness argument above does not reach this shape: every core reads
+  // and writes that same scalar, by construction, no matter how well behaved
+  // the deployment is. Core A can fill it having prepared the code only for A,
+  // and core B then loads a non-null pointer on its very first call and branches
+  // to a page it never sealed.
+  //
+  // There is no per-core information in the cell to recover the implication
+  // from, so the only sound rule is the platform one: allow the shared scalar
+  // only where a resolved pointer is callable everywhere the instant it exists.
+  // Elsewhere the probe simply keeps missing and the taskpool -- which does the
+  // per-core preparation -- serves every call. The AOT side still emits the
+  // probe for 0D entries; it is the fill, not the code, that is platform
+  // dependent.
+  if (numDims == 0 && !icacheCrossCoreExecutable()) {
+    if (!gIcacheFillRejectLogged[kFillRejectScalarShared]) {
+      gIcacheFillRejectLogged[kFillRejectScalarShared] = true;
+      EJIT_DIAG("icacheFill DECLINE func=%u: 0-dim entry shares one cell across "
+                "cores and this platform prepares execute permission per core, "
+                "so a peer could branch to code it has not sealed",
+                funcIndex);
+    }
+    return;
+  }
+  // No cell for this identity. The taskpool serves it; never index anyway.
+  if (!icacheDimsInRange(dims, numDims)) {
+    if (!gIcacheFillRejectLogged[kFillRejectDimRange]) {
+      gIcacheFillRejectLogged[kFillRejectDimRange] = true;
+      EJIT_DIAG("icacheFill DECLINE func=%u: an instance id is >= the table's "
+                "per-dim bound %u, so this identity has no cell",
+                funcIndex, EJIT_ICACHE_DIM_SIZE);
     }
     return;
   }
@@ -575,12 +690,37 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
     }
     return;
   }
-  // Relaxed store into the SHARED cell. Cores write disjoint identities, so the
-  // only colliding writer is a drain storing 0 (and the guard above rules out
-  // the one unsafe order). The reader's indirect call carries a data dependency
-  // on the value, so no release is needed.
-  uintptr_t idx = icacheLinearize(dims, numDims);
-  icacheCell(reg.base, idx).storeRelaxed(reinterpret_cast<uintptr_t>(fnPtr));
+  // Relaxed, and no cross-core publication happens here: under the disjointness
+  // contract the core that READS this cell is this core, and it already made
+  // the code executable for itself (prepareExecForCurrentCore: split,
+  // enable_ex, dc cvau / ic ivau / dsb ish / isb) earlier in program order.
+  // Cross-core visibility of the CODE is the owner's broadcast maintenance.
+  // Arm BEFORE the store, with release, so a drain that could see this cell
+  // non-null is guaranteed to see the flag set and therefore walk. Setting it
+  // after the store would let a drain read 0, skip, and leave the cell behind.
+  state_->icacheArmed.storeRelease(1);
+  const uintptr_t idx = icacheLinearize(dims, numDims);
+  EJitAtomicUPtr &cell = icacheCell(reg.base, idx);
+  cell.storeRelaxed(reinterpret_cast<uintptr_t>(fnPtr));
+
+  // Re-validate AFTER the store and retract on conflict. The checks above only
+  // PRECEDE the store: a drain can begin after they pass, zero this cell, and
+  // finish before the store lands, stranding a pre-toggle specialization that
+  // nothing clears again -- and a preempted filler makes that gap unbounded.
+  // If a drain overlapped, it has either bumped the sequence or is still in
+  // flight, and both are visible here. Writing 0 discards only this core's own
+  // fill (disjointness), and a null cell is always safe.
+  if (state_->icacheDrainsInFlight.loadAcquire() != 0 ||
+      static_cast<uint32_t>(token) != state_->icacheDrainSeq.loadAcquire()) {
+    cell.storeRelaxed(0);
+    if (!gIcacheFillRejectLogged[kFillRejectRetracted]) {
+      gIcacheFillRejectLogged[kFillRejectRetracted] = true;
+      EJIT_DIAG("icacheFill RETRACT func=%u: a drain began after the fill was "
+                "cleared to proceed; cell reset to 0",
+                funcIndex);
+    }
+    return;
+  }
   if (!gIcacheFillOkLogged) {
     gIcacheFillOkLogged = true;
     EJIT_DIAG("icacheFill OK func=%u cell=%p[%llu] fn=%p -- the inline cache is "
@@ -656,6 +796,35 @@ bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,
   if (enabled)
     state_->anyInstanceActivated.storeRelease(1);
   return flipped;
+}
+
+uint32_t EJitSharedTaskPool::setAllInstancesEnabled(uint32_t dimType,
+                                                    bool enabled) {
+  if (!state_ || dimType >= kEJitSharedDimTypes) {
+    EJIT_DIAG("shared setAllInstancesEnabled reject: state=%p dim=%u (OOR "
+              "dim<%u)",
+              (void *)state_, dimType, kEJitSharedDimTypes);
+    return 0;
+  }
+  const uint8_t desired = enabled ? 1 : 0;
+  uint32_t flippedCount = 0;
+  for (uint32_t i = 0; i < kEJitSharedInstances; ++i) {
+    // compareExchange takes `expected` by reference and writes back the
+    // observed value on failure, so it needs a fresh local each iteration.
+    uint8_t expected = enabled ? 0 : 1;
+    if (!state_->enabled[dimType][i].compareExchange(expected, desired))
+      continue;
+    ++flippedCount;
+    // As in setInstanceEnabled: version[] moves only on a real transition.
+    state_->version[dimType][i].fetchAdd(1);
+  }
+  // ONE epoch bump and ONE drain: both are global, so doing them per instance
+  // was pure amplification.
+  state_->dispatchEpoch.fetchAdd(1);
+  icacheDrainAll();
+  if (enabled)
+    state_->anyInstanceActivated.storeRelease(1);
+  return flippedCount;
 }
 
 bool EJitSharedTaskPool::versionsCurrent(const EJitCompileRequest &req) const {
@@ -1719,7 +1888,30 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode) {
   // before this (re)initialization must not find its snapshot still current
   // afterwards and fill a cell with a pointer from the previous generation.
   st->icacheDrainSeq.fetchAdd(1);
-  st->icacheDrainsInFlight.storeRelaxed(0);
+  // NOTE: icacheDrainsInFlight is deliberately NOT reset here. It is cleared by
+  // the owner AFTER it publishes the new generation, so a drain still running
+  // under the old one can observe the change and skip its decrement. Clearing
+  // it here -- before the generation moves -- leaves a window in which the
+  // straggler still believes the generation is its own and decrements a counter
+  // that was just zeroed, wrapping it to UINT32_MAX.
+  //
+  // Zeroing these lets a fresh blob start from "no per-core preparation, no
+  // releaser" instead of inheriting a dead generation's answer.
+  //
+  // Re-publication is NOT symmetric, and the asymmetry is a known limit rather
+  // than an oversight. Seal mode is set-only and monotone, so any facade that
+  // still needs per-core preparation re-asserts it on its next
+  // setSealMode()/setPrepareCodeCallback(), and init() re-asserts the owner's.
+  // The releaser count is only re-published by init(), and only for the owner's
+  // own releaseFn_: bind() runs once per facade, so a PEER facade that wired a
+  // releaser before the re-init is not restored into the new generation's
+  // count. Production keeps one facade per blob
+  // (EJitCompileDriver::sharedPool_), which makes that unreachable; see
+  // syncIcacheReleaserCount() for what closing it properly would take.
+  // A fresh generation starts with an empty table, so nothing is armed.
+  st->icacheArmed.storeRelaxed(0);
+  st->icachePerCorePrepare.storeRelaxed(0);
+  st->icacheReleasersWired.storeRelaxed(0);
   for (uint32_t i = 0; i < kEJitSharedMaxFuncIndex; ++i)
     st->inFlight[i].storeRelaxed(0);
   for (uint32_t i = 0; i < kEJitSharedQueueSlots; ++i) {
@@ -1837,8 +2029,21 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       // generation's code, and a cell carries no epoch to invalidate against.
       icacheDrainAll("owner-init");
       state_->generation.storeRelease(nextGen);
+      // Now that the new generation is visible, discard any in-flight count
+      // left by drains of the previous one: they will observe the generation
+      // change and skip their own decrement, so this cannot be undone by a
+      // straggler. Ordering matters -- see initSharedStorage().
+      state_->icacheDrainsInFlight.storeRelaxed(0);
       state_->ownerCoreId.storeRelease(self);
       state_->codeSharingEnabled.storeRelease(codeSharingEnabled_ ? 1u : 0u);
+      // initSharedStorage() just zeroed these for the new generation, so the
+      // owner's own answers have to go back in before any peer can bind and
+      // read them. Seal mode / prepareCode decide whether the 0-dim shared
+      // scalar may be armed at all, and a releaser wired before election still
+      // has to disable the table.
+      publishIcachePrepareMode();
+      if (releaseFn_)
+        state_->icacheReleasersWired.storeRelease(1);
       state_->lastInitError.storeRelease(0);
       state_->workerTaskId.storeRelease(0);
       // Publish the owner's funcIndex/dimType registration digest so peers can

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -510,13 +510,27 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
     }
     return;
   }
-  // Cross-core executability gate: this store publishes fnPtr to every core at
-  // once, including cores that have not prepared it. Where the platform needs
-  // per-core execute preparation a peer would jump to an address it has not
-  // sealed, so decline and let the taskpool -- which prepares -- serve every
-  // call. See icacheCrossCoreExecutable().
-  if (!icacheCrossCoreExecutable())
-    return;
+  // NO icacheCrossCoreExecutable() gate here, deliberately.
+  //
+  // Cells are addressed by dim identity, and the deployment contract is that
+  // cores drive DISJOINT ejit_period_lc instance indices. A core therefore only
+  // ever reads cells it filled itself, and it filled them after resolving
+  // through the taskpool -- which is where it did whatever per-core execute
+  // preparation the platform needs (4K seal / prepareCodeFn_). So the pointer
+  // it loads is always code it has already prepared, which is the guarantee a
+  // per-core .bss table used to give structurally.
+  //
+  // Gating on icacheCrossCoreExecutable() instead disables the cache in every
+  // build it is allowed in: EJitCompileDriver sets fourKSeal_ under
+  // EJIT_CODE_POOL_4K_SEAL and wires prepareCodeFn_ otherwise, both inside
+  // EJIT_SRE_SHARED_CODE_POINTERS, which the AOT probe requires. Both branches
+  // close it, so no cell was ever filled on any real target.
+  //
+  // What the gate would protect against is two cores sharing a dim identity,
+  // where the second loads a pointer only the first has sealed. That is a
+  // violation of the disjointness contract, and it cannot be detected from
+  // here: a cell carries no record of which core wrote it, and adding one puts
+  // a per-core gate back on a probe whose whole point is not having one.
   if (!state_ || !fnPtr || funcIndex >= EJIT_ICACHE_FUNC_SLOTS) {
     if (!gIcacheFillRejectLogged[kFillRejectArgs]) {
       gIcacheFillRejectLogged[kFillRejectArgs] = true;

--- a/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
+++ b/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
@@ -18,5 +18,12 @@ add_llvm_component_library(LLVMEmbeddedJIT
 # @__ejit_icache_fn_<name> as a [D]^numDims array; the runtime (LLVMEJIT)
 # linearizes with the same D on fill. Both targets get the identical value from
 # the top-level CMake var so array layout and linearization never disagree.
+#
+# EJIT_ICACHE_SECTION: the section that array is placed in — the inter-core
+# SHARED section on a multi-core target, so one partitioned table backs every
+# core and a period toggle can zero a peer's cells directly. Only this pass
+# needs it (the runtime reaches the table through the registered base address,
+# whatever section it came from), so it is defined here alone.
 target_compile_definitions(LLVMEmbeddedJIT PRIVATE
-  EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE})
+  EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE}
+  EJIT_ICACHE_SECTION="${EJIT_ICACHE_SECTION}")

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -68,14 +68,15 @@ static cl::opt<bool> EJitWrapperTiming(
              "JIT call, and read-token release in ejit_entry wrappers"));
 
 // Emit a per-function inline-cache probe DIRECTLY in the ejit_entry wrapper
-// (not a call). On a hit the wrapper loads its per-function @__ejit_icache_fn_
-// <name> slot (one atomic acquire load), null-checks it, and tail-calls the
+// (not a call). On a hit the wrapper loads its cell out of the per-function
+// @__ejit_icache_fn_<name> table (one load), null-checks it, and tail-calls the
 // cached specialization - NO ejit_icache_try call, NO read-token, NO per-call
 // guards, NO funcIndex/IdxValid on the hit path. Just "pointer non-null? jump".
 // On a miss it falls through to jit_slow -> ejit_taskpool_compile_or_get, which
-// fills the slot on success (icacheFill). v2: sticky monomorphic - the slot is
-// filled once (first resolution) and read forever, so the probe needs no
-// version/dims re-validation. Default off. Requires the runtime to be built
+// fills the cell on success (icacheFill). The probe carries NO freshness check:
+// the table is SHARED across cores (EJitIcacheSection), so an activate or
+// deactivate zeroes the cells directly and the next probe on any core misses.
+// Default off. Requires the runtime to be built
 // with EJIT_SRE_SHARED_CODE_POINTERS (production preset): the inline probe has
 // no per-call cross-core gate, so it is only safe when a cached pointer is
 // callable on any core. When combined with -ejit-wrapper-timing the icache hit
@@ -86,6 +87,25 @@ static cl::opt<bool> EJitInlineCache(
     cl::desc("Emit a per-function inline-cache probe (a direct load of the "
              "cached specialization pointer) before the taskpool "
              "compile_or_get call in ejit_entry wrappers"));
+
+// Section for the per-function @__ejit_icache_fn_<name> cell table. In the
+// inter-core SHARED section (.mc_shared, where the taskpool state blob also
+// lives) the table is ONE object every core reads, so a deactivate zeroes a
+// peer's cells directly. Left empty it lands in .bss, which on a multi-core
+// target is per-core private.
+//
+// Placement is a link-time contract with no runtime check behind it: the symbol
+// resolves to the same virtual address either way, so a per-core table under a
+// cross-core runtime is undetectable. Default comes from the CMake
+// EJIT_ICACHE_SECTION var; the flag lets tests pin a value.
+#ifndef EJIT_ICACHE_SECTION
+#define EJIT_ICACHE_SECTION ""
+#endif
+static cl::opt<std::string> EJitIcacheSection(
+    "ejit-icache-section", cl::init(EJIT_ICACHE_SECTION), cl::Hidden,
+    cl::desc("Section for the @__ejit_icache_fn_<name> inline-cache cell "
+             "table. Must name the inter-core SHARED section on a multi-core "
+             "target; empty leaves the table in per-core .bss"));
 
 // When the inline-cache probe is enabled, put the frame-less dispatcher
 // (probe + two tail calls, ~16-48 bytes) into a dedicated
@@ -259,17 +279,20 @@ struct IcacheSlotInfo {
   unsigned NumDims = 0;
 };
 
-// Per-function pointer-typed global holding the frozen inline-cache slot: the
-// specialization pointer once resolved, null until then. Internal linkage (each
+// Per-function pointer-typed global holding the inline-cache cell table: the
+// specialization pointer for each dim identity once resolved, null until then
+// and null again after a period toggle drains it. Internal linkage (each
 // module's copy is wired into the runtime slot-pointer table by name at
-// registration). 8-byte aligned so the atomic acquire load / one-shot CAS the
-// runtime pairs against it are lock-free on aarch64. The wrapper reads it
-// DIRECTLY (load atomic acquire + null-check + indirect call) - no
-// ejit_icache_try call, no per-call guards - so the hit path is one load.
+// registration). 8-byte aligned so each cell is one naturally-aligned,
+// tear-free access: a drain on another core zeroing a cell under a reading
+// probe yields the old pointer or 0, never a torn value.
+//
+// Placed in EJitIcacheSection when set - SHARED across cores, partitioned by
+// dim identity so writers never collide.
 //
 // Multi-version: the global is a [D]^NumDims array (D = EJIT_ICACHE_DIM_SIZE,
 // power-of-2) indexed by the ejit_dim argument values, so each dim identity
-// gets its own frozen fnPtr cell. NumDims=0 is a scalar ptr (= v2 monomorphic).
+// gets its own cell. NumDims=0 is a scalar ptr (one cell).
 static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
                                                  StringRef FuncName,
                                                  unsigned NumDims) {
@@ -291,6 +314,8 @@ static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
   auto *GV = new GlobalVariable(M, SlotTy, /*isConstant=*/false,
                                 GlobalValue::InternalLinkage, Init, GVName);
   GV->setAlignment(Align(8));
+  if (!EJitIcacheSection.empty())
+    GV->setSection(EJitIcacheSection);
   return GV;
 }
 
@@ -892,6 +917,12 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       }
       LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
       ICSlotLoad->setAlignment(Align(8));
+      // Monotonic, nothing stronger: the cell is shared, so a peer's drain can
+      // store 0 concurrently and the atomic makes that a defined race (old
+      // pointer or 0) instead of UB. The value is self-contained and the call
+      // below carries a data dependency on it, so acquire would buy nothing and
+      // cost an LDAR per hit. Lowers to the same LDR on AArch64.
+      ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
       Value *TAfterIcache = nullptr;
       if (EJitWrapperTiming)
         TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -279,6 +279,74 @@ struct IcacheSlotInfo {
   unsigned NumDims = 0;
 };
 
+// A period whose bound this module cannot prove. Larger than any legal
+// EJIT_ICACHE_DIM_SIZE, so dimsProvablyInRange() declines on it without needing
+// a second lookup structure.
+static constexpr uint32_t kUnprovablePeriodArraySize = ~0u;
+
+// Map periodName -> the largest declared ejit_period_arr element count, from
+// this module's globals. Used to decide whether an entry's dim arguments can be
+// trusted to index the cell table.
+//
+// The MAXIMUM matters, and taking the last one visited is a bug: the runtime
+// permits SEVERAL arrays under one period and activates them as a group, so a
+// lifecycle's valid identities run up to the largest sibling. Recording an 8
+// because it happened to be declared after a 32 would let dimsProvablyInRange()
+// approve a 16-cell probe for a period that legally produces identity 31, and
+// the wrapper would form an inbounds GEP past its own table -- into whatever
+// shares the section -- before the slow-path range check is ever reachable.
+// Aggregating the max makes the answer independent of module order.
+static std::map<std::string, uint32_t> collectPeriodArraySizes(const Module &M) {
+  std::map<std::string, uint32_t> Sizes;
+  for (const GlobalVariable &GV : M.globals()) {
+    const MDNode *MD = GV.getMetadata(MD_EJIT_METADATA);
+    if (!MD || !hasMDStringEntry(MD, TAG_EJIT_PERIOD_ARR))
+      continue;
+    StringRef PeriodName = getMDStringValue(MD, TAG_EJIT_PERIOD_ARR);
+    if (PeriodName.empty())
+      continue;
+    // A count of 0 is "this global does not state one". That is an unknown
+    // bound, not a small one, so it must survive being maxed against a sibling
+    // that does state one -- otherwise the order of the two decides the answer
+    // again, which is the bug being fixed.
+    const uint32_t Declared = getMDIntValue(MD, TAG_EJIT_PERIOD_ARR);
+    const uint32_t Effective = Declared ? Declared : kUnprovablePeriodArraySize;
+    auto It = Sizes.find(PeriodName.str());
+    if (It == Sizes.end())
+      Sizes.emplace(PeriodName.str(), Effective);
+    else
+      It->second = std::max(It->second, Effective);
+  }
+  return Sizes;
+}
+
+// Whether every ejit_dim argument of \p F provably lands inside the
+// [D]^numDims cell table.
+//
+// The accepted ranges do not agree: the taskpool takes instance ids up to
+// MAX_INSTANCES (256) and a period array may declare MAX_PERIOD_ARR_SIZE (100)
+// entries, against a D of 16. The probe indexes with the raw argument and has
+// no room to check, so an id of 16 would read past the wrapper's global into
+// its neighbour in the shared section and branch there.
+//
+// Rather than spend hit-path instructions, the probe is not emitted unless the
+// bound is provable: the function is still wrapped and the taskpool serves it,
+// the same degradation as running out of slots. An array declared in another
+// TU is not provable here and so also declines.
+static bool dimsProvablyInRange(const Function &F,
+                                const std::map<std::string, uint32_t> &Sizes) {
+  for (const PeriodArrIndInfo &Info : getPeriodArrIndInfo(F)) {
+    auto It = Sizes.find(Info.PeriodName);
+    if (It == Sizes.end())
+      return false; // size not visible in this module
+    // A count of 0 never reaches here: collectPeriodArraySizes() maps
+    // "not stated" to kUnprovablePeriodArraySize, which fails this same test.
+    if (It->second > EJIT_ICACHE_DIM_SIZE)
+      return false;
+  }
+  return true;
+}
+
 // Per-function pointer-typed global holding the inline-cache cell table: the
 // specialization pointer for each dim identity once resolved, null until then
 // and null again after a period toggle drains it. Internal linkage (each
@@ -585,8 +653,20 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
   // it is only safe when a cached pointer is callable on any core.
   std::map<std::string, IcacheSlotInfo> IcacheFnGlobals;
   if (EJitInlineCache) {
+    const std::map<std::string, uint32_t> PeriodArraySizes =
+        collectPeriodArraySizes(M);
     for (Function *F : EntryFuncs) {
       unsigned NumDims = getPeriodArrIndInfo(*F).size();
+      // Skip functions whose dim arguments could index outside the table. The
+      // probe cannot bounds-check without giving up its shape, so it is not
+      // emitted at all; the taskpool serves the function instead.
+      if (!dimsProvablyInRange(*F, PeriodArraySizes)) {
+        LLVM_DEBUG(dbgs() << "ejit-wrapper-gen: no inline cache for "
+                          << F->getName()
+                          << ": dim range not provably < " << EJIT_ICACHE_DIM_SIZE
+                          << "\n");
+        continue;
+      }
       // Skip functions exceeding the cache dimensionality cap from the icache
       // map. They are still wrapped (taskpool path) but without an icache probe;
       // the per-function DimCount > EJIT_ICACHE_MAX_DIMS check below emits the

--- a/llvm/test/Transforms/EmbeddedJIT/Inputs/ejit-icache-period-arr-max-smallfirst.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/Inputs/ejit-icache-period-arr-max-smallfirst.ll
@@ -1,0 +1,22 @@
+; Input for ejit-wrapper-gen-icache-period-arr-max.ll: identical to that test's
+; module except the two "wide" arrays are declared SMALL (8) first and BIG (32)
+; second.
+;
+; This is the FIRST-wins half of the matrix. Visiting in declaration order, a
+; first-wins collectPeriodArraySizes() keeps 8 and wrongly approves the probe;
+; a last-wins one happens to keep 32 and declines for the wrong reason. The
+; sibling file has the opposite order and so catches last-wins. Only taking the
+; maximum is correct for both.
+
+define i32 @over_cap_entry(i32 %idx) !ejit.metadata !1 {
+entry:
+  %v = load i32, ptr @small
+  ret i32 %v
+}
+
+@small = global i32 0, !ejit.metadata !11
+@big   = global i32 0, !ejit.metadata !10
+
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"wide", i32 0}}
+!10 = distinct !{!{!"ejit_period_arr", !"wide", i32 32}}
+!11 = distinct !{!{!"ejit_period_arr", !"wide", i32 8}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-period-arr-max.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-period-arr-max.ll
@@ -1,0 +1,74 @@
+; A period may own SEVERAL ejit_period_arr globals, activated as a group, so its
+; valid instance ids run up to the LARGEST of them. collectPeriodArraySizes()
+; must therefore aggregate a maximum, not keep whichever global the module
+; happens to list last.
+;
+; If it keeps the last one, the answer depends on declaration order: with sizes
+; 32 and 8 under one period, visiting 8 last records 8, dimsProvablyInRange()
+; approves the entry, and the wrapper emits a probe whose GEP is bounded by
+; EJIT_ICACHE_DIM_SIZE (16) even though the lifecycle can legally produce
+; identity 31. That GEP is inbounds on a 16-cell table and lands outside it --
+; in the shared section, in whatever object comes next -- and the probe branches
+; through it before the slow path's range check is ever reachable.
+;
+; Both orders must therefore decline the probe. The entry is still wrapped; the
+; taskpool serves it, which is the documented degradation.
+;
+; The two orders catch different wrong implementations: BIG-first (this file)
+; catches last-wins, SMALL-first (the Inputs sibling) catches first-wins.
+;
+; --implicit-check-not spans the whole module, so the over-cap cell table must
+; not appear anywhere -- as a global, a GEP operand, or a registration argument.
+
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s \
+; RUN:   | FileCheck %s --check-prefix=BIGFIRST \
+; RUN:       --implicit-check-not=__ejit_icache_fn_over_cap_entry
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S \
+; RUN:       %S/Inputs/ejit-icache-period-arr-max-smallfirst.ll \
+; RUN:   | FileCheck %s --check-prefix=SMALLFIRST \
+; RUN:       --implicit-check-not=__ejit_icache_fn_over_cap_entry
+
+; --- Declared 32 then 8: the order that made a last-wins implementation record
+; --- 8 and emit the probe. An entry under a period whose arrays ALL fit still
+; --- gets its table, so the max aggregation does not just disable everything. ---
+; BIGFIRST: @__ejit_icache_fn_in_cap_entry = internal global [16 x ptr] zeroinitializer
+
+; --- over_cap_entry: no probe, straight to the taskpool. ---
+; BIGFIRST-LABEL: define i32 @over_cap_entry(
+; BIGFIRST-NOT: jit_icache_dispatch
+; BIGFIRST: call {{.*}}@ejit_taskpool_compile_or_get
+
+; --- in_cap_entry: probe present, indexing its own 16-cell table. ---
+; BIGFIRST-LABEL: define i32 @in_cap_entry(
+; BIGFIRST: getelementptr {{.*}} ptr @__ejit_icache_fn_in_cap_entry, i32 0, i32 {{.*}}
+
+; --- Declared 8 then 32: identical outcome. ---
+; SMALLFIRST-LABEL: define i32 @over_cap_entry(
+; SMALLFIRST-NOT: jit_icache_dispatch
+; SMALLFIRST: call {{.*}}@ejit_taskpool_compile_or_get
+
+define i32 @over_cap_entry(i32 %idx) !ejit.metadata !1 {
+entry:
+  %v = load i32, ptr @big
+  ret i32 %v
+}
+
+define i32 @in_cap_entry(i32 %idx) !ejit.metadata !2 {
+entry:
+  %v = load i32, ptr @okA
+  ret i32 %v
+}
+
+; "wide" owns two arrays: 32 entries and 8 entries, declared large-first here.
+@big   = global i32 0, !ejit.metadata !10
+@small = global i32 0, !ejit.metadata !11
+; "narrow" owns two arrays, both within EJIT_ICACHE_DIM_SIZE.
+@okA = global i32 0, !ejit.metadata !12
+@okB = global i32 0, !ejit.metadata !13
+
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"wide", i32 0}}
+!2 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"narrow", i32 0}}
+!10 = distinct !{!{!"ejit_period_arr", !"wide", i32 32}}
+!11 = distinct !{!{!"ejit_period_arr", !"wide", i32 8}}
+!12 = distinct !{!{!"ejit_period_arr", !"narrow", i32 8}}
+!13 = distinct !{!{!"ejit_period_arr", !"narrow", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -141,5 +141,9 @@ entry:
 !0 = distinct !{!{!"ejit_entry"}}
 !1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
 !2 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
+; Both arrays must declare no more entries than EJIT_ICACHE_DIM_SIZE (16), or
+; dimsProvablyInRange() declines the probe for any entry indexed by them and the
+; ICACHE checks below have nothing to match. `trp` used to say 32, which
+; silently turned two_dim_entry into a no-probe entry.
 !10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
-!11 = distinct !{!{!"ejit_period_arr", !"trp", i32 32}}
+!11 = distinct !{!{!"ejit_period_arr", !"trp", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -1,24 +1,32 @@
 ; -ejit-inline-cache (ON): emits an inline probe DIRECTLY in the ejit_entry
 ; wrapper - a GEP into the per-function @__ejit_icache_fn_<name> [D]^numDims
-; array (D = EJIT_ICACHE_DIM_SIZE, power-of-2) by the ejit_dim argument values,
-; then a plain load + null-check; the hit path (jit_icache_dispatch) calls the
-; cached specialization directly with NO ejit_icache_try call and NO
-; ejit_taskpool_release_read. numDims=0 is a scalar slot (no GEP). Default
-; (OFF): the original 4-block wrapper, no icache. Idempotent: running the pass
-; twice does not duplicate the probe.
+; cell table (D = EJIT_ICACHE_DIM_SIZE, power-of-2) by the ejit_dim argument
+; values, then ONE monotonic load + null-check; the hit path
+; (jit_icache_dispatch) calls the cached specialization directly with NO
+; ejit_icache_try call and NO ejit_taskpool_release_read. The load is atomic
+; because the table is shared across cores (a peer's period toggle zeroes cells
+; in place); monotonic is the weakest order that makes that a defined race, and
+; lowers to the same LDR a plain load would. There is NO freshness check on the
+; hit path - draining the shared cells IS the invalidation. numDims=0 is a
+; scalar cell (no GEP). Default (OFF): the original 4-block wrapper, no icache.
+; Idempotent: running the pass twice does not duplicate the probe.
 
-; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s --check-prefix=ICACHE
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s | FileCheck %s --check-prefix=ICACHE
 ; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s --check-prefix=NOICACHE
-; RUN: opt -passes=ejit-wrapper-gen,ejit-wrapper-gen -ejit-inline-cache -S %s | FileCheck %s --check-prefix=IDEM
+; RUN: opt -passes=ejit-wrapper-gen,ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s | FileCheck %s --check-prefix=IDEM
 ; --- -ejit-inline-cache + -ejit-dispatcher-cluster + -ejit-missfn-cold ---
-; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-dispatcher-cluster -ejit-missfn-cold -S %s | FileCheck %s --check-prefix=OPT
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-dispatcher-cluster -ejit-missfn-cold -S %s | FileCheck %s --check-prefix=OPT
 ; --- -ejit-wrapper-timing + -ejit-inline-cache: the hit path emits trace calls
 ;     AFTER the specialization call, so it must NOT be musttail (musttail must
 ;     immediately precede a ret). Verify the module is valid (opt verifies by
 ;     default) and the hit path is a plain call. Regression for the broken-IR
 ;     boot crash where codegen silently dropped the ejit_entry function. ---
-; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-wrapper-timing -disable-output %s
-; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-wrapper-timing -S %s | FileCheck %s --check-prefix=TIMING
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-wrapper-timing -disable-output %s
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-wrapper-timing -S %s | FileCheck %s --check-prefix=TIMING
+; --- -ejit-icache-section: the cell table goes into the inter-core SHARED
+;     section, which is what lets a deactivate on one core zero the cells every
+;     other core probes. Nothing else about the wrapper changes. ---
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section=.mc_shared -S %s | FileCheck %s --check-prefix=SECTION
 
 ; --- icache globals: [D]^numDims, D=8 (EJIT_ICACHE_DIM_SIZE). 0D is scalar. ---
 ; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, align 8
@@ -31,7 +39,7 @@
 ; ICACHE-NOT: section
 ; ICACHE-NOT: ejit_icache_try
 ; ICACHE-NOT: getelementptr
-; ICACHE: load ptr, ptr @__ejit_icache_fn_zero_dim_entry, align 8
+; ICACHE: load atomic ptr, ptr @__ejit_icache_fn_zero_dim_entry monotonic, align 8
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
 ; ICACHE: call {{.*}} %ejit_ic_fn
@@ -42,7 +50,7 @@
 ; ICACHE-NOT: section
 ; ICACHE-NOT: ejit_icache_try
 ; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
-; ICACHE: load ptr, ptr {{.*}}, align 8
+; ICACHE: load atomic ptr, ptr {{.*}} monotonic, align 8
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
 ; ICACHE: call {{.*}} %ejit_ic_fn
@@ -72,6 +80,20 @@
 ; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0)
 ; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1)
 ; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 2)
+
+; --- -ejit-icache-section (default .mc_shared, pinned here so the test does not
+;     depend on the CMake value): every cell table lands in the inter-core
+;     shared section and the probe is unchanged (one monotonic load + null
+;     check, no freshness compare). The other RUN lines pin it EMPTY to check
+;     the plain-.bss shape. ---
+; SECTION-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, section ".mc_shared", align 8
+; SECTION-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, section ".mc_shared", align 8
+; SECTION-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, section ".mc_shared", align 8
+; SECTION-LABEL: define i32 @one_dim_entry(
+; SECTION: load atomic ptr, ptr {{.*}} monotonic, align 8
+; SECTION-LABEL: jit_icache_dispatch:
+; SECTION-NOT: load
+; SECTION: call {{.*}} %ejit_ic_fn
 
 ; --- Default (flag OFF): no icache anywhere; original compile_or_get path. ---
 ; NOICACHE-LABEL: define i32 @one_dim_entry(

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -227,7 +227,8 @@ protected:
   // Register a test-local stand-in for the wrapper's @__ejit_icache_fn_<name>
   // cell table.
   void registerSlot(uint32_t funcIndex, void *base, uint32_t numDims) {
-    ASSERT_TRUE(ejitIcacheRegisterSlot(funcIndex, base, numDims));
+    ASSERT_EQ(ejitIcacheRegisterSlot(funcIndex, base, numDims),
+              EJitIcacheRegResult::Ok);
   }
 
   // Bring up a single owner on core 0 with the mock compiler and (by default)
@@ -1666,7 +1667,13 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
 // table is POD, dump state contains metadata only, and each bucket carries the
 // NO_RECLAIM seqlock publishSeq word.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 8u); // v8 added icacheDrainSeq
+  // v8 added icacheDrainSeq / icacheDrainsInFlight; v9 added the icache gates
+  // that must be shared rather than per-facade (icachePerCorePrepare,
+  // icacheReleasersWired), the icacheArmed drain-skip flag, and the shared
+  // one-shot diagnostic mask. Bump this deliberately: the blob is mapped at one
+  // address by every core, so a layout change that slips through unversioned is
+  // a silent cross-core corruption.
+  EXPECT_EQ(kEJitSharedAbiVersion, 9u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -2972,9 +2979,13 @@ TEST_F(SharedTaskPoolTest, InlineCacheRegistrationRejectsAnOverCapShape) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
-  EXPECT_FALSE(ejitIcacheRegisterSlot(3, &cells[0], EJIT_ICACHE_MAX_DIMS + 1));
-  EXPECT_FALSE(ejitIcacheRegisterSlot(3, nullptr, 1));
-  EXPECT_FALSE(ejitIcacheRegisterSlot(EJIT_ICACHE_FUNC_SLOTS, &cells[0], 1));
+  EXPECT_EQ(ejitIcacheRegisterSlot(3, &cells[0], EJIT_ICACHE_MAX_DIMS + 1),
+            EJitIcacheRegResult::Invalid);
+  EXPECT_EQ(ejitIcacheRegisterSlot(3, nullptr, 1),
+            EJitIcacheRegResult::Invalid);
+  // Capacity, NOT a defect: callers must degrade rather than fail init.
+  EXPECT_EQ(ejitIcacheRegisterSlot(EJIT_ICACHE_FUNC_SLOTS, &cells[0], 1),
+            EJitIcacheRegResult::CapacityMiss);
 
   // Nothing was registered, so nothing can be served and -- the point of the
   // cap -- a drain has no over-sized array to walk.
@@ -2983,9 +2994,15 @@ TEST_F(SharedTaskPoolTest, InlineCacheRegistrationRejectsAnOverCapShape) {
   ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
 
   // A shape at the cap is accepted.
-  EXPECT_TRUE(ejitIcacheRegisterSlot(3, &cells[0], 1));
+  EXPECT_EQ(ejitIcacheRegisterSlot(3, &cells[0], 1), EJitIcacheRegResult::Ok);
 }
 
+// Cross-core executability gate. A shared cell publishes the pointer to every
+// core the instant it is written, so it may only be filled where a resolved
+// fnPtr is callable on every core with no per-core work. Wiring per-core
+// execute preparation (a prepareCode callback, or 4K-seal mode) makes that
+// false, and the fill must decline rather than hand a peer an address it has
+// not sealed.
 // The fill does NOT depend on cross-core executability, and must not: every
 // build the AOT probe is allowed in (EJIT_SRE_SHARED_CODE_POINTERS) wires either
 // fourKSeal_ or prepareCodeFn_, so gating on icacheCrossCoreExecutable() here
@@ -2997,16 +3014,21 @@ TEST_F(SharedTaskPoolTest, InlineCacheRegistrationRejectsAnOverCapShape) {
 // prepared the code. See the header.
 TEST_F(SharedTaskPoolTest, InlineCacheFillsWhenCoresPrepareIndividually) {
   constexpr uint32_t kFunc = 3;
+  constexpr uint32_t kInst = 2;
   void *fn = codeFor(kFunc);
+  // A DIMENSIONED entry: the identity is what partitions the table, so this is
+  // the shape the disjointness argument actually covers. (The 0-dim shape has
+  // one shared scalar and is gated separately -- see the test below.)
+  const EJitDimPair d[1] = {{0, kInst}};
 
   {
     EJitSharedTaskPool pool;
     bringUpOwner(pool);
-    uintptr_t slot = 0;
-    registerSlot(kFunc, &slot, 0);
+    uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+    registerSlot(kFunc, cells, 1);
     ASSERT_TRUE(pool.icacheCrossCoreExecutable());
-    pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
-    ASSERT_NE(slot, 0u) << "baseline: no per-core preparation, fill allowed";
+    pool.icacheFill(kFunc, fn, d, 1, pool.icacheBeginResolve());
+    ASSERT_NE(cells[kInst], 0u) << "baseline: no per-core preparation, fill allowed";
 
     // Legacy 2M path: a wired prepareCode callback means each core makes the
     // pointer executable itself. The cache is still filled -- the core that
@@ -3014,15 +3036,17 @@ TEST_F(SharedTaskPoolTest, InlineCacheFillsWhenCoresPrepareIndividually) {
     PrepareLog prepare;
     pool.setPrepareCodeCallback(&mockPrepareCode, &prepare);
     EXPECT_FALSE(pool.icacheCrossCoreExecutable())
-        << "the platform state is still reported, it is just not a fill gate";
-    slot = 0;
-    pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
-    EXPECT_NE(slot, 0u) << "prepareCode wired: fill must still happen";
+        << "a wired prepareCodeFn_ IS per-core work, so the platform state is "
+           "still reported -- it is just not a fill gate for a dimensioned "
+           "entry";
+    cells[kInst] = 0;
+    pool.icacheFill(kFunc, fn, d, 1, pool.icacheBeginResolve());
+    EXPECT_NE(cells[kInst], 0u) << "prepareCode wired: fill must still happen";
 
     pool.setPrepareCodeCallback(nullptr, nullptr);
-    slot = 0;
-    pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
-    EXPECT_NE(slot, 0u) << "callback unwired: fill unchanged";
+    cells[kInst] = 0;
+    pool.icacheFill(kFunc, fn, d, 1, pool.icacheBeginResolve());
+    EXPECT_NE(cells[kInst], 0u) << "callback unwired: fill unchanged";
     pool.ownerShutdown(); // release the blob so the 4K pool below can own it
   }
 
@@ -3034,12 +3058,96 @@ TEST_F(SharedTaskPoolTest, InlineCacheFillsWhenCoresPrepareIndividually) {
     RangeCtx range;
     EJitSharedTaskPool sealPool;
     bringUpOwner4K(sealPool, fourK, range);
-    uintptr_t slot = 0;
-    registerSlot(kFunc, &slot, 0);
-    EXPECT_FALSE(sealPool.icacheCrossCoreExecutable());
+    uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+    registerSlot(kFunc, cells, 1);
+    // 4K seal is no longer counted as per-core preparation: the seal acts on an
+    // address space every core translates through, so it does not make a
+    // resolved pointer core-local.
+    EXPECT_TRUE(sealPool.icacheCrossCoreExecutable());
+    sealPool.icacheFill(kFunc, fn, d, 1, sealPool.icacheBeginResolve());
+    EXPECT_NE(cells[kInst], 0u)
+        << "4K-seal mode: fill must happen, or the inline cache "
+           "is dead on every real target";
+  }
+}
+
+// A 0-dim entry has ONE cell and no identity to partition it by, so the
+// disjointness contract cannot cover it: core B necessarily reads the cell core
+// A wrote. Under per-core execute preparation that means B branches to a page
+// it never sealed, on its very first call, without entering the taskpool. The
+// shared scalar is therefore allowed ONLY where a resolved pointer is callable
+// everywhere the instant it exists.
+TEST_F(SharedTaskPoolTest, InlineCacheDeclinesScalarFillWhenCoresPrepareIndividually) {
+  constexpr uint32_t kFunc = 6;
+  void *fn = codeFor(kFunc);
+
+  // Legacy whole-2MiB path: a wired prepareCodeFn_ is real per-core work, so a
+  // pointer one core resolved is NOT callable on a peer until that peer
+  // prepares. The 0-dim shape has one cell and no identity to partition it by,
+  // so core B necessarily reads what core A wrote -- decline.
+  {
+    ejitIcacheClearAll();
+    EJitSharedTaskPool coreA;
+    bringUpOwner(coreA);
+    PrepareLog prepare;
+    coreA.setPrepareCodeCallback(&mockPrepareCode, &prepare);
+    uintptr_t scalar = 0;
+    registerSlot(kFunc, &scalar, 0);
+    ASSERT_FALSE(coreA.icacheCrossCoreExecutable());
+
+    coreA.icacheFill(kFunc, fn, nullptr, 0, coreA.icacheBeginResolve());
+    EXPECT_EQ(scalar, 0u)
+        << "0-dim cell is shared by every core: filling it under per-core "
+           "preparation publishes code core B has not prepared";
+
+    // Core B binds the same blob and the same (still empty) table. Its probe
+    // must miss, so the call goes to the taskpool, which prepares for B. The
+    // gate reaches B through the SHARED icachePerCorePrepare, not through B's
+    // own (unset) callback.
+    EJitCoreId::setCurrentForTest(1);
+    EJitSharedTaskPool coreB;
+    coreB.bind(coreA.state());
+    EXPECT_FALSE(coreB.icacheCrossCoreExecutable());
+    void *out = reinterpret_cast<void *>(0x1234);
+    EXPECT_FALSE(coreB.icacheTry(kFunc, nullptr, 0, &out));
+    EXPECT_EQ(out, nullptr);
+    coreB.icacheFill(kFunc, fn, nullptr, 0, coreB.icacheBeginResolve());
+    EXPECT_EQ(scalar, 0u) << "a peer must not arm the shared scalar either";
+    EJitCoreId::setCurrentForTest(0);
+    coreA.ownerShutdown();
+  }
+
+  // 4K-seal mode: NOT per-core preparation. The seal acts on an address space
+  // every core translates through, so a resolved pointer is callable everywhere
+  // and the shared scalar is sound. Counting the seal here left every 0-dim
+  // entry on the full taskpool path on the only platform the cache ships on.
+  {
+    ejitIcacheClearAll();
+    FourKLog fourK;
+    RangeCtx range;
+    EJitSharedTaskPool sealPool;
+    bringUpOwner4K(sealPool, fourK, range);
+    uintptr_t scalar = 0;
+    registerSlot(kFunc, &scalar, 0);
+    ASSERT_TRUE(sealPool.icacheCrossCoreExecutable());
     sealPool.icacheFill(kFunc, fn, nullptr, 0, sealPool.icacheBeginResolve());
-    EXPECT_NE(slot, 0u) << "4K-seal mode: fill must happen, or the inline cache "
-                           "is dead on every real target";
+    EXPECT_NE(scalar, 0u)
+        << "4K seal must not block the 0-dim fill, or f_0-shaped entries never "
+           "reach the inline cache on the production board";
+    sealPool.ownerShutdown();
+  }
+
+  // No preparation of any kind: unchanged, the shared scalar fills.
+  {
+    ejitIcacheClearAll();
+    EJitSharedTaskPool pool;
+    bringUpOwner(pool);
+    uintptr_t scalar = 0;
+    registerSlot(kFunc, &scalar, 0);
+    ASSERT_TRUE(pool.icacheCrossCoreExecutable());
+    pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+    EXPECT_NE(scalar, 0u)
+        << "no per-core preparation: the shared scalar is safe and must fill";
   }
 }
 
@@ -3076,6 +3184,256 @@ TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
   pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
+}
+
+// A drain walks every cell of every registered slot. At bring-up nothing is
+// cached yet, so that walk writes 0 over 0 -- and there is one per
+// ejit_activate per core, which on a 22-core image with five slots at dims 0..4
+// is ~12M pointless stores to shared memory. icacheArmed lets a drain skip the
+// walk entirely until something is actually cached.
+//
+// What must NOT happen is a skip that strands a live cell, so this pins both
+// halves: the skip when cold, and the walk once armed.
+TEST_F(SharedTaskPoolTest, DrainSkipsTheWalkUntilSomethingIsCached) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  auto *st = pool.state();
+  constexpr uint32_t kFunc = 3;
+  constexpr uint32_t kInst = 2;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  registerSlot(kFunc, cells, 1);
+  const EJitDimPair d[1] = {{0, kInst}};
+
+  // Cold: nothing armed, so a toggle must not walk. Poison a cell behind the
+  // runtime's back -- a drain that walked would clear it.
+  ASSERT_EQ(st->icacheArmed.loadAcquire(), 0u);
+  cells[7] = 0xDEADBEEF;
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 1, true));
+  EXPECT_EQ(cells[7], 0xDEADBEEFu)
+      << "a cold drain must skip the walk, not zero the table";
+  // The sequence still moves: a resolve in flight must still see a drain.
+  EXPECT_EQ(st->icacheArmed.loadAcquire(), 0u);
+  cells[7] = 0;
+
+  // A fill arms the table.
+  const uint32_t seqBefore = pool.icacheDrainSeq();
+  pool.icacheFill(kFunc, codeFor(kFunc), d, 1, pool.icacheBeginResolve());
+  ASSERT_NE(cells[kInst], 0u);
+  EXPECT_EQ(st->icacheArmed.loadAcquire(), 1u)
+      << "icacheFill must arm before it publishes";
+  EXPECT_GT(pool.icacheDrainSeq(), seqBefore - 1u);
+
+  // Armed: the next drain walks and empties the cell, then disarms.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 2, true));
+  EXPECT_EQ(cells[kInst], 0u) << "an armed drain must still clear the table";
+  EXPECT_EQ(st->icacheArmed.loadAcquire(), 0u)
+      << "a completed walk must disarm, or every later drain walks for nothing";
+
+  // And it re-arms on the next fill, so the optimization is not one-shot.
+  pool.icacheFill(kFunc, codeFor(kFunc), d, 1, pool.icacheBeginResolve());
+  EXPECT_EQ(st->icacheArmed.loadAcquire(), 1u);
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 3, true));
+  EXPECT_EQ(cells[kInst], 0u);
+
+  ejitIcacheClearAll();
+}
+
+// Wiring a releaser is ONE invalidation event and must cost one drain.
+// retireDispatchCache() already empties the cell table, so an extra explicit
+// icacheDrainAll() next to it walked every slot twice and moved icacheDrainSeq
+// by two -- which also invalidates twice as many in-flight resolve tokens as the
+// event actually justifies.
+TEST_F(SharedTaskPoolTest, WiringAReleaserDrainsExactlyOnce) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  registerSlot(kFunc, cells, 1);
+  const EJitDimPair d[1] = {{0, 1}};
+  pool.icacheFill(kFunc, codeFor(kFunc), d, 1, pool.icacheBeginResolve());
+  ASSERT_NE(cells[1], 0u);
+
+  const uint32_t before = pool.icacheDrainSeq();
+  ReleaseLog rel;
+  pool.setReleaser(&mockRelease, &rel);
+  EXPECT_EQ(cells[1], 0u) << "the table must still be drained";
+  EXPECT_EQ(pool.icacheDrainSeq(), before + 1u)
+      << "one event, one drain: retireDispatchCache already drains";
+
+  // Unwiring is not an invalidation event and must not drain at all.
+  const uint32_t afterWire = pool.icacheDrainSeq();
+  pool.setReleaser(nullptr, nullptr);
+  EXPECT_EQ(pool.icacheDrainSeq(), afterWire);
+
+  ejitIcacheClearAll();
+}
+
+// bind() and setReleaser() both reconcile this facade's contribution to the
+// shared releaser count, so a facade that is bound more than once -- or wired
+// and then re-bound -- must still count exactly one. Double counting leaves the
+// count stuck above zero and the cache disabled with no way back.
+TEST_F(SharedTaskPoolTest, ReleaserCountIsIdempotentAcrossRebind) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  registerSlot(kFunc, cells, 1);
+  const EJitDimPair d[1] = {{0, 1}};
+
+  ReleaseLog rel;
+  EJitSharedTaskPool peer;
+  peer.setReleaser(&mockRelease, &rel); // wired BEFORE binding
+  peer.bind(owner.state());
+  peer.bind(owner.state()); // re-bind: must not count twice
+  peer.bind(owner.state());
+
+  owner.icacheFill(kFunc, codeFor(kFunc), d, 1, owner.icacheBeginResolve());
+  EXPECT_EQ(cells[1], 0u) << "peer's releaser must disable the shared table";
+
+  // One unwire must therefore be enough to re-open it.
+  peer.setReleaser(nullptr, nullptr);
+  owner.icacheFill(kFunc, codeFor(kFunc), d, 1, owner.icacheBeginResolve());
+  EXPECT_NE(cells[1], 0u)
+      << "count was incremented more than once for a single facade";
+
+  ejitIcacheClearAll();
+}
+
+// The reclamation gate must live in the BLOB, not in the facade that wired the
+// releaser. One table backs every core and the AOT probe consults no gate at
+// all, so if the disable state were core-private a peer facade -- whose own
+// flag is still clear -- could refill the cells the owner just drained, and the
+// owner would then reclaim code another core is still calling.
+//
+// Single-pool tests cannot see this: it takes two facades over one blob.
+TEST_F(SharedTaskPoolTest, InlineCacheReclamationGateIsSharedAcrossFacades) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  constexpr uint32_t kFunc = 5;
+  constexpr uint32_t kInst = 1;
+  // A dimensioned entry, so the 0-dim platform gate is not what is under test.
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  registerSlot(kFunc, cells, 1);
+  const EJitDimPair d[1] = {{0, kInst}};
+  void *fn = codeFor(kFunc);
+
+  // A second facade over the SAME blob, as a peer core would have.
+  EJitSharedTaskPool peer;
+  peer.bind(owner.state());
+
+  // Baseline: no releaser anywhere, so the peer may fill.
+  peer.icacheFill(kFunc, fn, d, 1, peer.icacheBeginResolve());
+  ASSERT_NE(cells[kInst], 0u) << "baseline: no releaser, peer fill allowed";
+
+  // The OWNER wires a releaser. Two things must follow, and neither of them is
+  // visible to the peer's own icacheReclamationSafe_, which is still true.
+  ReleaseLog rel;
+  owner.setReleaser(&mockRelease, &rel);
+  EXPECT_EQ(cells[kInst], 0u)
+      << "wiring a releaser must drain the shared table, not just block fills";
+
+  peer.icacheFill(kFunc, fn, d, 1, peer.icacheBeginResolve());
+  EXPECT_EQ(cells[kInst], 0u)
+      << "a peer facade must not re-arm a table the owner disabled";
+
+  // Unwiring the last releaser re-opens the gate for every facade.
+  owner.setReleaser(nullptr, nullptr);
+  peer.icacheFill(kFunc, fn, d, 1, peer.icacheBeginResolve());
+  EXPECT_NE(cells[kInst], 0u)
+      << "gate must re-open once the last releaser is gone";
+
+  // And the count is what re-opens it, not the last writer: with the PEER
+  // holding a releaser, the owner unwiring its own must leave the cache shut.
+  peer.setReleaser(&mockRelease, &rel);
+  owner.setReleaser(&mockRelease, &rel);
+  owner.setReleaser(nullptr, nullptr);
+  cells[kInst] = 0;
+  owner.icacheFill(kFunc, fn, d, 1, owner.icacheBeginResolve());
+  EXPECT_EQ(cells[kInst], 0u)
+      << "one facade unwiring must not re-arm while another still holds one";
+  peer.setReleaser(nullptr, nullptr);
+  owner.icacheFill(kFunc, fn, d, 1, owner.icacheBeginResolve());
+  EXPECT_NE(cells[kInst], 0u) << "last releaser gone: gate re-opens";
+
+  ejitIcacheClearAll();
+}
+
+// setInstanceEnabled() does not require Ready, so a peer drain can still be
+// walking cells when the owner shuts down and a new owner claims the blob. The
+// exact interleaving that used to corrupt the protocol:
+//
+//   peer:      icacheDrainsInFlight.fetchAdd(1), starts walking
+//   old owner: publishes Uninitialized
+//   new owner: claims the blob and clears the counter
+//   peer:      finishes and fetchSub(1)  ->  0 - 1  ==  UINT32_MAX
+//
+// After that icacheBeginResolve() refuses every token forever -- it declines
+// while any drain is in flight -- and no later drain can repair the count,
+// since each one is +1 then -1. The inline cache is then permanently dead with
+// no diagnostic.
+//
+// Two things prevent it. The new owner clears the counter only AFTER publishing
+// the new generation, and a drain retires its increment only if the generation
+// is still the one it announced under.
+TEST_F(SharedTaskPoolTest, ReinitCannotUnderflowAStragglerDrainCounter) {
+  ejitIcacheClearAll();
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  auto *st = owner.state();
+  const uint32_t staleGen = st->generation.loadAcquire();
+
+  // A peer drain announces itself and begins walking. This is exactly the first
+  // half of icacheDrainAll().
+  st->icacheDrainsInFlight.fetchAdd(1);
+  ASSERT_EQ(st->icacheDrainsInFlight.loadAcquire(), 1u);
+  // While it is in flight nothing may resolve -- the drain's reach is unknown.
+  EXPECT_EQ(owner.icacheBeginResolve(), kEJitIcacheNoResolve);
+
+  // The owner hands the blob over and a new owner claims it, mid-walk.
+  owner.ownerShutdown();
+  EJitSharedTaskPool nextOwner;
+  bringUpOwner(nextOwner);
+  ASSERT_EQ(nextOwner.state(), st) << "same blob, new generation";
+  const uint32_t freshGen = st->generation.loadAcquire();
+  ASSERT_NE(freshGen, staleGen);
+  EXPECT_EQ(st->icacheDrainsInFlight.loadAcquire(), 0u)
+      << "re-init must discard the straggler's increment";
+
+  // Now the straggler finishes, through the real retire path, still stamped
+  // with the generation it started under.
+  ejitIcacheRetireDrain(st, staleGen);
+  EXPECT_EQ(st->icacheDrainsInFlight.loadAcquire(), 0u)
+      << "a straggler from a dead generation must not decrement";
+
+  // The observable consequence: resolves still get tokens and fills still land.
+  const uint64_t token = nextOwner.icacheBeginResolve();
+  ASSERT_NE(token, kEJitIcacheNoResolve)
+      << "the counter underflowed: every resolve is refused from here on";
+  constexpr uint32_t kFunc = 4;
+  constexpr uint32_t kInst = 3;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  registerSlot(kFunc, cells, 1);
+  const EJitDimPair d[1] = {{0, kInst}};
+  nextOwner.icacheFill(kFunc, codeFor(kFunc), d, 1,
+                       nextOwner.icacheBeginResolve());
+  EXPECT_NE(cells[kInst], 0u) << "the cache must still work after the re-init";
+
+  // A retire stamped with the CURRENT generation still decrements, so the
+  // generation check has not simply disabled the accounting.
+  st->icacheDrainsInFlight.fetchAdd(1);
+  ejitIcacheRetireDrain(st, freshGen);
+  EXPECT_EQ(st->icacheDrainsInFlight.loadAcquire(), 0u);
+
+  // And it saturates: an unmatched retire cannot drive the count negative.
+  ejitIcacheRetireDrain(st, freshGen);
+  EXPECT_EQ(st->icacheDrainsInFlight.loadAcquire(), 0u)
+      << "retire must saturate at zero, never wrap";
+
+  ejitIcacheClearAll();
 }
 
 // Multi-version: a 2-dim icache holds one fnPtr per dim identity, so different

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2986,13 +2986,16 @@ TEST_F(SharedTaskPoolTest, InlineCacheRegistrationRejectsAnOverCapShape) {
   EXPECT_TRUE(ejitIcacheRegisterSlot(3, &cells[0], 1));
 }
 
-// Cross-core executability gate. A shared cell publishes the pointer to every
-// core the instant it is written, so it may only be filled where a resolved
-// fnPtr is callable on every core with no per-core work. Wiring per-core
-// execute preparation (a prepareCode callback, or 4K-seal mode) makes that
-// false, and the fill must decline rather than hand a peer an address it has
-// not sealed.
-TEST_F(SharedTaskPoolTest, InlineCacheDeclinesFillWhenCoresPrepareIndividually) {
+// The fill does NOT depend on cross-core executability, and must not: every
+// build the AOT probe is allowed in (EJIT_SRE_SHARED_CODE_POINTERS) wires either
+// fourKSeal_ or prepareCodeFn_, so gating on icacheCrossCoreExecutable() here
+// would leave the inline cache inert everywhere it is supposed to run.
+//
+// What makes a cell safe to jump to under per-core preparation is the deployment
+// contract that cores drive disjoint dim identities: a core only reads cells it
+// filled itself, after resolving through the taskpool, which is where it
+// prepared the code. See the header.
+TEST_F(SharedTaskPoolTest, InlineCacheFillsWhenCoresPrepareIndividually) {
   constexpr uint32_t kFunc = 3;
   void *fn = codeFor(kFunc);
 
@@ -3002,27 +3005,29 @@ TEST_F(SharedTaskPoolTest, InlineCacheDeclinesFillWhenCoresPrepareIndividually) 
     uintptr_t slot = 0;
     registerSlot(kFunc, &slot, 0);
     ASSERT_TRUE(pool.icacheCrossCoreExecutable());
-  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+    pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
     ASSERT_NE(slot, 0u) << "baseline: no per-core preparation, fill allowed";
 
-    // Legacy 2M path: a wired prepareCode callback means each core must make the
-    // pointer executable itself.
+    // Legacy 2M path: a wired prepareCode callback means each core makes the
+    // pointer executable itself. The cache is still filled -- the core that
+    // fills has already prepared, and disjointness keeps peers off this cell.
     PrepareLog prepare;
     pool.setPrepareCodeCallback(&mockPrepareCode, &prepare);
-    EXPECT_FALSE(pool.icacheCrossCoreExecutable());
+    EXPECT_FALSE(pool.icacheCrossCoreExecutable())
+        << "the platform state is still reported, it is just not a fill gate";
     slot = 0;
-        pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
-    EXPECT_EQ(slot, 0u) << "prepareCode wired: fill must decline";
+    pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+    EXPECT_NE(slot, 0u) << "prepareCode wired: fill must still happen";
 
     pool.setPrepareCodeCallback(nullptr, nullptr);
-    EXPECT_TRUE(pool.icacheCrossCoreExecutable());
-        pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
-    EXPECT_NE(slot, 0u) << "callback unwired: fill allowed again";
+    slot = 0;
+    pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+    EXPECT_NE(slot, 0u) << "callback unwired: fill unchanged";
     pool.ownerShutdown(); // release the blob so the 4K pool below can own it
   }
 
-  // 4K-seal mode: each core splits its pool and seals the code's pages before
-  // executing a peer's code, so the shared cell may not be filled at all.
+  // 4K-seal mode: the mode the production board runs. This is the case that was
+  // silently disabling the whole feature.
   {
     ejitIcacheClearAll();
     FourKLog fourK;
@@ -3033,7 +3038,8 @@ TEST_F(SharedTaskPoolTest, InlineCacheDeclinesFillWhenCoresPrepareIndividually) 
     registerSlot(kFunc, &slot, 0);
     EXPECT_FALSE(sealPool.icacheCrossCoreExecutable());
     sealPool.icacheFill(kFunc, fn, nullptr, 0, sealPool.icacheBeginResolve());
-    EXPECT_EQ(slot, 0u) << "4K-seal mode: fill must decline";
+    EXPECT_NE(slot, 0u) << "4K-seal mode: fill must happen, or the inline cache "
+                           "is dead on every real target";
   }
 }
 

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -211,9 +211,24 @@ class SharedTaskPoolTest : public ::testing::Test {
 protected:
   void SetUp() override {
     EJitCoreId::resetForTest();
+    // Unregister every icache slot around EVERY test, not just the icache ones.
+    // The registry is process-static and its bases are test-local arrays, so a
+    // slot left registered by a test that returned early (a failed ASSERT) would
+    // have icacheDrainAll() -- which any setInstanceEnabled reaches -- write
+    // through a dangling pointer in the next test.
+    ejitIcacheClearAll();
     state_ = std::make_unique<EJitSharedTaskPoolState>();
   }
-  void TearDown() override { EJitCoreId::resetForTest(); }
+  void TearDown() override {
+    ejitIcacheClearAll();
+    EJitCoreId::resetForTest();
+  }
+
+  // Register a test-local stand-in for the wrapper's @__ejit_icache_fn_<name>
+  // cell table.
+  void registerSlot(uint32_t funcIndex, void *base, uint32_t numDims) {
+    ASSERT_TRUE(ejitIcacheRegisterSlot(funcIndex, base, numDims));
+  }
 
   // Bring up a single owner on core 0 with the mock compiler and (by default)
   // no injected worker (the test drives pollOne()).
@@ -1651,7 +1666,7 @@ TEST_F(SharedTaskPoolTest, FourKGenerationChangeDuringPrepareNotReturned) {
 // table is POD, dump state contains metadata only, and each bucket carries the
 // NO_RECLAIM seqlock publishSeq word.
 TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
-  EXPECT_EQ(kEJitSharedAbiVersion, 7u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 8u); // v8 added icacheDrainSeq
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -2672,52 +2687,48 @@ TEST_F(SharedTaskPoolTest, DISABLED_HotHitContendedBench) {
 #endif // __aarch64__
 
 //===----------------------------------------------------------------------===//
-// Per-function inline cache (v2 sticky monomorphic): frozen read, one-shot
-// fill, range guards, and the reclamation safety gate. Asserts behavior
-// (boolean + pointer), not stats.
+// Per-function inline cache: SHARED PARTITIONED CELL TABLE.
+//
+// The probe carries no freshness check, so everything that keeps a cell honest
+// happens in the runtime and is pinned here: the fill, the cross-core drain on
+// a period toggle, the guard that stops a resolve from putting back a cell the
+// drain just cleared, and the registration/range gates. Assertions are on
+// behaviour (boolean + pointer), never on stats.
+//
+// A test-local array stands in for the wrapper's @__ejit_icache_fn_<name>
+// table. In production that array is in the inter-core shared section, so the
+// ONE array these tests register models the ONE table every core sees -- which
+// is exactly what makes "core A's drain clears core B's cell" testable in a
+// single-process simulation.
 //===----------------------------------------------------------------------===//
-TEST_F(SharedTaskPoolTest, InlineCacheStickyFrozen) {
-  ejitIcacheClearAll();
+TEST_F(SharedTaskPoolTest, InlineCacheFillAndServe) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool); // core 0 owner, Ready, code sharing off (owner-only).
   constexpr uint32_t kFunc = 3;
-  // Register a per-function icache slot (the wrapper's @__ejit_icache_fn_
-  // global, here a test-local stand-in) so icacheFill has somewhere to write.
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
 
-  // Cold icache misses (empty slot).
+  // Cold icache misses (empty cell).
   EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
 
-  // Fill on a resolve -> subsequent probe hits, returning the frozen fnPtr.
-  pool.icacheFill(kFunc, fn, nullptr, 0);
+  // Fill on a resolve -> subsequent probe hits, returning the cached fnPtr.
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
 
-  // Frozen: a period toggle bumps the version, but v2 does NOT re-validate, so
-  // the cached specialization is still served (the slot is never refilled or
-  // invalidated). This is the v2 contract - the specialization is invariant.
-  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
-  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, false)); // bump version
-  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
-  EXPECT_EQ(out, fn);
-
-  // No one-shot CAS (per-core-private slot -> plain store). A later fill
-  // OVERWRITES; under the contract the specialization is invariant per identity,
-  // so a later resolve carries the SAME pointer and the overwrite is harmless.
-  // Verify a same-pointer re-fill leaves the served pointer unchanged.
-  pool.icacheFill(kFunc, fn, nullptr, 0);
+  // Plain store, no one-shot CAS: cores write disjoint identities, so a later
+  // resolve of the SAME identity carries the same pointer and the overwrite is
+  // semantically a no-op. Verify the served pointer is unchanged.
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
 
   // Out-of-range funcIndex misses without touching memory.
   EXPECT_FALSE(pool.icacheTry(EJIT_ICACHE_FUNC_SLOTS, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
-
-  ejitIcacheClearAll();
 }
 
 // The funcIndex space is dense up to EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX, so the
@@ -2734,49 +2745,312 @@ TEST_F(SharedTaskPoolTest, InlineCacheHighFuncIndex) {
   // Top of the table: funcIndex = EJIT_ICACHE_FUNC_SLOTS - 1.
   constexpr uint32_t kTop = EJIT_ICACHE_FUNC_SLOTS - 1;
   uintptr_t slotTop = 0;
-  ejitIcacheRegisterSlot(kTop, &slotTop, 0);
+  registerSlot(kTop, &slotTop, 0);
   void *fnTop = codeFor(kTop);
   void *out = nullptr;
 
   EXPECT_FALSE(pool.icacheTry(kTop, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
-  pool.icacheFill(kTop, fnTop, nullptr, 0);
+  pool.icacheFill(kTop, fnTop, nullptr, 0, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kTop, nullptr, 0, &out));
   EXPECT_EQ(out, fnTop);
 
   // Mid-table index that the old 64-slot table would have dropped.
   constexpr uint32_t kMid = 2000;
   uintptr_t slotMid = 0;
-  ejitIcacheRegisterSlot(kMid, &slotMid, 0);
+  registerSlot(kMid, &slotMid, 0);
   void *fnMid = codeFor(kMid);
-  pool.icacheFill(kMid, fnMid, nullptr, 0);
+  pool.icacheFill(kMid, fnMid, nullptr, 0, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kMid, nullptr, 0, &out));
   EXPECT_EQ(out, fnMid);
 
   // icacheFill at funcIndex == EJIT_ICACHE_FUNC_SLOTS stays a no-op and must
   // not disturb the neighbouring top slot.
-  pool.icacheFill(EJIT_ICACHE_FUNC_SLOTS, fnMid, nullptr, 0);
+  pool.icacheFill(EJIT_ICACHE_FUNC_SLOTS, fnMid, nullptr, 0,
+                  pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kTop, nullptr, 0, &out));
   EXPECT_EQ(out, fnTop);
 
   ejitIcacheClearAll();
 }
 
-// Safety gate: wiring a releaser means code may be freed, and v2 does no
-// HP-scan retire, so the cache auto-disables (icacheTry always misses,
-// icacheFill no-op) to avoid UAF. Unwiring the releaser re-enables it.
-TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
-  ejitIcacheClearAll();
+// The core claim of the shared-table design: a period toggle EMPTIES the cell,
+// so the very next probe misses and re-resolves. No epoch is published, no core
+// has to notice anything -- the cell itself is gone.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainsOnPeriodToggle) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
   uintptr_t slot = 0;
-  ejitIcacheRegisterSlot(kFunc, &slot, 0);
+  registerSlot(kFunc, &slot, 0);
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  // Activate, then deactivate: either end of the mutation window drains.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_EQ(slot, 0u) << "activate must empty the cell";
+
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, false));
+  EXPECT_EQ(slot, 0u) << "deactivate must empty the cell";
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, nullptr);
+
+  // And the cache is not poisoned: a fresh resolve refills and serves again.
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+}
+
+// What a per-core table cannot do. Two cores fill DISJOINT partitions of the
+// same shared table (the deployment premise: each core drives its own
+// ejit_period_lc instance indices). A toggle issued on a THIRD core zeroes both
+// partitions, so neither of the other cores keeps calling a stale
+// specialization -- and neither of them had to call into the runtime to find
+// out.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainReachesEveryCorePartition) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  constexpr uint32_t D = EJIT_ICACHE_DIM_SIZE;
+  uintptr_t cells[D] = {};
+  registerSlot(kFunc, &cells[0], 1);
+
+  // Core 1 owns instance 1, core 2 owns instance 2. Disjoint cells. The
+  // assertions read the cells directly, which is what the AOT probe does -- the
+  // probe has no cross-core gate, unlike icacheTry (see its comment).
+  EJitDimPair id1[1] = {{0, 1}};
+  EJitDimPair id2[1] = {{0, 2}};
+  void *fn1 = codeFor(kFunc);
+  void *fn2 = codeFor(kFunc + 1);
+
+  EJitCoreId::setCurrentForTest(1);
+  pool.icacheFill(kFunc, fn1, id1, 1, pool.icacheBeginResolve());
+  EJitCoreId::setCurrentForTest(2);
+  pool.icacheFill(kFunc, fn2, id2, 1, pool.icacheBeginResolve());
+
+  // Each core wrote its own partition, and only its own.
+  EXPECT_EQ(cells[1], reinterpret_cast<uintptr_t>(fn1));
+  EXPECT_EQ(cells[2], reinterpret_cast<uintptr_t>(fn2));
+  for (uint32_t i = 0; i < D; ++i)
+    if (i != 1 && i != 2)
+      ASSERT_EQ(cells[i], 0u) << "cell " << i << " was written by no core";
+
+  // A toggle on core 3 -- which never filled anything and owns neither
+  // partition -- clears both. This is what a per-core table cannot do: core 1
+  // and core 2 need not call into the runtime, or notice anything at all.
+  EJitCoreId::setCurrentForTest(3);
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 7, true));
+  EXPECT_EQ(cells[1], 0u);
+  EXPECT_EQ(cells[2], 0u);
+}
+
+// The drain runs on EVERY setInstanceEnabled call, not only the one that moves
+// the shared bit. N cores each bracket their own period-value writes over one
+// shared bit, so a caller that LOST the CAS may still have rewritten its own
+// copy -- and its peers' cells are just as stale. version[] moves only on the
+// real transition, because runCompile DISCARDS an in-flight compile when it
+// changes.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainsEvenWhenTheEnableBitDoesNotMove) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0);
+
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true)); // first: flips the bit
+  const uint32_t versionAfterFirst = state_->version[0][5].loadAcquire();
+  const uint32_t drainsAfterFirst = pool.icacheDrainSeq();
+
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_NE(slot, 0u);
+
+  // Second core activating the same instance: loses the CAS, changes no shared
+  // state -- and still drains, because it may have rewritten its own period
+  // values.
+  EXPECT_FALSE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_EQ(slot, 0u) << "a lost CAS must still drain";
+  EXPECT_GT(pool.icacheDrainSeq(), drainsAfterFirst);
+  EXPECT_EQ(state_->version[0][5].loadAcquire(), versionAfterFirst)
+      << "version[] must not move without a real transition";
+}
+
+// A resolve that started BEFORE a drain must not put its result back
+// afterwards: the pointer may be specialized for the period values the toggle
+// just replaced, and nothing later would clear it again.
+TEST_F(SharedTaskPoolTest, InlineCacheDropsAFillThatRacedADrain) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0);
+
+  // Enter the taskpool (token taken), then a peer toggles a period, then the
+  // resolve completes and tries to fill with the now-stale token.
+  const uint64_t staleTok = pool.icacheBeginResolve();
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, staleTok);
+  EXPECT_EQ(slot, 0u) << "a fill from a resolve older than the drain is dropped";
+
+  void *out = nullptr;
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  // The NEXT resolve takes a fresh token and fills normally.
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, pool.icacheBeginResolve());
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, codeFor(kFunc));
+
+  // The drain brackets itself: it moves the sequence, and leaves no in-flight
+  // count behind for the next resolve to trip over.
+  const uint64_t before = pool.icacheBeginResolve();
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 6, true));
+  const uint64_t after = pool.icacheBeginResolve();
+  EXPECT_NE(after, kEJitIcacheNoResolve) << "drain left in-flight raised";
+  EXPECT_NE(after, before);
+}
+
+// A fill with no usable token is dropped rather than accepted on the strength
+// of a zero word. icacheBeginResolve() hands back kEJitIcacheNoResolve whenever
+// it cannot vouch for the window (notably: a drain already in flight, whose
+// reach over the table is unknown).
+TEST_F(SharedTaskPoolTest, InlineCacheFillRequiresAValidResolveToken) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0);
+
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, kEJitIcacheNoResolve);
+  EXPECT_EQ(slot, 0u);
+
+  const uint64_t tok = pool.icacheBeginResolve();
+  EXPECT_NE(tok, kEJitIcacheNoResolve);
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, tok);
+  EXPECT_NE(slot, 0u);
+}
+
+// ejit_clear_cache() / ejit_invalidate() / a compile-mode change retire cached
+// (identity -> fnPtr) mappings from outside the taskpool. The inline cache
+// answers the same question with no epoch of its own, so it is emptied too.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainsOnRetireDispatchCache) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0);
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_NE(slot, 0u);
+
+  pool.retireDispatchCache();
+  EXPECT_EQ(slot, 0u);
+}
+
+// Tearing down the generation retires the code the cells point at. Draining
+// here is what retires them on every core at once.
+TEST_F(SharedTaskPoolTest, InlineCacheDrainsOnOwnerShutdown) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0);
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_NE(slot, 0u);
+
+  pool.ownerShutdown();
+  EXPECT_EQ(slot, 0u);
+}
+
+// numDims sizes the [D]^numDims array the drain walks, so an over-cap value
+// would make the drain write far past the end of the wrapper's global. Reject
+// the registration instead: the cell stays null and the taskpool serves every
+// call.
+TEST_F(SharedTaskPoolTest, InlineCacheRegistrationRejectsAnOverCapShape) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  EXPECT_FALSE(ejitIcacheRegisterSlot(3, &cells[0], EJIT_ICACHE_MAX_DIMS + 1));
+  EXPECT_FALSE(ejitIcacheRegisterSlot(3, nullptr, 1));
+  EXPECT_FALSE(ejitIcacheRegisterSlot(EJIT_ICACHE_FUNC_SLOTS, &cells[0], 1));
+
+  // Nothing was registered, so nothing can be served and -- the point of the
+  // cap -- a drain has no over-sized array to walk.
+  void *out = nullptr;
+  EXPECT_FALSE(pool.icacheTry(3, nullptr, EJIT_ICACHE_MAX_DIMS + 1, &out));
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+
+  // A shape at the cap is accepted.
+  EXPECT_TRUE(ejitIcacheRegisterSlot(3, &cells[0], 1));
+}
+
+// Cross-core executability gate. A shared cell publishes the pointer to every
+// core the instant it is written, so it may only be filled where a resolved
+// fnPtr is callable on every core with no per-core work. Wiring per-core
+// execute preparation (a prepareCode callback, or 4K-seal mode) makes that
+// false, and the fill must decline rather than hand a peer an address it has
+// not sealed.
+TEST_F(SharedTaskPoolTest, InlineCacheDeclinesFillWhenCoresPrepareIndividually) {
+  constexpr uint32_t kFunc = 3;
+  void *fn = codeFor(kFunc);
+
+  {
+    EJitSharedTaskPool pool;
+    bringUpOwner(pool);
+    uintptr_t slot = 0;
+    registerSlot(kFunc, &slot, 0);
+    ASSERT_TRUE(pool.icacheCrossCoreExecutable());
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+    ASSERT_NE(slot, 0u) << "baseline: no per-core preparation, fill allowed";
+
+    // Legacy 2M path: a wired prepareCode callback means each core must make the
+    // pointer executable itself.
+    PrepareLog prepare;
+    pool.setPrepareCodeCallback(&mockPrepareCode, &prepare);
+    EXPECT_FALSE(pool.icacheCrossCoreExecutable());
+    slot = 0;
+        pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+    EXPECT_EQ(slot, 0u) << "prepareCode wired: fill must decline";
+
+    pool.setPrepareCodeCallback(nullptr, nullptr);
+    EXPECT_TRUE(pool.icacheCrossCoreExecutable());
+        pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+    EXPECT_NE(slot, 0u) << "callback unwired: fill allowed again";
+    pool.ownerShutdown(); // release the blob so the 4K pool below can own it
+  }
+
+  // 4K-seal mode: each core splits its pool and seals the code's pages before
+  // executing a peer's code, so the shared cell may not be filled at all.
+  {
+    ejitIcacheClearAll();
+    FourKLog fourK;
+    RangeCtx range;
+    EJitSharedTaskPool sealPool;
+    bringUpOwner4K(sealPool, fourK, range);
+    uintptr_t slot = 0;
+    registerSlot(kFunc, &slot, 0);
+    EXPECT_FALSE(sealPool.icacheCrossCoreExecutable());
+    sealPool.icacheFill(kFunc, fn, nullptr, 0, sealPool.icacheBeginResolve());
+    EXPECT_EQ(slot, 0u) << "4K-seal mode: fill must decline";
+  }
+}
+
+// Safety gate: wiring a releaser means code may be freed, and the cache does no
+// HP-scan retire, so it auto-disables (icacheTry always misses, icacheFill
+// no-op) to avoid UAF. Unwiring the releaser re-enables it.
+TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0);
   void *fn = codeFor(kFunc);
   void *out = nullptr;
 
   // Before a releaser: fill -> hit.
-  pool.icacheFill(kFunc, fn, nullptr, 0);
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
 
@@ -2785,33 +3059,32 @@ TEST_F(SharedTaskPoolTest, InlineCacheAutoDisablesWhenReclamationWired) {
   pool.setReleaser(&mockRelease, &rel);
   EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
-  pool.icacheFill(kFunc, fn, nullptr, 0); // no-op: the gate blocks the fill
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve()); // no-op: the gate blocks the fill
   EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, nullptr);
 
-  // Unwire the releaser: the gate re-opens; fill -> hit works again.
+  // Unwire the releaser: the gate re-opens; fill -> hit works again. Wiring the
+  // releaser drained the table (retireDispatchCache), so this models a FRESH
+  // resolve -- in production every fill is preceded by an entry-point arm.
   pool.setReleaser(nullptr, nullptr);
-  pool.icacheFill(kFunc, fn, nullptr, 0);
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
   EXPECT_EQ(out, fn);
-
-  ejitIcacheClearAll();
 }
 
-// Multi-version: a 2-dim icache holds one frozen fnPtr per dim identity, so
-// different (i,j) combos serve different specializations (the v2 monomorphic
-// bug - one slot for all identities - is fixed). Distinct identities fill
-// distinct cells; one-shot per cell; shape mismatch misses.
+// Multi-version: a 2-dim icache holds one fnPtr per dim identity, so different
+// (i,j) combos serve different specializations. Distinct identities fill
+// distinct cells; a shape mismatch misses; and a drain clears every identity,
+// not just the one the draining core happened to use.
 TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
-  ejitIcacheClearAll();
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   constexpr uint32_t kFunc = 3;
-  // A 2-dim [D][D] slot (D = EJIT_ICACHE_DIM_SIZE), zero-initialized. The
-  // runtime reaches cells through an EJitAtomicUPtr* + linearized index.
+  // A 2-dim [D][D] table (D = EJIT_ICACHE_DIM_SIZE), zero-initialized. The
+  // runtime reaches cells through a base pointer + linearized index.
   constexpr uint32_t D = EJIT_ICACHE_DIM_SIZE;
   uintptr_t slots[D][D] = {};
-  ejitIcacheRegisterSlot(kFunc, &slots[0][0], 2);
+  registerSlot(kFunc, &slots[0][0], 2);
 
   void *fn00 = codeFor(kFunc);
   void *fn01 = codeFor(kFunc + 1);
@@ -2826,9 +3099,9 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
   EXPECT_FALSE(pool.icacheTry(kFunc, id01, 2, &out));
 
   // Fill each identity with its own fnPtr.
-  pool.icacheFill(kFunc, fn00, id00, 2);
-  pool.icacheFill(kFunc, fn01, id01, 2);
-  pool.icacheFill(kFunc, fn10, id10, 2);
+  pool.icacheFill(kFunc, fn00, id00, 2, pool.icacheBeginResolve());
+  pool.icacheFill(kFunc, fn01, id01, 2, pool.icacheBeginResolve());
+  pool.icacheFill(kFunc, fn10, id10, 2, pool.icacheBeginResolve());
 
   // Each identity serves its OWN fnPtr (multi-version: no cross-contamination).
   EXPECT_TRUE(pool.icacheTry(kFunc, id00, 2, &out));
@@ -2838,11 +3111,8 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
   EXPECT_TRUE(pool.icacheTry(kFunc, id10, 2, &out));
   EXPECT_EQ(out, fn10);
 
-  // No one-shot CAS (per-core-private -> plain store): a later fill of (0,0)
-  // OVERWRITES with the latest pointer. Under the contract a later resolve of
-  // the same identity carries the same pointer, so re-fill with fn00 is a no-op
-  // semantically; verify the served pointer is still fn00.
-  pool.icacheFill(kFunc, fn00, id00, 2);
+  // Re-fill of (0,0) with the same pointer leaves the served pointer alone.
+  pool.icacheFill(kFunc, fn00, id00, 2, pool.icacheBeginResolve());
   EXPECT_TRUE(pool.icacheTry(kFunc, id00, 2, &out));
   EXPECT_EQ(out, fn00);
 
@@ -2850,7 +3120,15 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
   EXPECT_FALSE(pool.icacheTry(kFunc, id00, 1, &out));
   EXPECT_FALSE(pool.icacheTry(kFunc, id00, 0, &out));
 
-  ejitIcacheClearAll();
+  // A drain walks the whole [D][D] table: every identity is cleared, wherever
+  // in the array it sits.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_FALSE(pool.icacheTry(kFunc, id00, 2, &out));
+  EXPECT_FALSE(pool.icacheTry(kFunc, id01, 2, &out));
+  EXPECT_FALSE(pool.icacheTry(kFunc, id10, 2, &out));
+  for (uint32_t i = 0; i < D; ++i)
+    for (uint32_t j = 0; j < D; ++j)
+      ASSERT_EQ(slots[i][j], 0u) << "cell [" << i << "][" << j << "] survived";
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The `-ejit-inline-cache` probe is four instructions inside ejit_entry: GEP, load, null check, tail call. That shape is only affordable because the probe never asks whether the cell is still valid, so invalidation has to happen to the cell itself, from outside. 

With `@__ejit_icache_fn_<name>` in per-core `.bss` a deactivate could only reach the core it ran on, and a permanently hot peer (never misses, never calls the runtime again) kept executing a specialization baked from period values that had since changed. Nothing could reach it.

As an alternative to [106](https://github.com/dongjianqiang2/llvm-project/pull/106), this patch will emit the cell table into `EJIT_ICACHE_SECTION` instead, defaulting to the inter-core `.mc_shared` region the taskpool state blob already lives in. One partitioned table then backs every core, and `setInstanceEnabled` invalidates by zeroing the cells in place, which reaches a peer's cells directly. The hit path is unchanged: still `adrp/add/ldr/cbz/br`, with the probe's load raised to a monotonic atomic (the identical `LDR` on AArch64) so a concurrent drain is a defined race with a bounded outcome rather than UB.

Assisted-by: Claude Opus 5.0