### PR TITLE
[EJIT] Reject ejit_entry combined with ejit_period_lc on one function

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13503,6 +13503,8 @@ def err_ejit_entry_recursive : Error<
   "ejit_entry function %0 cannot be recursive">;
 def err_ejit_period_lc_no_index : Error<
   "ejit_period_lc(%0) requires a corresponding ejit_period_arr_ind(%0) parameter">;
+def err_ejit_entry_lc_conflict : Error<
+  "'ejit_entry' and 'ejit_period_lc' cannot be combined on function %0">;
 def warn_ejit_may_const_modified_without_lc : Warning<
   "modifying ejit_may_const field %0 of %1 without ejit_period_lc attribute">,
   InGroup<EmbeddedJIT>;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -80,6 +80,10 @@ void checkEjitPeriodArrIndLimit(Sema &S, const FunctionDecl *FD);
 // Defined in SemaEJIT.cpp.
 void checkEjitAlwaysInlineConflict(Sema &S, FunctionDecl *FD);
 
+// Forward declaration for EmbeddedJIT ejit_entry / ejit_period_lc conflict
+// check. Defined in SemaEJIT.cpp.
+void checkEjitEntryLcConflict(Sema &S, FunctionDecl *FD, bool AfterMerge);
+
 // Forward declaration for EmbeddedJIT missing-attribute-on-definition check.
 // Defined in SemaEJIT.cpp.
 void checkEjitAttrMissingOnDefinition(Sema &S, FunctionDecl *FD);
@@ -10531,6 +10535,10 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
   // (it conflicts with the noinline CodeGen/PASS3 add for LTO survival).
   checkEjitAlwaysInlineConflict(*this, NewFD);
 
+  // ejit_entry and ejit_period_lc are mutually exclusive on one function:
+  // PASS3 (wrapper) and PASS4 (lifecycle guards) both rewrite its body.
+  checkEjitEntryLcConflict(*this, NewFD, /*AfterMerge=*/false);
+
   const auto *NewTVA = NewFD->getAttr<TargetVersionAttr>();
   if (Context.getTargetInfo().getTriple().isAArch64() && NewTVA &&
       !NewTVA->isDefaultVersion() &&
@@ -12281,6 +12289,10 @@ bool Sema::CheckFunctionDeclaration(Scope *S, FunctionDecl *NewFD,
       NewFD->addAttr(OverloadableAttr::CreateImplicit(Context));
     }
   }
+
+  // A function redeclaration may have assembled ejit_entry on one declaration
+  // and ejit_period_lc on another; only the merged declaration shows the pair.
+  checkEjitEntryLcConflict(*this, NewFD, /*AfterMerge=*/true);
 
   // A function defined without ejit_entry / ejit_period_lc even though a
   // prior declaration carries the attribute is not JIT-specialized: warn and

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -306,6 +306,72 @@ void checkEjitPeriodArrIndLimit(Sema &S, const FunctionDecl *FD) {
   }
 }
 
+/// checkEjitEntryLcConflict - ejit_entry and ejit_period_lc are mutually
+/// exclusive on one function. PASS3 (EJitWrapperGen) replaces an entry's body
+/// with a single-function dispatch wrapper, and PASS4 (EJitPeriodHandler)
+/// inserts lifecycle guards at a lifecycle function's entry and returns; the
+/// two rewrites would both claim the body. Reject the combination at the
+/// source instead of letting the AOT pipeline fight over the function.
+///
+/// Called twice per declaration:
+///  * from ActOnFunctionDeclarator after ProcessDeclAttributes (AfterMerge ==
+///    false), where the check is independent of the source order of the two
+///    attributes;
+///  * from CheckFunctionDeclaration after MergeFunctionDecl (AfterMerge ==
+///    true), which is the only point that sees a combination assembled from
+///    attributes written on DIFFERENT declarations. There the check fires
+///    only when exactly one attribute was inherited from an earlier
+///    declaration: if both were written on this declarator the first call
+///    already diagnosed the pair, and if both are inherited some earlier
+///    declaration already was the first to carry both.
+/// reportEjitEntryLcConflict - Emit the conflict diagnostic: the error at
+/// \p ErrorLoc, the "conflicting attribute is here" note at \p NoteLoc.
+/// Split out of checkEjitEntryLcConflict because the explicit-instantiation
+/// site (ActOnExplicitInstantiation) knows which attribute ITS declarator
+/// wrote and anchors the error there.
+void reportEjitEntryLcConflict(Sema &S, const FunctionDecl *FD,
+                               SourceLocation ErrorLoc,
+                               SourceLocation NoteLoc) {
+  S.Diag(ErrorLoc, diag::err_ejit_entry_lc_conflict) << FD;
+  S.Diag(NoteLoc, diag::note_conflicting_attribute);
+}
+
+void checkEjitEntryLcConflict(Sema &S, FunctionDecl *FD, bool AfterMerge) {
+  if (!FD)
+    return;
+  const EjitEntryAttr *EA = FD->getAttr<EjitEntryAttr>();
+  const EjitPeriodLcAttr *LA = FD->getAttr<EjitPeriodLcAttr>();
+  if (!EA || !LA)
+    return;
+  if (AfterMerge) {
+    if (EA->isInherited() == LA->isInherited())
+      return;
+    // If the immediate previous declaration already carried both, the
+    // conflict was diagnosed there; repeating one attribute on a later
+    // redeclaration must not re-fire (attributes written after a definition
+    // are rejected by clang's own redeclaration rules before they reach
+    // this merge).
+    const FunctionDecl *Prev = FD->getPreviousDecl();
+    if (Prev && Prev->hasAttr<EjitEntryAttr>() &&
+        Prev->hasAttr<EjitPeriodLcAttr>())
+      return;
+    // Instantiations reproduce the pattern's attribute pair; the pattern
+    // declaration was diagnosed already.
+    if (FD->isTemplateInstantiation())
+      return;
+    // Exactly one attribute came from an earlier declaration: point the
+    // error at the attribute written on THIS declaration and the note at
+    // the inherited one, not the other way around.
+    if (EA->isInherited()) {
+      reportEjitEntryLcConflict(S, FD, LA->getLocation(), EA->getLocation());
+      return;
+    }
+    reportEjitEntryLcConflict(S, FD, EA->getLocation(), LA->getLocation());
+    return;
+  }
+  reportEjitEntryLcConflict(S, FD, LA->getLocation(), EA->getLocation());
+}
+
 /// checkEjitAlwaysInlineConflict - An ejit_entry / ejit_period_lc function
 /// must stay out-of-line: CodeGen and PASS3 mark it noinline so it survives
 /// the LTO inliner for PASS1 (bitcode extraction), PASS3 (wrapper), and

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -44,6 +44,14 @@
 using namespace clang;
 using namespace sema;
 
+// Forward declaration for the EmbeddedJIT ejit_entry / ejit_period_lc conflict
+// diagnostic (defined in SemaEJIT.cpp; the check itself lives in SemaDecl.cpp's
+// call sites). Explicit instantiation declarators bypass ActOnFunctionDeclarator
+// and CheckFunctionDeclaration, so ActOnExplicitInstantiation emits the
+// diagnostic itself.
+void reportEjitEntryLcConflict(Sema &S, const FunctionDecl *FD,
+                               SourceLocation ErrorLoc, SourceLocation NoteLoc);
+
 // Exported for use by Parser.
 SourceRange
 clang::getTemplateParamsRange(TemplateParameterList const * const *Ps,
@@ -10749,8 +10757,30 @@ DeclResult Sema::ActOnExplicitInstantiation(Scope *S,
         return (Decl*) nullptr;
   }
 
+  // Explicit instantiation declarators bypass ActOnFunctionDeclarator and
+  // CheckFunctionDeclaration, so the ejit_entry / ejit_period_lc conflict is
+  // checked here, after the declarator's attributes land on the
+  // specialization. Snapshot each attribute first: if the pair already
+  // existed (copied from the pattern, where it was diagnosed), do not
+  // re-report it.
+  const bool HadEntry = Specialization->hasAttr<EjitEntryAttr>();
+  const bool HadLc = Specialization->hasAttr<EjitPeriodLcAttr>();
   ProcessDeclAttributeList(S, Specialization, D.getDeclSpec().getAttributes());
   ProcessAPINotes(Specialization);
+  if ((!HadEntry || !HadLc) && Specialization->hasAttr<EjitEntryAttr>() &&
+      Specialization->hasAttr<EjitPeriodLcAttr>()) {
+    // The pair was completed by this declarator. Anchor the error at the
+    // attribute written HERE when exactly one was new; with both written
+    // keep the error-at-ejit_period_lc convention of the declarator check.
+    const EjitEntryAttr *EA = Specialization->getAttr<EjitEntryAttr>();
+    const EjitPeriodLcAttr *LA = Specialization->getAttr<EjitPeriodLcAttr>();
+    if (!HadEntry && HadLc)
+      reportEjitEntryLcConflict(*this, Specialization, EA->getLocation(),
+                                LA->getLocation());
+    else
+      reportEjitEntryLcConflict(*this, Specialization, LA->getLocation(),
+                                EA->getLocation());
+  }
 
   // In MSVC mode, dllimported explicit instantiation definitions are treated as
   // instantiation declarations.

--- a/clang/test/Sema/ejit_attr_missing_on_definition.cpp
+++ b/clang/test/Sema/ejit_attr_missing_on_definition.cpp
@@ -19,12 +19,122 @@ void lc_fn(__attribute__((ejit_period_arr_ind("static"))) int idx);
 // expected-note@-2 {{'ejit_period_lc' declared here}}
 void lc_fn(int idx) {} // expected-warning {{function 'lc_fn' is declared with 'ejit_period_lc' but defined without it; EmbeddedJIT specialization is disabled for this definition}}
 
-// --- Definition repeats ejit_entry but omits ejit_period_lc: warn only for lc ---
+// --- Error: ejit_entry and ejit_period_lc cannot be combined ---
+// PASS3 (EJitWrapperGen) rewrites an entry's body and PASS4
+// (EJitPeriodHandler) inserts lifecycle guards; one function cannot be both.
 
 __attribute__((ejit_entry, ejit_period_lc("static")))
-void mixed_fn(__attribute__((ejit_period_arr_ind("static"))) int idx);
-// expected-note@-2 {{'ejit_period_lc' declared here}}
-__attribute__((ejit_entry)) void mixed_fn(int idx) {} // expected-warning {{function 'mixed_fn' is declared with 'ejit_period_lc' but defined without it; EmbeddedJIT specialization is disabled for this definition}}
+void conflict_fn(__attribute__((ejit_period_arr_ind("static"))) int idx) {}
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'conflict_fn'}}
+// expected-note@-3 {{conflicting attribute is here}}
+
+// --- Error regardless of attribute order ---
+
+__attribute__((ejit_period_lc("static"), ejit_entry))
+void conflict_fn_rev(__attribute__((ejit_period_arr_ind("static"))) int idx) {}
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'conflict_fn_rev'}}
+// expected-note@-3 {{conflicting attribute is here}}
+
+// --- Error when the two attributes arrive on different declarations ---
+
+__attribute__((ejit_entry))
+void cross_fn(__attribute__((ejit_period_arr_ind("static"))) int idx);
+// expected-note@-2 {{conflicting attribute is here}}
+__attribute__((ejit_period_lc("static")))
+void cross_fn(__attribute__((ejit_period_arr_ind("static"))) int idx);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'cross_fn'}}
+
+// --- No duplicate conflict error: the pair was already diagnosed on the
+//     prototype; the definition repeating only ejit_entry gets the usual
+//     missing-on-definition treatment for the omitted ejit_period_lc ---
+
+__attribute__((ejit_entry, ejit_period_lc("static")))
+void once_fn(__attribute__((ejit_period_arr_ind("static"))) int idx);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'once_fn'}}
+// expected-note@-3 {{conflicting attribute is here}}
+// expected-note@-4 {{'ejit_period_lc' declared here}}
+__attribute__((ejit_entry))
+void once_fn(__attribute__((ejit_period_arr_ind("static"))) int idx) {}
+// expected-warning@-1 {{function 'once_fn' is declared with 'ejit_period_lc' but defined without it; EmbeddedJIT specialization is disabled for this definition}}
+
+// --- Error with the reverse cross-declaration order: the error points at
+//     the attribute written on THIS declaration, the note at the inherited
+//     one ---
+
+__attribute__((ejit_period_lc("static")))
+void cross_fn_rev(__attribute__((ejit_period_arr_ind("static"))) int idx);
+// expected-note@-2 {{conflicting attribute is here}}
+__attribute__((ejit_entry))
+void cross_fn_rev(__attribute__((ejit_period_arr_ind("static"))) int idx);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'cross_fn_rev'}}
+
+// --- Error: both attributes written on an explicit instantiation declarator
+//     (that path bypasses ActOnFunctionDeclarator) ---
+
+template <typename T>
+void ei_fn(__attribute__((ejit_period_arr_ind("static"))) int) {}
+template __attribute__((ejit_entry, ejit_period_lc("static")))
+void ei_fn<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'ei_fn<int>'}}
+// expected-note@-3 {{conflicting attribute is here}}
+
+// --- Error: an explicit instantiation assembles the pair (ejit_entry on the
+//     pattern, ejit_period_lc written here) ---
+
+template <typename T>
+__attribute__((ejit_entry))
+void ei_fn2(__attribute__((ejit_period_arr_ind("static"))) int) {}
+// expected-note@-2 {{conflicting attribute is here}}
+template __attribute__((ejit_period_lc("static")))
+void ei_fn2<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'ei_fn2<int>'}}
+
+// --- No duplicate: the pair was diagnosed on the pattern; a plain explicit
+//     instantiation reproduces it silently ---
+
+template <typename T>
+__attribute__((ejit_entry, ejit_period_lc("static")))
+void ei_fn3(__attribute__((ejit_period_arr_ind("static"))) int) {}
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'ei_fn3'}}
+// expected-note@-3 {{conflicting attribute is here}}
+template void ei_fn3<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+
+// --- Error with the mirror order: ejit_period_lc on the pattern, ejit_entry
+//     written on the instantiation. The error anchors at the attribute
+//     written HERE, the note at the pre-existing one ---
+
+template <typename T>
+__attribute__((ejit_period_lc("static")))
+void ei_fn4(__attribute__((ejit_period_arr_ind("static"))) int) {}
+// expected-note@-2 {{conflicting attribute is here}}
+template __attribute__((ejit_entry))
+void ei_fn4<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'ei_fn4<int>'}}
+
+// --- The pair assembled across TWO explicit instantiation declarations
+//     (an extern declaration then the definition), lc first then entry: the
+//     error anchors at the entry written on the current declaration ---
+
+template <typename T>
+void m_fn(__attribute__((ejit_period_arr_ind("static"))) int) {}
+extern template __attribute__((ejit_period_lc("static")))
+void m_fn<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+// expected-note@-2 {{conflicting attribute is here}}
+template __attribute__((ejit_entry))
+void m_fn<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'm_fn<int>'}}
+
+// --- ... and entry first then lc: the error anchors at the lc written on
+//     the current declaration ---
+
+template <typename T>
+void m_fn2(__attribute__((ejit_period_arr_ind("static"))) int) {}
+extern template __attribute__((ejit_entry))
+void m_fn2<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+// expected-note@-2 {{conflicting attribute is here}}
+template __attribute__((ejit_period_lc("static")))
+void m_fn2<int>(__attribute__((ejit_period_arr_ind("static"))) int);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'm_fn2<int>'}}
 
 // --- No warning: definition repeats the attribute ---
 

--- a/clang/test/Sema/ejit_entry_lc_conflict.c
+++ b/clang/test/Sema/ejit_entry_lc_conflict.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+// C mode: the ejit_entry / ejit_period_lc conflict check applies on the C
+// path of ActOnFunctionDeclarator / CheckFunctionDeclaration too, not only
+// the C++ one (see ejit_attr_missing_on_definition.cpp).
+
+// --- Error: both attributes on one declarator ---
+
+__attribute__((ejit_entry, ejit_period_lc("static")))
+int f(__attribute__((ejit_period_arr_ind("static"))) int idx) { return idx; }
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'f'}}
+// expected-note@-3 {{conflicting attribute is here}}
+
+// --- Error: assembled across declarations (entry on the prototype, lc on
+//     the redeclaration) ---
+
+__attribute__((ejit_entry))
+int g(__attribute__((ejit_period_arr_ind("static"))) int idx);
+// expected-note@-2 {{conflicting attribute is here}}
+__attribute__((ejit_period_lc("static")))
+int g(__attribute__((ejit_period_arr_ind("static"))) int idx);
+// expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'g'}}

--- a/jit_design_doc/CLANG_ATTR_DESIGN.md
+++ b/jit_design_doc/CLANG_ATTR_DESIGN.md
@@ -466,6 +466,11 @@ static void handleEjitPeriodArrIndAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 /// 语义检查:
 ///   1. 仅可标记在 FunctionDecl 上 (由 Subjects 保证)
 ///   2. 不支持递归函数
+///   3. 不能与 ejit_period_lc 同时标记（checkEjitEntryLcConflict，与书写
+///      顺序无关。三处检查：ActOnFunctionDeclarator 属性处理完毕后 [同一
+///      声明上的组合]、CheckFunctionDeclaration 的 MergeFunctionDecl 之后
+///      [跨声明的组合]、ActOnExplicitInstantiation 属性落地后 [显式实例化
+///      声明不走前两条路径]）
 static void handleEjitEntryAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   auto *FD = cast<FunctionDecl>(D);
 
@@ -491,6 +496,8 @@ static void handleEjitEntryAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 /// 语义检查:
 ///   1. 仅可标记在 FunctionDecl 上
 ///   2. 必须有对应的 ejit_period_arr_ind(name) 参数
+///   3. 不能与 ejit_entry 同时标记（见 4.3.5 检查 3；同一函数可标记多个
+///      ejit_period_lc，这是 multi-period 入口的正常形态）
 static void handleEjitPeriodLcAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   auto *FD = cast<FunctionDecl>(D);
 


### PR DESCRIPTION
PASS3 (EJitWrapperGen) rewrites an entry's body into a dispatch wrapper and PASS4 (EJitPeriodHandler) inserts lifecycle guards at a lifecycle function's entry/returns, so a function carrying both attributes would have its body claimed by two AOT passes. Diagnose the combination as a hard error in Sema.

Checked at three points, each covering a path the others miss:
- ActOnFunctionDeclarator after ProcessDeclAttributes: both attributes on one declarator, independent of source order;
- CheckFunctionDeclaration after MergeFunctionDecl: combinations assembled across redeclarations (guarded so an already-diagnosed pair never re-fires);
- ActOnExplicitInstantiation after the declarator's attributes land: explicit instantiation declarations bypass both of the above (per-attribute snapshots gate re-reporting, and the error anchors at the attribute written on the current declaration).

Template instantiations reproduce the pattern's pair silently; the pattern declaration was diagnosed already.