### PR TITLE
[EJIT] Use one-load representative inline cache

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -390,6 +390,7 @@ def doit_gc_merge(args):
         # reachable from this root + ejit_init's .ejit_period walk, no explicit
         # root needed.
         "ejit_register_icache_slot",
+        "ejit_icache_claim",
     ]
 
     defined = set()

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -45,7 +45,9 @@
 #ifndef EJIT_ICACHE_MAX_DIMS
 #define EJIT_ICACHE_MAX_DIMS 4u
 #endif
-
+#ifndef EJIT_ICACHE_REPRESENTATIVE_DIMS
+#define EJIT_ICACHE_REPRESENTATIVE_DIMS (EJIT_ICACHE_MAX_DIMS + 1u)
+#endif
 namespace llvm {
 namespace ejit {
 
@@ -96,6 +98,9 @@ constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 // ejit_icache_try call - so the hit path is one load + null-check + indirect
 // call. Signature: void ejit_register_icache_slot(const char *name, void *slot).
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
+// Miss-only admission for the representative inline-cache mode. Returns 1
+// when this identity owns the function's single specialization, 0 otherwise.
+constexpr const char *FN_ICACHE_CLAIM = "ejit_icache_claim";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -176,6 +176,10 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 void ejit_register_icache_slot(const char *funcName, void *slot,
                                uint32_t numDims);
 
+// Miss-only representative-version admission. The wrapper's hit path never
+// calls this function; it directly loads the cached function pointer.
+uint32_t ejit_icache_claim(uint32_t funcIndex, uint64_t identityKey);
+
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index
 // only; there is no array-pointer dimension in the active state (a period name
 // with multiple arrays is activated as a whole for that instance).

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -187,6 +187,9 @@ enum class EJitWorkerStep : uint32_t {
 #ifndef EJIT_ICACHE_MAX_DIMS
 #define EJIT_ICACHE_MAX_DIMS 4u
 #endif
+#ifndef EJIT_ICACHE_REPRESENTATIVE_DIMS
+#define EJIT_ICACHE_REPRESENTATIVE_DIMS (EJIT_ICACHE_MAX_DIMS + 1u)
+#endif
 
 /// Resolve token (see EJitSharedTaskPool::icacheBeginResolve): bit 32 marks a
 /// usable token, the low 32 bits carry the drain sequence it was taken at. A
@@ -226,6 +229,11 @@ enum class EJitIcacheRegResult { Ok, CapacityMiss, Invalid };
 
 EJitIcacheRegResult ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
                                            uint32_t numDims);
+
+/// Atomically admit the first identity for a representative inline-cache
+/// slot. Repeated claims by that identity succeed; every other identity is
+/// rejected. identityKey 0 is reserved for invalid input.
+bool ejitIcacheClaim(uint32_t funcIndex, uint64_t identityKey);
 
 /// Diagnostic: dump every registered icache slot to the diagnostic log.
 /// Shows funcIndex, base pointer, numDims, the per-slot cell capacity

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -504,11 +504,15 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
   case EJitIcacheRegResult::Invalid:
     EJitRegistrationStore::instance().recordError(
         EJIT_ERR_INVALID_PARAM,
-        "icache slot invalid: null base or numDims above the cap", funcName);
-    EJIT_DIAG("register_icache_slot FAIL name=%s: numDims=%u above the cap %u",
-              funcName, numDims, EJIT_ICACHE_MAX_DIMS);
+        "icache slot invalid: null base or unknown registration mode", funcName);
+    EJIT_DIAG("register_icache_slot FAIL name=%s: invalid mode/dims=%u",
+              funcName, numDims);
     break;
   }
+}
+
+uint32_t ejit_icache_claim(uint32_t funcIndex, uint64_t identityKey) {
+  return ejitIcacheClaim(funcIndex, identityKey) ? 1u : 0u;
 }
 
 ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -41,10 +41,8 @@ static_assert((EJIT_ICACHE_DIM_SIZE & (EJIT_ICACHE_DIM_SIZE - 1)) == 0,
               "EJIT_ICACHE_DIM_SIZE must be a power of 2 "
               "(the icache hit path uses shift-based indexing).");
 
-// The AOT wrapper emits [D]^numDims slot arrays up to EJIT_ICACHE_MAX_DIMS;
-// the shared cache identity stores dims up to kEJitSharedMaxDims. A drift
-// between the two would let the AOT emit 5+ dim wrappers whose identity the
-// runtime truncates — silently serving the wrong specialization.
+// Entry identities and the legacy multi-version table support the same number
+// of dimensions. Representative mode is registered with a separate sentinel.
 static_assert(EJIT_ICACHE_MAX_DIMS == llvm::ejit::kEJitSharedMaxDims,
               "EJIT_ICACHE_MAX_DIMS (AOT wrapper dim cap) must equal "
               "kEJitSharedMaxDims (shared cache identity cap).");
@@ -148,10 +146,10 @@ constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 /// cacheLookupNd block can also reference it.
 constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
-// Per-function inline-cache slot registry (multi-version direct-indexed). Each
-// entry records the wrapper's per-function @__ejit_icache_fn_<name> global base
-// (a uintptr_t cell, or a [D]^numDims array of them for a multi-version entry)
-// plus its dimensionality, registered by name at ejit_auto_register /
+// Per-function inline-cache slot registry. Legacy entries are multi-version
+// direct-indexed arrays; representative entries are {fnPtr, identityKey}
+// objects selected by EJIT_ICACHE_REPRESENTATIVE_DIMS. They are registered by
+// name at ejit_auto_register /
 // .ejit_period time via ejit_register_icache_slot (which calls
 // ejitIcacheRegisterSlot). The wrapper reads the cell directly (a GEP by the
 // ejit_dim arg values + one load + null-check + indirect call) with NO
@@ -194,8 +192,17 @@ inline EJitAtomicUPtr &icacheCell(uintptr_t *base, uintptr_t idx) {
   return reinterpret_cast<EJitAtomicUPtr *>(base)[idx];
 }
 
-// Cells in a [D]^numDims array. numDims is capped at registration.
+inline EJitAtomicU64 &icacheRepresentativeKey(uintptr_t *base) {
+  static_assert(sizeof(uintptr_t) == sizeof(uint64_t),
+                "representative inline cache requires a 64-bit target");
+  return reinterpret_cast<EJitAtomicU64 *>(base + 1)[0];
+}
+
+// Cells drained for one registration. A representative object has one pointer
+// cell; its adjacent admission key intentionally survives lifecycle drains.
 inline uintptr_t icacheCellCount(uint32_t numDims) {
+  if (numDims == EJIT_ICACHE_REPRESENTATIVE_DIMS)
+    return 1;
   uintptr_t n = 1;
   for (uint32_t i = 0; i < numDims; ++i)
     n *= EJIT_ICACHE_DIM_SIZE;
@@ -225,6 +232,22 @@ static uintptr_t icacheLinearize(const EJitDimPair *dims, uint32_t numDims) {
   return idx;
 }
 
+// Stable, non-zero identity used only on representative-cache misses/fills.
+// Instance ids are runtime-bounded to 8 bits; adding one reserves zero for an
+// invalid/unclaimed key. Four 0xff ids produce 0x100000000, which fits in i64.
+static uint64_t icacheRepresentativeIdentity(const EJitDimPair *dims,
+                                             uint32_t numDims) {
+  if (numDims > EJIT_ICACHE_MAX_DIMS || (numDims != 0 && !dims))
+    return 0;
+  uint64_t key = 0;
+  for (uint32_t i = 0; i < numDims; ++i) {
+    if (dims[i].instanceId >= 256u)
+      return 0;
+    key = (key << 8) | dims[i].instanceId;
+  }
+  return key + 1;
+}
+
 } // namespace
 
 EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex,
@@ -235,7 +258,7 @@ EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex,
   // numDims sizes the array the drain walks, so an out-of-cap value writes far
   // past the wrapper's global. The AOT pass never emits one, but numDims also
   // arrives from a uint64 registry field and the public C ABI -- don't trust it.
-  if (numDims > EJIT_ICACHE_MAX_DIMS)
+  if (numDims > EJIT_ICACHE_REPRESENTATIVE_DIMS)
     return EJitIcacheRegResult::Invalid;
   // Checked LAST so malformed data is still reported as malformed. Running out
   // of slots while the function registry holds 4096 is expected and degrades.
@@ -244,6 +267,19 @@ EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex,
   gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
   gIcacheSlots[funcIndex].numDims = numDims;
   return EJitIcacheRegResult::Ok;
+}
+
+bool llvm::ejit::ejitIcacheClaim(uint32_t funcIndex, uint64_t identityKey) {
+  if (identityKey == 0 || funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
+    return false;
+  EJitIcacheSlotReg &reg = gIcacheSlots[funcIndex];
+  if (!reg.base || reg.numDims != EJIT_ICACHE_REPRESENTATIVE_DIMS)
+    return false;
+  EJitAtomicU64 &key = icacheRepresentativeKey(reg.base);
+  uint64_t expected = 0;
+  if (key.compareExchange(expected, identityKey))
+    return true;
+  return expected == identityKey;
 }
 
 void llvm::ejit::ejitIcacheClearAll() {
@@ -341,7 +377,7 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
     const EJitIcacheSlotReg &reg = gIcacheSlots[f];
     if (!reg.base)
       continue;
-    if (reg.numDims > EJIT_ICACHE_MAX_DIMS)
+    if (reg.numDims > EJIT_ICACHE_REPRESENTATIVE_DIMS)
       continue; // defence in depth: never walk past a mis-sized array
     const uintptr_t cells = icacheCellCount(reg.numDims);
 #ifdef EJIT_DIAG_ENABLE
@@ -485,9 +521,12 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
   if (!state_ || funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
     return false;
   EJitIcacheSlotReg &reg = gIcacheSlots[funcIndex];
-  // Unregistered function, or shape mismatch (caller's numDims != registered):
-  // miss.
-  if (!reg.base || numDims != reg.numDims)
+  const bool representative =
+      reg.numDims == EJIT_ICACHE_REPRESENTATIVE_DIMS;
+  // A representative object accepts every legal caller shape; legacy tables
+  // retain exact shape matching.
+  if (!reg.base || (representative ? numDims > EJIT_ICACHE_MAX_DIMS
+                                   : numDims != reg.numDims))
     return false;
   // The cache is only meaningful once the pool is Ready.
   if (state_->initState.loadAcquire() != kReady)
@@ -504,13 +543,13 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
 #endif
   if (!mayReadPtr)
     return false;
-  if (!icacheDimsInRange(dims, numDims))
+  if (!representative && !icacheDimsInRange(dims, numDims))
     return false;
   // Read this identity's cell. Relaxed is enough, and is what the AOT probe
   // emits: the cell holds a self-contained pointer, the caller's indirect call
   // depends on the value loaded (data dependency), and the only cross-core
   // write is a drain storing 0 -- which yields a miss, never a bad pointer.
-  uintptr_t idx = icacheLinearize(dims, numDims);
+  uintptr_t idx = representative ? 0 : icacheLinearize(dims, numDims);
   uintptr_t p = icacheCell(reg.base, idx).loadRelaxed();
   if (p == 0)
     return false;
@@ -640,7 +679,10 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
     return;
   }
   EJitIcacheSlotReg &reg = gIcacheSlots[funcIndex];
-  if (!reg.base || numDims != reg.numDims) {
+  const bool representative =
+      reg.numDims == EJIT_ICACHE_REPRESENTATIVE_DIMS;
+  if (!reg.base || (representative ? numDims > EJIT_ICACHE_MAX_DIMS
+                                   : numDims != reg.numDims)) {
     // Unregistered, or shape mismatch: nowhere to write. A null base means this
     // core never ran ejit_register_icache_slot for this function -- the AOT
     // .ejit_period entry is missing, or the name did not resolve to funcIndex.
@@ -666,18 +708,19 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   // per-core preparation -- serves every call. The AOT side still emits the
   // probe for 0D entries; it is the fill, not the code, that is platform
   // dependent.
-  if (numDims == 0 && !icacheCrossCoreExecutable()) {
+  if ((numDims == 0 || representative) && !icacheCrossCoreExecutable()) {
     if (!gIcacheFillRejectLogged[kFillRejectScalarShared]) {
       gIcacheFillRejectLogged[kFillRejectScalarShared] = true;
-      EJIT_DIAG("icacheFill DECLINE func=%u: 0-dim entry shares one cell across "
-                "cores and this platform prepares execute permission per core, "
+      EJIT_DIAG("icacheFill DECLINE func=%u: scalar/representative entry "
+                "shares one cell across cores and this platform prepares "
+                "execute permission per core, "
                 "so a peer could branch to code it has not sealed",
                 funcIndex);
     }
     return;
   }
   // No cell for this identity. The taskpool serves it; never index anyway.
-  if (!icacheDimsInRange(dims, numDims)) {
+  if (!representative && !icacheDimsInRange(dims, numDims)) {
     if (!gIcacheFillRejectLogged[kFillRejectDimRange]) {
       gIcacheFillRejectLogged[kFillRejectDimRange] = true;
       EJIT_DIAG("icacheFill DECLINE func=%u: an instance id is >= the table's "
@@ -685,6 +728,18 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
                 funcIndex, EJIT_ICACHE_DIM_SIZE);
     }
     return;
+  }
+  if (representative) {
+    const uint64_t key = icacheRepresentativeIdentity(dims, numDims);
+    if (!ejitIcacheClaim(funcIndex, key)) {
+      if (!gIcacheFillRejectLogged[kFillRejectDimRange]) {
+        gIcacheFillRejectLogged[kFillRejectDimRange] = true;
+        EJIT_DIAG("icacheFill DECLINE func=%u: identity does not own the "
+                  "representative specialization",
+                  funcIndex);
+      }
+      return;
+    }
   }
   // Drop the fill if any drain overlapped this resolve: fnPtr may be specialized
   // for the period values the toggle just replaced, and restoring a cell the
@@ -717,9 +772,16 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   // non-null is guaranteed to see the flag set and therefore walk. Setting it
   // after the store would let a drain read 0, skip, and leave the cell behind.
   state_->icacheArmed.storeRelease(1);
-  const uintptr_t idx = icacheLinearize(dims, numDims);
+  const uintptr_t idx = representative ? 0 : icacheLinearize(dims, numDims);
   EJitAtomicUPtr &cell = icacheCell(reg.base, idx);
-  cell.storeRelaxed(reinterpret_cast<uintptr_t>(fnPtr));
+  const uintptr_t desired = reinterpret_cast<uintptr_t>(fnPtr);
+  if (representative) {
+    uintptr_t expected = 0;
+    if (!cell.compareExchange(expected, desired))
+      return; // Sticky first fill: never replace the representative version.
+  } else {
+    cell.storeRelaxed(desired);
+  }
 
   // Re-validate AFTER the store and retract on conflict. The checks above only
   // PRECEDE the store: a drain can begin after they pass, zero this cell, and
@@ -730,7 +792,12 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   // fill (disjointness), and a null cell is always safe.
   if (state_->icacheDrainsInFlight.loadAcquire() != 0 ||
       static_cast<uint32_t>(token) != state_->icacheDrainSeq.loadAcquire()) {
-    cell.storeRelaxed(0);
+    if (representative) {
+      uintptr_t expected = desired;
+      (void)cell.compareExchange(expected, 0);
+    } else {
+      cell.storeRelaxed(0);
+    }
     if (!gIcacheFillRejectLogged[kFillRejectRetracted]) {
       gIcacheFillRejectLogged[kFillRejectRetracted] = true;
       EJIT_DIAG("icacheFill RETRACT func=%u: a drain began after the fill was "

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -271,139 +271,28 @@ static GlobalVariable *getOrCreateFuncIndexGlobal(Module &M,
       ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), GVName);
 }
 
-// A per-function inline-cache global plus its dimensionality (number of
-// ejit_dim params). The runtime needs NumDims to linearize the [D]^NumDims
-// array on fill, and the hit-path emitter needs it to build the GEP.
+// A per-function representative inline-cache object.
 struct IcacheSlotInfo {
   GlobalVariable *GV = nullptr;
-  GlobalVariable *VersionGV = nullptr;
-  unsigned NumDims = 0;
 };
 
-// A period whose bound this module cannot prove. Larger than any legal
-// EJIT_ICACHE_DIM_SIZE, so dimsProvablyInRange() declines on it without needing
-// a second lookup structure.
-static constexpr uint32_t kUnprovablePeriodArraySize = ~0u;
-
-// Map periodName -> the largest declared ejit_period_arr element count, from
-// this module's globals. Used to decide whether an entry's dim arguments can be
-// trusted to index the cell table.
-//
-// The MAXIMUM matters, and taking the last one visited is a bug: the runtime
-// permits SEVERAL arrays under one period and activates them as a group, so a
-// lifecycle's valid identities run up to the largest sibling. Recording an 8
-// because it happened to be declared after a 32 would let dimsProvablyInRange()
-// approve a 16-cell probe for a period that legally produces identity 31, and
-// the wrapper would form an inbounds GEP past its own table -- into whatever
-// shares the section -- before the slow-path range check is ever reachable.
-// Aggregating the max makes the answer independent of module order.
-static std::map<std::string, uint32_t> collectPeriodArraySizes(const Module &M) {
-  std::map<std::string, uint32_t> Sizes;
-  for (const GlobalVariable &GV : M.globals()) {
-    const MDNode *MD = GV.getMetadata(MD_EJIT_METADATA);
-    if (!MD || !hasMDStringEntry(MD, TAG_EJIT_PERIOD_ARR))
-      continue;
-    StringRef PeriodName = getMDStringValue(MD, TAG_EJIT_PERIOD_ARR);
-    if (PeriodName.empty())
-      continue;
-    // A count of 0 is "this global does not state one". That is an unknown
-    // bound, not a small one, so it must survive being maxed against a sibling
-    // that does state one -- otherwise the order of the two decides the answer
-    // again, which is the bug being fixed.
-    const uint32_t Declared = getMDIntValue(MD, TAG_EJIT_PERIOD_ARR);
-    const uint32_t Effective = Declared ? Declared : kUnprovablePeriodArraySize;
-    auto It = Sizes.find(PeriodName.str());
-    if (It == Sizes.end())
-      Sizes.emplace(PeriodName.str(), Effective);
-    else
-      It->second = std::max(It->second, Effective);
-  }
-  return Sizes;
-}
-
-// Whether every ejit_dim argument of \p F provably lands inside the
-// [D]^numDims cell table.
-//
-// The accepted ranges do not agree: the taskpool takes instance ids up to
-// MAX_INSTANCES (256) and a period array may declare MAX_PERIOD_ARR_SIZE (100)
-// entries, against a D of 16. The probe indexes with the raw argument and has
-// no room to check, so an id of 16 would read past the wrapper's global into
-// its neighbour in the shared section and branch there.
-//
-// Rather than spend hit-path instructions, the probe is not emitted unless the
-// bound is provable: the function is still wrapped and the taskpool serves it,
-// the same degradation as running out of slots. An array declared in another
-// TU is not provable here and so also declines.
-static bool dimsProvablyInRange(const Function &F,
-                                const std::map<std::string, uint32_t> &Sizes) {
-  for (const PeriodArrIndInfo &Info : getPeriodArrIndInfo(F)) {
-    auto It = Sizes.find(Info.PeriodName);
-    if (It == Sizes.end())
-      return false; // size not visible in this module
-    // A count of 0 never reaches here: collectPeriodArraySizes() maps
-    // "not stated" to kUnprovablePeriodArraySize, which fails this same test.
-    if (It->second > EJIT_ICACHE_DIM_SIZE)
-      return false;
-  }
-  return true;
-}
-
-// Per-function pointer-typed global holding the inline-cache cell table: the
-// specialization pointer for each dim identity once resolved, null until then
-// and null again after a period toggle drains it. Internal linkage (each
-// module's copy is wired into the runtime slot-pointer table by name at
-// registration). 8-byte aligned so each cell is one naturally-aligned,
-// tear-free access: a drain on another core zeroing a cell under a reading
-// probe yields the old pointer or 0, never a torn value.
-//
-// Placed in EJitIcacheSection when set - SHARED across cores, partitioned by
-// dim identity so writers never collide.
-//
-// The pointer table keeps its [D]^NumDims runtime ABI, but the wrapper admits
-// only one identity and therefore only one cell can ever become non-null. Every
-// identity reads that representative cell once it has been filled.
-// NumDims=0 is a scalar ptr (one cell).
+// One shared representative cache object per function. Field 0 is deliberately
+// first and pointer-aligned: the hot wrapper reads it directly, matching the v2
+// one-load probe. Field 1 is the miss-only identity claim key used by the
+// runtime. Drains clear only field 0, preserving the admitted identity.
 static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
-                                                 StringRef FuncName,
-                                                 unsigned NumDims) {
+                                                 StringRef FuncName) {
   std::string GVName = ("__ejit_icache_fn_" + FuncName).str();
   if (auto *Existing = M.getGlobalVariable(GVName))
     return Existing;
   LLVMContext &Ctx = M.getContext();
   auto *PtrTy = PointerType::getUnqual(Ctx);
-  // Build [D]^NumDims (row-major); scalar ptr for NumDims==0.
-  Type *SlotTy = PtrTy;
-  const uint64_t D = EJIT_ICACHE_DIM_SIZE;
-  for (unsigned I = 0; I < NumDims; ++I)
-    SlotTy = ArrayType::get(SlotTy, D);
-  Constant *Init = nullptr;
-  if (NumDims == 0)
-    Init = ConstantPointerNull::get(PtrTy);
-  else
-    Init = ConstantAggregateZero::get(SlotTy);
-  auto *GV = new GlobalVariable(M, SlotTy, /*isConstant=*/false,
-                                GlobalValue::InternalLinkage, Init, GVName);
-  GV->setAlignment(Align(8));
-  if (!EJitIcacheSection.empty())
-    GV->setSection(EJitIcacheSection);
-  return GV;
-}
-
-// The inline cache deliberately admits one dimension identity per function.
-// Zero means unclaimed; the stored value is the row-major slot index plus one.
-// It lives beside the pointer table in shared memory so all cores agree on the
-// admitted identity. Lifecycle drains clear the pointer, but not this key, so
-// the same identity rebuilds the representative version after invalidation.
-static GlobalVariable *getOrCreateIcacheVersionGlobal(Module &M,
-                                                       StringRef FuncName) {
-  std::string GVName = ("__ejit_icache_version_" + FuncName).str();
-  if (auto *Existing = M.getGlobalVariable(GVName))
-    return Existing;
-  auto *I32Ty = Type::getInt32Ty(M.getContext());
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+  StructType *SlotTy = StructType::get(Ctx, {PtrTy, I64Ty});
   auto *GV = new GlobalVariable(
-      M, I32Ty, /*isConstant=*/false, GlobalValue::InternalLinkage,
-      ConstantInt::get(I32Ty, 0), GVName);
-  GV->setAlignment(Align(4));
+      M, SlotTy, /*isConstant=*/false, GlobalValue::InternalLinkage,
+      ConstantAggregateZero::get(SlotTy), GVName);
+  GV->setAlignment(Align(8));
   if (!EJitIcacheSection.empty())
     GV->setSection(EJitIcacheSection);
   return GV;
@@ -524,8 +413,9 @@ emitIcacheSlotRegistration(Module &M,
   for (auto &KV : Fns) {
     IRBuilder<> Builder(Ret);
     Value *Name = Builder.CreateGlobalString(KV.first);
-    Builder.CreateCall(FnReg, {Name, Builder.CreateBitCast(KV.second.GV, PtrTy),
-                               ConstantInt::get(I32Ty, KV.second.NumDims)});
+    Builder.CreateCall(
+        FnReg, {Name, Builder.CreateBitCast(KV.second.GV, PtrTy),
+                ConstantInt::get(I32Ty, EJIT_ICACHE_REPRESENTATIVE_DIMS)});
   }
 
   if (EnableEJitGlobalCtors && CreatedAutoReg)
@@ -549,7 +439,8 @@ emitIcacheSlotRegistration(Module &M,
         EntryTy, {ConstantInt::get(I32Ty, EJIT_REG_ICACHE_SLOT),
                   makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
                   ConstantExpr::getBitCast(KV.second.GV, PtrTy),
-                  ConstantInt::get(I64Ty, KV.second.NumDims)}));
+                  ConstantInt::get(I64Ty,
+                                   EJIT_ICACHE_REPRESENTATIVE_DIMS)}));
   }
   if (Entries.empty())
     return;
@@ -676,20 +567,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
   // callable on any core.
   std::map<std::string, IcacheSlotInfo> IcacheFnGlobals;
   if (EJitInlineCache) {
-    const std::map<std::string, uint32_t> PeriodArraySizes =
-        collectPeriodArraySizes(M);
     for (Function *F : EntryFuncs) {
       unsigned NumDims = getPeriodArrIndInfo(*F).size();
-      // Skip functions whose dim arguments could index outside the table. The
-      // probe cannot bounds-check without giving up its shape, so it is not
-      // emitted at all; the taskpool serves the function instead.
-      if (!dimsProvablyInRange(*F, PeriodArraySizes)) {
-        LLVM_DEBUG(dbgs() << "ejit-wrapper-gen: no inline cache for "
-                          << F->getName()
-                          << ": dim range not provably < " << EJIT_ICACHE_DIM_SIZE
-                          << "\n");
-        continue;
-      }
       // Skip functions exceeding the cache dimensionality cap from the icache
       // map. They are still wrapped (taskpool path) but without an icache probe;
       // the per-function DimCount > EJIT_ICACHE_MAX_DIMS check below emits the
@@ -697,9 +576,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       if (NumDims > EJIT_ICACHE_MAX_DIMS)
         continue;
       IcacheSlotInfo Info;
-      Info.GV = getOrCreateIcacheFnGlobal(M, F->getName(), NumDims);
-      Info.VersionGV = getOrCreateIcacheVersionGlobal(M, F->getName());
-      Info.NumDims = NumDims;
+      Info.GV = getOrCreateIcacheFnGlobal(M, F->getName());
       IcacheFnGlobals.emplace(F->getName().str(), Info);
     }
     emitIcacheSlotRegistration(M, IcacheFnGlobals);
@@ -792,27 +669,33 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     bool EmitIcacheProbe =
         EJitInlineCache && IcacheIt != IcacheFnGlobals.end();
 
+    auto *I64Ty = Type::getInt64Ty(Ctx);
     auto emitIcacheVersion = [&](IRBuilder<> &B, Function &Fn) -> Value * {
-      Value *Version = ConstantInt::get(I32Ty, 0);
+      Value *Version = ConstantInt::get(I64Ty, 0);
+      Value *Valid = ConstantInt::getTrue(Ctx);
       for (unsigned I = 0; I < DimCount; ++I) {
         Value *ArgVal = Fn.getArg(PeriodInds[I].ArgIndex);
         unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
         Value *Idx = ArgVal;
-        if (BW > 32)
-          Idx = B.CreateTrunc(ArgVal, I32Ty);
-        else if (BW < 32)
-          Idx = B.CreateZExt(ArgVal, I32Ty);
-        Version = B.CreateAdd(
-            B.CreateMul(Version, ConstantInt::get(I32Ty,
-                                                   EJIT_ICACHE_DIM_SIZE)),
-            Idx, "ejit_icache_linear");
+        if (BW > 64)
+          Idx = B.CreateTrunc(ArgVal, I64Ty);
+        else if (BW < 64)
+          Idx = B.CreateZExt(ArgVal, I64Ty);
+        Valid = B.CreateAnd(
+            Valid,
+            B.CreateICmpULT(Idx, ConstantInt::get(I64Ty, 256)),
+            "ejit_icache_identity_valid");
+        Version = B.CreateOr(
+            B.CreateShl(Version, ConstantInt::get(I64Ty, 8)), Idx,
+            "ejit_icache_identity");
       }
-      return B.CreateAdd(Version, ConstantInt::get(I32Ty, 1),
-                         "ejit_icache_version");
+      Version = B.CreateAdd(Version, ConstantInt::get(I64Ty, 1),
+                            "ejit_icache_version");
+      return B.CreateSelect(Valid, Version, ConstantInt::get(I64Ty, 0),
+                            "ejit_icache_claim_key");
     };
 
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
-    auto *I64Ty = Type::getInt64Ty(Ctx);
     bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
 
     // Timing callees (shared by hit and slow paths).
@@ -847,28 +730,24 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       Value *OutFnArg = B.CreatePointerCast(OutFnAlloca, PtrTy);
       Value *OutBucketArg = B.CreatePointerCast(OutBucketAlloca, PtrTy);
 
-      if (EmitIcacheProbe) {
-        Value *Version = emitIcacheVersion(B, Fn);
-        AtomicCmpXchgInst *Claim = B.CreateAtomicCmpXchg(
-            IcacheIt->second.VersionGV, ConstantInt::get(I32Ty, 0), Version,
-            Align(4), AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
-        Claim->setWeak(false);
-        Value *OldVersion = B.CreateExtractValue(Claim, 0);
-        Value *Claimed = B.CreateExtractValue(Claim, 1);
-        Value *SameVersion = B.CreateICmpEQ(OldVersion, Version);
-        Value *VersionAccepted = B.CreateOr(Claimed, SameVersion,
-                                            "ejit_icache_version_ok");
-        BasicBlock *VersionOKBB = BasicBlock::Create(
-            Ctx, "miss_version_ok", &Fn, CallBB);
-        B.CreateCondBr(VersionAccepted, VersionOKBB, FallbackBB);
-        B.SetInsertPoint(VersionOKBB);
-      }
-
       Value *FuncIdx = B.CreateLoad(
           I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
       Value *IdxValid = B.CreateICmpNE(
           FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
-      B.CreateCondBr(IdxValid, CallBB, FallbackBB);
+      if (EmitIcacheProbe) {
+        FunctionCallee ClaimFn = M.getOrInsertFunction(
+            FN_ICACHE_CLAIM,
+            FunctionType::get(I32Ty, {I32Ty, I64Ty}, false));
+        Value *Version = emitIcacheVersion(B, Fn);
+        Value *Claimed = B.CreateCall(ClaimFn, {FuncIdx, Version},
+                                      "ejit_icache_claimed");
+        Value *VersionAccepted = B.CreateICmpNE(
+            Claimed, ConstantInt::get(I32Ty, 0), "ejit_icache_version_ok");
+        B.CreateCondBr(B.CreateAnd(IdxValid, VersionAccepted), CallBB,
+                       FallbackBB);
+      } else {
+        B.CreateCondBr(IdxValid, CallBB, FallbackBB);
+      }
 
       B.SetInsertPoint(CallBB);
       auto emitDimTypeVal = [&](unsigned I) {
@@ -1029,7 +908,6 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
-      auto *JitIcacheProbe = BasicBlock::Create(Ctx, "jit_icache_probe", F);
       auto *JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
       auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
       IRBuilder<> B(JitEntry);
@@ -1041,26 +919,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
                                         "ejit_funcidx_t");
       }
       GlobalVariable *IcacheSlot = IcacheIt->second.GV;
-      GlobalVariable *IcacheVersion = IcacheIt->second.VersionGV;
-      unsigned NumDims = IcacheIt->second.NumDims;
-      LoadInst *StoredVersion =
-          B.CreateLoad(I32Ty, IcacheVersion, "ejit_icache_stored_version");
-      StoredVersion->setAlignment(Align(4));
-      StoredVersion->setAtomic(AtomicOrdering::Monotonic);
-      Value *HasVersion = B.CreateICmpNE(
-          StoredVersion, ConstantInt::get(I32Ty, 0), "ejit_icache_has_version");
-      HasVersion = B.CreateIntrinsic(Intrinsic::expect, {HasVersion->getType()},
-                                     {HasVersion, ConstantInt::getTrue(Ctx)});
-      B.CreateCondBr(HasVersion, JitIcacheProbe, JitMiss);
-
-      B.SetInsertPoint(JitIcacheProbe);
-      Value *SlotPtr = IcacheSlot;
-      if (NumDims > 0) {
-        Value *SlotIndex = B.CreateSub(
-            StoredVersion, ConstantInt::get(I32Ty, 1), "ejit_icache_slot_index");
-        SlotPtr = B.CreateInBoundsGEP(PtrTy, IcacheSlot, SlotIndex,
-                                      "ejit_ic_slot");
-      }
+      Value *SlotPtr = B.CreateStructGEP(IcacheSlot->getValueType(), IcacheSlot,
+                                         0, "ejit_ic_slot");
       LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
       ICSlotLoad->setAlignment(Align(8));
       // Monotonic, nothing stronger: the cell is shared, so a peer's drain can

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -69,9 +69,10 @@ static cl::opt<bool> EJitWrapperTiming(
 
 // Emit a per-function inline-cache probe DIRECTLY in the ejit_entry wrapper
 // (not a call). On a hit the wrapper loads its cell out of the per-function
-// @__ejit_icache_fn_<name> table (one load), null-checks it, and tail-calls the
-// cached specialization - NO ejit_icache_try call, NO read-token, NO per-call
-// guards, NO funcIndex/IdxValid on the hit path. Just "pointer non-null? jump".
+// @__ejit_icache_fn_<name> table, verifies that the call matches the one
+// admitted dimension identity, null-checks the cell, and tail-calls the cached
+// specialization. A different identity tail-calls the AOT fallback without
+// entering the taskpool.
 // On a miss it falls through to jit_slow -> ejit_taskpool_compile_or_get, which
 // fills the cell on success (icacheFill). The probe carries NO freshness check:
 // the table is SHARED across cores (EJitIcacheSection), so an activate or
@@ -276,6 +277,7 @@ static GlobalVariable *getOrCreateFuncIndexGlobal(Module &M,
 // array on fill, and the hit-path emitter needs it to build the GEP.
 struct IcacheSlotInfo {
   GlobalVariable *GV = nullptr;
+  GlobalVariable *VersionGV = nullptr;
   unsigned NumDims = 0;
 };
 
@@ -358,9 +360,9 @@ static bool dimsProvablyInRange(const Function &F,
 // Placed in EJitIcacheSection when set - SHARED across cores, partitioned by
 // dim identity so writers never collide.
 //
-// Multi-version: the global is a [D]^NumDims array (D = EJIT_ICACHE_DIM_SIZE,
-// power-of-2) indexed by the ejit_dim argument values, so each dim identity
-// gets its own cell. NumDims=0 is a scalar ptr (one cell).
+// The pointer table keeps its [D]^NumDims runtime ABI, but the wrapper admits
+// only one identity and therefore only one cell can ever become non-null.
+// NumDims=0 is a scalar ptr (one cell).
 static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
                                                  StringRef FuncName,
                                                  unsigned NumDims) {
@@ -382,6 +384,26 @@ static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
   auto *GV = new GlobalVariable(M, SlotTy, /*isConstant=*/false,
                                 GlobalValue::InternalLinkage, Init, GVName);
   GV->setAlignment(Align(8));
+  if (!EJitIcacheSection.empty())
+    GV->setSection(EJitIcacheSection);
+  return GV;
+}
+
+// The inline cache deliberately admits one dimension identity per function.
+// Zero means unclaimed; the stored value is the row-major slot index plus one.
+// It lives beside the pointer table in shared memory so all cores agree on the
+// admitted identity. Lifecycle drains clear the pointer, but not this key, so
+// the same identity may be rebuilt while every other identity stays on AOT.
+static GlobalVariable *getOrCreateIcacheVersionGlobal(Module &M,
+                                                       StringRef FuncName) {
+  std::string GVName = ("__ejit_icache_version_" + FuncName).str();
+  if (auto *Existing = M.getGlobalVariable(GVName))
+    return Existing;
+  auto *I32Ty = Type::getInt32Ty(M.getContext());
+  auto *GV = new GlobalVariable(
+      M, I32Ty, /*isConstant=*/false, GlobalValue::InternalLinkage,
+      ConstantInt::get(I32Ty, 0), GVName);
+  GV->setAlignment(Align(4));
   if (!EJitIcacheSection.empty())
     GV->setSection(EJitIcacheSection);
   return GV;
@@ -646,11 +668,12 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
   // Per-function inline-cache slot globals (@__ejit_icache_fn_<name>), created
   // and registered only when -ejit-inline-cache is on. The wrapper reads its
-  // slot directly (one atomic load + null-check + indirect call) on the hit
-  // path; the runtime writes the frozen specialization pointer through it on
-  // resolve. Requires the runtime to be built with EJIT_SRE_SHARED_CODE_POINTERS
-  // (production preset) - the inline probe has no per-call cross-core gate, so
-  // it is only safe when a cached pointer is callable on any core.
+  // slot and monomorphic version key directly on the hit path; the runtime
+  // writes the frozen specialization pointer through the existing slot ABI on
+  // resolve. Requires the runtime to be built with
+  // EJIT_SRE_SHARED_CODE_POINTERS (production preset) - the inline probe has no
+  // per-call cross-core gate, so it is only safe when a cached pointer is
+  // callable on any core.
   std::map<std::string, IcacheSlotInfo> IcacheFnGlobals;
   if (EJitInlineCache) {
     const std::map<std::string, uint32_t> PeriodArraySizes =
@@ -675,6 +698,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         continue;
       IcacheSlotInfo Info;
       Info.GV = getOrCreateIcacheFnGlobal(M, F->getName(), NumDims);
+      Info.VersionGV = getOrCreateIcacheVersionGlobal(M, F->getName());
       Info.NumDims = NumDims;
       IcacheFnGlobals.emplace(F->getName().str(), Info);
     }
@@ -768,6 +792,25 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     bool EmitIcacheProbe =
         EJitInlineCache && IcacheIt != IcacheFnGlobals.end();
 
+    auto emitIcacheVersion = [&](IRBuilder<> &B, Function &Fn) -> Value * {
+      Value *Version = ConstantInt::get(I32Ty, 0);
+      for (unsigned I = 0; I < DimCount; ++I) {
+        Value *ArgVal = Fn.getArg(PeriodInds[I].ArgIndex);
+        unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
+        Value *Idx = ArgVal;
+        if (BW > 32)
+          Idx = B.CreateTrunc(ArgVal, I32Ty);
+        else if (BW < 32)
+          Idx = B.CreateZExt(ArgVal, I32Ty);
+        Version = B.CreateAdd(
+            B.CreateMul(Version, ConstantInt::get(I32Ty,
+                                                   EJIT_ICACHE_DIM_SIZE)),
+            Idx, "ejit_icache_linear");
+      }
+      return B.CreateAdd(Version, ConstantInt::get(I32Ty, 1),
+                         "ejit_icache_version");
+    };
+
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
     auto *I64Ty = Type::getInt64Ty(Ctx);
     bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
@@ -803,6 +846,24 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       Value *OutBucketAlloca = B.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
       Value *OutFnArg = B.CreatePointerCast(OutFnAlloca, PtrTy);
       Value *OutBucketArg = B.CreatePointerCast(OutBucketAlloca, PtrTy);
+
+      if (EmitIcacheProbe) {
+        Value *Version = emitIcacheVersion(B, Fn);
+        AtomicCmpXchgInst *Claim = B.CreateAtomicCmpXchg(
+            IcacheIt->second.VersionGV, ConstantInt::get(I32Ty, 0), Version,
+            Align(4), AtomicOrdering::Monotonic, AtomicOrdering::Monotonic);
+        Claim->setWeak(false);
+        Value *OldVersion = B.CreateExtractValue(Claim, 0);
+        Value *Claimed = B.CreateExtractValue(Claim, 1);
+        Value *SameVersion = B.CreateICmpEQ(OldVersion, Version);
+        Value *VersionAccepted = B.CreateOr(Claimed, SameVersion,
+                                            "ejit_icache_version_ok");
+        BasicBlock *VersionOKBB = BasicBlock::Create(
+            Ctx, "miss_version_ok", &Fn, CallBB);
+        B.CreateCondBr(VersionAccepted, VersionOKBB, FallbackBB);
+        B.SetInsertPoint(VersionOKBB);
+      }
+
       Value *FuncIdx = B.CreateLoad(
           I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
       Value *IdxValid = B.CreateICmpNE(
@@ -979,6 +1040,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
                                         "ejit_funcidx_t");
       }
       GlobalVariable *IcacheSlot = IcacheIt->second.GV;
+      GlobalVariable *IcacheVersion = IcacheIt->second.VersionGV;
       unsigned NumDims = IcacheIt->second.NumDims;
       Value *SlotPtr = IcacheSlot;
       if (NumDims > 0) {
@@ -1003,10 +1065,19 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       // below carries a data dependency on it, so acquire would buy nothing and
       // cost an LDAR per hit. Lowers to the same LDR on AArch64.
       ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
+      Value *CurrentVersion = emitIcacheVersion(B, *F);
+      LoadInst *StoredVersion =
+          B.CreateLoad(I32Ty, IcacheVersion, "ejit_icache_stored_version");
+      StoredVersion->setAlignment(Align(4));
+      StoredVersion->setAtomic(AtomicOrdering::Monotonic);
       Value *TAfterIcache = nullptr;
       if (EJitWrapperTiming)
         TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
-      Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
+      Value *VersionMatches =
+          B.CreateICmpEQ(StoredVersion, CurrentVersion,
+                         "ejit_icache_version_match");
+      Value *IHit = B.CreateAnd(VersionMatches, B.CreateIsNotNull(ICSlotLoad),
+                                "ejit_icache_hit");
       IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
                                {IHit, ConstantInt::getTrue(Ctx)});
       B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -69,10 +69,9 @@ static cl::opt<bool> EJitWrapperTiming(
 
 // Emit a per-function inline-cache probe DIRECTLY in the ejit_entry wrapper
 // (not a call). On a hit the wrapper loads its cell out of the per-function
-// @__ejit_icache_fn_<name> table, verifies that the call matches the one
-// admitted dimension identity, null-checks the cell, and tail-calls the cached
-// specialization. A different identity tail-calls the AOT fallback without
-// entering the taskpool.
+// @__ejit_icache_fn_<name> table using the first admitted dimension identity,
+// null-checks that cell, and tail-calls the cached specialization. Once the
+// representative version is available, every identity calls that same version.
 // On a miss it falls through to jit_slow -> ejit_taskpool_compile_or_get, which
 // fills the cell on success (icacheFill). The probe carries NO freshness check:
 // the table is SHARED across cores (EJitIcacheSection), so an activate or
@@ -361,7 +360,8 @@ static bool dimsProvablyInRange(const Function &F,
 // dim identity so writers never collide.
 //
 // The pointer table keeps its [D]^NumDims runtime ABI, but the wrapper admits
-// only one identity and therefore only one cell can ever become non-null.
+// only one identity and therefore only one cell can ever become non-null. Every
+// identity reads that representative cell once it has been filled.
 // NumDims=0 is a scalar ptr (one cell).
 static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
                                                  StringRef FuncName,
@@ -393,7 +393,7 @@ static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
 // Zero means unclaimed; the stored value is the row-major slot index plus one.
 // It lives beside the pointer table in shared memory so all cores agree on the
 // admitted identity. Lifecycle drains clear the pointer, but not this key, so
-// the same identity may be rebuilt while every other identity stays on AOT.
+// the same identity rebuilds the representative version after invalidation.
 static GlobalVariable *getOrCreateIcacheVersionGlobal(Module &M,
                                                        StringRef FuncName) {
   std::string GVName = ("__ejit_icache_version_" + FuncName).str();
@@ -1029,6 +1029,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
+      auto *JitIcacheProbe = BasicBlock::Create(Ctx, "jit_icache_probe", F);
       auto *JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
       auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
       IRBuilder<> B(JitEntry);
@@ -1042,20 +1043,23 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       GlobalVariable *IcacheSlot = IcacheIt->second.GV;
       GlobalVariable *IcacheVersion = IcacheIt->second.VersionGV;
       unsigned NumDims = IcacheIt->second.NumDims;
+      LoadInst *StoredVersion =
+          B.CreateLoad(I32Ty, IcacheVersion, "ejit_icache_stored_version");
+      StoredVersion->setAlignment(Align(4));
+      StoredVersion->setAtomic(AtomicOrdering::Monotonic);
+      Value *HasVersion = B.CreateICmpNE(
+          StoredVersion, ConstantInt::get(I32Ty, 0), "ejit_icache_has_version");
+      HasVersion = B.CreateIntrinsic(Intrinsic::expect, {HasVersion->getType()},
+                                     {HasVersion, ConstantInt::getTrue(Ctx)});
+      B.CreateCondBr(HasVersion, JitIcacheProbe, JitMiss);
+
+      B.SetInsertPoint(JitIcacheProbe);
       Value *SlotPtr = IcacheSlot;
       if (NumDims > 0) {
-        SmallVector<Value *, 5> Indices;
-        Indices.push_back(ConstantInt::get(I32Ty, 0));
-        for (unsigned I = 0; I < NumDims; ++I) {
-          Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
-          unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
-          Value *Idx = ArgVal;
-          if (BW > 32) Idx = B.CreateTrunc(ArgVal, I32Ty);
-          else if (BW < 32) Idx = B.CreateZExt(ArgVal, I32Ty);
-          Indices.push_back(Idx);
-        }
-        SlotPtr = B.CreateInBoundsGEP(IcacheSlot->getValueType(), IcacheSlot,
-                                      Indices, "ejit_ic_slot");
+        Value *SlotIndex = B.CreateSub(
+            StoredVersion, ConstantInt::get(I32Ty, 1), "ejit_icache_slot_index");
+        SlotPtr = B.CreateInBoundsGEP(PtrTy, IcacheSlot, SlotIndex,
+                                      "ejit_ic_slot");
       }
       LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
       ICSlotLoad->setAlignment(Align(8));
@@ -1065,19 +1069,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       // below carries a data dependency on it, so acquire would buy nothing and
       // cost an LDAR per hit. Lowers to the same LDR on AArch64.
       ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
-      Value *CurrentVersion = emitIcacheVersion(B, *F);
-      LoadInst *StoredVersion =
-          B.CreateLoad(I32Ty, IcacheVersion, "ejit_icache_stored_version");
-      StoredVersion->setAlignment(Align(4));
-      StoredVersion->setAtomic(AtomicOrdering::Monotonic);
       Value *TAfterIcache = nullptr;
       if (EJitWrapperTiming)
         TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
-      Value *VersionMatches =
-          B.CreateICmpEQ(StoredVersion, CurrentVersion,
-                         "ejit_icache_version_match");
-      Value *IHit = B.CreateAnd(VersionMatches, B.CreateIsNotNull(ICSlotLoad),
-                                "ejit_icache_hit");
+      Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
       IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
                                {IHit, ConstantInt::getTrue(Ctx)});
       B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-period-arr-max.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-period-arr-max.ll
@@ -1,51 +1,28 @@
-; A period may own SEVERAL ejit_period_arr globals, activated as a group, so its
-; valid instance ids run up to the LARGEST of them. collectPeriodArraySizes()
-; must therefore aggregate a maximum, not keep whichever global the module
-; happens to list last.
-;
-; If it keeps the last one, the answer depends on declaration order: with sizes
-; 32 and 8 under one period, visiting 8 last records 8, dimsProvablyInRange()
-; approves the entry, and the wrapper emits a probe whose GEP is bounded by
-; EJIT_ICACHE_DIM_SIZE (16) even though the lifecycle can legally produce
-; identity 31. That GEP is inbounds on a 16-cell table and lands outside it --
-; in the shared section, in whatever object comes next -- and the probe branches
-; through it before the slow path's range check is ever reachable.
-;
-; Both orders must therefore decline the probe. The entry is still wrapped; the
-; taskpool serves it, which is the documented degradation.
-;
-; The two orders catch different wrong implementations: BIG-first (this file)
-; catches last-wins, SMALL-first (the Inputs sibling) catches first-wins.
-;
-; --implicit-check-not spans the whole module, so the over-cap cell table must
-; not appear anywhere -- as a global, a GEP operand, or a registration argument.
+; Representative mode no longer indexes a [D]^numDims table on the hit path.
+; Period arrays larger than the former D=16 limit are therefore safe and still
+; receive the fixed {fnPtr, identityKey} object, independent of declaration
+; order. This keeps the old regression input to prove that the size-based
+; all-or-nothing degradation is gone.
 
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s \
-; RUN:   | FileCheck %s --check-prefix=BIGFIRST \
-; RUN:       --implicit-check-not=__ejit_icache_fn_over_cap_entry
+; RUN:   | FileCheck %s --check-prefix=BIGFIRST
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S \
 ; RUN:       %S/Inputs/ejit-icache-period-arr-max-smallfirst.ll \
-; RUN:   | FileCheck %s --check-prefix=SMALLFIRST \
-; RUN:       --implicit-check-not=__ejit_icache_fn_over_cap_entry
+; RUN:   | FileCheck %s --check-prefix=SMALLFIRST
 
-; --- Declared 32 then 8: the order that made a last-wins implementation record
-; --- 8 and emit the probe. An entry under a period whose arrays ALL fit still
-; --- gets its table, so the max aggregation does not just disable everything. ---
-; BIGFIRST: @__ejit_icache_fn_in_cap_entry = internal global [16 x ptr] zeroinitializer
+; BIGFIRST-DAG: @__ejit_icache_fn_over_cap_entry = internal global { ptr, i64 } zeroinitializer
+; BIGFIRST-DAG: @__ejit_icache_fn_in_cap_entry = internal global { ptr, i64 } zeroinitializer
 
-; --- over_cap_entry: no probe, straight to the taskpool. ---
 ; BIGFIRST-LABEL: define i32 @over_cap_entry(
-; BIGFIRST-NOT: jit_icache_dispatch
-; BIGFIRST: call {{.*}}@ejit_taskpool_compile_or_get
+; BIGFIRST: load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
+; BIGFIRST-LABEL: jit_icache_dispatch:
 
-; --- in_cap_entry: probe present, indexing its own 16-cell table. ---
 ; BIGFIRST-LABEL: define i32 @in_cap_entry(
-; BIGFIRST: getelementptr {{.*}} ptr @__ejit_icache_fn_in_cap_entry, i32 0, i32 {{.*}}
+; BIGFIRST: load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
 
 ; --- Declared 8 then 32: identical outcome. ---
 ; SMALLFIRST-LABEL: define i32 @over_cap_entry(
-; SMALLFIRST-NOT: jit_icache_dispatch
-; SMALLFIRST: call {{.*}}@ejit_taskpool_compile_or_get
+; SMALLFIRST: load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
 
 define i32 @over_cap_entry(i32 %idx) !ejit.metadata !1 {
 entry:

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -1,7 +1,8 @@
 ; -ejit-inline-cache (ON): emits an inline probe DIRECTLY in the ejit_entry
 ; wrapper - a GEP into the per-function @__ejit_icache_fn_<name> [D]^numDims
 ; cell table (D = EJIT_ICACHE_DIM_SIZE, power-of-2) by the ejit_dim argument
-; values, then ONE monotonic load + null-check; the hit path
+; values, then monotonic pointer/version loads. The first identity is admitted;
+; any different identity reaches the AOT body without compile_or_get. The hit path
 ; (jit_icache_dispatch) calls the cached specialization directly with NO
 ; ejit_icache_try call and NO ejit_taskpool_release_read. The load is atomic
 ; because the table is shared across cores (a peer's period toggle zeroes cells
@@ -32,6 +33,9 @@
 ; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, align 8
 ; ICACHE-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, align 8
 ; ICACHE-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, align 8
+; ICACHE-DAG: @__ejit_icache_version_zero_dim_entry = internal global i32 0, align 4
+; ICACHE-DAG: @__ejit_icache_version_one_dim_entry = internal global i32 0, align 4
+; ICACHE-DAG: @__ejit_icache_version_two_dim_entry = internal global i32 0, align 4
 
 ; --- 0D entry: scalar slot, direct plain load (NO GEP).  Without extra flags
 ;     the dispatcher stays in default .text (no section attribute). ---
@@ -51,6 +55,8 @@
 ; ICACHE-NOT: ejit_icache_try
 ; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
 ; ICACHE: load atomic ptr, ptr {{.*}} monotonic, align 8
+; ICACHE: load atomic i32, ptr @__ejit_icache_version_one_dim_entry monotonic, align 4
+; ICACHE: icmp eq i32 %ejit_icache_stored_version, %ejit_icache_version
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
 ; ICACHE: call {{.*}} %ejit_ic_fn
@@ -60,6 +66,14 @@
 ; ICACHE-LABEL: define i32 @two_dim_entry(
 ; ICACHE-NOT: section
 ; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_two_dim_entry, i32 0, i32 {{.*}}, i32 {{.*}}
+
+; --- Slow path atomically admits the first version. A different version
+;     branches to miss_fallback before compile_or_get. ---
+; ICACHE-LABEL: define internal i32 @one_dim_entry_miss(
+; ICACHE: cmpxchg ptr @__ejit_icache_version_one_dim_entry, i32 0, i32 %ejit_icache_version monotonic monotonic, align 4
+; ICACHE: br i1 %ejit_icache_version_ok, label %miss_version_ok, label %miss_fallback
+; ICACHE-LABEL: miss_version_ok:
+; ICACHE: call i32 @ejit_taskpool_compile_or_get_1d
 
 ; --- OPT (dispatcher-cluster + missfn-cold ON): section and cold present ---
 ; OPT-LABEL: define i32 @zero_dim_entry(
@@ -89,6 +103,9 @@
 ; SECTION-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, section ".mc_shared", align 8
 ; SECTION-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, section ".mc_shared", align 8
 ; SECTION-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, section ".mc_shared", align 8
+; SECTION-DAG: @__ejit_icache_version_zero_dim_entry = internal global i32 0, section ".mc_shared", align 4
+; SECTION-DAG: @__ejit_icache_version_one_dim_entry = internal global i32 0, section ".mc_shared", align 4
+; SECTION-DAG: @__ejit_icache_version_two_dim_entry = internal global i32 0, section ".mc_shared", align 4
 ; SECTION-LABEL: define i32 @one_dim_entry(
 ; SECTION: load atomic ptr, ptr {{.*}} monotonic, align 8
 ; SECTION-LABEL: jit_icache_dispatch:

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -1,8 +1,8 @@
 ; -ejit-inline-cache (ON): emits an inline probe DIRECTLY in the ejit_entry
-; wrapper - a GEP into the per-function @__ejit_icache_fn_<name> [D]^numDims
-; cell table (D = EJIT_ICACHE_DIM_SIZE, power-of-2) by the ejit_dim argument
-; values, then monotonic pointer/version loads. The first identity is admitted;
-; any different identity reaches the AOT body without compile_or_get. The hit path
+; wrapper - the first dimension identity claims one cell in the per-function
+; @__ejit_icache_fn_<name> [D]^numDims table. Before that cell is filled, other
+; identities reach AOT without compile_or_get. Once filled, every identity loads
+; and calls the representative specialization from that same cell. The hit path
 ; (jit_icache_dispatch) calls the cached specialization directly with NO
 ; ejit_icache_try call and NO ejit_taskpool_release_read. The load is atomic
 ; because the table is shared across cores (a peer's period toggle zeroes cells
@@ -49,23 +49,26 @@
 ; ICACHE: call {{.*}} %ejit_ic_fn
 ; ICACHE: ret
 
-; --- 1D entry: [16 x ptr] slot, GEP by the single dim arg + plain load. ---
+; --- 1D entry: use the admitted version key, not the current dim argument, to
+;     select the representative slot. Every identity therefore reads one cell. ---
 ; ICACHE-LABEL: define i32 @one_dim_entry(
 ; ICACHE-NOT: section
 ; ICACHE-NOT: ejit_icache_try
-; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
-; ICACHE: load atomic ptr, ptr {{.*}} monotonic, align 8
 ; ICACHE: load atomic i32, ptr @__ejit_icache_version_one_dim_entry monotonic, align 4
-; ICACHE: icmp eq i32 %ejit_icache_stored_version, %ejit_icache_version
+; ICACHE: icmp ne i32 %ejit_icache_stored_version, 0
+; ICACHE-LABEL: jit_icache_probe:
+; ICACHE: %ejit_icache_slot_index = sub i32 %ejit_icache_stored_version, 1
+; ICACHE: getelementptr inbounds ptr, ptr @__ejit_icache_fn_one_dim_entry, i32 %ejit_icache_slot_index
+; ICACHE: load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
 ; ICACHE: call {{.*}} %ejit_ic_fn
 ; ICACHE: ret
 
-; --- 2D entry: [16 x [16 x ptr]] slot, 2-subscript GEP. ---
+; --- 2D entry: the row-major admitted key is likewise a single flattened GEP. ---
 ; ICACHE-LABEL: define i32 @two_dim_entry(
 ; ICACHE-NOT: section
-; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_two_dim_entry, i32 0, i32 {{.*}}, i32 {{.*}}
+; ICACHE: getelementptr inbounds ptr, ptr @__ejit_icache_fn_two_dim_entry, i32 %ejit_icache_slot_index
 
 ; --- Slow path atomically admits the first version. A different version
 ;     branches to miss_fallback before compile_or_get. ---
@@ -120,7 +123,7 @@
 
 ; --- Idempotent: two passes emit each probe exactly once. ---
 ; IDEM-LABEL: define i32 @one_dim_entry(
-; IDEM-COUNT-1: getelementptr {{.*}} @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
+; IDEM-COUNT-1: getelementptr {{.*}} @__ejit_icache_fn_one_dim_entry, i32 %ejit_icache_slot_index
 
 ; --- timing hit path: plain call (NOT musttail) + trace + ret. The miss path
 ;     stays musttail (no trailing calls), so we only forbid musttail within the

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -1,6 +1,6 @@
 ; -ejit-inline-cache (ON): emits an inline probe DIRECTLY in the ejit_entry
-; wrapper - the first dimension identity claims one cell in the per-function
-; @__ejit_icache_fn_<name> [D]^numDims table. Before that cell is filled, other
+; wrapper - the first dimension identity claims the per-function
+; @__ejit_icache_fn_<name> representative object. Before its pointer is filled, other
 ; identities reach AOT without compile_or_get. Once filled, every identity loads
 ; and calls the representative specialization from that same cell. The hit path
 ; (jit_icache_dispatch) calls the cached specialization directly with NO
@@ -29,53 +29,46 @@
 ;     other core probes. Nothing else about the wrapper changes. ---
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section=.mc_shared -S %s | FileCheck %s --check-prefix=SECTION
 
-; --- icache globals: [D]^numDims, D=8 (EJIT_ICACHE_DIM_SIZE). 0D is scalar. ---
-; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, align 8
-; ICACHE-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, align 8
-; ICACHE-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, align 8
-; ICACHE-DAG: @__ejit_icache_version_zero_dim_entry = internal global i32 0, align 4
-; ICACHE-DAG: @__ejit_icache_version_one_dim_entry = internal global i32 0, align 4
-; ICACHE-DAG: @__ejit_icache_version_two_dim_entry = internal global i32 0, align 4
+; --- icache globals: fixed {fnPtr, miss-only identity key} objects. ---
+; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global { ptr, i64 } zeroinitializer, align 8
+; ICACHE-DAG: @__ejit_icache_fn_one_dim_entry = internal global { ptr, i64 } zeroinitializer, align 8
+; ICACHE-DAG: @__ejit_icache_fn_two_dim_entry = internal global { ptr, i64 } zeroinitializer, align 8
+; ICACHE-NOT: __ejit_icache_version_
 
 ; --- 0D entry: scalar slot, direct plain load (NO GEP).  Without extra flags
 ;     the dispatcher stays in default .text (no section attribute). ---
 ; ICACHE-LABEL: define i32 @zero_dim_entry(
 ; ICACHE-NOT: section
 ; ICACHE-NOT: ejit_icache_try
-; ICACHE-NOT: getelementptr
-; ICACHE: load atomic ptr, ptr @__ejit_icache_fn_zero_dim_entry monotonic, align 8
+; ICACHE: getelementptr inbounds { ptr, i64 }, ptr @__ejit_icache_fn_zero_dim_entry, i32 0, i32 0
+; ICACHE-NEXT: load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
 ; ICACHE: call {{.*}} %ejit_ic_fn
 ; ICACHE: ret
 
-; --- 1D entry: use the admitted version key, not the current dim argument, to
-;     select the representative slot. Every identity therefore reads one cell. ---
+; --- 1D entry: hit path ignores the current dim and reads the fixed slot. ---
 ; ICACHE-LABEL: define i32 @one_dim_entry(
 ; ICACHE-NOT: section
 ; ICACHE-NOT: ejit_icache_try
-; ICACHE: load atomic i32, ptr @__ejit_icache_version_one_dim_entry monotonic, align 4
-; ICACHE: icmp ne i32 %ejit_icache_stored_version, 0
-; ICACHE-LABEL: jit_icache_probe:
-; ICACHE: %ejit_icache_slot_index = sub i32 %ejit_icache_stored_version, 1
-; ICACHE: getelementptr inbounds ptr, ptr @__ejit_icache_fn_one_dim_entry, i32 %ejit_icache_slot_index
+; ICACHE-NOT: ejit_icache_stored_version
+; ICACHE: getelementptr inbounds { ptr, i64 }, ptr @__ejit_icache_fn_one_dim_entry, i32 0, i32 0
 ; ICACHE: load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
 ; ICACHE: call {{.*}} %ejit_ic_fn
 ; ICACHE: ret
 
-; --- 2D entry: the row-major admitted key is likewise a single flattened GEP. ---
+; --- 2D entry: same fixed-slot load; no dimension-dependent GEP. ---
 ; ICACHE-LABEL: define i32 @two_dim_entry(
 ; ICACHE-NOT: section
-; ICACHE: getelementptr inbounds ptr, ptr @__ejit_icache_fn_two_dim_entry, i32 %ejit_icache_slot_index
+; ICACHE: getelementptr inbounds { ptr, i64 }, ptr @__ejit_icache_fn_two_dim_entry, i32 0, i32 0
 
-; --- Slow path atomically admits the first version. A different version
-;     branches to miss_fallback before compile_or_get. ---
+; --- Slow path asks the runtime to admit the first identity. A different
+;     identity branches to miss_fallback before compile_or_get. ---
 ; ICACHE-LABEL: define internal i32 @one_dim_entry_miss(
-; ICACHE: cmpxchg ptr @__ejit_icache_version_one_dim_entry, i32 0, i32 %ejit_icache_version monotonic monotonic, align 4
-; ICACHE: br i1 %ejit_icache_version_ok, label %miss_version_ok, label %miss_fallback
-; ICACHE-LABEL: miss_version_ok:
+; ICACHE: call i32 @ejit_icache_claim(i32 %ejit_funcidx, i64 %ejit_icache_claim_key)
+; ICACHE: br i1 {{.*}}, label %miss_call, label %miss_fallback
 ; ICACHE: call i32 @ejit_taskpool_compile_or_get_1d
 
 ; --- OPT (dispatcher-cluster + missfn-cold ON): section and cold present ---
@@ -93,22 +86,19 @@
 ; OPT-SAME: #[[MISS_ATTRS]]
 ; OPT-DAG: attributes #[[MISS_ATTRS]] = { cold noinline }
 
-; --- registration carries numDims (3rd arg): 0 / 1 / 2 (DAG: order-independent). ---
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0)
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1)
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 2)
+; --- registration uses representative-mode discriminator 5. ---
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 5)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 5)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 5)
 
 ; --- -ejit-icache-section (default .mc_shared, pinned here so the test does not
 ;     depend on the CMake value): every cell table lands in the inter-core
 ;     shared section and the probe is unchanged (one monotonic load + null
 ;     check, no freshness compare). The other RUN lines pin it EMPTY to check
 ;     the plain-.bss shape. ---
-; SECTION-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, section ".mc_shared", align 8
-; SECTION-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, section ".mc_shared", align 8
-; SECTION-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, section ".mc_shared", align 8
-; SECTION-DAG: @__ejit_icache_version_zero_dim_entry = internal global i32 0, section ".mc_shared", align 4
-; SECTION-DAG: @__ejit_icache_version_one_dim_entry = internal global i32 0, section ".mc_shared", align 4
-; SECTION-DAG: @__ejit_icache_version_two_dim_entry = internal global i32 0, section ".mc_shared", align 4
+; SECTION-DAG: @__ejit_icache_fn_zero_dim_entry = internal global { ptr, i64 } zeroinitializer, section ".mc_shared", align 8
+; SECTION-DAG: @__ejit_icache_fn_one_dim_entry = internal global { ptr, i64 } zeroinitializer, section ".mc_shared", align 8
+; SECTION-DAG: @__ejit_icache_fn_two_dim_entry = internal global { ptr, i64 } zeroinitializer, section ".mc_shared", align 8
 ; SECTION-LABEL: define i32 @one_dim_entry(
 ; SECTION: load atomic ptr, ptr {{.*}} monotonic, align 8
 ; SECTION-LABEL: jit_icache_dispatch:
@@ -123,7 +113,7 @@
 
 ; --- Idempotent: two passes emit each probe exactly once. ---
 ; IDEM-LABEL: define i32 @one_dim_entry(
-; IDEM-COUNT-1: getelementptr {{.*}} @__ejit_icache_fn_one_dim_entry, i32 %ejit_icache_slot_index
+; IDEM-COUNT-1: load atomic ptr, ptr %ejit_ic_slot monotonic, align 8
 
 ; --- timing hit path: plain call (NOT musttail) + trace + ret. The miss path
 ;     stays musttail (no trailing calls), so we only forbid musttail within the
@@ -161,9 +151,5 @@ entry:
 !0 = distinct !{!{!"ejit_entry"}}
 !1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
 !2 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
-; Both arrays must declare no more entries than EJIT_ICACHE_DIM_SIZE (16), or
-; dimsProvablyInRange() declines the probe for any entry indexed by them and the
-; ICACHE checks below have nothing to match. `trp` used to say 32, which
-; silently turned two_dim_entry into a no-probe entry.
 !10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
 !11 = distinct !{!{!"ejit_period_arr", !"trp", i32 16}}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -3042,7 +3042,8 @@ TEST_F(SharedTaskPoolTest, InlineCacheRegistrationRejectsAnOverCapShape) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
-  EXPECT_EQ(ejitIcacheRegisterSlot(3, &cells[0], EJIT_ICACHE_MAX_DIMS + 1),
+  EXPECT_EQ(ejitIcacheRegisterSlot(3, &cells[0],
+                                   EJIT_ICACHE_REPRESENTATIVE_DIMS + 1),
             EJitIcacheRegResult::Invalid);
   EXPECT_EQ(ejitIcacheRegisterSlot(3, nullptr, 1),
             EJitIcacheRegResult::Invalid);
@@ -3058,6 +3059,83 @@ TEST_F(SharedTaskPoolTest, InlineCacheRegistrationRejectsAnOverCapShape) {
 
   // A shape at the cap is accepted.
   EXPECT_EQ(ejitIcacheRegisterSlot(3, &cells[0], 1), EJitIcacheRegResult::Ok);
+}
+
+struct alignas(8) RepresentativeIcacheSlot {
+  uintptr_t fn = 0;
+  uint64_t identityKey = 0;
+};
+
+TEST_F(SharedTaskPoolTest, InlineCacheRepresentativeServesEveryIdentity) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  RepresentativeIcacheSlot slot;
+  registerSlot(kFunc, &slot, EJIT_ICACHE_REPRESENTATIVE_DIMS);
+  EJitDimPair cell1[1] = {{0, 1}};
+  EJitDimPair cell2[1] = {{0, 2}};
+  void *fn1 = codeFor(kFunc);
+  void *fn2 = codeFor(kFunc + 1);
+
+  EXPECT_TRUE(ejitIcacheClaim(kFunc, 2));
+  EXPECT_TRUE(ejitIcacheClaim(kFunc, 2));
+  EXPECT_FALSE(ejitIcacheClaim(kFunc, 3));
+
+  pool.icacheFill(kFunc, fn1, cell1, 1, pool.icacheBeginResolve());
+  ASSERT_EQ(slot.fn, reinterpret_cast<uintptr_t>(fn1));
+
+  // The production wrapper performs exactly this fixed scalar read. Its
+  // arguments no longer participate in the hit path, so cell2 gets cell1's
+  // representative specialization.
+  void *out = nullptr;
+  EXPECT_TRUE(pool.icacheTry(kFunc, cell2, 1, &out));
+  EXPECT_EQ(out, fn1);
+
+  // A slow-path attempt by cell2 cannot replace the representative pointer.
+  pool.icacheFill(kFunc, fn2, cell2, 1, pool.icacheBeginResolve());
+  EXPECT_EQ(slot.fn, reinterpret_cast<uintptr_t>(fn1));
+}
+
+TEST_F(SharedTaskPoolTest, InlineCacheRepresentativeDrainPreservesOwner) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  RepresentativeIcacheSlot slot;
+  registerSlot(kFunc, &slot, EJIT_ICACHE_REPRESENTATIVE_DIMS);
+  EJitDimPair cell1[1] = {{0, 1}};
+  EJitDimPair cell2[1] = {{0, 2}};
+  void *fn = codeFor(kFunc);
+
+  ASSERT_TRUE(ejitIcacheClaim(kFunc, 2));
+  pool.icacheFill(kFunc, fn, cell1, 1, pool.icacheBeginResolve());
+  ASSERT_NE(slot.fn, 0u);
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_EQ(slot.fn, 0u);
+  EXPECT_EQ(slot.identityKey, 2u);
+
+  // A different identity keeps using AOT while the representative is empty;
+  // only the original owner may rebuild it for the new lifecycle values.
+  EXPECT_FALSE(ejitIcacheClaim(kFunc, 3));
+  pool.icacheFill(kFunc, codeFor(kFunc + 1), cell2, 1,
+                  pool.icacheBeginResolve());
+  EXPECT_EQ(slot.fn, 0u);
+  pool.icacheFill(kFunc, fn, cell1, 1, pool.icacheBeginResolve());
+  EXPECT_EQ(slot.fn, reinterpret_cast<uintptr_t>(fn));
+}
+
+TEST_F(SharedTaskPoolTest, InlineCacheRepresentativeRejectsInvalidIdentity) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  RepresentativeIcacheSlot slot;
+  registerSlot(kFunc, &slot, EJIT_ICACHE_REPRESENTATIVE_DIMS);
+  EJitDimPair invalid[1] = {{0, 256}};
+
+  EXPECT_FALSE(ejitIcacheClaim(kFunc, 0));
+  pool.icacheFill(kFunc, codeFor(kFunc), invalid, 1,
+                  pool.icacheBeginResolve());
+  EXPECT_EQ(slot.fn, 0u);
+  EXPECT_EQ(slot.identityKey, 0u);
 }
 
 // Cross-core executability gate. A shared cell publishes the pointer to every


### PR DESCRIPTION
## Summary

- restore the inline-cache v2 hot-path shape: one fixed atomic pointer load, one null check, and the indirect tail call
- move representative-identity admission entirely to the miss path
- add a backward-compatible runtime registration mode for `{fnPtr, identityKey}` objects while retaining legacy 0-4D multi-version slots
- let the first admitted identity build the sole JIT specialization; every identity uses that pointer after publication
- preserve lifecycle drain, cross-core executable, reclamation, and raced-fill protections

## Motivation

The wrapper-only implementation still loaded a shared version key and derived a table slot on every hit. That reduced version count, but added work to the hottest path.

This revision follows the historical inline-cache v2 layout without dropping the safety work added since v2. The wrapper directly probes field 0 of a fixed per-function object. Its identity key lives in field 1 and is accessed only by `ejit_icache_claim` and runtime fill logic on misses.

The first identity remains sticky across lifecycle invalidation: drains clear only `fnPtr`, so only that identity may rebuild the representative specialization. Other identities use AOT while the pointer is empty, then share the representative JIT version once it is republished.

## Compatibility

Legacy wrappers registering dimensions 0 through 4 retain their existing multi-version behavior with the new runtime. New representative wrappers register mode 5 and require the matching runtime because they call the new miss-only `ejit_icache_claim` entry point. Wrapper and EJIT runtime should therefore be shipped together for this mode.

## Validation

- compiled `EJitWrapperGen.cpp`, `EJitRuntime.cpp`, and `EJitSharedTaskPool.cpp` with the project Clang configuration and warning flags
- compiled the updated `EJitSharedTaskPoolTest.cpp`
- linked a focused Windows test binary against the existing LLVM test dependencies
- all 18 inline-cache tests passed, including representative sharing, sticky admission, lifecycle drain/refill, invalid identities, legacy multi-version behavior, cross-core gates, and reclamation gates
- updated wrapper lit expectations for the fixed object, one-load hit path, miss-only claim, mode-5 registration, and period arrays larger than the old table dimension
- `git diff --check` passes

The local build tree did not contain `opt`; the updated lit files were compile-reviewed but not executed locally.