### PR TITLE
[EJIT] Separate function and module dump views

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_EXECUTIONENGINE_EJIT_EJITORCENGINE_H
 #define LLVM_EXECUTIONENGINE_EJIT_EJITORCENGINE_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/Support/Error.h"
@@ -20,18 +21,29 @@
 #endif
 
 namespace llvm {
+class Module;
+
 namespace ejit {
 
 class PeriodArrayRegistry;
 class EJitRuntimeState;
 struct EJitSharedTaskPoolState;
 
+namespace detail {
+/// Render one function definition without the rest of its specialization
+/// module. Exposed for focused dump-path testing; callers should use the
+/// ejit_dump_* APIs.
+bool renderDumpFunctionIR(const Module &M, StringRef fnName, std::string &out);
+void renderDumpModuleIR(const Module &M, std::string &out);
+} // namespace detail
+
 /// Set a function-name filter for JIT IR+ASM diagnostic capture. When non-
 /// empty, the engine captures (saves in memory) the post-optimization IR and
-/// the emitted assembly of any specialization whose entry name matches, the
-/// next time it is compiled. "*" matches every specialization. Empty/null
-/// disables further capture (already-captured entries are retained). Captured
-/// entries are printed on demand via printDumped().
+/// emitted assembly for both the matching entry function and its complete
+/// specialization module, the next time it is compiled. "*" matches every
+/// specialization. Empty/null disables further capture (already-captured
+/// entries are retained). Use printDumped() for the entry-only view and
+/// printDumpedModule() for the complete module.
 void setDumpFuncFilter(const std::string &name);
 
 /// Bind the optional shared taskpool dump state. In a shared-taskpool build
@@ -44,7 +56,14 @@ void setDumpSharedState(EJitSharedTaskPoolState *state);
 /// null/empty) through EJIT_DIAG, one line per IR/ASM line. Names with no
 /// saved capture are reported as missing. Paired with setDumpFuncFilter():
 /// capture at compile time, print selectively later.
-void printDumped(const char *name);
+/// Returns true when a local payload was printed or matching remote-owner
+/// metadata was found.
+bool printDumped(const char *name);
+
+/// Print the complete specialization module captured for \p name (or every
+/// saved module when \p name is null/empty). Payloads are worker-local; unlike
+/// printDumped(), this function does not consult cross-core metadata.
+bool printDumpedModule(const char *name);
 
 struct SpecializationContext {
   std::string fnName;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -290,17 +290,24 @@ uint32_t ejit_taskpool_get_worker_core();
 
 /// Enable name-filtered JIT IR+ASM capture. When \p name is non-null and
 /// non-empty, the next time a specialization whose entry name exactly matches
-/// \p name is JIT-compiled, the engine saves (in memory) its post-optimization
-/// IR and emitted assembly for later printing. Pass NULL or "" to disable
-/// further capture (already-saved entries are retained). Capture is exact-name
-/// unless name is "*", which captures every specialization. Full payloads stay
-/// on the worker core and are never copied into shared taskpool memory.
+/// \p name is JIT-compiled, the engine saves (in memory) post-optimization IR
+/// and emitted assembly for both the entry function and its complete
+/// specialization module. Pass NULL or "" to disable further capture
+/// (already-saved entries are retained). Capture is exact-name unless name is
+/// "*", which captures every specialization. Full payloads stay on the worker
+/// core and are never copied into shared taskpool memory.
 void ejit_dump_func(const char *name);
 
 /// Print the saved worker-local IR+ASM for \p name through the platform log.
 /// Passing NULL or "" prints every entry saved on the calling core. A
 /// non-worker core reports which worker owns the latest matching capture.
 void ejit_print_dumped(const char *name);
+
+/// Print the complete specialization module captured for \p name, including
+/// all retained function definitions in that module. Passing NULL or ""
+/// prints every module saved on the calling core. This is worker-local and
+/// does not perform cross-core lookup.
+void ejit_print_dumped_module(const char *name);
 
 /// Enable or disable capture of every JIT-compiled specialization. Equivalent
 /// to ejit_dump_func("*") when enabled. Captures are keyed by function name in

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -111,7 +111,8 @@ struct EJitOrcEngine::Impl {
   /// TargetMachine used for the name-filtered ASM diagnostic dump (created
   /// once from the same JITTargetMachineBuilder the JIT compiles with, so the
   /// emitted assembly matches the real JIT output). Null if creation failed.
-  std::unique_ptr<TargetMachine> dumpTM;
+  std::unique_ptr<TargetMachine> dumpFunctionTM;
+  std::unique_ptr<TargetMachine> dumpModuleTM;
 };
 
 namespace llvm {
@@ -255,8 +256,10 @@ static bool getActiveDumpFilter(std::string &out) {
 /// Saved IR+ASM for a captured specialization (latest per function name).
 struct DumpEntry {
   uint64_t cacheKey = 0;
-  std::string IR;
-  std::string ASM;
+  std::string FunctionIR;
+  std::string FunctionASM;
+  std::string ModuleIR;
+  std::string ModuleASM;
 };
 
 // Process-wide store of captured IR+ASM, filled by the IR transform layer
@@ -402,19 +405,75 @@ static bool printSharedDumpHint(const char *name) {
 /// Called from the IR transform layer when the filter matches: save the
 /// post-optimization IR and emitted ASM for later selective printing.
 static void captureDump(const std::string &fnName, uint64_t cacheKey,
-                        std::string IR, std::string ASM) {
-  EJIT_DIAG_DEBUG("capture enter func=%s ir_size=%u asm_size=%u &store=%p",
-            fnName.c_str(), (unsigned)IR.size(), (unsigned)ASM.size(),
-            (void *)&gDumpStore);
+                        std::string FunctionIR, std::string FunctionASM,
+                        std::string ModuleIR, std::string ModuleASM) {
+  EJIT_DIAG_DEBUG(
+      "capture enter func=%s func_ir=%u func_asm=%u module_ir=%u "
+      "module_asm=%u &store=%p",
+      fnName.c_str(), (unsigned)FunctionIR.size(),
+      (unsigned)FunctionASM.size(), (unsigned)ModuleIR.size(),
+      (unsigned)ModuleASM.size(), (void *)&gDumpStore);
   std::lock_guard<DumpMutexType> lock(gDumpMutex);
   EJIT_DIAG_DEBUG("capture store_size before=%u", (unsigned)gDumpStore.size());
-  gDumpStore[fnName] = DumpEntry{cacheKey, std::move(IR), std::move(ASM)};
+  gDumpStore[fnName] =
+      DumpEntry{cacheKey, std::move(FunctionIR), std::move(FunctionASM),
+                std::move(ModuleIR), std::move(ModuleASM)};
   EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   // Publish only small metadata. Full text remains in the worker-local map.
   const DumpEntry &E = gDumpStore[fnName];
-  captureSharedDumpMetadata(fnName, cacheKey, E.IR.size(), E.ASM.size());
+  captureSharedDumpMetadata(fnName, cacheKey, E.FunctionIR.size(),
+                            E.FunctionASM.size());
 #endif
+}
+
+/// Render only the requested entry definition. A specialization module may
+/// contain the entry's entire transitive call closure; printing the Module here
+/// makes ejit_print_dumped("foo") indistinguishable from a dump-all operation.
+bool detail::renderDumpFunctionIR(const Module &M, StringRef fnName,
+                                  std::string &out) {
+  const Function *F = M.getFunction(fnName);
+  if (!F || F->isDeclaration())
+    return false;
+
+  raw_string_ostream OS(out);
+  F->print(OS);
+  OS << '\n';
+  OS.flush();
+  return true;
+}
+
+void detail::renderDumpModuleIR(const Module &M, std::string &out) {
+  raw_string_ostream OS(out);
+  M.print(OS, nullptr);
+  OS.flush();
+}
+
+/// Clone a diagnostic codegen module with only the requested function body.
+/// Other function definitions become declarations, preserving the target
+/// function's calls while avoiding a second codegen of its whole closure.
+/// Global definitions stay intact so addressing and constant-pool decisions
+/// match the real JIT module as closely as possible.
+static std::unique_ptr<Module>
+cloneDumpFunctionModule(const Module &M, StringRef fnName) {
+  ValueToValueMapTy VMap;
+  return CloneModule(M, VMap, [fnName](const GlobalValue *GV) {
+    const auto *F = dyn_cast<Function>(GV);
+    return !F || F->getName() == fnName;
+  });
+}
+
+static bool renderDumpAssembly(TargetMachine &TM, std::unique_ptr<Module> M,
+                               std::string &out) {
+  SmallVector<char, 0> AsmBuf;
+  raw_svector_ostream AOS(AsmBuf);
+  legacy::PassManager PM;
+  if (TM.addPassesToEmitFile(PM, AOS, /*DwoOut=*/nullptr,
+                             CodeGenFileType::AssemblyFile))
+    return false;
+  PM.run(*M);
+  out.assign(AsmBuf.begin(), AsmBuf.end());
+  return true;
 }
 
 /// Print one stored entry: header (name, key hi/lo, IR/ASM sizes) followed by
@@ -429,16 +488,35 @@ static void printOneDumpSafe(const char *requestedName,
   EJIT_DIAG_RAW("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
                 "key_lo=0x%08x ir_size=%u asm_size=%u",
                 requestedName ? requestedName : "(list)", storedName.c_str(),
-                keyHi, keyLo, (unsigned)e.IR.size(), (unsigned)e.ASM.size());
-  if (!e.IR.empty())
-    dumpLinesSafe("dump IR", e.IR);
-  if (!e.ASM.empty())
-    dumpLinesSafe("dump ASM", e.ASM);
+                keyHi, keyLo, (unsigned)e.FunctionIR.size(),
+                (unsigned)e.FunctionASM.size());
+  if (!e.FunctionIR.empty())
+    dumpLinesSafe("dump IR", e.FunctionIR);
+  if (!e.FunctionASM.empty())
+    dumpLinesSafe("dump ASM", e.FunctionASM);
+}
+
+static void printOneModuleDumpSafe(const char *requestedName,
+                                   const std::string &storedName,
+                                   const DumpEntry &e) {
+  uint32_t keyHi = (uint32_t)(e.cacheKey >> 32);
+  uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
+  (void)keyHi;
+  (void)keyLo;
+  EJIT_DIAG_RAW("print_dumped_module hit requested=%s stored=%s "
+                "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u",
+                requestedName ? requestedName : "(list)", storedName.c_str(),
+                keyHi, keyLo, (unsigned)e.ModuleIR.size(),
+                (unsigned)e.ModuleASM.size());
+  if (!e.ModuleIR.empty())
+    dumpLinesSafe("dump module IR", e.ModuleIR);
+  if (!e.ModuleASM.empty())
+    dumpLinesSafe("dump module ASM", e.ModuleASM);
 }
 
 /// Print saved IR+ASM through EJIT_DIAG, one line per IR/ASM line. A null/empty
 /// name prints all payloads available on this core.
-void printDumped(const char *name) {
+bool printDumped(const char *name) {
   EJIT_DIAG_DEBUG("print_dumped enter name=%s &filter=%p &store=%p",
                   (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
                   (void *)&gDumpStore);
@@ -451,7 +529,7 @@ void printDumped(const char *name) {
       auto it = gDumpStore.find(name);
       if (it != gDumpStore.end()) {
         printOneDumpSafe(name, it->first, it->second);
-        return;
+        return true;
       }
     } else if (!gDumpStore.empty()) {
       EJIT_DIAG_RAW("print_dumped saved entries=%u", (unsigned)gDumpStore.size());
@@ -459,20 +537,47 @@ void printDumped(const char *name) {
         printOneDumpSafe(nullptr, kv.first, kv.second);
         ejitDiagPrintThrottle();
       }
-      return;
+      return true;
     }
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   // A non-worker core cannot read the worker-private payload. Shared state
   // carries only enough metadata to direct the caller to the owning core.
   if (printSharedDumpHint(name))
-    return;
+    return true;
 #endif
   if (hasName)
     EJIT_DIAG_DEBUG("print_dumped miss name=%s store_size=%u", name,
                     (unsigned)gDumpStore.size());
   else
     EJIT_DIAG_RAW("print_dumped: nothing saved");
+  return false;
+}
+
+bool printDumpedModule(const char *name) {
+  bool hasName = name && name[0];
+  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  if (hasName) {
+    auto it = gDumpStore.find(name);
+    if (it != gDumpStore.end()) {
+      printOneModuleDumpSafe(name, it->first, it->second);
+      return true;
+    }
+    EJIT_DIAG_DEBUG("print_dumped_module miss name=%s store_size=%u", name,
+                    (unsigned)gDumpStore.size());
+    return false;
+  }
+  if (gDumpStore.empty()) {
+    EJIT_DIAG_RAW("print_dumped_module: nothing saved");
+    return false;
+  }
+  EJIT_DIAG_RAW("print_dumped_module saved entries=%u",
+                (unsigned)gDumpStore.size());
+  for (auto &kv : gDumpStore) {
+    printOneModuleDumpSafe(nullptr, kv.first, kv.second);
+    ejitDiagPrintThrottle();
+  }
+  return true;
 }
 
 } // namespace ejit
@@ -524,7 +629,11 @@ EJitOrcEngine::Create(const Config &config,
   // name-filtered ASM diagnostic dump. Failure is non-fatal — the dump is
   // simply unavailable.
   if (auto TMOrErr = JTMBOrErr->createTargetMachine())
-    engine->P->dumpTM = std::move(*TMOrErr);
+    engine->P->dumpFunctionTM = std::move(*TMOrErr);
+  else
+    consumeError(TMOrErr.takeError());
+  if (auto TMOrErr = JTMBOrErr->createTargetMachine())
+    engine->P->dumpModuleTM = std::move(*TMOrErr);
   else
     consumeError(TMOrErr.takeError());
 
@@ -689,13 +798,17 @@ EJitOrcEngine::Create(const Config &config,
                             (void *)&gDumpFuncFilter);
             if (match) {
               // IR capture always runs first so it succeeds even if the ASM
-              // diagnostic path is disabled or fails.
-              std::string IR;
-              raw_string_ostream IOS(IR);
-              M.print(IOS, nullptr);
-              IOS.flush();
+              // diagnostic path is disabled or fails. Capture only the entry
+              // definition: M also contains its full direct-call closure.
+              std::string FunctionIR;
+              if (!detail::renderDumpFunctionIR(M, ctx->fnName, FunctionIR))
+                EJIT_DIAG("dump capture: function not found fn=%s",
+                          ctx->fnName.c_str());
+              std::string ModuleIR;
+              detail::renderDumpModuleIR(M, ModuleIR);
 
-              std::string Asm;
+              std::string FunctionAsm;
+              std::string ModuleAsm;
               // Textual ASM emit goes through addPassesToEmitFile ->
               // addAsmPrinter -> createMCStreamer(AssemblyFile). Under
               // EJIT_TRIM_LLVM_BACKEND that path is compile-time removed and
@@ -712,38 +825,30 @@ EJitOrcEngine::Create(const Config &config,
               // path of the emit does not call errs(), so once the path is
               // compiled in it is SRE-safe.
 #if !defined(EJIT_TRIM_LLVM_BACKEND) || defined(EJIT_DUMP_ASM)
-              if (engine->P->dumpTM) {
+              if (engine->P->dumpFunctionTM && engine->P->dumpModuleTM) {
                 EJIT_DIAG_DEBUG("dump asm begin fn=%s", ctx->fnName.c_str());
-                SmallVector<char, 0> AsmBuf;
-                raw_svector_ostream AOS(AsmBuf);
-                legacy::PassManager PM;
-                if (!engine->P->dumpTM->addPassesToEmitFile(
-                        PM, AOS, /*DwoOut=*/nullptr,
-                        CodeGenFileType::AssemblyFile)) {
-                  EJIT_DIAG_DEBUG("dump asm PM.run begin fn=%s", ctx->fnName.c_str());
-                  // Clone M before running codegen so this diagnostic ASM emit
-                  // path cannot perturb the live module handed back to the JIT
-                  // for real compilation (codegen is IR-read-only in theory,
-                  // but target passes are not guaranteed to never touch IR).
-                  // The clone is local to this diagnostic path and discarded.
-                  std::unique_ptr<Module> MClone = CloneModule(M);
-                  PM.run(*MClone);
-                  EJIT_DIAG_DEBUG("dump asm PM.run end fn=%s", ctx->fnName.c_str());
-                  Asm.assign(AsmBuf.begin(), AsmBuf.end());
-                  EJIT_DIAG_DEBUG("dump asm size=%u fn=%s", (unsigned)Asm.size(),
-                            ctx->fnName.c_str());
-                } else {
+                bool FunctionOK = renderDumpAssembly(
+                    *engine->P->dumpFunctionTM,
+                    cloneDumpFunctionModule(M, ctx->fnName), FunctionAsm);
+                bool ModuleOK = renderDumpAssembly(
+                    *engine->P->dumpModuleTM, CloneModule(M), ModuleAsm);
+                if (!FunctionOK || !ModuleOK) {
                   EJIT_DIAG_DEBUG("dump asm addPassesToEmitFile failed fn=%s",
-                            ctx->fnName.c_str());
+                                  ctx->fnName.c_str());
                 }
+                EJIT_DIAG_DEBUG(
+                    "dump asm sizes function=%u module=%u fn=%s",
+                    (unsigned)FunctionAsm.size(), (unsigned)ModuleAsm.size(),
+                    ctx->fnName.c_str());
               }
 #else
               EJIT_DIAG_DEBUG("dump asm skipped (EJIT_TRIM_LLVM_BACKEND, "
                               "EJIT_DUMP_ASM off) fn=%s; IR captured",
                               ctx->fnName.c_str());
 #endif
-              captureDump(ctx->fnName, ctx->cacheKey, std::move(IR),
-                          std::move(Asm));
+              captureDump(ctx->fnName, ctx->cacheKey,
+                          std::move(FunctionIR), std::move(FunctionAsm),
+                          std::move(ModuleIR), std::move(ModuleAsm));
             }
           }
         });

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1518,7 +1518,13 @@ void ejit_dump_func(const char *name) {
 void ejit_print_dumped(const char *name) {
   // gDumpSharedState is bound once in ejit_init; no per-call rebind needed.
   EJIT_DIAG_RAW("print_dumped name=%s", (name && name[0]) ? name : "(all)");
-  printDumped(name);
+  (void)printDumped(name);
+}
+
+void ejit_print_dumped_module(const char *name) {
+  EJIT_DIAG_RAW("print_dumped_module name=%s",
+                (name && name[0]) ? name : "(all)");
+  (void)printDumpedModule(name);
 }
 
 void ejit_dump_all(bool enable) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
+#include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #ifdef EJIT_SRE_SHARED_TASKPOOL
@@ -30,6 +31,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h"
 #endif
 #include "llvm/AsmParser/Parser.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
@@ -37,6 +39,7 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 #ifndef EJIT_FREESTANDING
@@ -45,6 +48,80 @@
 
 using namespace llvm;
 using namespace llvm::ejit;
+
+TEST(EJitDump, FunctionAndModuleViewsHaveDifferentScopes) {
+  LLVMContext Ctx;
+  Module M("dump_selective", Ctx);
+  auto *I32 = Type::getInt32Ty(Ctx);
+  auto *FT = FunctionType::get(I32, {I32}, false);
+  auto *Helper = Function::Create(FT, Function::InternalLinkage,
+                                  "dump_helper", &M);
+  IRBuilder<> B(BasicBlock::Create(Ctx, "entry", Helper));
+  B.CreateRet(B.CreateAdd(Helper->getArg(0), B.getInt32(1)));
+
+  auto *Entry =
+      Function::Create(FT, Function::ExternalLinkage, "dump_entry", &M);
+  B.SetInsertPoint(BasicBlock::Create(Ctx, "entry", Entry));
+  B.CreateRet(B.CreateCall(Helper, {Entry->getArg(0)}));
+
+  std::string Output;
+  ASSERT_TRUE(
+      llvm::ejit::detail::renderDumpFunctionIR(M, "dump_entry", Output));
+  EXPECT_NE(Output.find("@dump_entry("), std::string::npos) << Output;
+  EXPECT_EQ(Output.find("define internal"), std::string::npos) << Output;
+  EXPECT_NE(Output.find("@dump_helper("), std::string::npos) << Output;
+
+  Output.clear();
+  llvm::ejit::detail::renderDumpModuleIR(M, Output);
+  EXPECT_NE(Output.find("define internal"), std::string::npos) << Output;
+  EXPECT_NE(Output.find("@dump_helper("), std::string::npos) << Output;
+}
+
+TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
+  std::string Bitcode;
+  {
+    LLVMContext Ctx;
+    Module M("dump_all_entries", Ctx);
+    auto *I32 = Type::getInt32Ty(Ctx);
+    auto *FT = FunctionType::get(I32, {I32}, false);
+    for (StringRef Name : {"dump_a", "dump_b", "dump_c"}) {
+      auto *F = Function::Create(FT, Function::ExternalLinkage, Name, &M);
+      IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
+      B.CreateRet(B.CreateAdd(F->getArg(0), B.getInt32(Name.back())));
+    }
+    raw_string_ostream OS(Bitcode);
+    WriteBitcodeToFile(M, OS);
+    OS.flush();
+  }
+
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  EJitRuntimeState State;
+  Config Cfg;
+  auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
+  ASSERT_TRUE(static_cast<bool>(EngineOrErr));
+  auto Engine = std::move(*EngineOrErr);
+
+  setDumpFuncFilter("*");
+  for (auto [Name, Key] :
+       {std::pair<const char *, uint64_t>{"dump_a", 0xda},
+        {"dump_b", 0xdb}, {"dump_c", 0xdc}}) {
+    SpecializationContext Ctx;
+    Ctx.fnName = Name;
+    Ctx.cacheKey = Key;
+    Engine->setActiveContext(&Ctx);
+    ASSERT_FALSE(errorToBool(Engine->loadBitcodeModule(Bitcode, Key, Name)));
+    auto FnOrErr = Engine->lookup(Key, Name);
+    ASSERT_TRUE(static_cast<bool>(FnOrErr));
+  }
+  Engine->setActiveContext(nullptr);
+  setDumpFuncFilter("");
+
+  for (const char *Name : {"dump_a", "dump_b", "dump_c"}) {
+    EXPECT_TRUE(printDumped(Name)) << Name;
+    EXPECT_TRUE(printDumpedModule(Name)) << Name;
+  }
+}
 
 namespace llvm {
 namespace ejit {


### PR DESCRIPTION
## Summary

- make `ejit_print_dumped(name)` print only the requested entry function instead of the whole specialization module
- add `ejit_print_dumped_module(name)` for explicitly printing the complete captured module
- retain both function-scoped and module-scoped IR/ASM payloads for enabled dump captures
- add an SRE core 8/core 18 board demo covering three independently compiled entries
- keep dump payloads worker-local; this PR does not add cross-core transport

## Motivation

The previous capture path stored the complete optimized module under each entry name. As a result, `ejit_print_dumped("FuncB")` was indistinguishable from a dump-all operation and made it difficult to inspect one independently compiled entry. Separating the two views preserves selective inspection while keeping the full-module view available through an explicit API.

## Impact

Normal JIT execution is unchanged. The additional module payload and diagnostic ASM generation are only active while `ejit_dump_func()` or `ejit_dump_all(true)` capture is enabled.

The lipo GC-root list retains the new public API so board images linked from `ejit.o` do not discard it.

## Board demo

Use `ejit_test/ejit_dump_sre_multicore_test.c` in the board test image and build EJIT with `EJIT_DUMP_ASM=ON`:

1. Run `test_ejit_period` on core 8 to start the owner worker and enable capture.
2. Run it on core 18 to compile `dump_demo_func_a/b/c`.
3. Run it again on core 8 to print all three function views and the complete module for `dump_demo_func_b`.

The function-B view references `dump_demo_helper` without defining it; the complete module view contains the helper definition/body.

## Validation

- dump-specific regression tests: 2/2 passed on the feature baseline
- EJitPgo regression suite excluding the pre-existing flaky full-cycle case: 13/13 passed
- current `ejit_dev_spec4`: runtime, ORC, and unit-test sources pass direct syntax compilation
- SRE multicore demo passes strict C11 syntax compilation
- `lipo.py` passes Python bytecode compilation