### PR TITLE
[EJIT] slim the extracted bitcode: externalize big closure helpers

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -168,6 +168,7 @@ NC='\033[0m'
 
 ALL_TESTS=(
   ejit_attr_test
+  ejit_closure_slim_test
   ejit_complex_test
   ejit_config_api_test
   ejit_dump_test

--- a/ejit_test/ejit_closure_slim_test.c
+++ b/ejit_test/ejit_closure_slim_test.c
@@ -1,0 +1,144 @@
+/**
+ * Closure-slimming end-to-end test.
+ *
+ * PASS1 externalizes closure helpers at or above 16 raw-IR instructions:
+ * the extracted bitcode keeps only a declaration, and the AOT side registers
+ * the original body (internal helpers under a deterministic
+ * ejit_static.<module>.<name> key) so the isolated spec JITDylib can resolve
+ * the call. Helpers below the threshold stay as definitions; small inline
+ * helpers are consumed by the preopt inliner.
+ *
+ * All non-inline helpers here carry noinline, mirroring the
+ * -finline-hint-functions world (where the frontend marks every non-inline
+ * function noinline) so the externalization set is annotation-driven.
+ *
+ * Verifies: results match AOT semantics AND the JIT really compiled
+ * (entryCount > 0; a broken registration would fall back to AOT silently).
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ejit_test_helpers.h"
+
+//===-- test data ---------------------------------------------------------===//
+
+struct CellCfg {
+  ejit_may_const uint32_t cellType;
+  uint32_t traffic;
+};
+ejit_period_arr(cell) struct CellCfg g_cells[16];
+
+//===-- helpers -----------------------------------------------------------===//
+
+// external + big: externalized, name kept
+uint32_t __attribute__((noinline)) ext_helper_big(uint32_t x) {
+  uint32_t r = x + 1;
+  for (uint32_t i = 0; i < 64; i++) {
+    r = r * 31 + i;
+    r ^= (r << 7) ^ i;
+    r -= r % 29;
+    r += (r >> 2) + x;
+  }
+  return r;
+}
+
+// static + big: externalized + renamed, resolved via registration
+static uint32_t __attribute__((noinline)) st_helper_big(uint32_t x) {
+  uint32_t r = x + 1;
+  for (uint32_t i = 0; i < 64; i++) {
+    r = r * 13 + i;
+    r ^= (r << 5) ^ i;
+    r -= r % 31;
+    r += (r >> 3) + x;
+  }
+  return r;
+}
+
+// static + small: below the externalize threshold, stays in the bitcode
+static uint32_t __attribute__((noinline)) st_helper_small(uint32_t x) {
+  return x ^ 0x55;
+}
+
+// static + reads may_const: externalized like any other helper; its AOT
+// body reads live values, which the entry-side guard keeps consistent
+static uint32_t __attribute__((noinline)) st_helper_mayconst(uint32_t i) {
+  uint32_t r = g_cells[i].cellType;
+  for (uint32_t k = 0; k < 8; k++)
+    r = r * 3 + g_cells[(i + k) % 16].traffic;
+  return r;
+}
+
+// inlinehint: consumed by the preopt inliner
+static inline uint32_t hint_helper(uint32_t x) { return x * 7 + 3; }
+
+//===-- entries -----------------------------------------------------------===//
+
+ejit_entry uint32_t entry1(ejit_period_arr_ind(cell) uint8_t ci) {
+  uint32_t r = ext_helper_big(ci);
+  r += st_helper_big(r);
+  r += st_helper_small(r);
+  r += st_helper_mayconst(ci);
+  r = hint_helper(r);
+  return r;
+}
+
+ejit_entry uint32_t entry2(ejit_period_arr_ind(cell) uint8_t ci) {
+  uint32_t r = st_helper_big(ci);
+  r = ext_helper_big(r);
+  r += st_helper_mayconst(ci);
+  r = hint_helper(r);
+  return r;
+}
+
+//===-- main --------------------------------------------------------------===//
+
+int main(int argc, char **argv) {
+  uint8_t ci = (uint8_t)(argc > 1 ? atoi(argv[1]) : 0);
+  int failures = 0;
+
+  printf("=== Closure Slim Test ===\ncellIdx=%u\n\n", ci);
+
+  ejit_config_t cfg;
+  ejit_default_config(&cfg);
+  int rc = (int)ejit_init(&cfg);
+  if (rc != 0) { printf("FAIL: init %d\n", rc); return 1; }
+
+  g_cells[ci].cellType = 42;
+  g_cells[ci].traffic = 7;
+  ejit_activate("cell", ci);
+  ejit_drain_taskpool();
+
+  uint32_t r1 = entry1(ci);
+  uint32_t e1 = ext_helper_big(ci);
+  e1 += st_helper_big(e1);
+  e1 += st_helper_small(e1);
+  e1 += st_helper_mayconst(ci);
+  e1 = hint_helper(e1);
+  printf("  entry1: got=%u expected=%u [%s]\n", r1, e1,
+         r1 == e1 ? "MATCH" : "MISMATCH");
+  if (r1 != e1) failures++;
+
+  uint32_t r2 = entry2(ci);
+  uint32_t e2 = st_helper_big(ci);
+  e2 = ext_helper_big(e2);
+  e2 += st_helper_mayconst(ci);
+  e2 = hint_helper(e2);
+  printf("  entry2: got=%u expected=%u [%s]\n", r2, e2,
+         r2 == e2 ? "MATCH" : "MISMATCH");
+  if (r2 != e2) failures++;
+
+  ejit_stats_t s;
+  ejit_get_stats(&s);
+  printf("  entries: %zu  JIT: %s\n", s.entryCount,
+         s.entryCount > 0 ? "ACTIVE" : "AOT-FALLBACK-ONLY");
+  if (s.entryCount == 0) {
+    printf("  FAIL: no JIT entries (silent AOT fallback)\n");
+    failures++;
+  }
+
+  ejit_shutdown();
+  printf("=== Closure Slim Test %s ===\n", failures ? "FAILED" : "PASSED");
+  return failures ? 1 : 0;
+}

--- a/jit_design_doc/EJIT_BITCODE_SLIMMING.md
+++ b/jit_design_doc/EJIT_BITCODE_SLIMMING.md
@@ -1,0 +1,169 @@
+# EmbeddedJIT 提取 bitcode 闭包瘦身设计文档
+
+**版本**: 1.0
+**日期**: 2026-08-20
+**关联**: SPEC4.md, PASS1_EJitRegisterBitcode.md, PASS5_EJitAotModulePass.md, PASS7_EJitRuntime_OrcJITLink.md, EJIT_DIAGNOSTICS.md
+**目标**: 在保住特化收益的前提下,显著缩小 PASS1 提取进 `__ejit_bitcode` 的模块体积
+
+---
+
+## 1. 背景与问题
+
+PASS1(`EJitRegisterBitcodePass`)按**传递闭包**提取:从所有 `ejit_entry` 出发,沿 call 图收集全部可达函数与它们引用的全局变量,整包序列化进 bitcode。helper 多的模块,bitcode 体积随闭包线性膨胀。
+
+已有的相关工作:
+
+- **preopt cleanup + 内联**(commit `0ffe768af503`):inliner 之前加 frontend-cleanup round,使小函数/inlinehint helper 内联进 entry,其 standalone 定义被 GlobalDCE 删除——已消化掉一部分闭包
+- **`-finline-hint-functions`**(团队即将在场景构建中开启):未标 `inline` 的函数被前端加 `noinline`,两个管线的 inliner 都不内联它们 → preopt 后**幸存者集合变大且由源码标注完全确定**,这是本方案的主要处理对象
+
+关键约束(决定方案形态):
+
+| 约束 | 来源 |
+|---|---|
+| JIT 管线刻意不跑 inliner,依赖 AOT 时间内联 | EJitOptimizer.cpp `runPipeline` 注释 |
+| 模块内 callee 体是特化面:StructFieldPass 折叠 may_const load、IPSCCP 跨调用边传播常量 | EJitOptimizer.cpp Phase 1c/1d |
+| spec JITDylib 隔离,不回退主 JD 的进程符号搜索——**所有未定义符号只能靠显式注册解析,host 上 dlsym 也兜不了底** | EJitOrcEngine.cpp:1007-1019(absoluteSymbols define 在 spec JD 上) |
+| 提取的克隆模块中,`declare` 不能带 internal 链接(opt 报 `invalid linkage for function declaration`) | 实测 |
+
+## 2. 目标与非目标
+
+**目标**
+
+1. 缩小嵌入 bitcode;规则简单、显式,不堆积启发式
+2. 与 `-finline-hint-functions` 的"标注驱动"哲学一致:特化面由用户显式声明
+
+**非目标**
+
+- 不动 JIT 管线(EJitOptimizer 无 inliner 的设计保持)
+- 不改运行时 ABI、不改 `ejit_register_symbol` 接口
+- 不做 entry-only 提取(保留内联收益与特化面)
+
+## 3. 方案总览:内联后外链化
+
+```
+提取:传递闭包照旧全量(不做预先裁剪)
+  │
+  ├─ preopt(现状,不改):cleanup + AlwaysInliner + O2 module inliner
+  │     inlinehint 小函数 → 内联进 entry,GlobalDCE 删定义
+  │     noinline / 超阈值函数 → 全部存活
+  │
+  ├─ 【新增】内联后外链化(extractAndSerialize 内,
+  │    diagnostics 之后、internalize 之前 —— 顺序约束:
+  │    外链化必须先于 internalize,否则原始 external 链接信息丢失)
+  │
+  │   对每个非 entry 函数:
+  │     函数体 < 阈值(-ejit-externalize-min-insts,默认 16,见 §5)
+  │       → 保留定义(现有 internalize 照旧)
+  │     否则 → deleteBody() 转 declaration
+  │             原 internal 链接 → 改名 ejit_static.<basename>.<hash>.<函数> + ExternalLinkage
+  │             (原 external 链接 → 原名 ExternalLinkage)
+  │
+  └─ 序列化(现有 externalize-globals / internalize 逻辑不变)
+```
+
+决策树只有三条分支,全部显式:
+
+| 分支 | 条件 | 结果 |
+|---|---|---|
+| 内联消化 | inlinehint 且 cost ≤ 阈值 | 体进 entry,standalone 定义消失(已有) |
+| 外链 + 注册 | 非 entry 且函数体 ≥ 阈值 | declaration + AOT 侧注册 |
+| 单独特化 | 用户标 `ejit_entry` | 保留定义,自带 wrapper/注册/周期配置 |
+
+## 4. 关键设计决策
+
+### 4.1 分类放在内联后
+
+inliner 的 cost 分析就是"哪些函数值得保留函数体"的决策;内联后仍带定义且有调用点存活的函数,天然是外链化候选。**不在提取前重复实现大小/热度启发式**,也不做强制内联(违背 noinline 标注意图,且重新制造 JIT/AOT 分歧)。
+
+### 4.2 无 may_const 豁免
+
+读 may_const 全局的 helper 默认也外链化(正确性不受影响:外链 helper 读活值,entry 侧 guard 保证值与特化常量一致)。需要 helper 内部特化的场景,用户把它标成 `ejit_entry` 做独立特化——现有机制已验证支撑:
+
+- entry 不被 internalize(EJitRegisterBitcode.cpp internalize 步骤跳过 `TAG_EJIT_ENTRY`)
+- static 的 entry 也能被 JIT 强制外链(EJitOrcEngine.cpp:903-905)
+- 多 entry 闭包并集提取、嵌套特化(E 的 JIT 代码调 AOT 的 H,H 的 wrapper 分派到自己的 JIT 版本)
+
+### 4.3 注册机制:确定性改名 key
+
+spec JITDylib 隔离(见 §1)意味着**每个外链化的 helper(static 或 external、host 或 bare-metal)都必须显式注册**。而 `userSymbols` 是进程级扁平表(EJitOrcEngine.cpp:106),static 函数名只在模块内唯一——两个 TU 的同名 `static helper` 注册会互相覆盖,静默错绑。
+
+解决:确定性命名,key = `ejit_static.<sanitized 模块 basename>.<原始模块路径的完整 64 位哈希>.<函数名>`。
+
+- 提取侧把克隆模块中的 static helper 改名(只改副本,AOT 本体不动)
+- AOT 侧(PASS1 自身的注册发射)对**同闭包 + 同阈值规则**算出的 static helper 生成 `ejit_register_symbol(key, &helper)` 调用与 `.ejit_bitcode` 段条目
+- 两个发射点与提取改名共用同一个纯函数 `ejitRegistrationKey(M, F)`,无需跨 pass 传状态
+- basename 缩短 key(完整路径会让 key 长达 ~120 字符);哈希负责区分 basename 相同或 sanitize 后碰撞(`a-b.c` vs `a_b.c`)的模块
+- 点号在 ELF/JITLink 符号中合法,`mangleAndIntern` 原样处理
+- dlsym 误绑不存在(spec JD 隔离,不回退进程符号搜索),改名只为注册表 key 的进程内唯一性
+
+**威胁模型(已知残留)**:哈希区分的是模块路径,不区分同一路径的多次编译变体——同一个 `.c` 以不同 `-D` 编译两次再链接,两个 TU 的 static helper 生成相同 key,运行时 `userSymbols`(std::map,后写覆盖)可能绑错函数体。这是少见构建形态;彻底修复需要每 TU 的身份(如模块内容哈希),留作后续工作。
+
+### 4.4 诊断口径
+
+`runSpecializationDiagnostic` 保持在外链化**之前**运行(现状位置天然满足):"closure" 的 may_const 计数继续按源码级闭包统计,文案不变。
+
+## 5. 数据与阈值
+
+合成场景(entries 调用 static/external、大/小、读/不读 may_const、inlinehint 混合 helper),release clang dump + 真实 bitcode 字节测量(已做重组基线校正):
+
+| 场景 | 模块大小 | 存活 helper | 全部外链化节省 |
+|---|---|---|---|
+| 合成 + `-finline-hint-functions`(目标世界) | 4128 B | 5 | **520 B(12%)** |
+| 合成 无 flag(当前测试世界) | 4536 B | 2(小 helper 被成本内联) | 192 B(4%) |
+| `ejit_complex_test.c`(现有真实场景) | 5916 B | 0 | 0 |
+
+每函数 bitcode 体积(外链化净收益):2 指令=36B,3 指令=40B,7 指令=80B,18 指令=152B,26 指令=188B(每函数 ~30B 固定开销 + ~5-7B/指令)。
+
+注册开销估算:~190B/条(AOT 侧 key 字符串 ~50B(basename 后,见 §4.3)+ 地址 8B + 调用代码 ~20B;运行时 `userSymbols` 红黑树节点 + 字符串堆 ~110B)。若 key 用完整模块路径则字符串一项就 ~120B,故 §4.3 采用 basename。
+
+**阈值结论**:严格盈亏平衡点 ≈ 函数体 190B ≈ 20-25 条指令。取 **`getInstructionCount() >= 16` 外链,否则保留定义**——刻意偏激进:注册开销落在 AOT 二进制 rodata 与运行时 RAM,而省下的是嵌入 bitcode(Flash/缓存),本方案的目标资源是后者;两者不是一个账本。该阈值对 static/external、host/bare-metal 统一适用(§4.3:全部需注册)。
+
+## 6. 实现步骤
+
+### 6.1 PASS1 提取侧(`EJitRegisterBitcode.cpp`)
+
+`run()` 中在 `computeTransitiveClosure` 之后计算外链化集合(与注册侧同一规则、同一原始模块,天然一致):
+
+```
+ToExternalize = { F ∈ ClosureFuncs : 非 entry 且
+                  getInstructionCount() >= EJitExternalizeMinInsts }
+```
+
+阈值为 cl::opt(`-ejit-externalize-min-insts`,默认 16,定义在 EJitPassOptions.cpp),无需重编译即可按场景微调;0 表示去掉体积下限(全部外链)。
+
+`extractAndSerialize` 中、`runSpecializationDiagnostic` 之后、internalize 循环之前,应用:
+
+```
+for F in ToExternalize:
+  Cur = Extracted->getFunction(F 的名字)     // preopt 完全内联掉的已不存在
+  Cur->deleteBody()                          // 变 declaration
+  Cur->setLinkage(ExternalLinkage)           // declare 不能带 internal(实测 opt 报错)
+  Cur->setDSOLocal(false)                    // InternalLinkage 隐含 dso_local,改 linkage 不会清除
+  if 原 internal 链接:
+    Cur->setName(ejitStaticHelperKey(M.getName(), F->getName()))
+```
+
+决策集在 preopt 之前算、变换在 preopt 之后应用:被 preopt 内联消化掉的 helper(GlobalDCE 已删)自动跳过;两条注册路径(ctor + 段表)为它多发的死条目无害。
+
+### 6.2 AOT 侧注册(PASS1 自身的发射机制,非 PASS5)
+
+PASS1 已为闭包外部引用维护两套注册发射(ctor 路径 `generateSymbolRegisters` 发射 `ejit_register_symbol` 调用;bare-metal 路径 `generateRegistryTable` 往 `.ejit_bitcode` 段发射 `EJIT_REG_SYMBOL` 条目,运行时已有消费代码 `tableSymbols → userSymbols`)。外链化 helper 直接接入这两处:
+
+- key = `ejitStaticHelperKey(M.getName(), F->getName())`(internal)或原名(external,进程内唯一)
+- 地址取 AOT 原函数 `&F`(顺带使 `--gc-sections` 下函数体存活)
+- 无需动 PASS2-PASS5,无需跨 pass 传状态(决策集同源)
+
+### 6.3 测试
+
+- **lit**:`ejit-externalize-helpers.ll` —— 大 static → declaration+改名 / 小 static → 保留定义 / external → declaration / entry 不动;ctor 调用、key 字符串、段表条目均有 CHECK;提取侧与注册侧同文件双前缀校验
+- **集成**:`ejit_test/ejit_closure_slim_test.c`(noinline 标注模拟 `-finline-hint-functions` 世界;断言结果与 AOT 语义一致且 `entryCount > 0`,防止注册失败时静默回退 AOT)
+- **诊断**:外链化前运行 `runSpecializationDiagnostic`,输出不变
+- **回归**:EmbeddedJIT lit 全套 + clang CodeGen/Sema ejit lit 全套
+
+## 7. 开放决策
+
+| 项 | 建议 | 说明 |
+|---|---|---|
+| 阈值 | `-ejit-externalize-min-insts`(默认 16) | 已做成 cl::opt;严格盈亏平衡 ~20-25 指令(§5),16 是"Flash 优先"的偏激进取值,可按真实场景数据微调 |
+| 注册时机 | 挂在现有 AOT 注册函数(全局 ctor 路径) | 与现有 globals/period 注册一致 |
+| 未来优化 | 静态段注册(`.ejit_period` 风格 name→addr 表) | 可省去运行时 std::map 开销,进一步降低小函数外链成本 |

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
@@ -56,3 +56,15 @@ cl::opt<unsigned> EJitWarnFewMayConst(
     cl::desc("Warn when an ejit_entry's specialization closure has fewer than "
              "N ejit_may_const reads (0 = off). Example: "
              "-ejit-warn-few-mayconst=4 warns on 0..3 may-const reads."));
+
+// Closure-slimming threshold (PASS1): non-entry closure helpers with at
+// least this many raw-IR instructions are externalized from the extracted
+// bitcode (declaration only, resolved via the AOT-side registration). Below
+// it, the body is smaller than the ~190-byte registration record that
+// replaces it. 0 removes the size floor (externalize every surviving
+// helper). See jit_design_doc/EJIT_BITCODE_SLIMMING.md.
+cl::opt<unsigned> EJitExternalizeMinInsts(
+    "ejit-externalize-min-insts", cl::init(16), cl::Hidden,
+    cl::desc("Externalize non-entry closure helpers with at least this many "
+             "raw-IR instructions from the extracted bitcode (0 = no size "
+             "floor; see jit_design_doc/EJIT_BITCODE_SLIMMING.md)"));

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -28,7 +28,9 @@
 #include "llvm/Transforms/IPO/AlwaysInliner.h"
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/Scalar/EarlyCSE.h"
+#include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
+#include "llvm/Transforms/Scalar/SROA.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
@@ -216,7 +218,27 @@ static void preOptimizeBitcode(Module &M) {
   PB.registerModuleAnalyses(MAM);
   PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
 
-  // 1. Inline: AlwaysInline + cost-based inliner for small functions
+  // 1. Frontend-IR cleanup BEFORE inlining, mirroring the host O2 pipeline
+  //    (EarlyFPM + GlobalCleanupPM both precede its inliner). Raw CodeGen IR
+  //    keeps every C local as an alloca + store/load pair, which inflates the
+  //    inliner's computed callee cost ~4x; without this round the embedded
+  //    bitcode inlines far less than the same module compiled AOT - and the
+  //    JIT pipeline runs no inliner of its own (EJitOptimizer relies on this
+  //    AOT-time inlining), so every missed inline is a permanent call.
+  {
+    FunctionPassManager FPM;
+    FPM.addPass(LowerExpectIntrinsicPass());
+    FPM.addPass(SimplifyCFGPass());
+    FPM.addPass(SROAPass(SROAOptions::ModifyCFG));
+    FPM.addPass(EarlyCSEPass());
+    FPM.addPass(InstCombinePass());
+    FPM.addPass(SimplifyCFGPass());
+    for (Function &F : M.functions())
+      if (!F.isDeclaration())
+        FPM.run(F, FAM);
+  }
+
+  // 2. Inline: AlwaysInline + cost-based inliner for small functions
   {
     ModulePassManager MPM;
     MPM.addPass(AlwaysInlinerPass());
@@ -225,7 +247,8 @@ static void preOptimizeBitcode(Module &M) {
     MPM.run(M, MAM);
   }
 
-  // 2. Mem2Reg: promote allocas from inlined code to SSA
+  // 3. Mem2Reg: promote any allocas left after inlining (AlwaysInliner can
+  // still emit fresh ones around inlined code) to SSA
   {
     FunctionPassManager FPM;
     FPM.addPass(PromotePass());
@@ -234,7 +257,7 @@ static void preOptimizeBitcode(Module &M) {
         FPM.run(F, FAM);
   }
 
-  // 3. EarlyCSE + InstCombine: simplify and fold redundant computations
+  // 4. EarlyCSE + InstCombine: simplify and fold redundant computations
   {
     FunctionPassManager FPM;
     FPM.addPass(EarlyCSEPass());
@@ -244,7 +267,7 @@ static void preOptimizeBitcode(Module &M) {
         FPM.run(F, FAM);
   }
 
-  // 4. SimplifyCFG: flatten branches, merge blocks
+  // 5. SimplifyCFG: flatten branches, merge blocks
   {
     FunctionPassManager FPM;
     FPM.addPass(SimplifyCFGPass());
@@ -253,7 +276,7 @@ static void preOptimizeBitcode(Module &M) {
         FPM.run(F, FAM);
   }
 
-  // 5. Restore !ejit.may_const metadata that passes may have dropped
+  // 6. Restore !ejit.may_const metadata that passes may have dropped
   reAnnotateMayConst(M);
 }
 #else

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -9,6 +9,8 @@
 #include "llvm/Transforms/EmbeddedJIT/EJitPasses.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/Support/Format.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
@@ -39,6 +41,8 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
+#include "llvm/Support/Path.h"
+#include <cctype>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -49,16 +53,55 @@ extern cl::opt<bool> EJitWarnNoSpecialization;
 extern cl::opt<bool> EJitWarnUnusedDim;
 extern cl::opt<bool> EJitReportMayConst;
 extern cl::opt<unsigned> EJitWarnFewMayConst;
+extern cl::opt<unsigned> EJitExternalizeMinInsts;
 
 #define DEBUG_TYPE "ejit-register-bitcode"
 
+/// Deterministic process-wide unique registration key for an internal
+/// closure helper. Internal names are unique per module only — two TUs can
+/// both define `static int helper()`. Prefix the sanitized module BASENAME
+/// so the runtime's flat symbol table never binds a JIT'd helper to the
+/// wrong TU, plus the full 64-bit hash of the RAW module path: the sanitized
+/// basename alone can collide (`a-b.c` vs `a_b.c` both sanitize to `a_b_c`),
+/// and distinct build variants of one path (-D variations) are not
+/// distinguished (see the design doc threat model). The rename and the
+/// registration are generated in the same pass run, so run-local
+/// determinism is all the key requires. The extracted-bitcode rename and
+/// the AOT-side registration both derive the key from this one function.
+static std::string ejitStaticHelperKey(StringRef ModuleName,
+                                       StringRef FuncName) {
+  std::string Key = "ejit_static.";
+  for (char C : sys::path::filename(ModuleName))
+    Key.push_back(isalnum(static_cast<unsigned char>(C)) || C == '_' ? C : '_');
+  Key += '.';
+  raw_string_ostream OS(Key);
+  OS << format_hex(static_cast<uint64_t>(hash_value(ModuleName)), 16,
+                   /*Upper=*/false);
+  OS.flush();
+  Key += '.';
+  Key += FuncName;
+  return Key;
+}
+
+/// Registration key for an externalized closure helper: internal helpers
+/// get their deterministic unique key, externally-linked helpers keep their
+/// (already process-unique) name. Single source of truth shared by the
+/// extracted-bitcode rename and both registration emitters, so the three
+/// sites can never disagree.
+static std::string ejitRegistrationKey(const Module &M, const Function &F) {
+  return F.hasLocalLinkage() ? ejitStaticHelperKey(M.getName(), F.getName())
+                             : F.getName().str();
+}
+
+static bool isEjitEntryFunction(const Function &F) {
+  return hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY);
+}
+
 static void collectEntryFunctions(Module &M,
                                   SmallVectorImpl<Function *> &EntryFuncs) {
-  for (Function &F : M.functions()) {
-    MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
-    if (hasMDStringEntry(MD, TAG_EJIT_ENTRY))
+  for (Function &F : M.functions())
+    if (isEjitEntryFunction(F))
       EntryFuncs.push_back(&F);
-  }
 }
 
 static const GlobalVariable *findRootGV(const Value *V, APInt &Offset,
@@ -604,7 +647,8 @@ runSpecializationDiagnostic(Module &Extracted,
 static std::string extractAndSerialize(Module &M,
     const SetVector<Function *> &Funcs,
     const SetVector<GlobalVariable *> &Globals,
-    const SmallVectorImpl<Function *> &EntryFuncs) {
+    const SmallVectorImpl<Function *> &EntryFuncs,
+    const SetVector<Function *> &ToExternalize) {
 
   auto Extracted = CloneModule(M);
   DenseSet<StringRef> FuncNames;
@@ -649,6 +693,35 @@ static std::string extractAndSerialize(Module &M,
   // exact bitcode the JIT will specialize). Must run before the extern
   // conversion below so GV definitions (and their !ejit.metadata) are intact.
   runSpecializationDiagnostic(*Extracted, EntryFuncs);
+
+  // Externalize the closure helpers that generateSymbolRegisters /
+  // generateRegistryTable register on the AOT side: turn each surviving
+  // (i.e. not fully preopt-inlined) helper into an external declaration so
+  // its body is not serialized into the bitcode. Internal helpers are
+  // renamed to their deterministic registration key (their AOT symbol is
+  // invisible to the JIT linker); externally-linked helpers keep their
+  // already process-unique name. Runs before the internalize step below so
+  // the original linkage is still visible here.
+  unsigned Externalized = 0;
+  for (Function *F : ToExternalize) {
+    Function *Cur = Extracted->getFunction(F->getName());
+    if (!Cur || Cur->isDeclaration())
+      continue; // fully inlined by preOptimizeBitcode
+    bool WasLocal = Cur->hasLocalLinkage();
+    Cur->deleteBody();
+    Cur->setVisibility(GlobalValue::DefaultVisibility);
+    Cur->setLinkage(GlobalValue::ExternalLinkage);
+    // The declaration is now resolved from outside the module (AOT-side
+    // registration), so it must not be marked dso_local. InternalLinkage
+    // implies dso_local and changing the linkage does not clear it.
+    Cur->setDSOLocal(false);
+    if (WasLocal)
+      Cur->setName(ejitRegistrationKey(M, *F));
+    ++Externalized;
+  }
+  LLVM_DEBUG(dbgs() << "ejit-register-bitcode: externalized " << Externalized
+                    << " of " << ToExternalize.size()
+                    << " closure helper(s) in bitcode\n");
 
   // Convert kept non-constant global definitions to external declarations
   // so the JIT linker resolves them from the host process. Constants (e.g.
@@ -725,6 +798,7 @@ static void generateSymbolRegisters(
     Module &M,
     const SetVector<Function *> &ClosureFuncs,
     const SetVector<GlobalVariable *> &ClosureGlobals,
+    const SetVector<Function *> &ToExternalize,
     Function *AutoReg) {
   LLVMContext &Ctx = M.getContext();
   const DataLayout &DL = M.getDataLayout();
@@ -810,6 +884,19 @@ static void generateSymbolRegisters(
       }
     }
   }
+
+  // Register externalized closure helpers under the same deterministic keys
+  // extractAndSerialize renamed them to in the bitcode. The address is the
+  // AOT original — taking it also keeps the body alive under --gc-sections.
+  for (Function *F : ToExternalize) {
+    std::string Key = ejitRegistrationKey(M, *F);
+    if (registered.insert(Key).second) {
+      IRBuilder<> Builder(InsertBefore);
+      Builder.CreateCall(M.getFunction(FN_REGISTER_SYMBOL),
+                         {Builder.CreateGlobalString(Key),
+                          Builder.CreateBitCast(F, PtrTy)});
+    }
+  }
 }
 
 /// Recursively walk a Constant (initializer of a GlobalVariable) and
@@ -835,12 +922,14 @@ static void
 generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
                       const SetVector<Function *> &ClosureFuncs,
                       const SetVector<GlobalVariable *> &ClosureGlobals,
+                      const SetVector<Function *> &ToExternalize,
                       GlobalVariable *BitcodeGV);
 
 static void generateRegisterCall(Module &M, GlobalVariable *BitcodeGV,
                                  const SmallVectorImpl<Function *> &EntryFuncs,
                                  const SetVector<Function *> &ClosureFuncs,
-                                 const SetVector<GlobalVariable *> &ClosureGlobals) {
+                                 const SetVector<GlobalVariable *> &ClosureGlobals,
+                                 const SetVector<Function *> &ToExternalize) {
   LLVMContext &Ctx = M.getContext();
   auto *VoidTy = Type::getVoidTy(Ctx);
   auto *PtrTy = PointerType::getUnqual(Ctx);
@@ -873,13 +962,15 @@ static void generateRegisterCall(Module &M, GlobalVariable *BitcodeGV,
 
   // Auto-register external symbols referenced by the closure so the JIT
   // can resolve them without manual ejit_register_symbol calls.
-  generateSymbolRegisters(M, ClosureFuncs, ClosureGlobals, AutoReg);
+  generateSymbolRegisters(M, ClosureFuncs, ClosureGlobals, ToExternalize,
+                          AutoReg);
 
   if (EnableEJitGlobalCtors)
     appendToGlobalCtors(M, AutoReg, EJIT_CTOR_PRIORITY);
 
   // Always build the static registry table for bare-metal / testing fallback.
-  generateRegistryTable(M, EntryFuncs, ClosureFuncs, ClosureGlobals, BitcodeGV);
+  generateRegistryTable(M, EntryFuncs, ClosureFuncs, ClosureGlobals,
+                        ToExternalize, BitcodeGV);
 }
 
 /// Emit this translation unit's bitcode registry entries as a private array in
@@ -891,6 +982,7 @@ static void
 generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
                       const SetVector<Function *> &ClosureFuncs,
                       const SetVector<GlobalVariable *> &ClosureGlobals,
+                      const SetVector<Function *> &ToExternalize,
                       GlobalVariable *BitcodeGV) {
   LLVMContext &Ctx = M.getContext();
   auto *I32Ty = Type::getInt32Ty(Ctx);
@@ -995,6 +1087,22 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
     }
   }
 
+  // Externalized closure helpers: same keys as generateSymbolRegisters, so
+  // the bare-metal section walk (no ctors) resolves them identically.
+  for (Function *F : ToExternalize) {
+    std::string Key = ejitRegistrationKey(M, *F);
+    Constant *NameStr = ConstantDataArray::getString(Ctx, Key, true);
+    auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
+        GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
+    Entries.push_back(ConstantStruct::get(EntryTy, {
+        ConstantInt::get(I32Ty, EJIT_REG_SYMBOL),            // EJIT_REG_SYMBOL
+        ConstantExpr::getBitCast(NameGV, PtrTy),             // name1: key
+        ConstantPointerNull::get(PtrTy),
+        ConstantExpr::getBitCast(F, PtrTy),                  // AOT original
+        ConstantInt::get(I64Ty, 0),
+    }));
+  }
+
   // No sentinel entry: the runtime iterates the linker-provided
   // [__start_ejit_bitcode, __stop_ejit_bitcode) range over the dedicated
   // section, so each translation unit contributes only its own entries.
@@ -1038,10 +1146,22 @@ EJitRegisterBitcodePass::run(Module &M, ModuleAnalysisManager &) {
   if (ClosureFuncs.empty())
     return PreservedAnalyses::all();
 
+  // Helpers to externalize: non-entry closure functions whose bodies cost
+  // more than the AOT registration record that replaces them. Computed on
+  // the raw module so extractAndSerialize and generateSymbolRegisters /
+  // generateRegistryTable all agree on the same set.
+  SetVector<Function *> ToExternalize;
+  for (Function *F : ClosureFuncs)
+    if (!isEjitEntryFunction(*F) &&
+        F->getInstructionCount() >= EJitExternalizeMinInsts)
+      ToExternalize.insert(F);
+
   std::string Bitcode =
-      extractAndSerialize(M, ClosureFuncs, ClosureGlobals, EntryFuncs);
+      extractAndSerialize(M, ClosureFuncs, ClosureGlobals, EntryFuncs,
+                          ToExternalize);
   GlobalVariable *BitcodeGV = embedBitcode(M, Bitcode);
-  generateRegisterCall(M, BitcodeGV, EntryFuncs, ClosureFuncs, ClosureGlobals);
+  generateRegisterCall(M, BitcodeGV, EntryFuncs, ClosureFuncs, ClosureGlobals,
+                       ToExternalize);
 
   return PreservedAnalyses::none();
 }

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-few-mayconst.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-few-mayconst.ll
@@ -10,11 +10,13 @@
 ; 1 read → warn (below threshold 4).
 ; CHECK: EJit warning: ejit_entry function 'entry_one' has only 1 ejit_may_const read
 
-; 3 reads in the closure (direct + callee) → warn.
-; CHECK: EJit warning: ejit_entry function 'entry_three_via_helper' has only 3 ejit_may_const reads
-
 ; 0 reads → warn (below threshold 4).
 ; CHECK: EJit warning: ejit_entry function 'entry_zero' has only 0 ejit_may_const reads
+
+; 3 reads in the closure (direct + callee) → warn.
+; Warnings are emitted in module order (entry_one, entry_zero, then
+; entry_three_via_helper).
+; CHECK: EJit warning: ejit_entry function 'entry_three_via_helper' has only 3 ejit_may_const reads
 
 ; 4 reads → at threshold → no warning.
 ; CHECK-NOT: EJit warning: ejit_entry function 'entry_four'

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-report-mayconst.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-report-mayconst.ll
@@ -7,6 +7,11 @@
 ; read counts over the specialization closure: K total, J inside loops.
 
 ; A single may_const read inside a self-loop -> 1 total, 1 in loops.
+; The loop must resist preOptimizeBitcode's full O2 function-simplification
+; round: a constant trip count gets fully unrolled (one read per unrolled
+; body, no loop left) and a loop-invariant load gets LICM'd out. Hence the
+; opaque %n bound and the loop-variant GEP index - the shape real hot loops
+; have (g_arr[i].field).
 ; CHECK: EJit info: ejit_entry function 'entry_loop': 1 ejit_may_const read (1 in loops)
 
 ; A single may_const read in straight-line code -> 1 total, 0 in loops.
@@ -17,19 +22,23 @@
 
 @cell_data = global [16 x i32] zeroinitializer, !ejit.metadata !10
 
-define i32 @entry_loop(i32 %c) !ejit.metadata !20 {
+declare void @sink(i32)
+
+define i32 @entry_loop(i32 %c, i32 %n) !ejit.metadata !20 {
 entry:
   br label %loop
 loop:
   %i = phi i32 [0, %entry], [%i.next, %loop]
-  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %c
+  %acc = phi i32 [0, %entry], [%acc.next, %loop]
+  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %i
   %v = load i32, ptr %p, !ejit.may_const !{}
+  call void @sink(i32 %v)
+  %acc.next = add i32 %acc, %v
   %i.next = add i32 %i, 1
-  %cond = icmp slt i32 %i.next, 10
+  %cond = icmp slt i32 %i.next, %n
   br i1 %cond, label %loop, label %exit
 exit:
-  %v.out = phi i32 [%v, %loop]
-  ret i32 %v.out
+  ret i32 %acc.next
 }
 
 define i32 @entry_noloop(i32 %c) !ejit.metadata !20 {

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
@@ -1,0 +1,264 @@
+; RUN: rm -rf %t-dump && mkdir -p %t-dump
+; RUN: opt -passes=ejit-register-bitcode -ejit-dump-bitcode-dir=%t-dump -S < %s > %t.out
+; RUN: FileCheck %s --check-prefix=MOD < %t.out
+; RUN: opt -S %t-dump/*.bc | FileCheck %s --check-prefix=EXT
+; RUN: rm -rf %t-dump-hi && mkdir -p %t-dump-hi
+; RUN: opt -passes=ejit-register-bitcode -ejit-externalize-min-insts=1000 -ejit-dump-bitcode-dir=%t-dump-hi -S < %s > %t.out-hi
+; RUN: opt -S %t-dump-hi/*.bc | FileCheck %s --check-prefix=HI
+;
+; Closure helpers at or above -ejit-externalize-min-insts (default 16)
+; instructions are externalized: the extracted bitcode keeps only a
+; declaration, and the
+; AOT side registers the original body so the isolated spec JITDylib (no
+; dlsym fallback) can resolve it. Internal helpers are renamed to
+; ejit_static.<basename>.<full-64bit-hash>.<name> — internal names are
+; unique per module only, two TUs can both define `static helper`, and the
+; runtime's flat symbol table would otherwise bind a JIT'd call to the
+; wrong TU; the hash of the raw module path keeps sanitized names
+; collision-free.
+; Externally-linked helpers keep their process-unique name. Helpers below
+; the threshold stay as definitions: the registration record (~160 bytes)
+; costs more than the body. See jit_design_doc/EJIT_BITCODE_SLIMMING.md.
+;
+; All helpers except hint_big are noinline so preOptimizeBitcode's inliner
+; does not consume them (mirrors the -finline-hint-functions world, where
+; non-inline functions carry noinline). hint_big is an inlinehint helper
+; above the threshold: preopt inlines it away, the extraction skips it, and
+; the AOT side still registers it (harmless dead entry, by design).
+;
+; NOTE: the pass mutates only its extraction clone; the -S output (MOD) is
+; the ORIGINAL module plus the embedded bitcode, the ejit_auto_register
+; calls, and the .ejit_bitcode registry section.
+
+@cell_data = global [16 x i32] zeroinitializer, !ejit.metadata !10
+
+; big static helper (>= 16 inst) -> externalized + renamed
+define internal i32 @st_helper_big(i32 %x) #0 {
+entry:
+  %a0 = add i32 %x, 1
+  %a1 = mul i32 %a0, 3
+  %a2 = xor i32 %a1, %x
+  %a3 = sub i32 %a2, 5
+  %a4 = or i32 %a3, %a0
+  %a5 = shl i32 %a4, 1
+  %a6 = lshr i32 %a5, 2
+  %a7 = and i32 %a6, %a1
+  %a8 = add i32 %a7, %a2
+  %a9 = mul i32 %a8, %a3
+  %a10 = xor i32 %a9, %a4
+  %a11 = sub i32 %a10, %a5
+  %a12 = or i32 %a11, %a6
+  %a13 = shl i32 %a12, 3
+  %a14 = lshr i32 %a13, 1
+  %a15 = and i32 %a14, %a7
+  %a16 = add i32 %a15, %a8
+  %a17 = mul i32 %a16, %a9
+  %a18 = xor i32 %a17, %a10
+  ret i32 %a18
+}
+
+; inlinehint helper above the threshold: consumed by preopt's inliner, but
+; still registered on the AOT side (dead entry, by design)
+define internal i32 @hint_big(i32 %x) #1 {
+entry:
+  %h0 = add i32 %x, 2
+  %h1 = mul i32 %h0, 5
+  %h2 = xor i32 %h1, %x
+  %h3 = sub i32 %h2, 7
+  %h4 = or i32 %h3, %h0
+  %h5 = shl i32 %h4, 2
+  %h6 = lshr i32 %h5, 3
+  %h7 = and i32 %h6, %h1
+  %h8 = add i32 %h7, %h2
+  %h9 = mul i32 %h8, %h3
+  %h10 = xor i32 %h9, %h4
+  %h11 = sub i32 %h10, %h5
+  %h12 = or i32 %h11, %h6
+  %h13 = shl i32 %h12, 1
+  %h14 = lshr i32 %h13, 2
+  %h15 = and i32 %h14, %h7
+  %h16 = add i32 %h15, %h8
+  %h17 = mul i32 %h16, %h9
+  ret i32 %h17
+}
+
+; small static helper (< 16 inst) -> kept as a definition
+define internal i32 @st_helper_small(i32 %x) #0 {
+entry:
+  %s0 = xor i32 %x, 85
+  %s1 = add i32 %s0, 1
+  ret i32 %s1
+}
+
+; big external helper -> externalized, name kept
+define i32 @ext_helper_big(i32 %x) #0 {
+entry:
+  %b0 = add i32 %x, 2
+  %b1 = mul i32 %b0, 5
+  %b2 = xor i32 %b1, %x
+  %b3 = sub i32 %b2, 7
+  %b4 = or i32 %b3, %b0
+  %b5 = shl i32 %b4, 2
+  %b6 = lshr i32 %b5, 3
+  %b7 = and i32 %b6, %b1
+  %b8 = add i32 %b7, %b2
+  %b9 = mul i32 %b8, %b3
+  %b10 = xor i32 %b9, %b4
+  %b11 = sub i32 %b10, %b5
+  %b12 = or i32 %b11, %b6
+  %b13 = shl i32 %b12, 1
+  %b14 = lshr i32 %b13, 2
+  %b15 = and i32 %b14, %b7
+  %b16 = add i32 %b15, %b8
+  %b17 = mul i32 %b16, %b9
+  ret i32 %b17
+}
+
+; small external helper -> kept as a definition
+define i32 @ext_helper_small(i32 %x) #0 {
+entry:
+  %e0 = mul i32 %x, 3
+  %e1 = add i32 %e0, 1
+  ret i32 %e1
+}
+
+; exactly at the threshold (15 non-terminator + ret = 16) -> externalized
+define i32 @boundary_helper(i32 %x) #0 {
+entry:
+  %c1 = add i32 %x, 1
+  %c2 = add i32 %c1, 1
+  %c3 = add i32 %c2, 1
+  %c4 = add i32 %c3, 1
+  %c5 = add i32 %c4, 1
+  %c6 = add i32 %c5, 1
+  %c7 = add i32 %c6, 1
+  %c8 = add i32 %c7, 1
+  %c9 = add i32 %c8, 1
+  %c10 = add i32 %c9, 1
+  %c11 = add i32 %c10, 1
+  %c12 = add i32 %c11, 1
+  %c13 = add i32 %c12, 1
+  %c14 = add i32 %c13, 1
+  %c15 = add i32 %c14, 1
+  ret i32 %c15
+}
+
+; just below the threshold (14 non-terminator + ret = 15) -> kept
+define i32 @kept_15inst(i32 %x) #0 {
+entry:
+  %k1 = add i32 %x, 1
+  %k2 = add i32 %k1, 1
+  %k3 = add i32 %k2, 1
+  %k4 = add i32 %k3, 1
+  %k5 = add i32 %k4, 1
+  %k6 = add i32 %k5, 1
+  %k7 = add i32 %k6, 1
+  %k8 = add i32 %k7, 1
+  %k9 = add i32 %k8, 1
+  %k10 = add i32 %k9, 1
+  %k11 = add i32 %k10, 1
+  %k12 = add i32 %k11, 1
+  %k13 = add i32 %k12, 1
+  %k14 = add i32 %k13, 1
+  ret i32 %k14
+}
+
+define i32 @entry(i32 %idx) !ejit.metadata !20 {
+entry:
+  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %idx
+  %v = load i32, ptr %p, !ejit.may_const !{}
+  %r1 = call i32 @st_helper_big(i32 %v)
+  %r2 = call i32 @st_helper_small(i32 %r1)
+  %r3 = call i32 @ext_helper_big(i32 %r2)
+  %r4 = call i32 @ext_helper_small(i32 %r3)
+  %r5 = call i32 @hint_big(i32 %r4)
+  %r6 = call i32 @boundary_helper(i32 %r5)
+  %r7 = call i32 @kept_15inst(i32 %r6)
+  ret i32 %r7
+}
+
+; an entry above the threshold must never be externalized
+define i32 @entry_big(i32 %idx) !ejit.metadata !21 {
+entry:
+  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %idx
+  %v = load i32, ptr %p, !ejit.may_const !{}
+  %j1 = add i32 %v, 1
+  %j2 = add i32 %j1, 1
+  %j3 = add i32 %j2, 1
+  %j4 = add i32 %j3, 1
+  %j5 = add i32 %j4, 1
+  %j6 = add i32 %j5, 1
+  %j7 = add i32 %j6, 1
+  %j8 = add i32 %j7, 1
+  %j9 = add i32 %j8, 1
+  %j10 = add i32 %j9, 1
+  %j11 = add i32 %j10, 1
+  %j12 = add i32 %j11, 1
+  %j13 = add i32 %j12, 1
+  %j14 = add i32 %j13, 1
+  %j15 = add i32 %j14, 1
+  %j16 = add i32 %j15, 1
+  %j17 = add i32 %j16, 1
+  ret i32 %j17
+}
+
+attributes #0 = { noinline }
+attributes #1 = { inlinehint }
+
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}, !{!"ejit_may_const_field", i32 0}}
+!20 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!21 = distinct !{!{!"ejit_entry"}}
+
+; MOD side: registration records for the externalized helpers. The module
+; name comes from stdin ("<stdin>", basename sanitized to "_stdin_"), so
+; internal-helper keys are ejit_static._stdin_.<full-64bit-hash>.<name> —
+; the hash segment is checked loosely.
+; ToExternalize discovery order is stack-reversed (boundary, hint_big,
+; ext_helper_big, st_helper_big), hence the ordered section checks.
+; MOD: c"boundary_helper\00"
+; MOD: [48 x i8] c"ejit_static._stdin_.{{0x[0-9a-f]+}}.hint_big\00"
+; MOD: c"ext_helper_big\00"
+; MOD: [53 x i8] c"ejit_static._stdin_.{{0x[0-9a-f]+}}.st_helper_big\00"
+; MOD: { i32 3, ptr @{{.*}}, ptr null, ptr @boundary_helper, i64 0 }
+; MOD: { i32 3, ptr @{{.*}}, ptr null, ptr @hint_big, i64 0 }
+; MOD: { i32 3, ptr @{{.*}}, ptr null, ptr @ext_helper_big, i64 0 }
+; MOD: { i32 3, ptr @{{.*}}, ptr null, ptr @st_helper_big, i64 0 }
+; MOD-NOT: ptr @st_helper_small
+; MOD-NOT: ptr @ext_helper_small
+; MOD-NOT: ptr @kept_15inst
+; MOD: define internal void @ejit_auto_register() {
+; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @st_helper_big)
+; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @ext_helper_big)
+; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @hint_big)
+; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @boundary_helper)
+; MOD-NOT: @st_helper_small
+; MOD-NOT: @ext_helper_small
+; MOD-NOT: @kept_15inst
+; MOD-NOT: @entry_big
+; MOD: }
+
+; EXT side: the extracted bitcode. Big helpers are declarations (the static
+; one renamed to its registration key); small helpers stay as internal
+; definitions; entries keep their bodies; hint_big is gone (inlined).
+; EXT: declare i32 @ejit_static._stdin_.{{0x[0-9a-f]+}}.st_helper_big(i32)
+; EXT: define internal i32 @st_helper_small(i32 %x)
+; EXT: declare i32 @ext_helper_big(i32)
+; EXT: define internal i32 @ext_helper_small(i32 %x)
+; EXT: declare i32 @boundary_helper(i32)
+; EXT: define internal i32 @kept_15inst(i32 %x)
+; EXT: define i32 @entry(i32 %idx) {{.*}} {
+; EXT: tail call i32 @ejit_static._stdin_.{{0x[0-9a-f]+}}.st_helper_big(i32 %v)
+; EXT: tail call i32 @st_helper_small(i32 %r1)
+; EXT: tail call i32 @ext_helper_big(i32 %r2)
+; EXT: tail call i32 @ext_helper_small(i32 %r3)
+; EXT: tail call i32 @boundary_helper(i32 {{.*}})
+; EXT: tail call i32 @kept_15inst(i32 {{.*}})
+; EXT: define i32 @entry_big(i32 %idx) {{.*}} {
+; EXT-NOT: @st_helper_big
+; EXT-NOT: @hint_big
+
+; HI side: -ejit-externalize-min-insts=1000 removes the size floor — even
+; the big helpers stay as definitions in the bitcode (the internalize step
+; has run, so both are internal).
+; HI: define internal i32 @st_helper_big(i32 %x)
+; HI: define internal i32 @ext_helper_big(i32 %x)

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-preopt-inline-cost.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-preopt-inline-cost.ll
@@ -1,0 +1,218 @@
+; RUN: rm -rf %t-dump && mkdir -p %t-dump
+; RUN: opt -passes=ejit-register-bitcode -ejit-dump-bitcode-dir=%t-dump -S <%s >/dev/null
+; RUN: opt -S %t-dump/*.bc | FileCheck %s
+;
+; The inliner inside preOptimizeBitcode must see CLEANED IR, not the raw
+; frontend IR. On raw CodeGen IR every C local is an alloca + store/load
+; pair, which inflates the inliner's computed callee cost ~4x (measured:
+; cost=785 vs threshold=487 for this helper raw, no remark after cleanup),
+; so an inline-hinted helper with several call sites that the AOT O2
+; pipeline inlines stays a real call in the embedded bitcode - permanently,
+; because the JIT pipeline runs no inliner of its own and relies on this
+; AOT-time inlining (see EJitOptimizer::runPipeline).
+;
+; preOptimizeBitcode therefore runs a frontend-cleanup round (mirroring the
+; host O2 EarlyFPM + GlobalCleanupPM: LowerExpect/SimplifyCFG/SROA/EarlyCSE/
+; InstCombine) BEFORE AlwaysInliner + the O2 module inliner. This test locks
+; that ordering in: the helper below is sized so that its raw-IR cost exceeds
+; the inliner threshold while its post-cleanup cost does not.
+;
+; NOTE: preOptimizeBitcode is a no-op in debug builds (cyclic link
+; dependency LLVMPasses <-> LLVMEmbeddedJIT); run EJIT lit tests on release
+; builds (see CLAUDE.md).
+
+@cell_data = global [16 x i32] zeroinitializer, !ejit.metadata !10
+
+; helper: inlinehint + internal, mimics frontend IR (allocas + loads/stores)
+define internal i32 @hint_helper(i32 %a, i32 %b) #0 {
+entry:
+  %x = alloca i32
+  %y = alloca i32
+  store i32 %a, ptr %x
+  store i32 %b, ptr %y
+  %la0 = load i32, ptr %x
+  %lb0 = load i32, ptr %y
+  %s0 = add i32 %la0, %lb0
+  store i32 %s0, ptr %x
+  %la1 = load i32, ptr %x
+  %lb1 = load i32, ptr %y
+  %s1 = mul i32 %la1, %lb1
+  store i32 %s1, ptr %y
+  %la2 = load i32, ptr %x
+  %lb2 = load i32, ptr %y
+  %s2 = xor i32 %la2, %lb2
+  store i32 %s2, ptr %x
+  %la3 = load i32, ptr %x
+  %lb3 = load i32, ptr %y
+  %s3 = and i32 %la3, %lb3
+  store i32 %s3, ptr %y
+  %la4 = load i32, ptr %x
+  %lb4 = load i32, ptr %y
+  %s4 = sub i32 %la4, %lb4
+  store i32 %s4, ptr %x
+  %la5 = load i32, ptr %x
+  %lb5 = load i32, ptr %y
+  %s5 = or i32 %la5, %lb5
+  store i32 %s5, ptr %y
+  %la6 = load i32, ptr %x
+  %lb6 = load i32, ptr %y
+  %s6 = add i32 %la6, %lb6
+  store i32 %s6, ptr %x
+  %la7 = load i32, ptr %x
+  %lb7 = load i32, ptr %y
+  %s7 = mul i32 %la7, %lb7
+  store i32 %s7, ptr %y
+  %la8 = load i32, ptr %x
+  %lb8 = load i32, ptr %y
+  %s8 = xor i32 %la8, %lb8
+  store i32 %s8, ptr %x
+  %la9 = load i32, ptr %x
+  %lb9 = load i32, ptr %y
+  %s9 = and i32 %la9, %lb9
+  store i32 %s9, ptr %y
+  %la10 = load i32, ptr %x
+  %lb10 = load i32, ptr %y
+  %s10 = sub i32 %la10, %lb10
+  store i32 %s10, ptr %x
+  %la11 = load i32, ptr %x
+  %lb11 = load i32, ptr %y
+  %s11 = or i32 %la11, %lb11
+  store i32 %s11, ptr %y
+  %la12 = load i32, ptr %x
+  %lb12 = load i32, ptr %y
+  %s12 = add i32 %la12, %lb12
+  store i32 %s12, ptr %x
+  %la13 = load i32, ptr %x
+  %lb13 = load i32, ptr %y
+  %s13 = mul i32 %la13, %lb13
+  store i32 %s13, ptr %y
+  %la14 = load i32, ptr %x
+  %lb14 = load i32, ptr %y
+  %s14 = xor i32 %la14, %lb14
+  store i32 %s14, ptr %x
+  %la15 = load i32, ptr %x
+  %lb15 = load i32, ptr %y
+  %s15 = and i32 %la15, %lb15
+  store i32 %s15, ptr %y
+  %la16 = load i32, ptr %x
+  %lb16 = load i32, ptr %y
+  %s16 = sub i32 %la16, %lb16
+  store i32 %s16, ptr %x
+  %la17 = load i32, ptr %x
+  %lb17 = load i32, ptr %y
+  %s17 = or i32 %la17, %lb17
+  store i32 %s17, ptr %y
+  %la18 = load i32, ptr %x
+  %lb18 = load i32, ptr %y
+  %s18 = add i32 %la18, %lb18
+  store i32 %s18, ptr %x
+  %la19 = load i32, ptr %x
+  %lb19 = load i32, ptr %y
+  %s19 = mul i32 %la19, %lb19
+  store i32 %s19, ptr %y
+  %la20 = load i32, ptr %x
+  %lb20 = load i32, ptr %y
+  %s20 = xor i32 %la20, %lb20
+  store i32 %s20, ptr %x
+  %la21 = load i32, ptr %x
+  %lb21 = load i32, ptr %y
+  %s21 = and i32 %la21, %lb21
+  store i32 %s21, ptr %y
+  %la22 = load i32, ptr %x
+  %lb22 = load i32, ptr %y
+  %s22 = sub i32 %la22, %lb22
+  store i32 %s22, ptr %x
+  %la23 = load i32, ptr %x
+  %lb23 = load i32, ptr %y
+  %s23 = or i32 %la23, %lb23
+  store i32 %s23, ptr %y
+  %la24 = load i32, ptr %x
+  %lb24 = load i32, ptr %y
+  %s24 = add i32 %la24, %lb24
+  store i32 %s24, ptr %x
+  %la25 = load i32, ptr %x
+  %lb25 = load i32, ptr %y
+  %s25 = mul i32 %la25, %lb25
+  store i32 %s25, ptr %y
+  %la26 = load i32, ptr %x
+  %lb26 = load i32, ptr %y
+  %s26 = xor i32 %la26, %lb26
+  store i32 %s26, ptr %x
+  %la27 = load i32, ptr %x
+  %lb27 = load i32, ptr %y
+  %s27 = and i32 %la27, %lb27
+  store i32 %s27, ptr %y
+  %la28 = load i32, ptr %x
+  %lb28 = load i32, ptr %y
+  %s28 = sub i32 %la28, %lb28
+  store i32 %s28, ptr %x
+  %la29 = load i32, ptr %x
+  %lb29 = load i32, ptr %y
+  %s29 = or i32 %la29, %lb29
+  store i32 %s29, ptr %y
+  %la30 = load i32, ptr %x
+  %lb30 = load i32, ptr %y
+  %s30 = add i32 %la30, %lb30
+  store i32 %s30, ptr %x
+  %la31 = load i32, ptr %x
+  %lb31 = load i32, ptr %y
+  %s31 = mul i32 %la31, %lb31
+  store i32 %s31, ptr %y
+  %la32 = load i32, ptr %x
+  %lb32 = load i32, ptr %y
+  %s32 = xor i32 %la32, %lb32
+  store i32 %s32, ptr %x
+  %la33 = load i32, ptr %x
+  %lb33 = load i32, ptr %y
+  %s33 = and i32 %la33, %lb33
+  store i32 %s33, ptr %y
+  %la34 = load i32, ptr %x
+  %lb34 = load i32, ptr %y
+  %s34 = sub i32 %la34, %lb34
+  store i32 %s34, ptr %x
+  %la35 = load i32, ptr %x
+  %lb35 = load i32, ptr %y
+  %s35 = or i32 %la35, %lb35
+  store i32 %s35, ptr %y
+  %la36 = load i32, ptr %x
+  %lb36 = load i32, ptr %y
+  %s36 = add i32 %la36, %lb36
+  store i32 %s36, ptr %x
+  %la37 = load i32, ptr %x
+  %lb37 = load i32, ptr %y
+  %s37 = mul i32 %la37, %lb37
+  store i32 %s37, ptr %y
+  %la38 = load i32, ptr %x
+  %lb38 = load i32, ptr %y
+  %s38 = xor i32 %la38, %lb38
+  store i32 %s38, ptr %x
+  %la39 = load i32, ptr %x
+  %lb39 = load i32, ptr %y
+  %s39 = and i32 %la39, %lb39
+  store i32 %s39, ptr %y
+  %r = load i32, ptr %x
+  ret i32 %r
+}
+
+define i32 @entry(i32 %c) !ejit.metadata !20 {
+  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %c
+  %v = load i32, ptr %p, !ejit.may_const !{}
+  %r1 = call i32 @hint_helper(i32 %v, i32 %c)
+  %r2 = call i32 @hint_helper(i32 %r1, i32 %v)
+  %sum = add i32 %r1, %r2
+  ret i32 %sum
+}
+
+attributes #0 = { inlinehint }
+
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}, !{!"ejit_may_const_field", i32 0}}
+!20 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+
+; The two calls must have been inlined into the entry at AOT time: nothing
+; between the entry's definition and its return references the helper, and
+; the may_const load must survive the whole preopt round (reAnnotateMayConst
+; is the safety net if any pass drops it).
+; CHECK: define i32 @entry(
+; CHECK-DAG: load i32, ptr {{.*}}, align 4, !ejit.may_const
+; CHECK-NOT: @hint_helper
+; CHECK: ret i32


### PR DESCRIPTION
PASS1 extracts the full transitive closure of every ejit_entry; helper
bodies dominate the embedded bitcode. Externalize non-entry closure
helpers at or above -ejit-externalize-min-insts (default 16) raw-IR
instructions: the bitcode keeps only a declaration, and the AOT side
registers the original body so the isolated spec JITDylib (no dlsym
fallback) can resolve the call.

- Internal helpers are renamed to a deterministic process-wide unique
  key ejit_static.<basename>.<hash-of-raw-module-path>.<name> —
  internal names are unique per module only, and two TUs can both
  define `static helper`; the runtime's flat symbol table would
  otherwise bind a JIT'd call to the wrong TU.
- Registration reuses PASS1's existing emitters: ejit_register_symbol
  calls in ejit_auto_register (ctor path) and EJIT_REG_SYMBOL entries
  in the .ejit_bitcode section (bare-metal path); the runtime already
  consumes the latter into userSymbols. ejitRegistrationKey() is the
  single source of truth shared by the rename and both emitters.
- The decision set is computed on the raw module before preopt and
  applied after it, so helpers the inliner fully consumed are skipped;
  entries are never externalized; the threshold is a cl::opt so
  scenarios can tune it without rebuilding the toolchain.

Measured on a synthetic mixed-helper scenario: 12% smaller extracted
bitcode under -finline-hint-functions (4% without). See
jit_design_doc/EJIT_BITCODE_SLIMMING.md for the design and data.