### PR TITLE
EJIT: Clear hidden visibility on declarations in extracted bitcode

### DIFF
--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -633,6 +633,20 @@ static std::string extractAndSerialize(Module &M,
     GV.setInitializer(nullptr);
     GV.setLinkage(GlobalValue::ExternalLinkage);
   }
+
+  // Clear hidden/protected visibility on all declarations so the JIT linker
+  // can resolve them from the host process or userSymbols map. Hidden
+  // visibility symbols are not exported from the AOT binary's dynamic symbol
+  // table; if preserved in the extracted bitcode, JITLink refuses to resolve
+  // them against externally-supplied absolute symbols, causing spurious
+  // "Symbols not found" errors.
+  for (Function &F : Extracted->functions())
+    if (F.isDeclaration() && !F.hasDefaultVisibility())
+      F.setVisibility(GlobalValue::DefaultVisibility);
+  for (GlobalVariable &GV : Extracted->globals())
+    if (GV.isDeclaration() && !GV.hasDefaultVisibility())
+      GV.setVisibility(GlobalValue::DefaultVisibility);
+
   logEJitGlobalMeta("extract-after-extern", *Extracted);
 
   // Optionally dump the extracted module for debugging (e.g. to confirm an

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -640,6 +640,12 @@ static std::string extractAndSerialize(Module &M,
   // table; if preserved in the extracted bitcode, JITLink refuses to resolve
   // them against externally-supplied absolute symbols, causing spurious
   // "Symbols not found" errors.
+  //
+  // NOTE: Only Function and GlobalVariable declarations are traversed here.
+  // GlobalAlias and GlobalIFunc are not handled — they are unused in the
+  // bare-metal embedded scenarios that EJIT targets, and the closure
+  // collector (computeTransitiveClosure / collectReferencedGlobals) does
+  // not emit them.
   for (Function &F : Extracted->functions())
     if (F.isDeclaration() && !F.hasDefaultVisibility())
       F.setVisibility(GlobalValue::DefaultVisibility);

--- a/llvm/test/Transforms/EmbeddedJIT/hidden-visibility-symbol-registration.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/hidden-visibility-symbol-registration.ll
@@ -1,0 +1,55 @@
+; RUN: opt -passes=ejit-register-bitcode -S %s | FileCheck %s
+;
+; Regression test: hidden-visibility external declarations must still be
+; registered via ejit_register_symbol, and their visibility must be cleared
+; in the extracted bitcode so JITLink can resolve them against the
+; userSymbols map. Hidden visibility symbols are not exported from the AOT
+; binary's dynamic symbol table; if preserved in the extracted bitcode,
+; JITLink refuses to resolve them against externally-supplied absolute
+; symbols, causing "Symbols not found" errors.
+;
+; The visibility clearing itself happens inside extractAndSerialize (the
+; serialized bitcode opaque blob), so this test verifies the registration
+; side — hidden symbols must appear in the auto-register function.
+
+; Hidden-visibility external function — the case that was broken.
+declare hidden void @hidden_func()
+declare hidden i32 @hidden_func_ret()
+
+; Default-visibility external function — control; should always work.
+declare void @default_func()
+
+; Hidden-visibility external global
+@hidden_glob = external hidden global i32
+; Default-visibility external global
+@default_glob = external global i32
+
+define i32 @ejit_entry_hidden() !ejit.metadata !1 {
+; CHECK-LABEL: define i32 @ejit_entry_hidden()
+  call void @hidden_func()
+  %v = call i32 @hidden_func_ret()
+  ret i32 %v
+}
+
+define i32 @ejit_entry_mixed() !ejit.metadata !2 {
+; CHECK-LABEL: define i32 @ejit_entry_mixed()
+  call void @default_func()
+  call void @hidden_func()
+  %a = load i32, ptr @hidden_glob
+  %b = load i32, ptr @default_glob
+  %s = add i32 %a, %b
+  ret i32 %s
+}
+
+; The auto-register function must emit ejit_register_symbol for ALL
+; externals referenced by the closure — including hidden-visibility ones.
+; CHECK: define internal void @ejit_auto_register()
+; CHECK-DAG: call void @ejit_register_symbol({{.*}}@hidden_func)
+; CHECK-DAG: call void @ejit_register_symbol({{.*}}@hidden_func_ret)
+; CHECK-DAG: call void @ejit_register_symbol({{.*}}@default_func)
+; CHECK-DAG: call void @ejit_register_symbol({{.*}}@hidden_glob)
+; CHECK-DAG: call void @ejit_register_symbol({{.*}}@default_glob)
+
+!0 = !{!"ejit_entry"}
+!1 = !{!0}
+!2 = !{!0}

--- a/llvm/test/Transforms/EmbeddedJIT/hidden-visibility-symbol-registration.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/hidden-visibility-symbol-registration.ll
@@ -1,38 +1,41 @@
-; RUN: opt -passes=ejit-register-bitcode -S %s | FileCheck %s
+; RUN: rm -rf %t-dump && mkdir -p %t-dump
+; RUN: opt -passes=ejit-register-bitcode -ejit-dump-bitcode-dir=%t-dump -S <%s >/dev/null
+; RUN: opt -S %t-dump/*.bc | FileCheck --check-prefix=EXTRACTED %s
+; RUN: opt -passes=ejit-register-bitcode -S %s | FileCheck --check-prefix=REG %s
 ;
-; Regression test: hidden-visibility external declarations must still be
-; registered via ejit_register_symbol, and their visibility must be cleared
-; in the extracted bitcode so JITLink can resolve them against the
-; userSymbols map. Hidden visibility symbols are not exported from the AOT
-; binary's dynamic symbol table; if preserved in the extracted bitcode,
-; JITLink refuses to resolve them against externally-supplied absolute
-; symbols, causing "Symbols not found" errors.
+; This test verifies two things:
 ;
-; The visibility clearing itself happens inside extractAndSerialize (the
-; serialized bitcode opaque blob), so this test verifies the registration
-; side — hidden symbols must appear in the auto-register function.
+;  1. Hidden-visibility external declarations referenced by ejit_entry
+;     functions still get ejit_register_symbol calls (REG check — the
+;     registration side). No regression from existing behaviour.
+;
+;  2. In the *extracted bitcode* (the module that the JIT actually
+;     compiles), hidden/protected visibility on declarations is cleared
+;     to DefaultVisibility. This is the actual fix — without it JITLink
+;     refuses to resolve hidden symbols against the userSymbols map.
+;     The EXTRACTED checks run against the bitcode dumped by
+;     -ejit-dump-bitcode-dir.
 
-; Hidden-visibility external function — the case that was broken.
+; Hidden-visibility external function
 declare hidden void @hidden_func()
-declare hidden i32 @hidden_func_ret()
-
-; Default-visibility external function — control; should always work.
+; Protected-visibility external function
+declare protected void @protected_func()
+; Default-visibility external function — control
 declare void @default_func()
-
 ; Hidden-visibility external global
 @hidden_glob = external hidden global i32
 ; Default-visibility external global
 @default_glob = external global i32
 
 define i32 @ejit_entry_hidden() !ejit.metadata !1 {
-; CHECK-LABEL: define i32 @ejit_entry_hidden()
+; REG-LABEL: define i32 @ejit_entry_hidden()
   call void @hidden_func()
-  %v = call i32 @hidden_func_ret()
-  ret i32 %v
+  call void @protected_func()
+  ret i32 0
 }
 
 define i32 @ejit_entry_mixed() !ejit.metadata !2 {
-; CHECK-LABEL: define i32 @ejit_entry_mixed()
+; REG-LABEL: define i32 @ejit_entry_mixed()
   call void @default_func()
   call void @hidden_func()
   %a = load i32, ptr @hidden_glob
@@ -41,14 +44,27 @@ define i32 @ejit_entry_mixed() !ejit.metadata !2 {
   ret i32 %s
 }
 
-; The auto-register function must emit ejit_register_symbol for ALL
-; externals referenced by the closure — including hidden-visibility ones.
-; CHECK: define internal void @ejit_auto_register()
-; CHECK-DAG: call void @ejit_register_symbol({{.*}}@hidden_func)
-; CHECK-DAG: call void @ejit_register_symbol({{.*}}@hidden_func_ret)
-; CHECK-DAG: call void @ejit_register_symbol({{.*}}@default_func)
-; CHECK-DAG: call void @ejit_register_symbol({{.*}}@hidden_glob)
-; CHECK-DAG: call void @ejit_register_symbol({{.*}}@default_glob)
+; Registration-side: all externals (including hidden) must be registered.
+; REG: define internal void @ejit_auto_register()
+; REG-DAG: call void @ejit_register_symbol({{.*}}@hidden_func)
+; REG-DAG: call void @ejit_register_symbol({{.*}}@protected_func)
+; REG-DAG: call void @ejit_register_symbol({{.*}}@default_func)
+; REG-DAG: call void @ejit_register_symbol({{.*}}@hidden_glob)
+; REG-DAG: call void @ejit_register_symbol({{.*}}@default_glob)
+
+; Extracted-bitcode side: all declarations must have default visibility.
+; The exact spelling may include dso_local (X86 default) — use DAG to
+; allow any interleaving.
+; EXTRACTED-DAG: declare{{.*}} void @hidden_func()
+; EXTRACTED-DAG: declare{{.*}} void @protected_func()
+; EXTRACTED-DAG: declare void @default_func()
+; EXTRACTED-DAG: @hidden_glob = external{{.*}} global i32
+; EXTRACTED-DAG: @default_glob = external global i32
+; No "hidden" or "protected" keyword on any declaration.
+; EXTRACTED-NOT: declare hidden
+; EXTRACTED-NOT: declare protected
+; EXTRACTED-NOT: external hidden
+; EXTRACTED-NOT: external protected
 
 !0 = !{!"ejit_entry"}
 !1 = !{!0}


### PR DESCRIPTION
## Problem
Hidden-visibility external symbols referenced by EJIT-compiled functions cause JIT link failures: `Symbols not found: [ xxx, yyy ]`.

## Fix
In `extractAndSerialize`, clear hidden/protected visibility on all declarations to `DefaultVisibility` before serialization.

## Test
- 43/43 EJIT lit tests pass (39 PASS + 4 XFAIL)
- New test: `hidden-visibility-symbol-registration.ll`

## Source
Cherry-picked from `worktree-fix-hidden-symbol-visibility`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)