### PR TITLE
[EJIT] Check ejit_period_lc's index parameter after the declaration merge

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -84,6 +84,13 @@ void checkEjitAlwaysInlineConflict(Sema &S, FunctionDecl *FD);
 // check. Defined in SemaEJIT.cpp.
 void checkEjitEntryLcConflict(Sema &S, FunctionDecl *FD, bool AfterMerge);
 
+// Forward declaration for EmbeddedJIT ejit_period_lc no-index check. Defined
+// in SemaEJIT.cpp.
+void checkEjitPeriodLcIndex(Sema &S, const FunctionDecl *FD);
+void checkEjitPeriodLcIndexNewAttrs(
+    Sema &S, const FunctionDecl *FD,
+    ArrayRef<const EjitPeriodLcAttr *> PreExisting);
+
 // Forward declaration for EmbeddedJIT missing-attribute-on-definition check.
 // Defined in SemaEJIT.cpp.
 void checkEjitAttrMissingOnDefinition(Sema &S, FunctionDecl *FD);
@@ -12293,6 +12300,12 @@ bool Sema::CheckFunctionDeclaration(Scope *S, FunctionDecl *NewFD,
   // A function redeclaration may have assembled ejit_entry on one declaration
   // and ejit_period_lc on another; only the merged declaration shows the pair.
   checkEjitEntryLcConflict(*this, NewFD, /*AfterMerge=*/true);
+
+  // Every written ejit_period_lc must find a matching ejit_period_arr_ind
+  // parameter on the MERGED declaration: the arr_ind may live on an earlier
+  // declaration's parameter (propagated by the merge), so this runs here
+  // rather than at attribute-handling time.
+  checkEjitPeriodLcIndex(*this, NewFD);
 
   // A function defined without ejit_entry / ejit_period_lc even though a
   // prior declaration carries the attribute is not JIT-specialized: warn and

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -247,7 +247,12 @@ void handleEjitEntryAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 /// handleEjitPeriodLcAttr - Process the ejit_period_lc(name) attribute.
 /// Checks:
 ///   1. Applies only to FunctionDecl
-///   2. Must have a corresponding ejit_period_arr_ind(name) parameter
+///
+/// The "must have a matching ejit_period_arr_ind(name) parameter" check is
+/// NOT here: at handler time only the CURRENT declaration's parameters exist,
+/// and the arr_ind may legitimately live on an earlier declaration's
+/// parameter (propagated by mergeParamDeclAttributes during the merge). The
+/// check runs after the merge instead -- see checkEjitPeriodLcIndex.
 void handleEjitPeriodLcAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   auto *FD = dyn_cast<FunctionDecl>(D);
   if (!FD) {
@@ -260,22 +265,6 @@ void handleEjitPeriodLcAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   StringRef PeriodName;
   if (!S.checkStringLiteralArgumentAttr(AL, 0, PeriodName))
     return;
-
-  // Check for matching ejit_period_arr_ind parameter
-  bool HasMatchingIdx = false;
-  for (const ParmVarDecl *P : FD->parameters()) {
-    if (auto *IdxAttr = P->getAttr<EjitPeriodArrIndAttr>()) {
-      if (IdxAttr->getPeriodName() == PeriodName) {
-        HasMatchingIdx = true;
-        break;
-      }
-    }
-  }
-
-  if (!HasMatchingIdx) {
-    S.Diag(AL.getLoc(), diag::err_ejit_period_lc_no_index) << PeriodName;
-    return;
-  }
 
   D->addAttr(::new (S.Context) EjitPeriodLcAttr(S.Context, AL, PeriodName));
 }
@@ -370,6 +359,60 @@ void checkEjitEntryLcConflict(Sema &S, FunctionDecl *FD, bool AfterMerge) {
     return;
   }
   reportEjitEntryLcConflict(S, FD, LA->getLocation(), EA->getLocation());
+}
+
+/// One attribute's no-index check: does the (merged) parameter list carry an
+/// ejit_period_arr_ind with the same period name? Diagnose at \p LA if not.
+static void checkEjitPeriodLcIndexForAttr(Sema &S, const FunctionDecl *FD,
+                                          const EjitPeriodLcAttr *LA) {
+  StringRef PeriodName = LA->getPeriodName();
+  for (const ParmVarDecl *P : FD->parameters()) {
+    if (auto *IdxAttr = P->getAttr<EjitPeriodArrIndAttr>())
+      if (IdxAttr->getPeriodName() == PeriodName)
+        return;
+  }
+  S.Diag(LA->getLocation(), diag::err_ejit_period_lc_no_index) << PeriodName;
+}
+
+/// checkEjitPeriodLcIndex - Every written (non-inherited) ejit_period_lc must
+/// name a period that a parameter of the MERGED function carries
+/// ejit_period_arr_ind for. Called from CheckFunctionDeclaration after
+/// MergeFunctionDecl: at attribute-handling time only the current
+/// declaration's parameters exist, and an arr_ind written on an earlier
+/// declaration's parameter is only propagated to this declaration's
+/// parameters by the merge (mergeParamDeclAttributes) -- checking before it
+/// would reject a valid redeclaration. Inherited lc attributes were checked
+/// on the declaration that wrote them, and template instantiations reproduce
+/// a pattern that was checked there.
+///
+/// The arr_ind must therefore be visible at or BEFORE the declaration that
+/// writes the lc: parameter attributes propagate forward only, so an arr_ind
+/// on a LATER declaration never reaches the declaration carrying the lc.
+void checkEjitPeriodLcIndex(Sema &S, const FunctionDecl *FD) {
+  if (!FD || FD->isTemplateInstantiation())
+    return;
+  for (const EjitPeriodLcAttr *LA : FD->specific_attrs<EjitPeriodLcAttr>()) {
+    if (LA->isInherited())
+      continue;
+    checkEjitPeriodLcIndexForAttr(S, FD, LA);
+  }
+}
+
+/// checkEjitPeriodLcIndexNewAttrs - Variant for ActOnExplicitInstantiation:
+/// only the lc attributes the declarator wrote (those not in
+/// \p PreExisting) are checked against the specialization's parameters.
+/// Attributes copied from the pattern are skipped here -- the pattern's own
+/// declarations were checked by checkEjitPeriodLcIndex.
+void checkEjitPeriodLcIndexNewAttrs(
+    Sema &S, const FunctionDecl *FD,
+    ArrayRef<const EjitPeriodLcAttr *> PreExisting) {
+  if (!FD)
+    return;
+  for (const EjitPeriodLcAttr *LA : FD->specific_attrs<EjitPeriodLcAttr>()) {
+    if (llvm::is_contained(PreExisting, LA))
+      continue;
+    checkEjitPeriodLcIndexForAttr(S, FD, LA);
+  }
 }
 
 /// checkEjitAlwaysInlineConflict - An ejit_entry / ejit_period_lc function

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -51,6 +51,11 @@ using namespace sema;
 // diagnostic itself.
 void reportEjitEntryLcConflict(Sema &S, const FunctionDecl *FD,
                                SourceLocation ErrorLoc, SourceLocation NoteLoc);
+// Forward declaration for the EmbeddedJIT ejit_period_lc no-index check
+// (defined in SemaEJIT.cpp; see also SemaDecl.cpp).
+void checkEjitPeriodLcIndexNewAttrs(
+    Sema &S, const FunctionDecl *FD,
+    ArrayRef<const EjitPeriodLcAttr *> PreExisting);
 
 // Exported for use by Parser.
 SourceRange
@@ -10765,6 +10770,9 @@ DeclResult Sema::ActOnExplicitInstantiation(Scope *S,
   // re-report it.
   const bool HadEntry = Specialization->hasAttr<EjitEntryAttr>();
   const bool HadLc = Specialization->hasAttr<EjitPeriodLcAttr>();
+  SmallVector<const EjitPeriodLcAttr *, 2> PreExistingLc;
+  for (const auto *A : Specialization->specific_attrs<EjitPeriodLcAttr>())
+    PreExistingLc.push_back(A);
   ProcessDeclAttributeList(S, Specialization, D.getDeclSpec().getAttributes());
   ProcessAPINotes(Specialization);
   if ((!HadEntry || !HadLc) && Specialization->hasAttr<EjitEntryAttr>() &&
@@ -10781,6 +10789,11 @@ DeclResult Sema::ActOnExplicitInstantiation(Scope *S,
       reportEjitEntryLcConflict(*this, Specialization, LA->getLocation(),
                                 EA->getLocation());
   }
+  // An ejit_period_lc written on this declarator must find its matching
+  // ejit_period_arr_ind parameter on the specialization (the pattern's
+  // parameter attributes are instantiated onto it); lc attributes copied
+  // from the pattern were checked on the pattern itself.
+  checkEjitPeriodLcIndexNewAttrs(*this, Specialization, PreExistingLc);
 
   // In MSVC mode, dllimported explicit instantiation definitions are treated as
   // instantiation declarations.

--- a/clang/test/Sema/ejit_attr_missing_on_definition.cpp
+++ b/clang/test/Sema/ejit_attr_missing_on_definition.cpp
@@ -136,6 +136,57 @@ template __attribute__((ejit_period_lc("static")))
 void m_fn2<int>(__attribute__((ejit_period_arr_ind("static"))) int);
 // expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'm_fn2<int>'}}
 
+// --- OK: the ejit_period_arr_ind may live on an earlier declaration's
+//     parameter; it is propagated by the declaration merge before the
+//     ejit_period_lc no-index check runs ---
+
+void ok_split_a(__attribute__((ejit_period_arr_ind("cell"))) int idx);
+__attribute__((ejit_period_lc("cell"))) void ok_split_a(int idx);
+
+__attribute__((ejit_period_lc("cell")))
+void ok_split_b(__attribute__((ejit_period_arr_ind("cell"))) int idx);
+__attribute__((ejit_period_lc("cell"))) void ok_split_b(int idx);
+
+void ok_split_def(__attribute__((ejit_period_arr_ind("cell"))) int idx);
+__attribute__((ejit_period_lc("cell"))) void ok_split_def(int idx) {}
+
+// --- Error: NO declaration provides a matching ejit_period_arr_ind; the lc
+//     written on the second declaration is diagnosed there ---
+
+void missing_idx(__attribute__((ejit_period_arr_ind("other"))) int idx);
+__attribute__((ejit_period_lc("cell"))) void missing_idx(int idx);
+// expected-error@-1 {{ejit_period_lc(cell) requires a corresponding ejit_period_arr_ind(cell) parameter}}
+
+// --- OK: an ejit_period_lc written on an explicit instantiation declarator
+//     finds its ejit_period_arr_ind on the pattern's parameter ---
+
+template <typename T>
+void ei_lc_ok(__attribute__((ejit_period_arr_ind("cell"))) int) {}
+template __attribute__((ejit_period_lc("cell")))
+void ei_lc_ok<int>(int);
+
+// --- Error: the pattern's parameter lacks the arr_ind, so an
+//     ejit_period_lc written on the instantiation declarator has no index ---
+
+template <typename T>
+void ei_lc_missing(int) {}
+template __attribute__((ejit_period_lc("cell")))
+void ei_lc_missing<int>(int);
+// expected-error@-2 {{ejit_period_lc(cell) requires a corresponding ejit_period_arr_ind(cell) parameter}}
+
+// --- Known limitation (pinned): clang silently discards parameter
+//     attributes on explicit instantiation declarators, so an
+//     ejit_period_arr_ind written here never attaches and the check errors.
+//     The arr_ind must live on the pattern's parameter. If clang ever starts
+//     applying declarator param attributes on explicit instantiations, this
+//     expectation must be revisited. ---
+
+template <typename T>
+void ei_lc_together(int) {}
+template __attribute__((ejit_period_lc("cell")))
+void ei_lc_together<int>(__attribute__((ejit_period_arr_ind("cell"))) int);
+// expected-error@-2 {{ejit_period_lc(cell) requires a corresponding ejit_period_arr_ind(cell) parameter}}
+
 // --- No warning: definition repeats the attribute ---
 
 __attribute__((ejit_entry)) int ok_entry_fn(void);

--- a/clang/test/Sema/ejit_entry_lc_conflict.c
+++ b/clang/test/Sema/ejit_entry_lc_conflict.c
@@ -20,3 +20,15 @@ int g(__attribute__((ejit_period_arr_ind("static"))) int idx);
 __attribute__((ejit_period_lc("static")))
 int g(__attribute__((ejit_period_arr_ind("static"))) int idx);
 // expected-error@-2 {{'ejit_entry' and 'ejit_period_lc' cannot be combined on function 'g'}}
+
+// --- OK: the ejit_period_arr_ind may live on an earlier declaration's
+//     parameter; it is propagated by the merge before the no-index check ---
+
+void h(__attribute__((ejit_period_arr_ind("cell"))) int idx);
+__attribute__((ejit_period_lc("cell"))) void h(int idx) {}
+
+// --- Error: NO declaration provides a matching ejit_period_arr_ind ---
+
+void missing_idx(__attribute__((ejit_period_arr_ind("other"))) int idx);
+__attribute__((ejit_period_lc("cell"))) void missing_idx(int idx);
+// expected-error@-1 {{ejit_period_lc(cell) requires a corresponding ejit_period_arr_ind(cell) parameter}}

--- a/jit_design_doc/CLANG_ATTR_DESIGN.md
+++ b/jit_design_doc/CLANG_ATTR_DESIGN.md
@@ -495,7 +495,13 @@ static void handleEjitEntryAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 /// handleEjitPeriodLcAttr - 处理 ejit_period_lc(name) 属性
 /// 语义检查:
 ///   1. 仅可标记在 FunctionDecl 上
-///   2. 必须有对应的 ejit_period_arr_ind(name) 参数
+///   2. 必须有对应的 ejit_period_arr_ind(name) 参数——该检查不在 handler
+///      内执行，而在 CheckFunctionDeclaration 的 MergeFunctionDecl 之后
+///      （checkEjitPeriodLcIndex）：arr_ind 可能写在更早声明的参数上，
+///      由参数属性传播补全后才可见；显式实例化声明由 ActOnExplicitInstantiation
+///      处的 checkEjitPeriodLcIndexNewAttrs 检查。注意：显式实例化声明器上
+///      的参数属性会被 clang 静默丢弃，所以 arr_ind 必须写在模板 pattern
+///      的参数上
 ///   3. 不能与 ejit_entry 同时标记（见 4.3.5 检查 3；同一函数可标记多个
 ///      ejit_period_lc，这是 multi-period 入口的正常形态）
 static void handleEjitPeriodLcAttr(Sema &S, Decl *D, const ParsedAttr &AL) {


### PR DESCRIPTION
handleEjitPeriodLcAttr checked for a matching ejit_period_arr_ind parameter before parameter attributes from prior declarations are merged, so an ejit_period_arr_ind written on an earlier declaration's parameter (propagated by mergeParamDeclAttributes during the merge) was invisible to the check and a valid redeclaration got a spurious error. Move the check to checkEjitPeriodLcIndex, called after MergeFunctionDecl: only non-inherited lc attributes are diagnosed, template instantiations are skipped (their pattern was checked), and the merged parameter list carries the propagated arr_ind.

Explicit instantiation declarators bypass CheckFunctionDeclaration, so ActOnExplicitInstantiation checks the lc attributes it actually wrote via a pre-existing-pointer snapshot (checkEjitPeriodLcIndexNewAttrs). Note that clang discards parameter attributes on explicit instantiation declarators, so the arr_ind must live on the pattern's parameter (pinned in the test).