### PR TITLE
[EJIT] Harden AOT/runtime config-sync with compile-time and configure-time checks

### DIFF
--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 
 using llvm::ejit::MAX_PERIOD_ARR_IND_PARAMS;
+using llvm::ejit::MAX_PERIOD_ARR_SIZE;
 
 using namespace clang;
 
@@ -145,7 +146,7 @@ void handleEjitPeriodArrAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (const ArrayType *AT = S.Context.getAsArrayType(VT)) {
     if (const auto *CAT = dyn_cast<ConstantArrayType>(AT)) {
       uint64_t Size = CAT->getSize().getZExtValue();
-      if (Size > 100) {
+      if (Size > MAX_PERIOD_ARR_SIZE) {
         S.Diag(AL.getLoc(), diag::err_ejit_period_arr_too_large)
             << VD << static_cast<unsigned>(Size);
         return;
@@ -294,7 +295,7 @@ void checkEjitPeriodArrIndLimit(Sema &S, const FunctionDecl *FD) {
     }
   }
 
-  if (Count > 4 && OverflowPVD) {
+  if (Count > MAX_PERIOD_ARR_IND_PARAMS && OverflowPVD) {
     // Get the attribute location from the overflow parameter
     if (auto *A = OverflowPVD->getAttr<EjitPeriodArrIndAttr>()) {
       S.Diag(A->getLocation(), diag::err_ejit_period_arr_ind_too_many)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -725,6 +725,7 @@ endif()
 # linearization agree. Default 16; the product overrides it via the preset.
 set(EJIT_ICACHE_DIM_SIZE 16 CACHE STRING
   "EJIT inline-cache per-dim bound D (must be a power of 2)")
+ejit_require_numeric(EJIT_ICACHE_DIM_SIZE)
 if(EJIT_ICACHE_DIM_SIZE LESS 1)
   message(FATAL_ERROR
     "EJIT_ICACHE_DIM_SIZE must be a positive power of 2, got ${EJIT_ICACHE_DIM_SIZE}")

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -628,12 +628,47 @@ if(EJIT_SRE_CODE_POOL)
   add_definitions(-DEJIT_SRE_ENABLE_EX)
 endif()
 
+# CMake's LESS/GREATER treat non-numeric strings as unequal to everything, so
+# a garbage cache value would silently BYPASS every numeric bounds check below
+# and only explode mid-build with a confusing -D<VAR>=garbage error. Reject
+# such values up front with a clear configure-time message. (Defined before
+# its first call site below.)
+function(ejit_require_numeric var)
+  if(NOT ${var} MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+      "${var} (\"${${var}}\") is not a non-negative integer. "
+      "The EmbeddedJIT numeric cache variables must be plain decimal integers.")
+  endif()
+endfunction()
+
 # Per-pool size in bytes (must be a multiple of the 2MiB enable_ex granularity).
 set(EJIT_SRE_CODE_POOL_SIZE "2097152" CACHE STRING
   "EmbeddedJIT SRE code pool size in bytes (default 2MiB)")
 # SRE memory partition number (ptNo) handed to SRE_MemDbgAlloc.
 set(EJIT_SRE_CODE_POOL_PTNO "8" CACHE STRING
   "EmbeddedJIT SRE code pool partition number (ptNo) for SRE_MemDbgAlloc")
+# Hard-check the pool geometry against the platform contract at configure time:
+# a non-2MiB-multiple pool breaks enable_ex page-granular sealing, and ptNo is
+# stored as an unsigned char by the SRE adapter (EJitSrePlatform.cpp), so >255
+# silently truncates.
+ejit_require_numeric(EJIT_SRE_CODE_POOL_SIZE)
+ejit_require_numeric(EJIT_SRE_CODE_POOL_PTNO)
+if(EJIT_SRE_CODE_POOL_SIZE LESS 1)
+  message(FATAL_ERROR
+    "EJIT_SRE_CODE_POOL_SIZE (${EJIT_SRE_CODE_POOL_SIZE}) must be >= 1 byte.")
+endif()
+math(EXPR _ejit_pool_size_rem "${EJIT_SRE_CODE_POOL_SIZE} % 2097152")
+if(NOT _ejit_pool_size_rem EQUAL 0)
+  message(FATAL_ERROR
+    "EJIT_SRE_CODE_POOL_SIZE (${EJIT_SRE_CODE_POOL_SIZE}) must be a multiple "
+    "of the 2MiB enable_ex granularity.")
+endif()
+unset(_ejit_pool_size_rem)
+if(EJIT_SRE_CODE_POOL_PTNO LESS 1 OR EJIT_SRE_CODE_POOL_PTNO GREATER 255)
+  message(FATAL_ERROR
+    "EJIT_SRE_CODE_POOL_PTNO (${EJIT_SRE_CODE_POOL_PTNO}) must be in [1, 255] "
+    "(it is stored as an unsigned char by the SRE adapter).")
+endif()
 if(EJIT_SRE_CODE_POOL)
   add_definitions(-DEJIT_SRE_CODE_POOL_SIZE=${EJIT_SRE_CODE_POOL_SIZE})
   add_definitions(-DEJIT_SRE_CODE_POOL_PTNO=${EJIT_SRE_CODE_POOL_PTNO})
@@ -686,7 +721,7 @@ endif()
 # @__ejit_icache_fn_<name> [D]^numDims inline-cache array. MUST be a power of 2
 # so the hit path indexes with shifts (no multiply). The same value is applied
 # to the runtime (LLVMEJIT -DEJIT_ICACHE_DIM_SIZE) and to the AOT pass (clang
-# -mllvm -ejit-icache-dim-size) so the AOT array layout and the runtime
+# -mllvm -print-ejit-icache-dim-size) so the AOT array layout and the runtime
 # linearization agree. Default 16; the product overrides it via the preset.
 set(EJIT_ICACHE_DIM_SIZE 16 CACHE STRING
   "EJIT inline-cache per-dim bound D (must be a power of 2)")
@@ -758,6 +793,29 @@ set(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY "1024" CACHE STRING
 # Flat dedup table capacity = max dense funcIndex (spec §3.5 inFlight_[]).
 set(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX "4096" CACHE STRING
   "EmbeddedJIT SRE taskpool flat dedup capacity (max dense funcIndex)")
+# Configure-time validation mirroring the compile-time static_asserts, so a bad
+# value fails at `cmake` time with a clear message instead of mid-build.
+ejit_require_numeric(EJIT_SRE_TASKPOOL_BUCKETS)
+ejit_require_numeric(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY)
+ejit_require_numeric(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX)
+if(EJIT_SRE_TASKPOOL_BUCKETS LESS 1 OR EJIT_SRE_TASKPOOL_BUCKETS GREATER 254)
+  message(FATAL_ERROR
+    "EJIT_SRE_TASKPOOL_BUCKETS (${EJIT_SRE_TASKPOOL_BUCKETS}) must be in "
+    "[1, 254] (bucket ids are stored in an 8-bit field).")
+endif()
+math(EXPR _ejit_queue_pow2
+  "${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY} & (${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY} - 1)")
+if(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY LESS 2 OR NOT _ejit_queue_pow2 EQUAL 0)
+  message(FATAL_ERROR
+    "EJIT_SRE_TASKPOOL_QUEUE_CAPACITY (${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}) "
+    "must be a power of two >= 2 (the ring queue indexes with a mask).")
+endif()
+unset(_ejit_queue_pow2)
+if(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX LESS 1)
+  message(FATAL_ERROR
+    "EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX (${EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX}) "
+    "must be >= 1.")
+endif()
 # EJIT_ICACHE_FUNC_SLOTS: capacity of the per-function inline-cache slot table
 # (gIcacheSlots[]). MUST be >= kEJitMaxFuncIndex (EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX),
 # else any funcIndex >= EJIT_ICACHE_FUNC_SLOTS has its icacheFill silently dropped
@@ -785,6 +843,21 @@ set(EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT "1" CACHE STRING
   "EmbeddedJIT worker inter-task throttle delay multiplier (n in n*base ticks after every task; 0 disables)")
 set(EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS "100" CACHE STRING
   "EmbeddedJIT worker throttle delay base in scheduler ticks (the base in MULT*DELAY_TICKS; 0 disables)")
+# Fail at configure time (not in the SRE platform layer's static_asserts) when
+# the worker geometry is nonsense.
+ejit_require_numeric(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE)
+ejit_require_numeric(EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT)
+ejit_require_numeric(EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS)
+if(EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE LESS 1)
+  message(FATAL_ERROR
+    "EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE (${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE}) "
+    "must be >= 1 byte.")
+endif()
+if(EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT LESS 0 OR
+   EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS LESS 0)
+  message(FATAL_ERROR
+    "EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT/DELAY_TICKS must be >= 0 (0 disables).")
+endif()
 if(EJIT_SRE_TASKPOOL)
   add_definitions(-DEJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS})
   add_definitions(-DEJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY})
@@ -815,6 +888,12 @@ option(EJIT_SRE_TASKPOOL_NO_RECLAIM
 # live in shared memory, so each bucket is a fixed slot array).
 set(EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS "16" CACHE STRING
   "EmbeddedJIT shared taskpool fixed cache slots per bucket")
+ejit_require_numeric(EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS)
+if(EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS LESS 1)
+  message(FATAL_ERROR
+    "EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS (${EJIT_SRE_SHARED_TASKPOOL_CACHE_SLOTS}) "
+    "must be >= 1 (fixed slot array per cache bucket).")
+endif()
 # Cross-core fnPtr sharing capability (spec §11). DEFAULT OFF: a non-owner core
 # cleanly falls back instead of reading a cache fnPtr. Turn ON only when the
 # platform GUARANTEES: same address space, the code pool mapped at the SAME VA
@@ -836,6 +915,7 @@ if(EJIT_SRE_SHARED_TASKPOOL)
   # its icacheFill silently dropped and the wrapper's inline probe misses
   # forever (every call falls through to MissFn -> tryCacheHit -> cacheHits++).
   # It must cover the full dense funcIndex space.
+  ejit_require_numeric(EJIT_ICACHE_FUNC_SLOTS)
   if(EJIT_ICACHE_FUNC_SLOTS LESS EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX)
     message(FATAL_ERROR
       "EJIT_ICACHE_FUNC_SLOTS (${EJIT_ICACHE_FUNC_SLOTS}) must be >= "

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -39,9 +39,12 @@ public:
 
   // Lifecycle — period-level (fans out to all arrays under periodName).
   // Returns false only in a taskpool build when periodName is not a registered
-  // lifecycle (no state is changed); always true in the legacy build.
-  bool activate(const std::string &periodName, uint8_t cellIdx);
-  bool deactivate(const std::string &periodName, uint8_t cellIdx);
+  // lifecycle (no state is changed), or when cellIdx >= kEJitMaxInstances;
+  // always true in the legacy build. cellIdx is uint32_t so an out-of-range
+  // instance index is rejected here instead of being truncated at the ABI
+  // boundary (see ejit_activate in EJitRuntime.h).
+  bool activate(const std::string &periodName, uint32_t cellIdx);
+  bool deactivate(const std::string &periodName, uint32_t cellIdx);
 
   bool activateAll(const std::string &periodName);
   bool deactivateAll(const std::string &periodName);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -48,7 +48,9 @@ public:
 
   bool activateAll(const std::string &periodName);
   bool deactivateAll(const std::string &periodName);
-  bool isActive(const std::string &periodName, uint8_t cellIdx) const;
+  // uint32_t like activate/deactivate: an out-of-range index is rejected
+  // (false) before any narrowing, never truncated into instance 0.
+  bool isActive(const std::string &periodName, uint32_t cellIdx) const;
 
   // Compilation
   /// Pre-computed cacheKey = funcIdx(32b) | dims(4x8b). The AOT wrapper
@@ -56,7 +58,9 @@ public:
 
   // Cache management
   void clearCache();
-  void invalidateByPeriod(const std::string &periodName, uint8_t cellIdx);
+  // uint32_t like activate/deactivate: an out-of-range index is rejected
+  // (no-op) before any narrowing, never truncated into instance 0.
+  void invalidateByPeriod(const std::string &periodName, uint32_t cellIdx);
   void invalidateAllByPeriod(const std::string &periodName);
 
   // Configuration

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -69,7 +69,12 @@ constexpr const char *TAG_EJIT_MAY_CONST_FIELD = "ejit_may_const_field";
 // Global variable and section names
 //===----------------------------------------------------------------------===//
 constexpr const char *GV_EJIT_BITCODE = "__ejit_bitcode";
-constexpr const char *SECT_EJIT_BITCODE = ".ejit.bitcode";
+// Registry input sections. MUST match the linker-script KEEP() patterns and
+// the __start_/__stop_ bounds symbols the runtime walks (EJit.cpp,
+// ejit_registry.ld): a typo on either side yields an empty registry with no
+// diagnostic. Keep these constants as the single source for the AOT side.
+constexpr const char *SECT_EJIT_BITCODE = ".ejit_bitcode";
+constexpr const char *SECT_EJIT_PERIOD = ".ejit_period";
 constexpr const char *FN_AUTO_REGISTER = "ejit_auto_register";
 constexpr const char *CTORS_GLOBAL = "llvm.global_ctors";
 
@@ -77,6 +82,9 @@ constexpr const char *CTORS_GLOBAL = "llvm.global_ctors";
 // Runtime function names (extern symbols called by AOT-generated code)
 //===----------------------------------------------------------------------===//
 constexpr const char *FN_REGISTER_BITCODE = "ejit_register_bitcode";
+// Symbol registration for the AOT-visible static-var symbol table
+// (EJitRuntime.cpp defines this entry point; the AOT pass emits the call).
+constexpr const char *FN_REGISTER_SYMBOL = "ejit_register_symbol";
 constexpr const char *FN_REGISTER_PERIOD_ARRAY = "ejit_register_period_array";
 constexpr const char *FN_REGISTER_STATIC_VAR = "ejit_register_static_var";
 constexpr const char *FN_REGISTER_LIFECYCLE = "ejit_register_lifecycle";
@@ -126,6 +134,10 @@ constexpr unsigned EJIT_CTOR_PRIORITY = 65535;
 //===----------------------------------------------------------------------===//
 // Limits
 //===----------------------------------------------------------------------===//
+// Sema consumes these via using-declarations (SemaEJIT.cpp). The user-facing
+// diagnostic TEXTS in clang/include/clang/Basic/DiagnosticSemaKinds.td
+// ("exceeds the maximum of 100" / "of 4") are a second copy — update them
+// together with these values.
 constexpr unsigned MAX_PERIOD_ARR_IND_PARAMS = 4;
 constexpr unsigned MAX_PERIOD_ARR_SIZE = 100;
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -117,8 +117,10 @@ constexpr const char *FN_TASKPOOL_TRACE_WRAPPER =
 // Wrapper-timing sentinel status passed to ejit_taskpool_trace_wrapper for
 // icache-hit samples so they aggregate as their own report line (get_fn_avg =
 // probe cost, release_avg = 0), separate from the slow-path compile_or_get
-// samples. Collision-free: real ejit_status_t as uint32_t is 0 or
-// 0xFFFFFFF6..0xFFFFFFFF (EJIT_OK / EJIT_ERR_* = -1..-10).
+// samples. The value is RESERVED in the ejit_status_t enum itself
+// (EJIT_STATUS_ICACHE_HIT_SENTINEL = 0xFE in EJitRuntime.h): a future real
+// status assigned 0xFE is a duplicate-enumerator compile error, and a
+// static_assert in EJitRuntime.cpp locks this constant to that enumerator.
 constexpr uint32_t kEJitIcacheHitTimingStatus = 0xFEu;
 // Lifecycle activation is keyed by period/lifecycle name + instance index only.
 // PASS4 emits these name-level calls at ejit_period_lc entry/exit; there is no

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -77,6 +77,13 @@ typedef enum {
   EJIT_ERR_DISABLED = -9,
   EJIT_ERR_INSTANCE_DISABLED = -10,
   EJIT_PENDING = 1,
+  /* RESERVED sentinel, NOT a real status: the AOT wrapper-timing path passes
+   * this value to ejit_taskpool_trace_wrapper to tag icache-hit samples (see
+   * kEJitIcacheHitTimingStatus in EJitCommon.h, locked to this enumerator by
+   * static_assert in EJitRuntime.cpp). Assigning this value to any real
+   * status is a duplicate-enumerator compile error, so the reservation is
+   * structural, not comment-only. */
+  EJIT_STATUS_ICACHE_HIT_SENTINEL = 0xFE,
 } ejit_status_t;
 
 typedef enum {
@@ -177,7 +184,10 @@ ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx);
 ejit_status_t ejit_deactivate(const char *periodName, uint32_t cellIdx);
 ejit_status_t ejit_activate_all(const char *periodName);
 ejit_status_t ejit_deactivate_all(const char *periodName);
-bool ejit_is_active(const char *periodName, uint8_t cellIdx);
+// uint32_t for the same reason as ejit_activate above: an out-of-range index
+// is rejected (returns false) instead of being truncated at the ABI boundary
+// and silently querying instance 0.
+bool ejit_is_active(const char *periodName, uint32_t cellIdx);
 
 // Compilation
 // ejit_taskpool_compile_or_get is the single compilation entry point for both
@@ -361,7 +371,10 @@ void ejit_print_version(void);
 
 // Cache
 void ejit_clear_cache(void);
-void ejit_invalidate(const char *periodName, uint8_t cellIdx);
+// uint32_t for the same reason as ejit_activate above: an out-of-range index
+// is rejected (no-op) instead of being truncated at the ABI boundary and
+// silently invalidating instance 0.
+void ejit_invalidate(const char *periodName, uint32_t cellIdx);
 
 // Statistics
 ejit_status_t ejit_get_stats(ejit_stats_t *stats);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -169,8 +169,12 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index
 // only; there is no array-pointer dimension in the active state (a period name
 // with multiple arrays is activated as a whole for that instance).
-ejit_status_t ejit_activate(const char *periodName, uint8_t cellIdx);
-ejit_status_t ejit_deactivate(const char *periodName, uint8_t cellIdx);
+// cellIdx is uint32_t on the ABI so an out-of-range instance index is
+// REJECTED by the runtime instead of being silently truncated to 8 bits at
+// the call boundary (the AOT wrapper passes an i32). The runtime checks
+// cellIdx < kEJitMaxInstances.
+ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx);
+ejit_status_t ejit_deactivate(const char *periodName, uint32_t cellIdx);
 ejit_status_t ejit_activate_all(const char *periodName);
 ejit_status_t ejit_deactivate_all(const char *periodName);
 bool ejit_is_active(const char *periodName, uint8_t cellIdx);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -107,20 +107,29 @@ enum class EJitWorkerStep : uint32_t {
 // the owner core uses the cache, so one global slot suffices.
 //===----------------------------------------------------------------------===//
 #ifndef EJIT_ICACHE_FUNC_SLOTS
-#define EJIT_ICACHE_FUNC_SLOTS 64u
+// Fallback ONLY for a non-CMake compile. The default must cover the full
+// dense funcIndex space (EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX, default 4096) —
+// the historical 64-slot default silently dropped icacheFill for every
+// funcIndex >= 64 and defeated the inline cache in production. The
+// static_assert in EJitSharedTaskPool.cpp hard-fails any build where
+// FUNC_SLOTS < MAX_FUNC_INDEX.
+#define EJIT_ICACHE_FUNC_SLOTS 4096u
 #endif
 
 // Per-dim bound D of the multi-version inline cache (@__ejit_icache_fn_<name>
 // is a [D]^numDims array). MUST be a power of 2 (the hit path indexes with
 // shifts, no multiply). The CMake EJIT_ICACHE_DIM_SIZE var overrides this
-// default; the AOT pass reads the same value via -mllvm -ejit-icache-dim-size
+// default; the same CMake var feeds the AOT pass, and configure time
+// cross-checks the built compiler via -mllvm -print-ejit-icache-dim-size,
 // so array layout and runtime linearization agree.
 #ifndef EJIT_ICACHE_DIM_SIZE
 #define EJIT_ICACHE_DIM_SIZE 16u
 #endif
 // Maximum number of ejit_dim params a cached ejit_entry may have. An entry
-// with more is a compile error (the wrapper is not emitted). 4 matches the
-// taskpool DimCount cap.
+// with more is a compile error (the wrapper is not emitted). Must equal
+// kEJitSharedMaxDims (EJitSharedTaskPoolState.h) and MAX_PERIOD_ARR_IND_PARAMS
+// (EJitCommon.h); hard-locked by static_asserts in EJitSharedTaskPool.cpp and
+// EJitRuntime.cpp.
 #ifndef EJIT_ICACHE_MAX_DIMS
 #define EJIT_ICACHE_MAX_DIMS 4u
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 
 # EJIT_ICACHE_DIM_SIZE: per-dim bound D of the multi-version inline cache.
 # Used by icacheFill/icacheTry linearization in EJitSharedTaskPool. Must match
-# the AOT -mllvm -ejit-icache-dim-size value (both from the top-level CMake
+# the AOT -mllvm -print-ejit-icache-dim-size value (both from the top-level CMake
 # var). Scoped to LLVMEJIT (the icache runtime lives here); gated on the shared
 # taskpool, which is the only build the icache is compiled under.
 if(EJIT_SRE_SHARED_TASKPOOL)

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -4,6 +4,7 @@
 #include "llvm/Config/Targets.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCompileDriver.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h" // SECT_EJIT_* section names
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitFuncRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLifecycleRegistry.h"
@@ -230,6 +231,20 @@ EJit::EJit(const Config &config) : config_(config) {
         }
       }
     };
+    // Diagnose an empty registry section before walking: on hosted builds the
+    // bounds are weak, so a missing linker script or a section-name typo (the
+    // AOT SECT_EJIT_* constants vs the script's KEEP patterns) silently yields
+    // an empty range — exactly the silent-desync class these diagnostics exist
+    // to catch. VERBOSE (not INFO): a bitcode-only app with no periods has a
+    // legitimately empty .ejit_period and must not warn at default level.
+    if (__start_ejit_bitcode == __stop_ejit_bitcode)
+      EJIT_DIAG_VERBOSE("registry walk: %s range is EMPTY "
+                        "(missing section or linker script mismatch)",
+                        SECT_EJIT_BITCODE);
+    if (__start_ejit_period == __stop_ejit_period)
+      EJIT_DIAG_VERBOSE("registry walk: %s range is EMPTY "
+                        "(missing section or linker script mismatch)",
+                        SECT_EJIT_PERIOD);
     walkRange(__start_ejit_bitcode, __stop_ejit_bitcode);
     walkRange(__start_ejit_period, __stop_ejit_period);
     for (auto &sym : tableSymbols)
@@ -374,7 +389,9 @@ void EJit::recordInitError(int code, const std::string &message,
             funcName.c_str());
 }
 
-bool EJit::activate(const std::string &periodName, uint8_t cellIdx) {
+bool EJit::activate(const std::string &periodName, uint32_t cellIdx) {
+  if (cellIdx >= kEJitMaxInstances)
+    return false;
 #ifdef EJIT_SRE_TASKPOOL
   // Taskpool build: a registered lifecycle updates the time-window activation
   // state AND the SwitchController (kept consistent; setEnabled bumps the
@@ -415,7 +432,9 @@ bool EJit::activate(const std::string &periodName, uint8_t cellIdx) {
 #endif
 }
 
-bool EJit::deactivate(const std::string &periodName, uint8_t cellIdx) {
+bool EJit::deactivate(const std::string &periodName, uint32_t cellIdx) {
+  if (cellIdx >= kEJitMaxInstances)
+    return false;
 #ifdef EJIT_SRE_TASKPOOL
   uint32_t dt = EJitLifecycleRegistry::instance().lookup(periodName);
   if (dt != kEJitInvalidDimType) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -523,7 +523,11 @@ bool EJit::deactivateAll(const std::string &periodName) {
 #endif
 }
 
-bool EJit::isActive(const std::string &periodName, uint8_t cellIdx) const {
+bool EJit::isActive(const std::string &periodName, uint32_t cellIdx) const {
+  // Range-check BEFORE any narrowing: the private state tables index by
+  // cellIdx, and a truncated 256 would silently read instance 0.
+  if (cellIdx >= kEJitMaxInstances)
+    return false;
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   // Cross-core: a registered lifecycle's activation lives in the shared
   // enabled bit (the producer's ejit_activate writes it). Query that, not the
@@ -536,12 +540,21 @@ bool EJit::isActive(const std::string &periodName, uint8_t cellIdx) const {
       return sp->isInstanceActive(dt, cellIdx);
   }
 #endif
-  return runtimeState_->isActive(periodName, cellIdx);
+  // Cell-index range already validated above; the private state still takes a
+  // uint8_t (its tables are sized kEJitMaxInstances, keyed by the validated
+  // index), so the narrowing here is provably safe.
+  return runtimeState_->isActive(periodName,
+                                 static_cast<uint8_t>(cellIdx));
 }
 
 void EJit::clearCache() { /* Legacy LRU cache retired */ }
 
-void EJit::invalidateByPeriod(const std::string &periodName, uint8_t cellIdx) {
+void EJit::invalidateByPeriod(const std::string &periodName, uint32_t cellIdx) {
+  // Range-check BEFORE any narrowing: a truncated 256 would invalidate
+  // instance 0. Legacy invalidation is a no-op, but the ABI contract is the
+  // same as the taskpool path.
+  if (cellIdx >= kEJitMaxInstances)
+    return;
   (void)periodName; (void)cellIdx;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -54,10 +54,17 @@ static_assert(EJIT_LOG_LVL_OFF == EJIT_LOG_OFF &&
               "EJIT_LOG_LVL_* (EJitDiag.h) must equal ejit_log_level_t "
               "(EJitRuntime.h) values.");
 
-// Wrapper-timing sentinel: must never collide with a real status. Real
-// statuses as uint32_t are 0 (EJIT_OK), 1 (EJIT_PENDING) and 0xFFFFFFF6..
-// 0xFFFFFFFF (EJIT_ERR_* = -1..-10). A collision would corrupt timing
-// aggregation in ejit_taskpool_trace_wrapper.
+// Wrapper-timing sentinel: must never collide with a real status. The value
+// is structurally RESERVED in the ejit_status_t enum itself
+// (EJIT_STATUS_ICACHE_HIT_SENTINEL = 0xFE) — a future real status assigned
+// 0xFE is a duplicate-enumerator compile error — and the two constants are
+// locked together here. The per-value comparisons below are a second,
+// explicit lock against every status that exists today: a collision would
+// corrupt timing aggregation in ejit_taskpool_trace_wrapper.
+static_assert(kEJitIcacheHitTimingStatus ==
+                  static_cast<uint32_t>(EJIT_STATUS_ICACHE_HIT_SENTINEL),
+              "kEJitIcacheHitTimingStatus (EJitCommon.h) must equal the "
+              "EJIT_STATUS_ICACHE_HIT_SENTINEL enumerator (EJitRuntime.h).");
 static_assert(kEJitIcacheHitTimingStatus != static_cast<uint32_t>(EJIT_OK) &&
                   kEJitIcacheHitTimingStatus !=
                       static_cast<uint32_t>(EJIT_PENDING) &&
@@ -541,9 +548,16 @@ ejit_status_t ejit_deactivate_all(const char *periodName) {
   return EJIT_OK;
 }
 
-bool ejit_is_active(const char *periodName, uint8_t cellIdx) {
+bool ejit_is_active(const char *periodName, uint32_t cellIdx) {
   if (!gEJIT) {
     EJIT_DIAG("is_active(%s,%u) failed: not initialized", periodName, cellIdx);
+    return false;
+  }
+  // Reject out-of-range indices instead of truncating at the ABI boundary and
+  // querying the wrong instance (pre-fix uint8_t signature).
+  if (cellIdx >= kEJitMaxInstances) {
+    EJIT_DIAG("is_active(%s,%u) rejected: instance index >= kEJitMaxInstances=%u",
+              periodName, cellIdx, kEJitMaxInstances);
     return false;
   }
   return gEJIT->isActive(periodName, cellIdx);
@@ -566,10 +580,17 @@ void ejit_clear_cache(void) {
 #endif
 }
 
-void ejit_invalidate(const char *periodName, uint8_t cellIdx) {
+void ejit_invalidate(const char *periodName, uint32_t cellIdx) {
   EJIT_DIAG("invalidate(%s,%u)", periodName, cellIdx);
   if (!gEJIT)
     return;
+  // Reject out-of-range indices instead of truncating at the ABI boundary and
+  // invalidating the wrong instance (pre-fix uint8_t signature).
+  if (cellIdx >= kEJitMaxInstances) {
+    EJIT_DIAG("invalidate(%s,%u) rejected: instance index >= kEJitMaxInstances=%u",
+              periodName, cellIdx, kEJitMaxInstances);
+    return;
+  }
   gEJIT->invalidateByPeriod(periodName, cellIdx);
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (auto *tp = gEJIT->sharedTaskPool())

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -5,13 +5,16 @@
 #include "llvm/Config/llvm-config.h"
 #include "llvm/ExecutionEngine/EJIT/EJit.h"
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h" // contract constants + kEJitMax*
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitFuncRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLifecycleRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h" // ejit_reg_entry_t layout
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+#include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h" // EJitDimPair layout
 // Build-time-generated: EJIT_GIT_COMMIT / EJIT_GIT_BRANCH (git HEAD of the
 // llvm-project source tree). Lives in the LLVMEJIT build directory.
 #include "EJitVersion.h"
@@ -32,6 +35,96 @@
 
 using namespace llvm;
 using namespace llvm::ejit;
+
+//===----------------------------------------------------------------------===//
+// Compile-time contract checks: each assert locks two independently defined
+// copies of one config value (AOT pass vs runtime, or runtime header vs
+// runtime header). Editing one copy without the other now fails the LLVMEJIT
+// build instead of silently desynchronizing — the exact class of bug that
+// shipped as EJIT_ICACHE_FUNC_SLOTS=64 vs a 4096 funcIndex space.
+//===----------------------------------------------------------------------===//
+
+// Log-level gate thresholds (EJitDiag.h macros) vs the public C ABI enum
+// (EJitRuntime.h): ejit_set_log_level() feeds the macros, so a drift would
+// change which diagnostics fire for a given API level.
+static_assert(EJIT_LOG_LVL_OFF == EJIT_LOG_OFF &&
+                  EJIT_LOG_LVL_INFO == EJIT_LOG_INFO &&
+                  EJIT_LOG_LVL_VERBOSE == EJIT_LOG_VERBOSE &&
+                  EJIT_LOG_LVL_DEBUG == EJIT_LOG_DEBUG,
+              "EJIT_LOG_LVL_* (EJitDiag.h) must equal ejit_log_level_t "
+              "(EJitRuntime.h) values.");
+
+// Wrapper-timing sentinel: must never collide with a real status. Real
+// statuses as uint32_t are 0 (EJIT_OK), 1 (EJIT_PENDING) and 0xFFFFFFF6..
+// 0xFFFFFFFF (EJIT_ERR_* = -1..-10). A collision would corrupt timing
+// aggregation in ejit_taskpool_trace_wrapper.
+static_assert(kEJitIcacheHitTimingStatus != static_cast<uint32_t>(EJIT_OK) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_PENDING) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_INVALID_PARAM) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_NOT_ACTIVE) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_COMPILE_FAILED) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_CACHE_FULL) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_MEMORY) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_BITCODE_NOT_FOUND) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_QUEUE_FULL) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_DEDUP_FULL) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_DISABLED) &&
+                  kEJitIcacheHitTimingStatus !=
+                      static_cast<uint32_t>(EJIT_ERR_INSTANCE_DISABLED),
+              "kEJitIcacheHitTimingStatus (0xFE) collides with a real "
+              "ejit_status_t value.");
+
+// Registry entry ABI: {i32 type; ptr; ptr; ptr; u64 size}, 8-byte aligned,
+// 40 bytes on 64-bit. The AOT passes emit these as constant structs and the
+// runtime walks them in EJit.cpp; the linker scripts (ejit_registry.ld,
+// ejit_baremetal.ld) hardcode the same alignment. EJIT targets are 64-bit
+// (aarch64_be / x86_64).
+#if UINTPTR_MAX == UINT64_MAX
+static_assert(sizeof(ejit_reg_entry_t) == 40,
+              "ejit_reg_entry_t must be 40 bytes on 64-bit "
+              "(AOT-emitted registry entry layout).");
+static_assert(alignof(ejit_reg_entry_t) == 8,
+              "ejit_reg_entry_t must be 8-byte aligned "
+              "(linker script ALIGN(8) contract).");
+#endif
+
+// Dim-pair identity layout: {uint32_t dimType, uint32_t instanceId}, field
+// order dimType-first, identical in the C ABI type and the queue POD type.
+// The AOT wrapper builds this struct in IR with the same order; a swap would
+// key the cache on the wrong identity.
+static_assert(offsetof(ejit_dim_pair_t, dimType) ==
+                      offsetof(EJitDimPair, dimType) &&
+                  offsetof(ejit_dim_pair_t, instanceId) ==
+                      offsetof(EJitDimPair, instanceId) &&
+                  sizeof(ejit_dim_pair_t) == sizeof(EJitDimPair),
+              "ejit_dim_pair_t (C ABI) and EJitDimPair (queue POD) must have "
+              "identical {dimType, instanceId} layout.");
+
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+// Shared-taskpool capacity constants must mirror the single-instance ones:
+// the shared cache's enabled[dimType][instanceId] tables index by these, and
+// a smaller shared copy would go OOB on the shared blob for indices the
+// single-instance side accepts.
+static_assert(kEJitMaxDimTypes == kEJitSharedDimTypes,
+              "kEJitMaxDimTypes (EJitCommon.h) must equal kEJitSharedDimTypes "
+              "(EJitSharedTaskPoolState.h).");
+static_assert(kEJitMaxInstances == kEJitSharedInstances,
+              "kEJitMaxInstances (EJitCommon.h) must equal "
+              "kEJitSharedInstances (EJitSharedTaskPoolState.h).");
+static_assert(kEJitMaxFuncIndex == kEJitSharedMaxFuncIndex,
+              "kEJitMaxFuncIndex (EJitCommon.h) must equal "
+              "kEJitSharedMaxFuncIndex (EJitSharedTaskPoolState.h).");
+#endif // EJIT_SRE_SHARED_TASKPOOL
 
 static EJit *gEJIT = nullptr;
 
@@ -386,10 +479,18 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
                     funcName, idx, numDims);
 }
 
-ejit_status_t ejit_activate(const char *periodName, uint8_t cellIdx) {
+ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx) {
   if (!gEJIT) {
     EJIT_DIAG("activate(%s,%u) failed: not initialized", periodName, cellIdx);
     return EJIT_ERR_NOT_ACTIVE;
+  }
+  // The AOT call site passes the instance index as an i32; reject anything the
+  // runtime tables cannot hold instead of silently activating the wrong
+  // instance (the pre-fix uint8_t signature truncated at the call boundary).
+  if (cellIdx >= kEJitMaxInstances) {
+    EJIT_DIAG("activate(%s,%u) failed: instance index >= kEJitMaxInstances=%u",
+              periodName, cellIdx, kEJitMaxInstances);
+    return EJIT_ERR_INVALID_PARAM;
   }
   EJIT_DIAG("activate(%s,%u)", periodName, cellIdx);
   // In a taskpool build this also syncs the SwitchController and returns false
@@ -400,10 +501,15 @@ ejit_status_t ejit_activate(const char *periodName, uint8_t cellIdx) {
   return EJIT_OK;
 }
 
-ejit_status_t ejit_deactivate(const char *periodName, uint8_t cellIdx) {
+ejit_status_t ejit_deactivate(const char *periodName, uint32_t cellIdx) {
   if (!gEJIT) {
     EJIT_DIAG("deactivate(%s,%u) failed: not initialized", periodName, cellIdx);
     return EJIT_ERR_NOT_ACTIVE;
+  }
+  if (cellIdx >= kEJitMaxInstances) {
+    EJIT_DIAG("deactivate(%s,%u) failed: instance index >= kEJitMaxInstances=%u",
+              periodName, cellIdx, kEJitMaxInstances);
+    return EJIT_ERR_INVALID_PARAM;
   }
   EJIT_DIAG("deactivate(%s,%u)", periodName, cellIdx);
   if (!gEJIT->deactivate(periodName, cellIdx))

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -34,6 +34,20 @@ static_assert(EJIT_ICACHE_FUNC_SLOTS >= EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX,
               "EJIT_ICACHE_FUNC_SLOTS must be >= EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX; "
               "otherwise icacheFill silently drops high-funcIndex entries.");
 
+// icacheLinearize indexes with shifts (idx = idx * D + instanceId), so D must
+// be a power of 2 — a non-pow2 D would corrupt the row-major stride silently.
+static_assert((EJIT_ICACHE_DIM_SIZE & (EJIT_ICACHE_DIM_SIZE - 1)) == 0,
+              "EJIT_ICACHE_DIM_SIZE must be a power of 2 "
+              "(the icache hit path uses shift-based indexing).");
+
+// The AOT wrapper emits [D]^numDims slot arrays up to EJIT_ICACHE_MAX_DIMS;
+// the shared cache identity stores dims up to kEJitSharedMaxDims. A drift
+// between the two would let the AOT emit 5+ dim wrappers whose identity the
+// runtime truncates — silently serving the wrong specialization.
+static_assert(EJIT_ICACHE_MAX_DIMS == llvm::ejit::kEJitSharedMaxDims,
+              "EJIT_ICACHE_MAX_DIMS (AOT wrapper dim cap) must equal "
+              "kEJitSharedMaxDims (shared cache identity cap).");
+
 using namespace llvm;
 using namespace llvm::ejit;
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -26,6 +26,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h" // seal/split granule contract
 
 #include <cstdint>
 
@@ -52,6 +53,16 @@ constexpr unsigned kSreMid = static_cast<unsigned>(EJIT_SRE_CODE_POOL_MID);
 constexpr size_t k2MiB = static_cast<size_t>(2) * 1024 * 1024;
 constexpr size_t k4KiB = static_cast<size_t>(4) * 1024;
 } // namespace
+
+// Hard-lock the platform split/seal granularities against the shared-pool
+// contract copies: splitting by one size and sealing by another would leave
+// RWX windows or fail seals — memory safety, not just a perf issue.
+static_assert(k2MiB == llvm::ejit::kEJitSharedSplitGranule,
+              "SRE pool split granule (2 MiB) must equal "
+              "kEJitSharedSplitGranule (EJitSharedTaskPoolState.h).");
+static_assert(k4KiB == llvm::ejit::kEJitSharedSealPage,
+              "SRE pool seal page (4 KiB) must equal "
+              "kEJitSharedSealPage (EJitSharedTaskPoolState.h).");
 
 //===----------------------------------------------------------------------===//
 // Platform primitives (declaration only — defined by the platform/business)

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -708,7 +708,7 @@ static void generateSymbolRegisters(
   auto *VoidTy = Type::getVoidTy(Ctx);
   auto *PtrTy = PointerType::getUnqual(Ctx);
 
-  M.getOrInsertFunction("ejit_register_symbol",
+  M.getOrInsertFunction(FN_REGISTER_SYMBOL,
       FunctionType::get(VoidTy, {PtrTy, PtrTy}, false));
 
   std::set<std::string> registered;
@@ -730,7 +730,7 @@ static void generateSymbolRegisters(
               std::string Name = Callee->getName().str();
               if (registered.insert(Name).second) {
                 IRBuilder<> Builder(InsertBefore);
-                Builder.CreateCall(M.getFunction("ejit_register_symbol"),
+                Builder.CreateCall(M.getFunction(FN_REGISTER_SYMBOL),
                     {Builder.CreateGlobalString(Name),
                      Builder.CreateBitCast(Callee, PtrTy)});
               }
@@ -754,7 +754,7 @@ static void generateSymbolRegisters(
             std::string Name = GV->getName().str();
             if (registered.insert(Name).second) {
               IRBuilder<> Builder(InsertBefore);
-              Builder.CreateCall(M.getFunction("ejit_register_symbol"),
+              Builder.CreateCall(M.getFunction(FN_REGISTER_SYMBOL),
                   {Builder.CreateGlobalString(Name),
                    Builder.CreateBitCast(GV, PtrTy)});
             }
@@ -992,7 +992,7 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
   auto *GV = new GlobalVariable(M, ArrayTy, /*isConstant=*/true,
                                 GlobalValue::PrivateLinkage, ArrayInit,
                                 ".ejit.registry.bitcode");
-  GV->setSection(".ejit_bitcode");
+  GV->setSection(SECT_EJIT_BITCODE);
   GV->setAlignment(M.getDataLayout().getABITypeAlign(EntryTy));
   appendToUsed(M, {GV});
 }

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterPeriod.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterPeriod.cpp
@@ -196,7 +196,7 @@ generateRegistryTablePeriod(
   auto *GV = new GlobalVariable(M, ArrayTy, /*isConstant=*/true,
                                 GlobalValue::PrivateLinkage, ArrayInit,
                                 ".ejit.registry.period");
-  GV->setSection(".ejit_period");
+  GV->setSection(SECT_EJIT_PERIOD);
   GV->setAlignment(M.getDataLayout().getABITypeAlign(EntryTy));
   appendToUsed(M, {GV});
 }

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -33,6 +33,18 @@
 #include <string>
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 
+// Hard-lock the AOT-side contract constants against each other (the runtime
+// side locks its own copies in EJitRuntime.cpp / EJitSharedTaskPool.cpp):
+// a drift between the wrapper dim cap and the Sema param cap would let one
+// stage emit what the other rejects, and a non-pow2 D corrupts the [D]^N
+// icache array stride.
+static_assert(EJIT_ICACHE_MAX_DIMS == llvm::ejit::MAX_PERIOD_ARR_IND_PARAMS,
+              "EJIT_ICACHE_MAX_DIMS must equal MAX_PERIOD_ARR_IND_PARAMS "
+              "(wrapper dim cap vs Sema ejit_period_arr_ind cap).");
+static_assert((EJIT_ICACHE_DIM_SIZE & (EJIT_ICACHE_DIM_SIZE - 1)) == 0,
+              "EJIT_ICACHE_DIM_SIZE must be a power of 2 "
+              "([D]^numDims icache array stride).");
+
 using namespace llvm;
 using namespace llvm::ejit;
 
@@ -218,7 +230,7 @@ emitLifecycleRegistration(Module &M,
   auto *GV = new GlobalVariable(
       M, ArrayTy, /*isConstant=*/true, GlobalValue::PrivateLinkage,
       ConstantArray::get(ArrayTy, Entries), ".ejit.registry.lifecycle");
-  GV->setSection(".ejit_period");
+  GV->setSection(SECT_EJIT_PERIOD);
   GV->setAlignment(M.getDataLayout().getABITypeAlign(EntryTy));
   appendToUsed(M, {GV});
 }
@@ -353,7 +365,7 @@ emitFuncIndexRegistration(Module &M,
   auto *GV = new GlobalVariable(
       M, ArrayTy, /*isConstant=*/true, GlobalValue::PrivateLinkage,
       ConstantArray::get(ArrayTy, Entries), ".ejit.registry.funcindex");
-  GV->setSection(".ejit_period");
+  GV->setSection(SECT_EJIT_PERIOD);
   GV->setAlignment(M.getDataLayout().getABITypeAlign(EntryTy));
   appendToUsed(M, {GV});
 }
@@ -430,7 +442,7 @@ emitIcacheSlotRegistration(Module &M,
   auto *GV = new GlobalVariable(
       M, ArrayTy, /*isConstant=*/true, GlobalValue::PrivateLinkage,
       ConstantArray::get(ArrayTy, Entries), ".ejit.registry.icache");
-  GV->setSection(".ejit_period");
+  GV->setSection(SECT_EJIT_PERIOD);
   GV->setAlignment(M.getDataLayout().getABITypeAlign(EntryTy));
   appendToUsed(M, {GV});
 }
@@ -590,9 +602,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     auto PeriodInds = getPeriodArrIndInfo(*F);
     unsigned DimCount = PeriodInds.size();
 
-    if (DimCount > 4) {
-      F->getContext().emitError("ejit-wrapper-gen: more than 4 "
-                                "ejit_period_arr_ind dimensions are not "
+    if (DimCount > EJIT_ICACHE_MAX_DIMS) {
+      F->getContext().emitError("ejit-wrapper-gen: more than "
+                                + Twine(EJIT_ICACHE_MAX_DIMS) +
+                                " ejit_period_arr_ind dimensions are not "
                                 "supported");
       continue;
     }

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -54,12 +54,16 @@ add_llvm_unittest(EJITTaskPoolTests
   )
 set(LLVM_LINK_COMPONENTS "${EJIT_TASKPOOL_LINK_COMPONENTS_SAVED}")
 
+# Numeric geometry must come from the CMake cache vars (not literals), so the
+# test TU compiles the shared sources with the SAME values as production
+# LLVMEJIT — a tuned cache var silently stopping being tested is exactly the
+# config-desync class this whole file guards against.
 target_compile_definitions(EJITTaskPoolTests PRIVATE
   EJIT_SRE_TASKPOOL
   EJIT_SRE_TASKPOOL_TESTING
   EJIT_STATS_ENABLE
-  EJIT_SRE_TASKPOOL_BUCKETS=32
-  EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
+  EJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS}
+  EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}
   EJIT_TASKPOOL_SOURCE_DIR="${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT"
   EJIT_TASKPOOL_INCLUDE_DIR="${LLVM_MAIN_SRC_DIR}/include/llvm/ExecutionEngine/EJIT"
   )
@@ -95,16 +99,17 @@ set(LLVM_LINK_COMPONENTS "${EJIT_SHARED_TASKPOOL_LINK_COMPONENTS_SAVED}")
 
 # The icache geometry must match the production LLVMEJIT build (same CMake
 # vars, same static_assert): these sources are compiled INTO the test target,
-# so without the definitions the header defaults apply and the FUNC_SLOTS
-# static_assert (64 >= 4096) fails.
+# so the ${EJIT_*} cache vars must be forwarded explicitly — the header
+# fallbacks exist only for non-CMake builds and the static_asserts would fire
+# (or silently test different geometry) if they diverged.
 target_compile_definitions(EJITSharedTaskPoolTests PRIVATE
   EJIT_SRE_TASKPOOL
   EJIT_SRE_SHARED_TASKPOOL
   EJIT_SRE_TASKPOOL_TESTING
   EJIT_STATS_ENABLE
-  EJIT_SRE_TASKPOOL_BUCKETS=32
-  EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
-  EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=1048576
+  EJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS}
+  EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}
+  EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE}
   EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE}
   EJIT_ICACHE_FUNC_SLOTS=${EJIT_ICACHE_FUNC_SLOTS}
   EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX=${EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX}
@@ -157,8 +162,8 @@ if(EJIT_BUILD_CACHE_QUERY_BENCH)
     EJIT_SRE_TASKPOOL
     EJIT_SRE_SHARED_TASKPOOL
     EJIT_SRE_TASKPOOL_TESTING
-    EJIT_SRE_TASKPOOL_BUCKETS=32
-    EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=1024
+    EJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS}
+    EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}
     EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE}
     EJIT_ICACHE_FUNC_SLOTS=${EJIT_ICACHE_FUNC_SLOTS}
     EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX=${EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -670,8 +670,8 @@ extern ejit_status_test_t ejit_init(const void *config);
 extern void ejit_shutdown(void);
 extern ejit_status_test_t ejit_activate(const char *, uint32_t);
 extern ejit_status_test_t ejit_deactivate(const char *, uint32_t);
-extern bool ejit_is_active(const char *, uint8_t);
-extern void ejit_invalidate(const char *, uint8_t);
+extern bool ejit_is_active(const char *, uint32_t);
+extern void ejit_invalidate(const char *, uint32_t);
 extern void ejit_clear_cache(void);
 extern void ejit_register_period_array(const char *, const char *, void *,
                                        uint64_t);
@@ -759,6 +759,13 @@ TEST(EJitCApi, DynamicCellIdxBoundaries) {
   // truncated to 8 bits at the call boundary and applied to the wrong cell.
   EXPECT_NE(ejit_activate("bound", 256u), EJIT_OK_C);
   EXPECT_NE(ejit_deactivate("bound", 256u), EJIT_OK_C);
+  // Same contract for the query/invalidate entry points: 256 must neither
+  // read nor invalidate instance 0.
+  ejit_activate("bound", (uint8_t)0);
+  EXPECT_TRUE(ejit_is_active("bound", (uint8_t)0));
+  EXPECT_FALSE(ejit_is_active("bound", 256u));
+  ejit_invalidate("bound", 256u);
+  EXPECT_TRUE(ejit_is_active("bound", (uint8_t)0)); // instance 0 untouched
   ejit_deactivate("bound", 0);
   EXPECT_FALSE(ejit_is_active("bound", 0));
   EXPECT_TRUE(ejit_is_active("bound", (uint8_t)255));

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -668,8 +668,8 @@ extern "C" {
 typedef enum { EJIT_OK_C = 0 } ejit_status_test_t;
 extern ejit_status_test_t ejit_init(const void *config);
 extern void ejit_shutdown(void);
-extern ejit_status_test_t ejit_activate(const char *, uint8_t);
-extern ejit_status_test_t ejit_deactivate(const char *, uint8_t);
+extern ejit_status_test_t ejit_activate(const char *, uint32_t);
+extern ejit_status_test_t ejit_deactivate(const char *, uint32_t);
 extern bool ejit_is_active(const char *, uint8_t);
 extern void ejit_invalidate(const char *, uint8_t);
 extern void ejit_clear_cache(void);
@@ -755,6 +755,10 @@ TEST(EJitCApi, DynamicCellIdxBoundaries) {
   EXPECT_TRUE(ejit_is_active("bound", (uint8_t)0));
   EXPECT_EQ(ejit_activate("bound", (uint8_t)255), EJIT_OK_C);
   EXPECT_TRUE(ejit_is_active("bound", (uint8_t)255));
+  // Out-of-range instance index must be REJECTED (post uint32_t-ABI fix), not
+  // truncated to 8 bits at the call boundary and applied to the wrong cell.
+  EXPECT_NE(ejit_activate("bound", 256u), EJIT_OK_C);
+  EXPECT_NE(ejit_deactivate("bound", 256u), EJIT_OK_C);
   ejit_deactivate("bound", 0);
   EXPECT_FALSE(ejit_is_active("bound", 0));
   EXPECT_TRUE(ejit_is_active("bound", (uint8_t)255));


### PR DESCRIPTION
Follow-up to the FUNC_SLOTS=64-vs-4096 fix (merged via #141): extrapolate to BOTH sides (AOT passes / clang Sema and the EJIT runtime) and lock every remaining config value that exists in multiple independently-editable copies with no hard check, so a drift fails the build or the configure instead of silently desynchronizing.

## Compiler side (AOT passes + clang Sema)

- `SECT_EJIT_BITCODE` had the WRONG value `.ejit.bitcode` (dead but a landmine) - fixed to `.ejit_bitcode`; the passes now emit sections via shared constants (`SECT_EJIT_PERIOD`, `FN_REGISTER_SYMBOL`) instead of string literals.
- Wrapper dim-cap error and Sema checks use `EJIT_ICACHE_MAX_DIMS` / `MAX_PERIOD_ARR_IND_PARAMS` / `MAX_PERIOD_ARR_SIZE` instead of literals; AOT-side static_asserts lock MAX_DIMS == param cap and the DIM_SIZE pow2 stride.

## Runtime side

- `EJitSharedTaskPool.h` FUNC_SLOTS fallback default 64u -> 4096u (non-CMake builds are now safe by default; the static_assert still backstops).
- `EJitRuntime.cpp`: a static_assert block locks the independently defined copies: `ejit_log_level_t` vs `EJIT_LOG_LVL_*` thresholds, the 0xFE wrapper-timing sentinel vs every `ejit_status_t` value, the 40-byte/8-align registry entry ABI, `ejit_dim_pair_t` vs `EJitDimPair` layout, and (shared-taskpool builds) `kEJitMax*` vs `kEJitShared*` capacities.
- `EJitSharedTaskPool.cpp`: D pow2 + MAX_DIMS == kEJitSharedMaxDims. `EJitSrePlatform.cpp`: 2MiB split granule / 4KiB seal page locked to the shared constants.
- `ejit_activate`/`ejit_deactivate` ABI widened uint8_t -> uint32_t; the runtime now REJECTS cellIdx >= kEJitMaxInstances (the uint8_t signature truncated at the call boundary and activated the wrong instance). gtest covers the rejection.
- `EJit.cpp`: empty registry-section ranges get a VERBOSE diagnostic instead of a silent empty walk on hosted builds.

## Build system

- Configure-time validation for all EJIT numeric cache vars (pool size 2MiB multiple + >= 1, ptNo [1,255], buckets [1,254], queue pow2 >= 2, maxFuncIndex >= 1, worker stack/throttle >= 0, cache slots >= 1) plus `ejit_require_numeric()` rejecting non-numeric strings (CMake LESS/GREATER silently bypasses bounds on them).
- Unit-test/bench targets forward the real cache-var values instead of hardcoded literals, so tuning a var keeps being tested.
- Stale `-mllvm -ejit-icache-dim-size` comment references corrected to `-print-ejit-icache-dim-size`.

## Verification

- LLVMEJIT + LLVMEmbeddedJIT + clang build clean (diag ON, shared taskpool, NO_RECLAIM, code pool on/off).
- 4 InlineCache gtests + 82 EJITTaskPool gtests pass; the 14 pre-existing config-dependent SharedTaskPool failures are unchanged from the unmodified baseline.
- Negative configure tests trigger the new FATAL_ERRORs (non-2MiB pool size, non-pow2 queue, out-of-range buckets, non-numeric value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)