### PR TITLE
[EJIT] Print all diagnostic dumps prefix-free; enrich fields, report walk completeness

### DIFF
--- a/jit_design_doc/EJIT_DIAG.md
+++ b/jit_design_doc/EJIT_DIAG.md
@@ -33,7 +33,9 @@ SRE 串口日志经 shell 环形 buffer 转发，相关平台参数只有两条�
 | compiled list | `ejit_taskpool_print_compiled` | 逐缓存条目 |
 | icache slots | `ejitDumpIcacheSlots` | 逐 slot |
 
-**compiled list 条目行**用 `EJIT_DIAG_RAW`（无 `[EJIT] func:line` 前缀）打印：前缀在逐条目行上完全相同，只占 ring buffer 空间，带前缀的汇总行仍保留便于检索。**汇总行先打印**（两遍遍历：第一遍只统计，第二遍才打印条目），报总数、槽位占用、统计遍历中被锁竞争跳过的桶数与按维度数分布（`byDims: 0d=.. 1d=..`，只列非零档）；若打印遍历本身又跳过桶，末尾补一行说明（固定行数，不延时），`forEachCompiled` 返回的统计使跳过的桶不再静默。dims 只打实际个数（无 `0:0` 填充）；VERBOSE 级同行追加 `ver/size/pool/gen`（版本快照、代码大小、池号、owner 代）。两遍遍历之间的并发 publish 可能使汇总与条目行略有出入（遍历本就不是快照）。
+**全部 dump 输出行（头/尾固定行与循环条目行）统一用 `EJIT_DIAG_RAW` 打印**（无 `[EJIT] func:line` 前缀）：同一前缀在一块 dump 里逐行重复，只占 ring buffer 空间；grep 锚点是各块自带的文字标签（`registry:`、`active periods:`、`code pool:`、`stats_t:`、`=== ... ===`、`compiled:` 等）。正常路径（非 dump）日志仍用 `EJIT_DIAG`，保留 func:line 来源；hosted 构建（std::printf 分支）同样无前缀。信息量增强：active cells 每 period 先打 `active=N` 计数行（0 个时打 `active=0`，替代原 "(no active cells)"；计数与条目行两遍扫描之间状态可能翻转，同 compiled list 一样非快照）；func meta 条目行为 `op=<原始操作数下标> tag=<名> vals=<值>`（op= 与 bitcode 中 `!ejit.metadata` 的操作数位置一一对应，被跳过的条目也占号）；IR/ASM 长行按 180 B 分块，非末块尾缀 `...`；icache slots 带函数名（模块 loader 按 funcIndex 解析，查不到为 `<unknown>`、未传 loader 为 `?`，超 24 字符截断）与槽容量 `cells=16^numDims`；taskpool stats 补 shared 诊断 9 字段（initState/ownerCore/gen/lastInitErr/initAttempts/share + workerTaskId/regFingerprint/execPrepFailed，直读 getDiagnostics()，不动 C ABI 结构体）；code pool stats 末行补 `total/used/usage` 汇总（total=reservedBytes，打印时整数千分比派生，无 FPU）。
+
+**compiled list 汇总行先打印**（两遍遍历：第一遍只统计，第二遍才打印条目），报总数、槽位占用、统计遍历中被锁竞争跳过的桶数与按维度数分布（`byDims: 0d=.. 1d=..`，只列非零档）；若打印遍历本身又跳过桶，末尾补一行说明（固定行数，不延时），`forEachCompiled` 返回的统计使跳过的桶不再静默。dims 只打实际个数（无 `0:0` 填充）；VERBOSE 级同行追加 `ver/size/pool/gen`（版本快照、代码大小、池号、owner 代）。两遍遍历之间的并发 publish 可能使汇总与条目行略有出入（遍历本就不是快照）。
 
 **范围之外**：正常路径日志（注册、编译、错误回报等）不延时；固定行数的 dump（taskpool/code pool stats）无循环、不延时；正常路径上已有的延时（worker 任务间节流等）保持不变。
 

--- a/jit_design_doc/EJIT_DIAG.md
+++ b/jit_design_doc/EJIT_DIAG.md
@@ -1,7 +1,7 @@
 # EmbeddedJIT 诊断 dump：逐行打印延时
 
-> 适用分支：`ejit-throttle-simplify-djq`
-> 开关：`EJIT_DIAG_PRINT_THROTTLE_TICKS`（CMake 缓存变量，默认 50，0 关闭）
+> 适用分支：`ejit-print-compiled-fmt-djq`
+> 开关：`EJIT_DIAG_PRINT_THROTTLE_TICKS`（CMake 缓存变量，默认 20，0 关闭）
 > 目标平台：`aarch64_be`（SRE，shell 环形 buffer 串口日志）
 
 ---
@@ -17,10 +17,10 @@ SRE 串口日志经 shell 环形 buffer 转发，相关平台参数只有两条�
 
 诊断 dump API 的**循环打印**（每个数据项一行）在每打印一行后调用 `ejitDiagPrintThrottle()`（`EJitDiag.h`），即**每循环一轮延时一次**：
 
-- 每次延时 `EJIT_DIAG_PRINT_THROTTLE_TICKS` 个调度 tick（`SRE_TaskDelay`，默认 **50** tick = 50 ms = 5 个消费者排空周期）
+- 每次延时 `EJIT_DIAG_PRINT_THROTTLE_TICKS` 个调度 tick（`SRE_TaskDelay`，默认 **20** tick = 20 ms = 2 个消费者排空周期：第一个周期完成排空，第二个周期是吸收消费者抖动与多核日志交错的裕量）
 - 仅在 `EJIT_DIAG_ENABLE` + `EJIT_FREESTANDING` 下生效；host 构建与诊断关闭时为零开销 no-op
 - 行未实际打印（日志级别低于 INFO）时不延时
-- 参数经 CMake 缓存变量传递（`llvm/CMakeLists.txt`，非负整数校验，0 关闭），`ejit-minimal-aarch64_be` 预设配 50
+- 参数经 CMake 缓存变量传递（`llvm/CMakeLists.txt`，非负整数校验，0 关闭），`ejit-minimal-aarch64_be` 预设配 20
 
 ## 3. 覆盖的循环
 
@@ -39,12 +39,12 @@ SRE 串口日志经 shell 环形 buffer 转发，相关平台参数只有两条�
 
 ## 4. 效果与依据
 
-- 实测：逐行 delay=2 tick（2 ms）时生产速率（1 行/2 ms）远超消费者排空容量（约 7 行/10 ms），丢行；delay=100 tick 稳定但过慢。预设 50 tick/行（50 ms = 5 个排空周期，28 行 dump ≈ 1.4 s）在排空边界上留有裕度，长行（compiled list VERBOSE 条目）也被 5 个排空周期覆盖，可按板子 UART 速率调低。
+- 实测：逐行 delay=2 tick（2 ms）时生产速率（1 行/2 ms）远超消费者排空容量（约 7 行/10 ms），丢行；delay=100 tick 稳定但过慢。选值 20 tick/行（20 ms = 2 个排空周期，28 行 dump ≈ 560 ms）：每行留 1 个完整排空周期裕量，多核日志交错场景下 ring（约 7 行）仍有 5 行以上余量；15 tick（1.5 个排空周期）裕量减半被否，50 tick（5 个排空周期，≈1.4 s）过于保守。长行（compiled list VERBOSE 条目）也被 2 个排空周期覆盖，可按板子 UART 速率再调。
 - 每个 dump 循环的逐项行是信息量最大的部分，也是唯一需要节流的部分——头部/汇总行数量固定且少，不参与延时。
 
 ## 5. 相关代码
 
 - `llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h` — `ejitDiagPrintThrottle()`、`EJIT_DIAG_PRINT_THROTTLE_TICKS` 默认值
 - `llvm/CMakeLists.txt` — `EJIT_DIAG_PRINT_THROTTLE_TICKS` 缓存变量与校验
-- `llvm/CMakePresets.json` — `ejit-minimal-aarch64_be` 预设（50）
+- `llvm/CMakePresets.json` — `ejit-minimal-aarch64_be` 预设（20）
 - `llvm/lib/ExecutionEngine/EJIT/` — `EJit.cpp` / `EJitRuntime.cpp` / `EJitOrcEngine.cpp` / `EJitSharedTaskPool.cpp` 中的循环调用点

--- a/jit_design_doc/EJIT_DIAG.md
+++ b/jit_design_doc/EJIT_DIAG.md
@@ -1,7 +1,7 @@
 # EmbeddedJIT 诊断 dump：逐行打印延时
 
 > 适用分支：`ejit-throttle-simplify-djq`
-> 开关：`EJIT_DIAG_PRINT_THROTTLE_TICKS`（CMake 缓存变量，默认 20，0 关闭）
+> 开关：`EJIT_DIAG_PRINT_THROTTLE_TICKS`（CMake 缓存变量，默认 50，0 关闭）
 > 目标平台：`aarch64_be`（SRE，shell 环形 buffer 串口日志）
 
 ---
@@ -11,16 +11,16 @@
 SRE 串口日志经 shell 环形 buffer 转发，相关平台参数只有两条：
 
 - **大小**：环形 buffer 512 B（部分配置 128 B）；单行日志约 60 B，16 B 对齐后约 64 B，512 B 约容纳 7 行
-- **频率**：消费者每 10 tick（100 ms）轮询排空一次
+- **频率**：消费者每 10 tick 轮询排空一次（1 tick = 1 ms，即 10 ms 一轮）
 
 ## 2. 机制
 
 诊断 dump API 的**循环打印**（每个数据项一行）在每打印一行后调用 `ejitDiagPrintThrottle()`（`EJitDiag.h`），即**每循环一轮延时一次**：
 
-- 每次延时 `EJIT_DIAG_PRINT_THROTTLE_TICKS` 个调度 tick（`SRE_TaskDelay`，默认 **20** tick = 200 ms = 2 个消费者排空周期）
+- 每次延时 `EJIT_DIAG_PRINT_THROTTLE_TICKS` 个调度 tick（`SRE_TaskDelay`，默认 **50** tick = 50 ms = 5 个消费者排空周期）
 - 仅在 `EJIT_DIAG_ENABLE` + `EJIT_FREESTANDING` 下生效；host 构建与诊断关闭时为零开销 no-op
 - 行未实际打印（日志级别低于 INFO）时不延时
-- 参数经 CMake 缓存变量传递（`llvm/CMakeLists.txt`，非负整数校验，0 关闭），`ejit-minimal-aarch64_be` 预设配 30
+- 参数经 CMake 缓存变量传递（`llvm/CMakeLists.txt`，非负整数校验，0 关闭），`ejit-minimal-aarch64_be` 预设配 50
 
 ## 3. 覆盖的循环
 
@@ -33,16 +33,18 @@ SRE 串口日志经 shell 环形 buffer 转发，相关平台参数只有两条�
 | compiled list | `ejit_taskpool_print_compiled` | 逐缓存条目 |
 | icache slots | `ejitDumpIcacheSlots` | 逐 slot |
 
+**compiled list 条目行**用 `EJIT_DIAG_RAW`（无 `[EJIT] func:line` 前缀）打印：前缀在逐条目行上完全相同，只占 ring buffer 空间，带前缀的汇总行仍保留便于检索。**汇总行先打印**（两遍遍历：第一遍只统计，第二遍才打印条目），报总数、槽位占用、统计遍历中被锁竞争跳过的桶数与按维度数分布（`byDims: 0d=.. 1d=..`，只列非零档）；若打印遍历本身又跳过桶，末尾补一行说明（固定行数，不延时），`forEachCompiled` 返回的统计使跳过的桶不再静默。dims 只打实际个数（无 `0:0` 填充）；VERBOSE 级同行追加 `ver/size/pool/gen`（版本快照、代码大小、池号、owner 代）。两遍遍历之间的并发 publish 可能使汇总与条目行略有出入（遍历本就不是快照）。
+
 **范围之外**：正常路径日志（注册、编译、错误回报等）不延时；固定行数的 dump（taskpool/code pool stats）无循环、不延时；正常路径上已有的延时（worker 任务间节流等）保持不变。
 
 ## 4. 效果与依据
 
-- 实测：逐行 delay=2 tick（20 ms）时生产者约 5 行/100 ms，卡在消费者排空边界，偶发丢行；delay=100 tick 稳定但过慢。预设 30 tick/行（28 行 dump ≈ 8.4 s）在排空边界上留有裕度且可接受，可按板子 UART 速率调低。
+- 实测：逐行 delay=2 tick（2 ms）时生产速率（1 行/2 ms）远超消费者排空容量（约 7 行/10 ms），丢行；delay=100 tick 稳定但过慢。预设 50 tick/行（50 ms = 5 个排空周期，28 行 dump ≈ 1.4 s）在排空边界上留有裕度，长行（compiled list VERBOSE 条目）也被 5 个排空周期覆盖，可按板子 UART 速率调低。
 - 每个 dump 循环的逐项行是信息量最大的部分，也是唯一需要节流的部分——头部/汇总行数量固定且少，不参与延时。
 
 ## 5. 相关代码
 
 - `llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h` — `ejitDiagPrintThrottle()`、`EJIT_DIAG_PRINT_THROTTLE_TICKS` 默认值
 - `llvm/CMakeLists.txt` — `EJIT_DIAG_PRINT_THROTTLE_TICKS` 缓存变量与校验
-- `llvm/CMakePresets.json` — `ejit-minimal-aarch64_be` 预设（30）
+- `llvm/CMakePresets.json` — `ejit-minimal-aarch64_be` 预设（50）
 - `llvm/lib/ExecutionEngine/EJIT/` — `EJit.cpp` / `EJitRuntime.cpp` / `EJitOrcEngine.cpp` / `EJitSharedTaskPool.cpp` 中的循环调用点

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -567,10 +567,10 @@ endif()
 # Per-line delay for diagnostic dump loops (registry, active cells, compiled
 # list, captured IR/ASM, icache slots): after each printed line the producer
 # delays EJIT_DIAG_PRINT_THROTTLE_TICKS scheduler ticks (SRE_TaskDelay) so the
-# serial-log shell consumer (ring buffer ~7 lines, 100 ms drain period) keeps
+# serial-log shell consumer (ring buffer ~7 lines, 10 ms drain period) keeps
 # up. Freestanding + EJIT_DIAG_ENABLE only; 0 disables. Consumed by
 # ejitDiagPrintThrottle() in EJitDiag.h.
-set(EJIT_DIAG_PRINT_THROTTLE_TICKS "20" CACHE STRING
+set(EJIT_DIAG_PRINT_THROTTLE_TICKS "50" CACHE STRING
   "EmbeddedJIT diagnostic dump print delay: SRE_TaskDelay scheduler ticks per printed line (0 disables)")
 if(EJIT_DIAG_ENABLE)
   if(NOT EJIT_DIAG_PRINT_THROTTLE_TICKS MATCHES "^[0-9]+$")

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -568,9 +568,11 @@ endif()
 # list, captured IR/ASM, icache slots): after each printed line the producer
 # delays EJIT_DIAG_PRINT_THROTTLE_TICKS scheduler ticks (SRE_TaskDelay) so the
 # serial-log shell consumer (ring buffer ~7 lines, 10 ms drain period) keeps
-# up. Freestanding + EJIT_DIAG_ENABLE only; 0 disables. Consumed by
+# up. Default 20 ticks = 2 drain periods per line: the first performs the
+# drain, the second is margin for consumer jitter and interleaved multi-core
+# logs. Freestanding + EJIT_DIAG_ENABLE only; 0 disables. Consumed by
 # ejitDiagPrintThrottle() in EJitDiag.h.
-set(EJIT_DIAG_PRINT_THROTTLE_TICKS "50" CACHE STRING
+set(EJIT_DIAG_PRINT_THROTTLE_TICKS "20" CACHE STRING
   "EmbeddedJIT diagnostic dump print delay: SRE_TaskDelay scheduler ticks per printed line (0 disables)")
 if(EJIT_DIAG_ENABLE)
   if(NOT EJIT_DIAG_PRINT_THROTTLE_TICKS MATCHES "^[0-9]+$")

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -87,7 +87,7 @@
         "EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT": "10",
         "EJIT_SHARED_SECTION_ATTR": "__attribute__((section(\".mc_shared\")))",
         "EJIT_DIAG_ENABLE": "ON",
-        "EJIT_DIAG_PRINT_THROTTLE_TICKS": "30",
+        "EJIT_DIAG_PRINT_THROTTLE_TICKS": "50",
         "EJIT_SRE_DIAG": "ON",
         "EJIT_DUMP_ASM": "ON",
         "EJIT_STATS_ENABLE": "ON",

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -87,7 +87,7 @@
         "EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT": "10",
         "EJIT_SHARED_SECTION_ATTR": "__attribute__((section(\".mc_shared\")))",
         "EJIT_DIAG_ENABLE": "ON",
-        "EJIT_DIAG_PRINT_THROTTLE_TICKS": "50",
+        "EJIT_DIAG_PRINT_THROTTLE_TICKS": "20",
         "EJIT_SRE_DIAG": "ON",
         "EJIT_DUMP_ASM": "ON",
         "EJIT_STATS_ENABLE": "ON",

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
@@ -56,12 +56,16 @@ extern int gEJitDiagLevel;
 // lines) and its consumer polls once per drain period (10 ticks; 1 tick =
 // 1 ms), so those loops call ejitDiagPrintThrottle() once per printed line:
 // each call delays the producer by EJIT_DIAG_PRINT_THROTTLE_TICKS scheduler
-// ticks (SRE_TaskDelay), letting the consumer drain between lines.
+// ticks (SRE_TaskDelay), letting the consumer drain between lines. The
+// default of 20 ticks buys 2 drain periods per printed line: the first
+// performs the drain, the second is margin for consumer jitter and
+// interleaved multi-core logs (measured: 2 ticks/line drops lines; 50
+// ticks/line is 5 drain periods and needlessly slow).
 // Compile-time configurable; 0 disables. Hosted builds do not delay;
 // diagnostics compiled out (no EJIT_DIAG_ENABLE) => pure no-op.
 
 #ifndef EJIT_DIAG_PRINT_THROTTLE_TICKS
-#define EJIT_DIAG_PRINT_THROTTLE_TICKS 50
+#define EJIT_DIAG_PRINT_THROTTLE_TICKS 20
 #endif
 
 #if defined(EJIT_DIAG_ENABLE) && defined(EJIT_FREESTANDING)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
@@ -86,6 +86,13 @@ inline void ejitDiagPrintThrottle() {
 #endif
 }
 
+/// Integer permille (used / reserved * 1000) for diagnostic "usage"
+/// rendering: freestanding-safe (no FPU), 0 when reserved == 0, truncating
+/// (never rounds up). The caller prints it as permille/10 "." permille%10.
+inline uint64_t ejitDiagPermille(uint64_t used, uint64_t reserved) {
+  return reserved ? used * 1000 / reserved : 0;
+}
+
 #ifdef EJIT_DIAG_ENABLE
 
 #ifdef EJIT_SRE_DIAG

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
@@ -53,15 +53,15 @@ extern int gEJitDiagLevel;
 // Diagnostic dumps (registry, active cells, compiled list, captured IR/ASM,
 // icache slots) emit one line per item inside a loop. On SRE builds the
 // serial-log shell ring buffer is small (512 B default, ~7 aligned 64-byte
-// lines) and its consumer polls once per drain period (10 ticks = 100 ms),
-// so those loops call ejitDiagPrintThrottle() once per printed line: each
-// call delays the producer by EJIT_DIAG_PRINT_THROTTLE_TICKS scheduler
+// lines) and its consumer polls once per drain period (10 ticks; 1 tick =
+// 1 ms), so those loops call ejitDiagPrintThrottle() once per printed line:
+// each call delays the producer by EJIT_DIAG_PRINT_THROTTLE_TICKS scheduler
 // ticks (SRE_TaskDelay), letting the consumer drain between lines.
 // Compile-time configurable; 0 disables. Hosted builds do not delay;
 // diagnostics compiled out (no EJIT_DIAG_ENABLE) => pure no-op.
 
 #ifndef EJIT_DIAG_PRINT_THROTTLE_TICKS
-#define EJIT_DIAG_PRINT_THROTTLE_TICKS 20
+#define EJIT_DIAG_PRINT_THROTTLE_TICKS 50
 #endif
 
 #if defined(EJIT_DIAG_ENABLE) && defined(EJIT_FREESTANDING)
@@ -96,6 +96,15 @@ extern "C" int SRE_printf(const char *fmt, ...);
       SRE_printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,               \
                  ##__VA_ARGS__);                                             \
   } while (0)
+// Same as EJIT_DIAG but WITHOUT the "[EJIT] func:line" prefix, for dump entry
+// lines inside a loop (e.g. ejit_taskpool_print_compiled): the prefix is
+// identical on every line of the dump and only eats ring-buffer space, and
+// the bracketing header/footer lines already carry it for grep-ability.
+#define EJIT_DIAG_RAW(fmt, ...)                                              \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_INFO)                                 \
+      SRE_printf(fmt "\n", ##__VA_ARGS__);                                   \
+  } while (0)
 #define EJIT_DIAG_VERBOSE(fmt, ...)                                          \
   do {                                                                       \
     if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE)                              \
@@ -117,6 +126,12 @@ extern "C" int SRE_printf(const char *fmt, ...);
       std::printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,              \
                   ##__VA_ARGS__);                                            \
   } while (0)
+// See the SRE variant above: prefix-free line for dump entry loops.
+#define EJIT_DIAG_RAW(fmt, ...)                                              \
+  do {                                                                       \
+    if (gEJitDiagLevel >= EJIT_LOG_LVL_INFO)                                 \
+      std::printf(fmt "\n", ##__VA_ARGS__);                                  \
+  } while (0)
 #define EJIT_DIAG_VERBOSE(fmt, ...)                                          \
   do {                                                                       \
     if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE)                              \
@@ -135,6 +150,7 @@ extern "C" int SRE_printf(const char *fmt, ...);
 
 // Expand to ((void)0) regardless of argument count by matching everything.
 #define EJIT_DIAG(...) ((void)0)
+#define EJIT_DIAG_RAW(...) ((void)0)
 #define EJIT_DIAG_VERBOSE(...) ((void)0)
 #define EJIT_DIAG_DEBUG(...) ((void)0)
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
@@ -107,10 +107,13 @@ extern "C" int SRE_printf(const char *fmt, ...);
       SRE_printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,               \
                  ##__VA_ARGS__);                                             \
   } while (0)
-// Same as EJIT_DIAG but WITHOUT the "[EJIT] func:line" prefix, for dump entry
-// lines inside a loop (e.g. ejit_taskpool_print_compiled): the prefix is
-// identical on every line of the dump and only eats ring-buffer space, and
-// the bracketing header/footer lines already carry it for grep-ability.
+// Same as EJIT_DIAG but WITHOUT the "[EJIT] func:line" prefix. ALL
+// diagnostic DUMP output prints through this macro - header and footer
+// lines as well as per-item entry lines - so a dump block carries no
+// per-line prefix and ring-buffer space goes to payload only. Grep
+// anchors are the blocks' own text labels ("registry:", "code pool:",
+// "stats_t:", "=== ... ===", "compiled:"). Normal-path (non-dump)
+// logging keeps EJIT_DIAG so the func:line origin stays attached.
 #define EJIT_DIAG_RAW(fmt, ...)                                              \
   do {                                                                       \
     if (gEJitDiagLevel >= EJIT_LOG_LVL_INFO)                                 \
@@ -137,7 +140,8 @@ extern "C" int SRE_printf(const char *fmt, ...);
       std::printf("[EJIT] %s:%d " fmt "\n", __func__, __LINE__,              \
                   ##__VA_ARGS__);                                            \
   } while (0)
-// See the SRE variant above: prefix-free line for dump entry loops.
+// See the SRE variant above: prefix-free lines for ALL diagnostic dump
+// output (headers and entry lines alike).
 #define EJIT_DIAG_RAW(fmt, ...)                                              \
   do {                                                                       \
     if (gEJitDiagLevel >= EJIT_LOG_LVL_INFO)                                 \

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -40,6 +40,8 @@
 namespace llvm {
 namespace ejit {
 
+class EJitModuleLoader;
+
 //===----------------------------------------------------------------------===//
 // Read-only diagnostics snapshot (spec §11 observability). Every field is a
 // plain copy of an atomic load; no field exposes a raw shared pointer.
@@ -226,12 +228,15 @@ EJitIcacheRegResult ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
                                            uint32_t numDims);
 
 /// Diagnostic: dump every registered icache slot to the diagnostic log.
-/// Shows funcIndex, base pointer, numDims, and cell[0] (the scalar or
-/// [0]...[0] cell) so the caller can quickly see which slots are wired,
-/// which are null, and whether the first cell has been filled.
+/// Shows funcIndex, base pointer, numDims, the per-slot cell capacity
+/// (16^numDims), and cell[0] (the scalar or [0]...[0] cell) so the caller
+/// can quickly see which slots are wired, which are null, and whether the
+/// first cell has been filled. When \p loader is given the slot's
+/// funcIndex is resolved to a function name ("<unknown>" when the registry
+/// has none; "?" without a loader).
 /// NOTE: dereferences base[0] of every registered slot — bases must be
 /// module-lifetime storage, never stack locals (see ejitIcacheClearAll).
-void ejitDumpIcacheSlots();
+void ejitDumpIcacheSlots(const EJitModuleLoader *loader = nullptr);
 
 /// Retire one in-flight drain that was announced under generation \p gen.
 ///

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -421,19 +421,29 @@ public:
   }
   EJitSharedTaskPoolState *state() const { return state_; }
 
-  /// Callback type for forEachCompiled: receives the funcIndex, its dim
-  /// identity (dimType:instanceId pairs, numDims entries), the compiled
-  /// function pointer, and the caller-provided context.
-  using CompiledFuncCallback = void (*)(uint32_t funcIndex,
-                                        const EJitDimPair *dims,
-                                        uint32_t numDims, void *fnPtr,
+  /// Callback type for forEachCompiled: receives the Ready cache slot itself
+  /// (funcIndex/dims/numDims/fnPtr plus publish metadata such as versions,
+  /// codeSize, poolId, generation) and the caller-provided context.
+  using CompiledFuncCallback = void (*)(const EJitSharedCacheSlot &slot,
                                         void *ctx);
+
+  /// Walk outcome of forEachCompiled, so diagnostics can report completeness
+  /// instead of silently missing contended buckets.
+  struct ForEachCompiledStats {
+    uint32_t visitedSlots = 0;   ///< Ready slots the callback ran for.
+    uint32_t skippedBuckets = 0; ///< Buckets skipped (write lock contention).
+  };
 
   /// Invoke \p cb once for every successfully compiled (Ready) cache entry.
   /// For diagnostics (e.g. ejit_taskpool_print_compiled). Best-effort: a slot
   /// mid-publish is skipped, and this is not a snapshot — concurrent publishes
-  /// may add entries during iteration.
-  void forEachCompiled(CompiledFuncCallback cb, void *ctx) const;
+  /// may add entries during iteration. A bucket whose write lock stays held
+  /// after a brief retry is skipped and reported in the returned stats. In a
+  /// NO_RECLAIM build the slot is read without the hit-path seqlock snapshot,
+  /// so a publish racing the write-flag check can tear a printed field;
+  /// diagnostics only, never a hit path.
+  ForEachCompiledStats forEachCompiled(CompiledFuncCallback cb,
+                                       void *ctx) const;
 
   //--- owner-only configuration (applied if this core wins election) ----------
   void setCompiler(CompileCallback fn, void *ctx) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -794,11 +794,11 @@ const EJitSharedTaskPool *EJit::sharedTaskPool() const {
 
 void EJit::printRegistry() const {
   const PeriodArrayRegistry &reg = runtimeState_->getRegistry();
-  EJIT_DIAG("registry: funcIndexes=%u lifecycles=%u",
-            EJitFuncRegistry::instance().count(),
-            EJitLifecycleRegistry::instance().count());
+  EJIT_DIAG_RAW("registry: funcIndexes=%u lifecycles=%u",
+                EJitFuncRegistry::instance().count(),
+                EJitLifecycleRegistry::instance().count());
 
-  EJIT_DIAG("registry: bitcodes (%u):", EJitFuncRegistry::instance().count());
+  EJIT_DIAG_RAW("registry: bitcodes (%u):", EJitFuncRegistry::instance().count());
   for (uint32_t idx = 0; idx < EJitFuncRegistry::instance().count(); ++idx) {
     const std::string &name = moduleLoader_->getFuncNameByFuncIdx(idx);
     if (name.empty())
@@ -807,21 +807,21 @@ void EJit::printRegistry() const {
     size_t sz = bc ? bc->size() : 0;
     if (!bc)
       consumeError(bc.takeError());
-    EJIT_DIAG("  idx=%u name=%s size=%zu", idx, name.c_str(), sz);
+    EJIT_DIAG_RAW("  idx=%u name=%s size=%zu", idx, name.c_str(), sz);
     ejitDiagPrintThrottle();
   }
 
-  EJIT_DIAG("registry: period arrays:");
+  EJIT_DIAG_RAW("registry: period arrays:");
   for (const auto &kv : reg.arraysByPeriod())
     for (const auto &info : kv.second) {
-      EJIT_DIAG("  period=%s var=%s base=%p size=%zu", kv.first.c_str(),
-                info.varName.c_str(), info.baseAddr, info.arraySize);
+      EJIT_DIAG_RAW("  period=%s var=%s base=%p size=%zu", kv.first.c_str(),
+                    info.varName.c_str(), info.baseAddr, info.arraySize);
       ejitDiagPrintThrottle();
     }
 
-  EJIT_DIAG("registry: static vars (%zu):", reg.getStaticVars().size());
+  EJIT_DIAG_RAW("registry: static vars (%zu):", reg.getStaticVars().size());
   for (const auto &sv : reg.getStaticVars()) {
-    EJIT_DIAG("  var=%s addr=%p", sv.varName.c_str(), sv.varAddr);
+    EJIT_DIAG_RAW("  var=%s addr=%p", sv.varName.c_str(), sv.varAddr);
     ejitDiagPrintThrottle();
   }
 }
@@ -829,13 +829,13 @@ void EJit::printRegistry() const {
 void EJit::printFuncMeta(const std::string &funcName) {
   uint32_t idx = EJitFuncRegistry::instance().lookup(funcName);
   if (idx == kEJitInvalidFuncIndex) {
-    EJIT_DIAG("func_meta: name=%s not registered", funcName.c_str());
+    EJIT_DIAG_RAW("func_meta: name=%s not registered", funcName.c_str());
     return;
   }
   auto bc = moduleLoader_->getBitcodeByFuncIdx(idx);
   if (!bc) {
-    EJIT_DIAG("func_meta: name=%s funcIdx=%u bitcode lookup error",
-              funcName.c_str(), idx);
+    EJIT_DIAG_RAW("func_meta: name=%s funcIdx=%u bitcode lookup error",
+                  funcName.c_str(), idx);
     consumeError(bc.takeError());
     return;
   }
@@ -843,27 +843,30 @@ void EJit::printFuncMeta(const std::string &funcName) {
   auto Buf = MemoryBuffer::getMemBuffer(*bc, "meta_" + std::to_string(idx) + ".bc");
   auto MOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
   if (!MOrErr) {
-    EJIT_DIAG("func_meta: name=%s funcIdx=%u parse bitcode error",
-              funcName.c_str(), idx);
+    EJIT_DIAG_RAW("func_meta: name=%s funcIdx=%u parse bitcode error",
+                  funcName.c_str(), idx);
     consumeError(MOrErr.takeError());
     return;
   }
   Function *F = (*MOrErr)->getFunction(funcName);
-  EJIT_DIAG("func_meta name=%s funcIdx=%u found=%d", funcName.c_str(), idx,
-            F && !F->isDeclaration() ? 1 : 0);
+  EJIT_DIAG_RAW("func_meta name=%s funcIdx=%u found=%d", funcName.c_str(), idx,
+                F && !F->isDeclaration() ? 1 : 0);
   if (!F || F->isDeclaration()) {
-    EJIT_DIAG("  (no definition in bitcode)");
+    EJIT_DIAG_RAW("  (no definition in bitcode)");
     return;
   }
   MDNode *MD = F->getMetadata(MD_EJIT_METADATA);
   if (!MD) {
-    EJIT_DIAG("  (no !ejit.metadata)");
+    EJIT_DIAG_RAW("  (no !ejit.metadata)");
     return;
   }
-  EJIT_DIAG("  ejit_entry=%d",
-            hasMDStringEntry(MD, TAG_EJIT_ENTRY) ? 1 : 0);
-  for (const MDOperand &Op : MD->operands()) {
-    auto *Sub = dyn_cast<MDNode>(Op.get());
+  EJIT_DIAG_RAW("  ejit_entry=%d",
+                hasMDStringEntry(MD, TAG_EJIT_ENTRY) ? 1 : 0);
+  // op= is the RAW operand index inside !ejit.metadata: entries skipped by
+  // the continue guards still consume an index, so a printed op= locates the
+  // entry in the bitcode exactly (no renumbering against skipped items).
+  for (unsigned op = 0; op < MD->getNumOperands(); ++op) {
+    auto *Sub = dyn_cast<MDNode>(MD->getOperand(op));
     if (!Sub || Sub->getNumOperands() == 0)
       continue;
     auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
@@ -888,7 +891,8 @@ void EJit::printFuncMeta(const std::string &funcName) {
         OS << "?";
     }
     OS.flush();
-    EJIT_DIAG("  %s %s", tag.str().c_str(), rest.c_str());
+    EJIT_DIAG_RAW("  op=%u tag=%s vals=%s", op, tag.str().c_str(),
+                  rest.c_str());
     ejitDiagPrintThrottle();
   }
 }
@@ -943,20 +947,21 @@ void EJit::printCodePoolStats() const {
 #ifdef EJIT_SRE_CODE_POOL
   ejit_code_pool_stats_t s{};
   if (!getCodePoolStats(&s)) {
-    EJIT_DIAG("code pool: not available (no engine)");
+    EJIT_DIAG_RAW("code pool: not available (no engine)");
     return;
   }
-  EJIT_DIAG("code pool: pools=%llu sealed=%llu active=%llu",
-            (unsigned long long)s.poolCount, (unsigned long long)s.sealedCount,
-            (unsigned long long)s.activeCount);
-  EJIT_DIAG("  bytes used=%llu reserved=%llu wasted=%llu",
-            (unsigned long long)s.usedBytes,
-            (unsigned long long)s.reservedBytes,
-            (unsigned long long)s.wastedBytes);
-  EJIT_DIAG("  sealInvocations=%llu splitInvocations=%llu finalizedRanges=%llu",
-            (unsigned long long)s.sealInvocations,
-            (unsigned long long)s.splitInvocations,
-            (unsigned long long)s.finalizedRangeCount);
+  EJIT_DIAG_RAW("code pool: pools=%llu sealed=%llu active=%llu",
+                (unsigned long long)s.poolCount,
+                (unsigned long long)s.sealedCount,
+                (unsigned long long)s.activeCount);
+  EJIT_DIAG_RAW("  bytes used=%llu reserved=%llu wasted=%llu",
+                (unsigned long long)s.usedBytes,
+                (unsigned long long)s.reservedBytes,
+                (unsigned long long)s.wastedBytes);
+  EJIT_DIAG_RAW("  sealInvocations=%llu splitInvocations=%llu finalizedRanges=%llu",
+                (unsigned long long)s.sealInvocations,
+                (unsigned long long)s.splitInvocations,
+                (unsigned long long)s.finalizedRangeCount);
   // Whole-pool usage summary, derived at print time (no new counters):
   // total = reservedBytes = capacity of every carved pool. Caveats:
   //  - 4K-seal mode rounds usedBytes up per allocation (page-aligned bump
@@ -965,34 +970,43 @@ void EJit::printCodePoolStats() const {
   //  - fixed-region mode counts only carved pools, so un-carved region
   //    space is not reflected in total.
   const uint64_t permille = ejitDiagPermille(s.usedBytes, s.reservedBytes);
-  EJIT_DIAG("  total=%llu used=%llu usage=%llu.%u%%",
-            (unsigned long long)s.reservedBytes,
-            (unsigned long long)s.usedBytes,
-            (unsigned long long)(permille / 10), (unsigned)(permille % 10));
+  EJIT_DIAG_RAW("  total=%llu used=%llu usage=%llu.%u%%",
+                (unsigned long long)s.reservedBytes,
+                (unsigned long long)s.usedBytes,
+                (unsigned long long)(permille / 10), (unsigned)(permille % 10));
+  (void)permille; // consumed by EJIT_DIAG_RAW only; silence DIAG-off builds
 #else
-  EJIT_DIAG("code pool: EJIT_SRE_CODE_POOL not enabled");
+  EJIT_DIAG_RAW("code pool: EJIT_SRE_CODE_POOL not enabled");
 #endif
 }
 
 void EJit::printActive() const {
   const PeriodArrayRegistry &reg = runtimeState_->getRegistry();
-  EJIT_DIAG("active periods:");
+  EJIT_DIAG_RAW("active periods:");
   // Query the same isActive() path the JIT gate uses (shared SwitchController
   // in shared-taskpool builds, per-instance arrayStates_ otherwise), so the
   // printed view matches the compile decision.
   for (const auto &kv : reg.arraysByPeriod()) {
     const std::string &period = kv.first;
+    // Count first so every period leads with its active-cell count; zero
+    // prints "active=0" (replaces the old "(no active cells)" marker).
+    // isActive() is a table lookup, so the second 256-cell scan per period
+    // is negligible next to the per-line print throttle.
     uint32_t activeCells = 0;
+    for (uint32_t cell = 0; cell < kEJitMaxInstances; ++cell)
+      if (isActive(period, static_cast<uint8_t>(cell)))
+        ++activeCells;
+    EJIT_DIAG_RAW("  period=%s active=%u", period.c_str(), activeCells);
+    ejitDiagPrintThrottle();
+    (void)activeCells; // consumed by EJIT_DIAG_RAW only; silence DIAG-off builds
     for (uint32_t cell = 0; cell < kEJitMaxInstances; ++cell) {
       if (isActive(period, static_cast<uint8_t>(cell))) {
-        EJIT_DIAG("  period=%s cell=%u", period.c_str(), cell);
+        EJIT_DIAG_RAW("  period=%s cell=%u", period.c_str(), cell);
         ejitDiagPrintThrottle();
-        ++activeCells;
       }
     }
-    if (activeCells == 0)
-      EJIT_DIAG("  period=%s (no active cells)", period.c_str());
   }
   // The built-in "static" time window is always active.
-  EJIT_DIAG("active static vars: %zu (always active)", reg.getStaticVars().size());
+  EJIT_DIAG_RAW("active static vars: %zu (always active)",
+                reg.getStaticVars().size());
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -957,6 +957,18 @@ void EJit::printCodePoolStats() const {
             (unsigned long long)s.sealInvocations,
             (unsigned long long)s.splitInvocations,
             (unsigned long long)s.finalizedRangeCount);
+  // Whole-pool usage summary, derived at print time (no new counters):
+  // total = reservedBytes = capacity of every carved pool. Caveats:
+  //  - 4K-seal mode rounds usedBytes up per allocation (page-aligned bump
+  //    cursor in EJitCodePool.cpp allocateCode), slightly over-reporting
+  //    usage;
+  //  - fixed-region mode counts only carved pools, so un-carved region
+  //    space is not reflected in total.
+  const uint64_t permille = ejitDiagPermille(s.usedBytes, s.reservedBytes);
+  EJIT_DIAG("  total=%llu used=%llu usage=%llu.%u%%",
+            (unsigned long long)s.reservedBytes,
+            (unsigned long long)s.usedBytes,
+            (unsigned long long)(permille / 10), (unsigned)(permille % 10));
 #else
   EJIT_DIAG("code pool: EJIT_SRE_CODE_POOL not enabled");
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -267,7 +267,7 @@ struct DumpEntry {
 static std::map<std::string, DumpEntry> gDumpStore;
 
 static void dumpBytesSafe(const char *label, const char *data, size_t n) {
-  EJIT_DIAG("=== %s begin size=%u ===", label, (unsigned)n);
+  EJIT_DIAG_RAW("=== %s begin size=%u ===", label, (unsigned)n);
   size_t i = 0;
   unsigned lineNo = 0;
   while (i < n) {
@@ -276,13 +276,17 @@ static void dumpBytesSafe(const char *label, const char *data, size_t n) {
       ++lineEnd;
     size_t pos = i;
     if (pos == lineEnd) {
-      EJIT_DIAG("%s:%u: ", label, lineNo);
+      EJIT_DIAG_RAW("%s:%u: ", label, lineNo);
     } else {
+      // A long source line is emitted in bounded chunks; every chunk but
+      // the last gets a trailing "..." so a wrapped line is tellable from
+      // consecutive short ones.
       while (pos < lineEnd) {
         size_t chunk = lineEnd - pos;
         if (chunk > 180)
           chunk = 180;
-        EJIT_DIAG("%s:%u: %.*s", label, lineNo, (int)chunk, data + pos);
+        EJIT_DIAG_RAW("%s:%u: %.*s%s", label, lineNo, (int)chunk, data + pos,
+                      pos + chunk < lineEnd ? "..." : "");
         pos += chunk;
       }
     }
@@ -291,7 +295,7 @@ static void dumpBytesSafe(const char *label, const char *data, size_t n) {
     i = lineEnd + 1;
   }
   (void)lineNo;
-  EJIT_DIAG("=== %s end lines=%u ===", label, lineNo);
+  EJIT_DIAG_RAW("=== %s end lines=%u ===", label, lineNo);
 }
 
 /// Emit a multi-line blob (IR or ASM) through EJIT_DIAG. SRE-safe: no lambda,
@@ -382,15 +386,15 @@ static bool printSharedDumpHint(const char *name) {
   (void)keyLo;
   (void)stored;
   if (workerCore == kEJitInvalidCoreId)
-    EJIT_DIAG("print_dumped: dump for \"%s\" is worker-local; run "
-              "ejit_print_dumped(\"%s\") on the worker core. ir_size=%u "
-              "asm_size=%u key_hi=0x%08x key_lo=0x%08x",
-              stored, stored, irSize, asmSize, keyHi, keyLo);
+    EJIT_DIAG_RAW("print_dumped: dump for \"%s\" is worker-local; run "
+                  "ejit_print_dumped(\"%s\") on the worker core. ir_size=%u "
+                  "asm_size=%u key_hi=0x%08x key_lo=0x%08x",
+                  stored, stored, irSize, asmSize, keyHi, keyLo);
   else
-    EJIT_DIAG("print_dumped: dump for \"%s\" is stored on worker core %u; "
-              "run ejit_print_dumped(\"%s\") on that core. ir_size=%u "
-              "asm_size=%u key_hi=0x%08x key_lo=0x%08x",
-              stored, workerCore, stored, irSize, asmSize, keyHi, keyLo);
+    EJIT_DIAG_RAW("print_dumped: dump for \"%s\" is stored on worker core %u; "
+                  "run ejit_print_dumped(\"%s\") on that core. ir_size=%u "
+                  "asm_size=%u key_hi=0x%08x key_lo=0x%08x",
+                  stored, workerCore, stored, irSize, asmSize, keyHi, keyLo);
   return true;
 }
 #endif
@@ -422,10 +426,10 @@ static void printOneDumpSafe(const char *requestedName,
   uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
   (void)keyHi;
   (void)keyLo;
-  EJIT_DIAG("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
-            "key_lo=0x%08x ir_size=%u asm_size=%u",
-            requestedName ? requestedName : "(list)", storedName.c_str(), keyHi,
-            keyLo, (unsigned)e.IR.size(), (unsigned)e.ASM.size());
+  EJIT_DIAG_RAW("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
+                "key_lo=0x%08x ir_size=%u asm_size=%u",
+                requestedName ? requestedName : "(list)", storedName.c_str(),
+                keyHi, keyLo, (unsigned)e.IR.size(), (unsigned)e.ASM.size());
   if (!e.IR.empty())
     dumpLinesSafe("dump IR", e.IR);
   if (!e.ASM.empty())
@@ -450,7 +454,7 @@ void printDumped(const char *name) {
         return;
       }
     } else if (!gDumpStore.empty()) {
-      EJIT_DIAG("print_dumped saved entries=%u", (unsigned)gDumpStore.size());
+      EJIT_DIAG_RAW("print_dumped saved entries=%u", (unsigned)gDumpStore.size());
       for (auto &kv : gDumpStore) {
         printOneDumpSafe(nullptr, kv.first, kv.second);
         ejitDiagPrintThrottle();
@@ -468,7 +472,7 @@ void printDumped(const char *name) {
     EJIT_DIAG_DEBUG("print_dumped miss name=%s store_size=%u", name,
                     (unsigned)gDumpStore.size());
   else
-    EJIT_DIAG("print_dumped: nothing saved");
+    EJIT_DIAG_RAW("print_dumped: nothing saved");
 }
 
 } // namespace ejit

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1329,41 +1329,56 @@ ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out) {
 void ejit_taskpool_print_stats() {
   ejit_taskpool_stats_t s = {0};
   ejit_taskpool_get_stats(&s);
-  EJIT_DIAG("stats_t:");
-  EJIT_DIAG("  cacheHits        = %llu",
-            static_cast<unsigned long long>(s.cacheHits));
-  EJIT_DIAG("  asyncCompiles    = %llu",
-            static_cast<unsigned long long>(s.asyncCompiles));
-  EJIT_DIAG("  asyncEnqueues    = %llu",
-            static_cast<unsigned long long>(s.asyncEnqueues));
-  EJIT_DIAG("  alreadyPending   = %llu",
-            static_cast<unsigned long long>(s.alreadyPending));
-  EJIT_DIAG("  queueFull        = %llu",
-            static_cast<unsigned long long>(s.queueFull));
-  EJIT_DIAG("  compileFailed    = %llu",
-            static_cast<unsigned long long>(s.compileFailed));
-  EJIT_DIAG("  publishFailed    = %llu",
-            static_cast<unsigned long long>(s.publishFailed));
-  EJIT_DIAG("  instanceDisabled = %llu",
-            static_cast<unsigned long long>(s.instanceDisabled));
-  EJIT_DIAG("  instanceDisabledPreActivate  = %llu   (init->activate window)",
-            static_cast<unsigned long long>(s.instanceDisabledPreActivate));
-  EJIT_DIAG("  instanceDisabledPostActivate = %llu   (after first activate)",
-            static_cast<unsigned long long>(
-                s.instanceDisabled > s.instanceDisabledPreActivate
-                    ? s.instanceDisabled - s.instanceDisabledPreActivate
-                    : 0));
-  EJIT_DIAG("  readyEntries     = %u", s.readyEntries);
-  EJIT_DIAG("  pendingEntries   = %u", s.pendingEntries);
-  EJIT_DIAG("  queueApproxSize  = %u", s.queueApproxSize);
-  EJIT_DIAG("  reserved         = %u", s.reserved);
+  EJIT_DIAG_RAW("stats_t:");
+  EJIT_DIAG_RAW("  cacheHits        = %llu",
+                static_cast<unsigned long long>(s.cacheHits));
+  EJIT_DIAG_RAW("  asyncCompiles    = %llu",
+                static_cast<unsigned long long>(s.asyncCompiles));
+  EJIT_DIAG_RAW("  asyncEnqueues    = %llu",
+                static_cast<unsigned long long>(s.asyncEnqueues));
+  EJIT_DIAG_RAW("  alreadyPending   = %llu",
+                static_cast<unsigned long long>(s.alreadyPending));
+  EJIT_DIAG_RAW("  queueFull        = %llu",
+                static_cast<unsigned long long>(s.queueFull));
+  EJIT_DIAG_RAW("  compileFailed    = %llu",
+                static_cast<unsigned long long>(s.compileFailed));
+  EJIT_DIAG_RAW("  publishFailed    = %llu",
+                static_cast<unsigned long long>(s.publishFailed));
+  EJIT_DIAG_RAW("  instanceDisabled = %llu",
+                static_cast<unsigned long long>(s.instanceDisabled));
+  EJIT_DIAG_RAW("  instanceDisabledPreActivate  = %llu   (init->activate window)",
+                static_cast<unsigned long long>(s.instanceDisabledPreActivate));
+  EJIT_DIAG_RAW("  instanceDisabledPostActivate = %llu   (after first activate)",
+                static_cast<unsigned long long>(
+                    s.instanceDisabled > s.instanceDisabledPreActivate
+                        ? s.instanceDisabled - s.instanceDisabledPreActivate
+                        : 0));
+  EJIT_DIAG_RAW("  readyEntries     = %u", s.readyEntries);
+  EJIT_DIAG_RAW("  pendingEntries   = %u", s.pendingEntries);
+  EJIT_DIAG_RAW("  queueApproxSize  = %u", s.queueApproxSize);
+  EJIT_DIAG_RAW("  reserved         = %u", s.reserved);
 
-  // Diagnostic: dump the inline-cache slot registry to help diagnose
-  // why cacheHits keeps growing despite icache being enabled.
 #ifdef EJIT_SRE_SHARED_TASKPOOL
-  ejitDumpIcacheSlots();
+  // Shared-pool fields not mirrored in the C ABI stats struct: read straight
+  // from the diagnostics snapshot (public getDiagnostics()), no ABI change.
+  if (EJitSharedTaskPool *sp = gEJIT ? gEJIT->sharedTaskPool() : nullptr) {
+    EJitSharedDiagnostics d;
+    sp->getDiagnostics(d);
+    EJIT_DIAG_RAW("  initState=%u ownerCore=%u gen=%u lastInitErr=%u "
+                  "initAttempts=%u share=%u",
+                  d.initState, d.ownerCoreId, d.generation, d.lastInitError,
+                  d.initAttempts, d.codeSharingEnabled);
+    EJIT_DIAG_RAW("  workerTaskId=%llu regFingerprint=%llu execPrepFailed=%llu",
+                  static_cast<unsigned long long>(d.workerTaskId),
+                  static_cast<unsigned long long>(d.registrationFingerprint),
+                  static_cast<unsigned long long>(d.executePrepareFailed));
+  }
+  // Diagnostic: dump the inline-cache slot registry to help diagnose
+  // why cacheHits keeps growing despite icache being enabled. Hand the
+  // module loader in so slots resolve to function names.
+  ejitDumpIcacheSlots(gEJIT ? &gEJIT->moduleLoader() : nullptr);
 #else
-  EJIT_DIAG("  icacheSlots       = (n/a: shared taskpool not built)");
+  EJIT_DIAG_RAW("  icacheSlots       = (n/a: shared taskpool not built)");
 #endif
 }
 
@@ -1374,7 +1389,7 @@ void ejit_taskpool_print_compiled() {
   return;
 #else
   if (!gEJIT) {
-    EJIT_DIAG("print_compiled: not initialized");
+    EJIT_DIAG_RAW("print_compiled: not initialized");
     return;
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
@@ -1384,7 +1399,7 @@ void ejit_taskpool_print_compiled() {
     return;
   EJitSharedTaskPool *sp = gEJIT->sharedTaskPool();
   if (!sp || !sp->state()) {
-    EJIT_DIAG("print_compiled: no shared taskpool / state");
+    EJIT_DIAG_RAW("print_compiled: no shared taskpool / state");
     return;
   }
   EJitModuleLoader &loader = gEJIT->moduleLoader();
@@ -1421,10 +1436,10 @@ void ejit_taskpool_print_compiled() {
   if (p >= end)
     p = end - 1;
   *p = '\0';
-  EJIT_DIAG("compiled: %u entries (%u/%u slots, %u buckets skipped)%s%s",
-            st.visitedSlots, st.visitedSlots,
-            kEJitSharedCacheBuckets * kEJitSharedCacheSlots,
-            st.skippedBuckets, byDims[0] ? " byDims: " : "", byDims);
+  EJIT_DIAG_RAW("compiled: %u entries (%u/%u slots, %u buckets skipped)%s%s",
+                st.visitedSlots, st.visitedSlots,
+                kEJitSharedCacheBuckets * kEJitSharedCacheSlots,
+                st.skippedBuckets, byDims[0] ? " byDims: " : "", byDims);
   // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
   // each printed line.
   EJitSharedTaskPool::ForEachCompiledStats st2 = sp->forEachCompiled(
@@ -1484,10 +1499,10 @@ void ejit_taskpool_print_compiled() {
   // contended buckets, its lines are incomplete relative to it — report the
   // shortfall (fixed line count, so no throttle) instead of dropping it.
   if (st2.skippedBuckets)
-    EJIT_DIAG("compiled: %u buckets skipped during entry walk",
-              st2.skippedBuckets);
+    EJIT_DIAG_RAW("compiled: %u buckets skipped during entry walk",
+                  st2.skippedBuckets);
 #else
-  EJIT_DIAG("print_compiled: shared taskpool not enabled");
+  EJIT_DIAG_RAW("print_compiled: shared taskpool not enabled");
 #endif
 #endif
 }
@@ -1502,7 +1517,7 @@ void ejit_dump_func(const char *name) {
 
 void ejit_print_dumped(const char *name) {
   // gDumpSharedState is bound once in ejit_init; no per-call rebind needed.
-  EJIT_DIAG("print_dumped name=%s", (name && name[0]) ? name : "(all)");
+  EJIT_DIAG_RAW("print_dumped name=%s", (name && name[0]) ? name : "(all)");
   printDumped(name);
 }
 
@@ -1549,7 +1564,7 @@ ejit_log_level_t ejit_get_log_level(void) {
 
 void ejit_print_registry(void) {
   if (!gEJIT) {
-    EJIT_DIAG("print_registry: not initialized");
+    EJIT_DIAG_RAW("print_registry: not initialized");
     return;
   }
   gEJIT->printRegistry();
@@ -1557,11 +1572,11 @@ void ejit_print_registry(void) {
 
 void ejit_print_func_meta(const char *funcName) {
   if (!funcName || !funcName[0]) {
-    EJIT_DIAG("print_func_meta: null/empty name");
+    EJIT_DIAG_RAW("print_func_meta: null/empty name");
     return;
   }
   if (!gEJIT) {
-    EJIT_DIAG("print_func_meta: not initialized");
+    EJIT_DIAG_RAW("print_func_meta: not initialized");
     return;
   }
   gEJIT->printFuncMeta(funcName);
@@ -1585,7 +1600,7 @@ ejit_status_t ejit_get_code_pool_stats(ejit_code_pool_stats_t *out) {
 
 void ejit_print_code_pool_stats(void) {
   if (!gEJIT) {
-    EJIT_DIAG("print_code_pool_stats: not initialized");
+    EJIT_DIAG_RAW("print_code_pool_stats: not initialized");
     return;
   }
   gEJIT->printCodePoolStats();
@@ -1593,7 +1608,7 @@ void ejit_print_code_pool_stats(void) {
 
 void ejit_print_active(void) {
   if (!gEJIT) {
-    EJIT_DIAG("print_active: not initialized");
+    EJIT_DIAG_RAW("print_active: not initialized");
     return;
   }
   gEJIT->printActive();

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1368,47 +1368,127 @@ void ejit_taskpool_print_stats() {
 }
 
 void ejit_taskpool_print_compiled() {
+#ifndef EJIT_DIAG_ENABLE
+  // Diagnostics compiled out: nothing can print, so do not walk the cache
+  // (the walk takes bucket read locks for no output).
+  return;
+#else
   if (!gEJIT) {
     EJIT_DIAG("print_compiled: not initialized");
     return;
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
+  // Every entry line is INFO-gated; below INFO the walk would hold bucket
+  // read locks while printing nothing.
+  if (gEJitDiagLevel < EJIT_LOG_LVL_INFO)
+    return;
   EJitSharedTaskPool *sp = gEJIT->sharedTaskPool();
   if (!sp || !sp->state()) {
     EJIT_DIAG("print_compiled: no shared taskpool / state");
     return;
   }
   EJitModuleLoader &loader = gEJIT->moduleLoader();
-  EJIT_DIAG("compiled functions:");
-  sp->forEachCompiled(
-      [](uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
-         void *fnPtr, void *ctx) {
-#ifdef EJIT_DIAG_ENABLE
-        const auto &loader = *static_cast<EJitModuleLoader *>(ctx);
-        const std::string &name = loader.getFuncNameByFuncIdx(funcIndex);
-        EJIT_DIAG("  funcIdx=%u name=%s numDims=%u "
-                  "dims=[%u:%u,%u:%u,%u:%u,%u:%u] fn=%p",
-                  funcIndex, name.empty() ? "<unknown>" : name.c_str(), numDims,
-                  numDims > 0 ? dims[0].dimType : 0,
-                  numDims > 0 ? dims[0].instanceId : 0,
-                  numDims > 1 ? dims[1].dimType : 0,
-                  numDims > 1 ? dims[1].instanceId : 0,
-                  numDims > 2 ? dims[2].dimType : 0,
-                  numDims > 2 ? dims[2].instanceId : 0,
-                  numDims > 3 ? dims[3].dimType : 0,
-                  numDims > 3 ? dims[3].instanceId : 0, fnPtr);
+  // Two walks so the summary line can print FIRST: a count-only pass tallies
+  // the numDims spread, then a print pass emits the throttled entry lines.
+  // The walk is documented best-effort (not a snapshot), so a concurrent
+  // publish between the passes can make the summary and the printed lines
+  // diverge by the same margin as any walk-based dump.
+  struct CountCtx {
+    uint32_t byDims[kEJitSharedMaxDims + 1];
+  } count = {{0}};
+  EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
+      [](const EJitSharedCacheSlot &slot, void *cbCtx) {
+        // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
+        // value so the tally cannot index past byDims.
+        uint32_t n = slot.numDims < kEJitSharedMaxDims ? slot.numDims
+                                                       : kEJitSharedMaxDims;
+        ++static_cast<CountCtx *>(cbCtx)->byDims[n];
+      },
+      &count);
+  // Summary line first (fixed line count, so no throttle): total, cache
+  // occupancy, contended buckets skipped by the count walk, and the numDims
+  // spread. Only the nonzero spread buckets are listed. 14 B per entry
+  // (" 4d=4294967295").
+  char byDims[(kEJitSharedMaxDims + 1) * 14 + 1];
+  char *p = byDims;
+  char *end = byDims + sizeof(byDims);
+  for (uint32_t d = 0; d <= kEJitSharedMaxDims && p < end; ++d) {
+    if (!count.byDims[d])
+      continue;
+    p += snprintf(p, (size_t)(end - p), "%s%ud=%u", p == byDims ? "" : " ", d,
+                  count.byDims[d]);
+  }
+  if (p >= end)
+    p = end - 1;
+  *p = '\0';
+  EJIT_DIAG("compiled: %u entries (%u/%u slots, %u buckets skipped)%s%s",
+            st.visitedSlots, st.visitedSlots,
+            kEJitSharedCacheBuckets * kEJitSharedCacheSlots,
+            st.skippedBuckets, byDims[0] ? " byDims: " : "", byDims);
+  // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
+  // each printed line.
+  EJitSharedTaskPool::ForEachCompiledStats st2 = sp->forEachCompiled(
+      [](const EJitSharedCacheSlot &slot, void *cbCtx) {
+        EJitModuleLoader &ld = *static_cast<EJitModuleLoader *>(cbCtx);
+        const std::string &name =
+            ld.getFuncNameByFuncIdx(slot.funcIndex);
+        // Per the publish protocol: fnPtr is read with acquire only after
+        // state==Ready was observed with acquire (forEachCompiled did).
+        void *fn = reinterpret_cast<void *>(slot.fnPtr.loadAcquire());
+        // Only the numDims leading pairs are meaningful; clamp a corrupt
+        // slot's numDims to the ABI maximum so the builders cannot overflow.
+        const uint32_t n =
+            slot.numDims < kEJitSharedMaxDims ? slot.numDims
+                                              : kEJitSharedMaxDims;
+        // dims=[d:i,...] for the n meaningful pairs, e.g. "1:5" / "1:5,2:7".
+        // Sized for the uint32 worst case: kEJitSharedMaxDims x
+        // ("4294967295:4294967295" = 21) + separators + NUL.
+        char dims[kEJitSharedMaxDims * 21 + (kEJitSharedMaxDims - 1) + 1];
+        char *p = dims;
+        char *end = dims + sizeof(dims);
+        for (uint32_t i = 0; i < n && p < end; ++i)
+          p += snprintf(p, (size_t)(end - p), "%s%u:%u", i ? "," : "",
+                        slot.dims[i].dimType, slot.dims[i].instanceId);
+        if (p >= end)
+          p = end - 1;
+        *p = '\0';
+        if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
+          // Same shape for the per-instance version snapshot (uint32 x
+          // kEJitSharedMaxDims + separators + NUL).
+          char ver[kEJitSharedMaxDims * 10 + (kEJitSharedMaxDims - 1) + 1];
+          p = ver;
+          end = ver + sizeof(ver);
+          for (uint32_t i = 0; i < n && p < end; ++i)
+            p += snprintf(p, (size_t)(end - p), "%s%u", i ? "," : "",
+                          slot.versions[i]);
+          if (p >= end)
+            p = end - 1;
+          *p = '\0';
+          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
+                        "ver=[%s] size=%llu pool=%u gen=%u",
+                        slot.funcIndex,
+                        name.empty() ? "<unknown>" : name.c_str(),
+                        slot.numDims, dims, fn, ver,
+                        static_cast<unsigned long long>(slot.codeSize),
+                        slot.poolId, slot.generation);
+        } else {
+          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p",
+                        slot.funcIndex,
+                        name.empty() ? "<unknown>" : name.c_str(),
+                        slot.numDims, dims, fn);
+        }
         ejitDiagPrintThrottle();
-#else
-        (void)funcIndex;
-        (void)dims;
-        (void)numDims;
-        (void)fnPtr;
-        (void)ctx;
-#endif
       },
       &loader);
+  // The summary counted the first walk; if the entry walk itself skipped
+  // contended buckets, its lines are incomplete relative to it — report the
+  // shortfall (fixed line count, so no throttle) instead of dropping it.
+  if (st2.skippedBuckets)
+    EJIT_DIAG("compiled: %u buckets skipped during entry walk",
+              st2.skippedBuckets);
 #else
   EJIT_DIAG("print_compiled: shared taskpool not enabled");
+#endif
 #endif
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -731,10 +731,11 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   }
 }
 
-void EJitSharedTaskPool::forEachCompiled(CompiledFuncCallback cb,
-                                         void *ctx) const {
+EJitSharedTaskPool::ForEachCompiledStats
+EJitSharedTaskPool::forEachCompiled(CompiledFuncCallback cb, void *ctx) const {
+  ForEachCompiledStats stats;
   if (!state_ || !cb)
-    return;
+    return stats;
   for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b) {
     EJitSharedCacheBucket &B = state_->buckets[b];
     // Acquire the per-bucket read lock; retry briefly if a writer is
@@ -748,18 +749,24 @@ void EJitSharedTaskPool::forEachCompiled(CompiledFuncCallback cb,
       }
       cpuRelax();
     }
-    if (!locked)
+    if (!locked) {
+      // Skipped, not silent: the caller reports it from the returned stats.
+      ++stats.skippedBuckets;
       continue;
+    }
     for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s) {
       const EJitSharedCacheSlot &slot = B.slots[s];
       if (static_cast<EJitSharedSlotState>(slot.state.loadAcquire()) !=
           EJitSharedSlotState::Ready)
         continue;
-      void *fn = reinterpret_cast<void *>(slot.fnPtr.loadAcquire());
-      cb(slot.funcIndex, slot.dims, slot.numDims, fn, ctx);
+      // Pass the whole slot; the callback reads fnPtr with its own acquire
+      // load, per the publish protocol (state Ready acquire orders it).
+      cb(slot, ctx);
+      ++stats.visitedSlots;
     }
     bucketReadRelease(B);
   }
+  return stats;
 }
 
 bool EJitSharedTaskPool::setInstanceEnabled(uint32_t dimType,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include <atomic>
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
 
@@ -259,9 +260,9 @@ void llvm::ejit::ejitIcacheClearAll() {
   }
 }
 
-void llvm::ejit::ejitDumpIcacheSlots() {
-  EJIT_DIAG("=== gIcacheSlots dump (%u slots) ===",
-            (unsigned)EJIT_ICACHE_FUNC_SLOTS);
+void llvm::ejit::ejitDumpIcacheSlots(const EJitModuleLoader *loader) {
+  EJIT_DIAG_RAW("=== gIcacheSlots dump (%u slots) ===",
+                (unsigned)EJIT_ICACHE_FUNC_SLOTS);
   uint32_t registered = 0;
   uint32_t filled = 0;
   for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
@@ -275,13 +276,29 @@ void llvm::ejit::ejitDumpIcacheSlots() {
     const uintptr_t c0 = icacheCell(reg.base, 0).loadRelaxed();
     if (c0)
       filled++;
-    EJIT_DIAG("  [%2u] base=%p numDims=%u cell[0]=%p %s",
-              f, (void *)reg.base, reg.numDims, (void *)c0,
-              c0 ? "(filled)" : "(empty)");
+    // The slot index IS the funcIndex (a static_assert above guarantees
+    // EJIT_ICACHE_FUNC_SLOTS >= EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX), so a
+    // loader resolves the function name: "<unknown>" when the registry
+    // holds no name for it, "?" when no loader was handed in (unit tests /
+    // runtime not yet initialized).
+    const char *name = "?";
+    if (loader) {
+      const std::string &s = loader->getFuncNameByFuncIdx(f);
+      name = s.empty() ? "<unknown>" : s.c_str();
+    }
+    (void)name; // consumed by EJIT_DIAG_RAW only; silence DIAG-off builds
+    EJIT_DIAG_RAW("  [%2u] %.24s base=%p numDims=%u cells=%u cell[0]=%p %s",
+                  f, name, (void *)reg.base, reg.numDims,
+                  (unsigned)icacheCellCount(reg.numDims), (void *)c0,
+                  c0 ? "(filled)" : "(empty)");
     ejitDiagPrintThrottle();
   }
-  EJIT_DIAG("=== icache slots: %u registered, %u with cell[0] filled ===",
-            registered, filled);
+  EJIT_DIAG_RAW("=== icache slots: %u registered, %u with cell[0] filled ===",
+                registered, filled);
+  // Both counters are consumed by the RAW macro above only; silence
+  // DIAG-off builds (same for `name` inside the loop).
+  (void)registered;
+  (void)filled;
 }
 
 void EJitSharedTaskPool::icacheDrainAll(const char *reason) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -13,6 +13,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJit.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitFuncRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLifecycleRegistry.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLogger.h"
@@ -3084,6 +3085,19 @@ TEST(EJitDiagnostics, CodePoolStatsNoCrash) {
 
 TEST(EJitDiagnostics, PrintCodePoolStatsNoCrash) {
   ejit_print_code_pool_stats(); // uninitialized or no pool: prints a notice
+}
+
+// ejitDiagPermille() drives the code-pool usage percentage: integer-only
+// (freestanding builds have no FPU), 0 when the denominator is 0, and
+// truncating (never rounds up).
+TEST(EJitDiagnostics, DiagPermille) {
+  EXPECT_EQ(ejitDiagPermille(0, 0), uint64_t{0});
+  EXPECT_EQ(ejitDiagPermille(7, 0), uint64_t{0});
+  EXPECT_EQ(ejitDiagPermille(50, 100), uint64_t{500});
+  EXPECT_EQ(ejitDiagPermille(65536, 524288), uint64_t{125}); // "12.5%"
+  EXPECT_EQ(ejitDiagPermille(1, 3), uint64_t{333});          // truncates
+  EXPECT_EQ(ejitDiagPermille(3, 2), uint64_t{1500});         // >100%: 4K-seal rounding
+  EXPECT_EQ(ejitDiagPermille(100, 100), uint64_t{1000});     // "100.0%"
 }
 
 TEST(EJitDiagnostics, PrintActiveNoCrash) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -648,6 +648,69 @@ TEST_F(SharedTaskPoolTest, PublishLookupAndReadTokenRelease) {
 }
 
 //===----------------------------------------------------------------------===//
+// forEachCompiled walk stats: visited Ready slots and skipped (write-lock
+// contended) buckets are reported, so a diagnostic dump is never silently
+// incomplete.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, ForEachCompiledReportsVisitedAndSkipped) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner, /*codeSharing=*/true);
+  EJitCoreId::setCurrentForTest(0);
+
+  // Two published entries: one 0-dim, one 1-dim.
+  publish(owner, 30);
+  owner.setInstanceEnabled(1, 4, true);
+  EJitDimPair d0[1] = {dim(1, 4)};
+  ASSERT_EQ(owner.compileOrGet(31, d0, 1, codeFor(31)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_TRUE(owner.pollOne());
+
+  auto isReady = [&](uint32_t b, uint32_t s) {
+    return state_->buckets[b].slots[s].state.loadAcquire() ==
+           static_cast<uint32_t>(EJitSharedSlotState::Ready);
+  };
+  uint32_t readyBefore = 0;
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
+    for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s)
+      readyBefore += isReady(b, s);
+  ASSERT_EQ(readyBefore, 2u);
+
+  struct Count {
+    uint32_t visited = 0;
+  };
+  auto cb = [](const EJitSharedCacheSlot &slot, void *ctx) {
+    ++static_cast<Count *>(ctx)->visited;
+    (void)slot;
+  };
+  Count count;
+  auto st = owner.forEachCompiled(cb, &count);
+  EXPECT_EQ(count.visited, 2u);
+  EXPECT_EQ(st.visitedSlots, 2u);
+  EXPECT_EQ(st.skippedBuckets, 0u);
+
+  // Hold bucket 0's writer flag: the walk's read-lock retries all fail, the
+  // bucket is skipped, and the callback only sees the other buckets.
+  state_->buckets[0].writeFlag.storeRelaxed(1);
+  uint32_t readyInB0 = 0;
+  for (uint32_t s = 0; s < kEJitSharedCacheSlots; ++s)
+    readyInB0 += isReady(0, s);
+
+  Count count2;
+  auto st2 = owner.forEachCompiled(cb, &count2);
+  EXPECT_EQ(st2.skippedBuckets, 1u);
+  EXPECT_EQ(st2.visitedSlots, 2u - readyInB0);
+  EXPECT_EQ(count2.visited, st2.visitedSlots);
+
+  state_->buckets[0].writeFlag.storeRelaxed(0);
+
+  // Every walk paired its bucketTryRead with bucketReadRelease: no read
+  // tokens are left held on any bucket (0 in both lock modes: the token
+  // build decrements back to 0, NO_RECLAIM never increments).
+  for (uint32_t b = 0; b < kEJitSharedCacheBuckets; ++b)
+    EXPECT_EQ(state_->buckets[b].readers.loadAcquire(), 0u) << "bucket " << b;
+}
+
+//===----------------------------------------------------------------------===//
 // 11/ Cross-core fnPtr sharing gate.
 //===----------------------------------------------------------------------===//
 TEST_F(SharedTaskPoolTest, CrossCoreFnPtrSharingGate) {


### PR DESCRIPTION
## Summary

诊断 dump 输出（串口 ring buffer + 人工读日志场景）做一轮整体打磨，4 个提交一条主线：**省字节、好检索、信息够定位**。

- **所有 dump 行统一走新增宏 `EJIT_DIAG_RAW`**（无 `[EJIT] func:line` 前缀，INFO 门控不变）：同一前缀在 dump 里逐行重复，每行白占 ~35 B ring buffer；grep 锚点改用各块自带的文字标签（`compiled:`、`code pool:`、`registry:`、`stats_t:`、`=== ... ===`）。正常路径日志仍用 `EJIT_DIAG`；hosted 与 SRE 分支行为一致。无前缀后 stats_t / code pool 两个不节流突发块从 ~700-900 B 缩到 ~350 B，单个 512 B ring 即可容纳。
- **compiled list 重排并补汇总**：汇总行（总数/槽位占用/跳桶数/按维度分布）**先打印**，节流条目行随后（两遍遍历）；`forEachCompiled` 返回 `{visitedSlots, skippedBuckets}` 并把整个槽位传给回调，锁竞争跳桶不再静默。
- **字段增强**：VERBOSE 条目行追加 `ver/size/pool/gen`；code pool 末行新增 `total/used/usage`；icache slots 带函数名与 `cells=16^numDims`；taskpool stats 补 9 个 shared 诊断字段；active 每 period 先打 `active=N`；func_meta 条目行 `op=` 用原始操作数下标；IR/ASM 长行 180 B 分块、非末块尾缀 `...`。
- **逐行节流校准**：消费者每 10 tick 排空一次（1 tick = 1 ms），选值 **20 tick/行 = 2 个排空周期**（第一个周期排空，第二个吸收消费者抖动与多核日志交错；实测 2 tick/行丢行、50 tick 过慢）。净效果：CMake 默认 20 保持不变，`ejit-minimal-aarch64_be` 预设 30 -> 20，排空周期注释/文档勘误 100 ms -> 10 ms。

## 逐项变更

| # | 区域 | 变更 |
|---|------|------|
| 1 | `EJitDiag.h` | 新增 `EJIT_DIAG_RAW`；`ejitDiagPermille()` 整数千分比（无 FPU、分母 0 得 0、只舍不入）；节流注释补选值依据 |
| 2 | compiled list | 汇总行先打；dims 只列实际 `numDims` 个对（无 `0:0` 填充）；VERBOSE 追加 `ver/size/pool/gen`；打印遍历跳桶时末尾补说明；DIAG 关闭或级别 < INFO 直接返回 |
| 3 | `forEachCompiled` | 回调改传 `const EJitSharedCacheSlot&`；返回 `{visitedSlots, skippedBuckets}` |
| 4 | code pool stats | 末行新增 `total/used/usage`（打印时派生，不加计数器、不动镜像结构） |
| 5 | icache slots | 经可选 loader 按 funcIndex 解析函数名（`<unknown>`/`?`，超 24 字符截断）；新增 `cells=16^numDims` |
| 6 | taskpool stats | shared 诊断 9 字段直读 `getDiagnostics()`，不改 C ABI |
| 7 | active cells | 每 period 先打 `period=<p> active=N`（0 时 `active=0`），再逐 cell 行 |
| 8 | func meta | 条目行 `op=<原始操作数下标> tag=<名> vals=<值>`，op= 与 `!ejit.metadata` 操作数位置一一对应 |
| 9 | IR/ASM dump | 长行按 180 B 分块，非末块尾缀 `...` |
| 10 | RAW 覆盖面 | registry / func_meta / active / code pool / stats_t / compiled / print_dumped / icache / `ejit_print_*` 守卫行全部无前缀；仅 RAW 使用的局部量补 `(void)` sink，DIAG-off 构建零警告 |
| 11 | 配置与文档 | 节流默认 20 不变、预设 30 -> 20；EJIT_DIAG.md 勘误并补依据 |

## 打印格式示例（与代码格式串逐一对应）

**compiled list（INFO）：**

```log
compiled: 3 entries (3/512 slots, 0 buckets skipped) byDims: 0d=1 1d=2
funcIdx=3 name=compute numDims=1 dims=[1:5] fn=0x7f8a0010
funcIdx=3 name=compute numDims=1 dims=[1:6] fn=0x7f8a0014
funcIdx=7 name=render numDims=0 dims=[] fn=0x7f8a0020
```

**VERBOSE 条目行（同行追加）与跳桶尾注（仅发生时）：**

```log
funcIdx=3 name=compute numDims=1 dims=[1:5] fn=0x7f8a0010 ver=[7] size=1280 pool=1 gen=1
compiled: 1 buckets skipped during entry walk
```

汇总行：`entries` = 计数遍历访问到的 Ready 槽数；`N/512` 槽位占用（512 = 默认 32 桶 × 16 槽，随 CMake 配置变化）；`buckets skipped` = **计数遍历**因写锁竞争跳过的桶；`byDims:` 按 0-4 维分布（只列非零档）。条目行逐行节流（20 tick/行 = 2 个排空周期）；汇总与尾注行数固定、不节流。

**code pool stats（末行为新增）：**

```log
code pool: pools=2 sealed=1 active=1
  bytes used=121856 reserved=4194304 wasted=4096
  sealInvocations=8 splitInvocations=0 finalizedRanges=2
  total=4194304 used=121856 usage=2.9%
```

**icache slots（自动附在 taskpool stats 之后） / active cells / IR 分块：**

```log
=== gIcacheSlots dump (4096 slots) ===
  [ 3] compute base=0x7f8a1234 numDims=1 cells=16 cell[0]=0x7f8a0010 (filled)
  [ 7] render base=0x7f8a5678 numDims=0 cells=1 cell[0]=0x0 (empty)
=== icache slots: 2 registered, 1 with cell[0] filled ===

active periods:
  period=cell active=2
  period=cell cell=5
  period=cell cell=9
active static vars: 3 (always active)

=== dump IR begin size=874 ===
dump IR:0: define i32 @compute(i32 %x) local_unnamed_addr #0 {
dump IR:1: define internal void @ejit_entry(...) ...some.aligned.args(...) ...
dump IR:1: ...rest.of.the.same.line
=== dump IR end lines=2 ===
```

**stats_t 尾部（shared 9 字段为新增，前 13 个计数器同前）：**

```log
  reserved         = 0
  initState=2 ownerCore=0 gen=1 lastInitErr=0 initAttempts=1 share=1
  workerTaskId=31 regFingerprint=595367882 execPrepFailed=0
```

## 已知限制

- dump 不是快照：compiled 两遍遍历、active 计数/逐 cell 两遍扫描之间的并发 publish/activate 可能使汇总与条目略有出入。
- NO_RECLAIM 构建下 `forEachCompiled` 读槽不做 hit 路径的 seqlock 快照，发布竞争可能撕打印字段（仅诊断路径）。
- `usage`：4K-seal 逐分配取整会轻微高估（>100.0% 即此症状）；fixed-region 模式 total 只计已 carved 池。

## Tests

- 新增 `SharedTaskPoolTest.ForEachCompiledReportsVisitedAndSkipped`、`EJitDiagnostics.DiagPermille`（分母 0、截断、>100%、100%）。
- 回归：EJITCodePoolTests 54/54、EJITTaskPoolTests 82/82；EJITSharedTaskPoolTests 5 个失败为存量（跨核共享/4K-seal，失败集未扩大）。
- diag-on（hosted 与 `EJIT_SRE_DIAG`）编译 0 错误；diag-off 构建零警告；改动文件 `-fsyntax-only -DEJIT_DIAG_ENABLE` 全量通过。

## Review checklist

- [ ] dump 行全部无前缀；正常路径日志仍带 `[EJIT] func:line`
- [ ] 示例输出与代码格式串一致
- [ ] 节流默认/预设均为 20 tick，CMake、EJitDiag.h、EJIT_DIAG.md 三处一致
- [ ] DIAG-off 构建 0 警告
- [ ] 汇总行（计数遍历）与尾注（打印遍历）的跳桶语义无歧义
- [ ] 新 gtest 通过；失败集未扩大

🤖 Generated with [Claude Code](https://claude.com/claude-code)
