### PR TITLE
[EJIT] Rate-limit null icache fill diagnostics

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -135,6 +135,11 @@ static_assert(kEJitMaxFuncIndex == kEJitSharedMaxFuncIndex,
 
 static EJit *gEJIT = nullptr;
 
+#ifdef EJIT_DIAG_ENABLE
+EJitAtomicU64 gIcacheNullFillSkips;
+constexpr uint64_t kIcacheNullFillLogEvery = 1000;
+#endif
+
 #ifdef EJIT_FREESTANDING
 extern "C" uint64_t SRE_CycleCountGet64(void);
 #endif
@@ -694,7 +699,14 @@ inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
                                     uint32_t numDims) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (!fnPtr) {
-    EJIT_DIAG("icacheFillOnSuccess SKIP func=%u: fnPtr is null", funcIndex);
+#ifdef EJIT_DIAG_ENABLE
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_DEBUG) {
+      uint64_t skips = gIcacheNullFillSkips.fetchAdd(1) + 1;
+      if (skips % kIcacheNullFillLogEvery == 0)
+        EJIT_DIAG_DEBUG("icacheFillOnSuccess null skips=%llu latest_func=%u",
+                        static_cast<unsigned long long>(skips), funcIndex);
+    }
+#endif
     return;
   }
   EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr;


### PR DESCRIPTION
## Summary

- remove per-call INFO logging for the expected null `fnPtr` returned while asynchronous compilation is pending
- keep the diagnostic available at DEBUG level
- aggregate null-fill skips across callers and emit one summary for every 1000 occurrences
- avoid counter updates entirely at INFO and VERBOSE levels

## Root cause

`ejitIcacheFillOnSuccess` runs on every wrapper miss. While compilation is pending or admission is deferred, a null `fnPtr` is normal and the AOT fallback serves the call. Logging that state at INFO produced thousands of lines from hot loops, obscured useful diagnostics, and could slow board tests enough to affect timeout behavior.

## Example

At DEBUG level the runtime now emits sparse summaries:

```text
icacheFillOnSuccess null skips=1000 latest_func=1
icacheFillOnSuccess null skips=2000 latest_func=0
```

## Validation

- change is isolated to `EJitRuntime.cpp`
- generated commit is based directly on the latest `ejit_dev_spec4`
- INFO and VERBOSE bypass both the log and aggregate counter

Full LLVM tests were not run locally because the available checkout has no configured build directory.
