### PR TITLE
[EJIT] Restrict specialization to one function

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -54,6 +54,10 @@ namespace ejit {
 //===----------------------------------------------------------------------===//
 constexpr const char *MD_EJIT_METADATA = "ejit.metadata";
 constexpr const char *MD_EJIT_MAY_CONST = "ejit.may_const";
+// Per-definition AOT fallback symbol emitted into extracted bitcode. The JIT
+// renames every non-active definition to this TU-unique symbol before turning
+// it into a declaration, so static helpers from different TUs cannot collide.
+constexpr const char *MD_EJIT_AOT_SYMBOL = "ejit.aot_symbol";
 
 //===----------------------------------------------------------------------===//
 // Metadata entry tags (first operand of sub-nodes in !ejit.metadata)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -32,9 +32,8 @@ public:
   /// Run the full JIT specialization pipeline:
   ///   1. Parameter substitution (ejit_period_arr_ind → constants)
   ///   2. InstCombine (fold GEP chains from substituted params)
-  ///   3. Inline (L2+: expand callee bodies so may_const GEPs are traceable)
-  ///   4. StructFieldPass (may_const loads → runtime constants)
-  ///   5. Core optimization pipeline (L1/L2/L3)
+  ///   3. StructFieldPass (may_const loads → runtime constants)
+  ///   4. Function-local optimization pipeline (L1/L2/L3)
   void runPipeline(Module &M, const SpecializationContext &ctx);
 
   /// Clear all cached analysis results. Must be called between compilations
@@ -50,17 +49,6 @@ private:
 
   /// Run EJitStructFieldPass on all functions.
   void runStructFieldPass(Module &M);
-
-  /// Push the specialized constants across call edges. The AOT inliner keeps a
-  /// call edge wherever it chose not to inline, so after phase 1 every call
-  /// site passes the period dims (and values derived from them) as ordinary
-  /// constant arguments — but the callee bodies still re-derive cell addressing
-  /// and re-test guards the entry already resolved. Internalizes every defined
-  /// non-ejit_entry function (IPSCCP only reasons about arguments of functions
-  /// whose call sites it can enumerate: local linkage, not address-taken), then
-  /// runs IPSCCP to propagate constant arguments into callee bodies and
-  /// constant returns back to call sites.
-  void runInterproceduralPropagation(Module &M);
 
   /// Run the EJIT optimization pipeline: a single fused sequence that exploits
   /// the just-substituted period-index / may_const constants to their fixed

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -30,6 +30,13 @@ class EJitRuntimeState;
 struct EJitSharedTaskPoolState;
 
 namespace detail {
+/// Keep only \p fnName as a definition. Every other definition is renamed to
+/// its registered AOT fallback symbol and converted to a declaration, so the
+/// JIT optimizer and code generator operate on exactly one function body.
+/// Returns false without modifying \p M if the entry or fallback metadata is
+/// missing or invalid.
+bool isolateFunctionForSpecialization(Module &M, StringRef fnName);
+
 /// Render one function definition without the rest of its specialization
 /// module. Exposed for focused dump-path testing; callers should use the
 /// ejit_dump_* APIs.

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -59,6 +59,7 @@ set(EJIT_SOURCES
   EJitRuntime.cpp
   EJitRegistryTable.c
   EJitOrcEngine.cpp
+  EJitFunctionIsolation.cpp
   EJitLinkDiagPlugin.cpp
   EJitLinkOptimizationPlugin.cpp
   EJitLibcallStubs.cpp

--- a/llvm/lib/ExecutionEngine/EJIT/EJitFunctionIsolation.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitFunctionIsolation.cpp
@@ -1,0 +1,58 @@
+//===-- EJitFunctionIsolation.cpp - Function-only JIT boundary -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+using namespace llvm;
+using namespace llvm::ejit;
+
+bool llvm::ejit::detail::isolateFunctionForSpecialization(Module &M,
+                                                           StringRef fnName) {
+  Function *Entry = M.getFunction(fnName);
+  if (!Entry || Entry->isDeclaration())
+    return false;
+
+  SmallVector<std::pair<Function *, std::string>, 16> Fallbacks;
+  StringSet<> FallbackNames;
+  for (Function &F : M.functions()) {
+    if (&F == Entry || F.isDeclaration() || F.isIntrinsic())
+      continue;
+
+    MDNode *MD = F.getMetadata(MD_EJIT_AOT_SYMBOL);
+    auto *Name = MD && MD->getNumOperands() == 1
+                     ? dyn_cast<MDString>(MD->getOperand(0))
+                     : nullptr;
+    if (!Name || Name->getString().empty() ||
+        !FallbackNames.insert(Name->getString()).second)
+      return false;
+    if (GlobalValue *Existing = M.getNamedValue(Name->getString()))
+      if (Existing != &F)
+        return false;
+    Fallbacks.push_back({&F, Name->getString().str()});
+  }
+
+  for (auto &[F, AotName] : Fallbacks) {
+    F->setName(AotName);
+    F->deleteBody();
+    F->setLinkage(GlobalValue::ExternalLinkage);
+    F->setVisibility(GlobalValue::DefaultVisibility);
+    F->setDSOLocal(false);
+    F->setDLLStorageClass(GlobalValue::DefaultStorageClass);
+    F->setUnnamedAddr(GlobalValue::UnnamedAddr::None);
+    F->setSection("");
+    if (F->hasComdat())
+      F->setComdat(nullptr);
+  }
+  return true;
+}

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -13,7 +13,6 @@
 // pipeline (PassBuilder::buildFunctionSimplificationPipeline); only the light
 // cleanupFPM_ and the LowerExpect prefix are hand-added below.
 #include "llvm/Transforms/InstCombine/InstCombine.h"
-#include "llvm/Transforms/IPO/SCCP.h"
 #include "llvm/Transforms/Scalar/ADCE.h"
 #include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
@@ -97,26 +96,14 @@ void EJitOptimizer::runPipeline(Module &M,
   runInstCombine(M);
   EJIT_DIAG_DEBUG("pipeline phase1b done: InstCombine");
   // Inlining is intentionally not run here: the AOT pre-optimization
-  // (EJitRegisterBitcodePass: AlwaysInline + ModuleInliner(O2)) already expanded
-  // callee bodies in the embedded bitcode, so their may_const GEP chains are
-  // already traceable to the global.
+  // (EJitRegisterBitcodePass: AlwaysInline + ModuleInliner(O2)) already made
+  // the permitted inline decisions. Only the resulting entry body is present.
   //   (c) Replace the may_const loads with their runtime constant values.
   runStructFieldPass(M);
   EJIT_DIAG_DEBUG("pipeline phase1c done: StructFieldPass");
-  //   (d) Push the constants across call edges. Wherever the AOT inliner kept
-  //       a call, the callee still re-derives cell addressing and re-tests
-  //       guards from its arguments — which phases 1a-1c just made constant at
-  //       every call site. IPSCCP propagates them into the callee bodies (and
-  //       constant returns back out).
-  runInterproceduralPropagation(M);
-  EJIT_DIAG_DEBUG("pipeline phase1d done: IPSCCP");
-  //   (e,f) The propagated arguments expose callee GEP chains exactly as 1a
-  //       did for the entry: fold them, then substitute the callee may_const
-  //       loads they root, so phases 2-4 exploit the constants in every
-  //       function, not just the entry.
-  runInstCombine(M);
-  runStructFieldPass(M);
-  EJIT_DIAG_DEBUG("pipeline phase1ef done: callee InstCombine+StructFieldPass");
+  // Every non-inlined callee is an external declaration bound to its AOT
+  // address before this transform runs. No interprocedural propagation is
+  // allowed here: the current entry is the only function body in the module.
 
   // Phases 2-4 — exploit those constants (scalar fixed point → loops →
   // re-specialize → cleanup). ctx.optLevel is accepted for ABI compatibility
@@ -172,30 +159,6 @@ void EJitOptimizer::runInstCombine(Module &M) {
   for (Function &F : M.functions())
     if (!F.isDeclaration())
       FPM.run(F, FAM_);
-}
-
-void EJitOptimizer::runInterproceduralPropagation(Module &M) {
-  // IPSCCP only reasons about a function's arguments when it can enumerate
-  // every call site: local linkage and no address-taken uses. The
-  // specialization module is self-contained — the JIT looks up only the
-  // ejit_entry symbols; every other definition is called module-internally and
-  // external references resolve to AOT symbols — so all non-entry definitions
-  // can be internalized. (Address-taken callees are internalized too; IPSCCP
-  // itself skips their arguments, and their symbols are still resolved
-  // module-internally.)
-  for (Function &F : M.functions()) {
-    if (F.isDeclaration() || F.hasLocalLinkage())
-      continue;
-    if (hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY))
-      continue;
-    // The IR verifier requires default visibility with local linkage.
-    F.setVisibility(GlobalValue::DefaultVisibility);
-    F.setLinkage(GlobalValue::InternalLinkage);
-  }
-
-  ModulePassManager MPM;
-  MPM.addPass(IPSCCPPass());
-  MPM.run(M, MAM_);
 }
 
 void EJitOptimizer::runStructFieldPass(Module &M) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -4,6 +4,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLinkDiagPlugin.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLinkOptimizationPlugin.h"
@@ -871,6 +872,19 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   if (!ModuleOrErr) {
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error", cacheKey);
     return ModuleOrErr.takeError();
+  }
+
+  // AOT pre-optimization has already made every permitted inline decision.
+  // From this point onward specialization is strictly function-local: retain
+  // only the requested entry body and resolve every residual call to the
+  // TU-unique AOT fallback symbol registered for that definition.
+  if (!detail::isolateFunctionForSpecialization(**ModuleOrErr, origFnName)) {
+    EJIT_DIAG("loadBitcode FAIL key=0x%016lx: function isolation metadata "
+              "invalid func=%s",
+              cacheKey, origFnName.c_str());
+    return make_error<StringError>("Function-only specialization metadata "
+                                   "missing or invalid: " + origFnName,
+                                   inconvertibleErrorCode());
   }
 
   Triple TT((*ModuleOrErr)->getTargetTriple());

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
@@ -26,23 +26,23 @@ cl::opt<std::string> EJitDumpBitcodeDir(
 cl::opt<bool> EJitWarnNoSpecialization(
     "ejit-warn-no-specialization", cl::init(true), cl::Hidden,
     cl::desc("Warn when an ejit_entry function reads no ejit_may_const field "
-             "in its specialization closure (no JIT specialization value)."));
+             "in its post-inline body (no JIT specialization value)."));
 
 cl::opt<bool> EJitWarnUnusedDim(
     "ejit-warn-unused-dim", cl::init(true), cl::Hidden,
     cl::desc("Warn when an ejit_entry declares ejit_period_arr_ind(P) but its "
-             "specialization closure never indexes an ejit_period_arr(P) "
+             "post-inline body never indexes an ejit_period_arr(P) "
              "(unused specialization dimension)."));
 
 // Optional info-level report (not a warning): per ejit_entry, count the
-// ejit_may_const reads in its specialization closure and how many sit inside
+// ejit_may_const reads in its post-inline body and how many sit inside
 // loops. A raw count is a poor specialization-value metric on its own (a
 // single read in a hot loop or feeding a branch is high value), so this only
 // reports the numbers for the user to judge - it does not gate or warn.
 cl::opt<bool> EJitReportMayConst(
     "ejit-report-mayconst", cl::init(false), cl::Hidden,
     cl::desc("Report per-ejit_entry ejit_may_const read counts (total and "
-             "in-loop) in the specialization closure, for manual "
+             "in-loop) in the post-inline body, for manual "
              "specialization-value assessment."));
 
 // Optional warning (off by default): warn when an ejit_entry's specialization
@@ -53,6 +53,6 @@ cl::opt<bool> EJitReportMayConst(
 // for manual review rather than asserting a defect.
 cl::opt<unsigned> EJitWarnFewMayConst(
     "ejit-warn-few-mayconst", cl::init(0), cl::Hidden,
-    cl::desc("Warn when an ejit_entry's specialization closure has fewer than "
+    cl::desc("Warn when an ejit_entry's post-inline body has fewer than "
              "N ejit_may_const reads (0 = off). Example: "
              "-ejit-warn-few-mayconst=4 warns on 0..3 may-const reads."));

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -33,7 +33,9 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MD5.h"
 #include "llvm/Support/Process.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
@@ -334,7 +336,6 @@ struct EjitFuncDiagInfo {
   unsigned MayConstCount = 0;        // # of !ejit.may_const loads (direct)
   unsigned MayConstInLoopCount = 0;  // subset sitting inside a loop
   SetVector<StringRef> RefsPeriodArr; // deduped period names referenced
-  SmallVector<const Function *, 4> Callees;  // direct, defined, non-intrinsic
 };
 
 /// One ejit_entry's declared dimensions, parsed from the original module's
@@ -376,7 +377,7 @@ static void computeLoopBBs(Function &F,
       LoopBBs.insert(&BB);
 }
 
-/// Compute direct (pre-propagation) diagnostic info for \p F. \p LoopBBs is
+/// Compute function-local diagnostic info for \p F. \p LoopBBs is
 /// optional (non-null only when the may_const count report is enabled).
 static void
 computeEjitFuncDiagInfo(Function &F, EjitFuncDiagInfo &Info, unsigned MayConstKind,
@@ -393,10 +394,6 @@ computeEjitFuncDiagInfo(Function &F, EjitFuncDiagInfo &Info, unsigned MayConstKi
           if (InLoop)
             ++Info.MayConstInLoopCount;
         }
-      if (auto *CB = dyn_cast<CallBase>(&I))
-        if (Function *Callee = CB->getCalledFunction())
-          if (!Callee->isDeclaration() && !Callee->isIntrinsic())
-            Info.Callees.push_back(Callee);
       // Collect referenced GVs for period-arr lookup in the same traversal.
       for (Value *Op : I.operands())
         if (auto *GV = rootGlobal(Op, DL))
@@ -423,13 +420,11 @@ computeEjitFuncDiagInfo(Function &F, EjitFuncDiagInfo &Info, unsigned MayConstKi
 
 /// AOT specialization diagnostics on the extracted bitcode (post-preOptimize),
 /// which is exactly what the JIT will specialize.
-///   #1: ejit_entry whose specialization closure reads no ejit_may_const field.
-///   #2: ejit_entry that declares ejit_period_arr_ind(P) but its closure never
+///   #1: ejit_entry whose post-inline body reads no ejit_may_const field.
+///   #2: ejit_entry that declares ejit_period_arr_ind(P) but its body never
 ///       indexes an ejit_period_arr(P).
-/// The closure is the direct-call reachability within the extracted module.
-/// External calls (declarations) and indirect calls (function pointers) do NOT
-/// count: the JIT cannot inline them, so their may_const reads never enter this
-/// entry's specialization. This keeps #1 sound (no false positives).
+/// AOT pre-inlining has already run. Residual callees execute as AOT and must
+/// not contribute to the specialization-value report.
 static void
 runSpecializationDiagnostic(Module &Extracted,
                             const SmallVectorImpl<Function *> &EntryFuncs) {
@@ -472,87 +467,45 @@ runSpecializationDiagnostic(Module &Extracted,
                             NeedLoops ? &LoopBBs : nullptr);
   }
 
-  // Fixpoint: propagate HasMayConstLoad and RefsPeriodArr up the call graph.
-  // The extracted module holds only the closure, so every function is reachable
-  // from some entry; the monotonic fixpoint converges quickly.
-  DenseMap<const Function *, bool> ClosureMC;
-  DenseMap<const Function *, SetVector<StringRef>> ClosureRefs;
-  for (auto &KV : Info) {
-    ClosureMC[KV.first] = KV.second.HasMayConstLoad;
-    ClosureRefs[KV.first] = KV.second.RefsPeriodArr;
-  }
-  bool Changed = true;
-  while (Changed) {
-    Changed = false;
-    for (auto &KV : Info) {
-      const Function *F = KV.first;
-      for (const Function *Callee : KV.second.Callees) {
-        if (!Info.count(Callee))
-          continue;
-        if (ClosureMC[Callee] && !ClosureMC[F]) {
-          ClosureMC[F] = true;
-          Changed = true;
-        }
-        for (StringRef P : ClosureRefs[Callee])
-          if (ClosureRefs[F].insert(P))
-            Changed = true;
-      }
-    }
-  }
-
   // Emit diagnostics per entry (locate in the extracted module by name).
   for (const EjitEntryDiag &ED : Entries) {
     const Function *EF = Extracted.getFunction(ED.Name);
     if (!EF || EF->isDeclaration())
       continue;
-    auto MCIt = ClosureMC.find(EF);
-    auto RefIt = ClosureRefs.find(EF);
-    if (MCIt == ClosureMC.end() || RefIt == ClosureRefs.end())
+    auto It = Info.find(EF);
+    if (It == Info.end())
       continue;
 
-    // #1: no ejit_may_const read in the specialization closure.
-    if (EJitWarnNoSpecialization && !MCIt->second)
+    // #1: no ejit_may_const read in the post-inline entry body.
+    if (EJitWarnNoSpecialization && !It->second.HasMayConstLoad)
       errs() << "EJit warning: ejit_entry function '" << EF->getName()
-             << "' reads no ejit_may_const field in its specialization "
-                "closure; no JIT specialization value, consider removing "
+             << "' reads no ejit_may_const field in its post-inline body; "
+                "no JIT specialization value, consider removing "
                 "ejit_entry\n";
 
-    // #2: declared dimension never referenced by the closure.
+    // #2: declared dimension never referenced by the post-inline body.
     if (EJitWarnUnusedDim)
       for (const std::string &P : ED.DeclaredDims)
-        if (RefIt->second.count(P) == 0)
+        if (It->second.RefsPeriodArr.count(P) == 0)
           errs() << "EJit warning: ejit_entry function '" << EF->getName()
                  << "' declares ejit_period_arr_ind('" << P
-                 << "') but its specialization closure never indexes an "
+                 << "') but its post-inline body never indexes an "
                     "ejit_period_arr('"
                  << P << "'); unused specialization dimension, consider "
                         "removing it\n";
   }
 
-  // Per-entry may_const read counts over the specialization closure (BFS).
-  // Used by the info report and the few-may-const warning; both share the
-  // same closure walk so they share one gated loop.
+  // Per-entry may_const read counts in the post-inline body.
   if (EJitReportMayConst || EJitWarnFewMayConst > 0) {
     for (const EjitEntryDiag &ED : Entries) {
       const Function *EF = Extracted.getFunction(ED.Name);
       if (!EF || EF->isDeclaration())
         continue;
-      // BFS the entry's direct-call closure within the extracted module.
-      DenseSet<const Function *> Seen;
-      SmallVector<const Function *, 8> WL{EF};
-      unsigned K = 0, J = 0;
-      while (!WL.empty()) {
-        const Function *F = WL.pop_back_val();
-        if (!Seen.insert(F).second)
-          continue;
-        auto It = Info.find(F);
-        if (It == Info.end())
-          continue;
-        K += It->second.MayConstCount;
-        J += It->second.MayConstInLoopCount;
-        for (const Function *Callee : It->second.Callees)
-          WL.push_back(Callee);
-      }
+      auto It = Info.find(EF);
+      if (It == Info.end())
+        continue;
+      unsigned K = It->second.MayConstCount;
+      unsigned J = It->second.MayConstInLoopCount;
 
       // Info report (not a warning): summary of all may-const reads.
       if (EJitReportMayConst)
@@ -570,7 +523,7 @@ runSpecializationDiagnostic(Module &Extracted,
       if (EJitWarnFewMayConst > 0 && K < EJitWarnFewMayConst && J == 0)
         errs() << "EJit warning: ejit_entry function '" << EF->getName()
                << "' has only " << K << " ejit_may_const read"
-               << (K == 1 ? "" : "s") << " in its specialization closure"
+               << (K == 1 ? "" : "s") << " in its post-inline body"
                << " (threshold: " << EJitWarnFewMayConst
                << "); low specialization surface, consider adding more"
                   " may-const fields\n";
@@ -578,7 +531,54 @@ runSpecializationDiagnostic(Module &Extracted,
   }
 }
 
-static std::string extractAndSerialize(Module &M,
+struct AotFallbackSymbol {
+  std::string JitName;
+  Function *AotFunction = nullptr;
+};
+
+struct ExtractedBitcode {
+  std::string Data;
+  SmallVector<AotFallbackSymbol, 16> AotFallbacks;
+};
+
+static std::string makeAotFallbackName(const Module &M, StringRef FuncName) {
+  MD5 Hash;
+  Hash.update(M.getModuleIdentifier());
+  Hash.update(StringRef("\0", 1));
+  Hash.update(FuncName);
+  MD5::MD5Result Result;
+  Hash.final(Result);
+  return ("__ejit_aot_" + utohexstr(Result.high(), true, 16) +
+          utohexstr(Result.low(), true, 16));
+}
+
+static Function *createEntryAotFallback(Function &F, StringRef AotName) {
+  Function *Clone = Function::Create(
+      F.getFunctionType(), GlobalValue::InternalLinkage,
+      AotName + ".body", F.getParent());
+  Clone->copyAttributesFrom(&F);
+
+  ValueToValueMapTy VMap;
+  VMap[&F] = Clone;
+  auto DestArg = Clone->arg_begin();
+  for (Argument &Arg : F.args()) {
+    DestArg->setName(Arg.getName());
+    VMap[&Arg] = &*DestArg++;
+  }
+  SmallVector<ReturnInst *, 8> Returns;
+  CloneFunctionInto(Clone, &F, VMap, CloneFunctionChangeType::GlobalChanges,
+                    Returns);
+
+  // The copy is a direct AOT body, not another public specialization entry.
+  // Clearing EJIT function metadata prevents the later wrapper pass from
+  // turning it into a dispatcher while retaining ordinary LLVM attributes.
+  Clone->setMetadata(MD_EJIT_METADATA, nullptr);
+  Clone->setVisibility(GlobalValue::DefaultVisibility);
+  Clone->setDSOLocal(true);
+  return Clone;
+}
+
+static ExtractedBitcode extractAndSerialize(Module &M,
     const SetVector<Function *> &Funcs,
     const SetVector<GlobalVariable *> &Globals,
     const SmallVectorImpl<Function *> &EntryFuncs) {
@@ -622,6 +622,24 @@ static std::string extractAndSerialize(Module &M,
   preOptimizeBitcode(*Extracted);
   logEJitGlobalMeta("extract-after-preOpt", *Extracted);
 
+  ExtractedBitcode Result;
+  for (Function &F : Extracted->functions()) {
+    if (F.isDeclaration() || F.isIntrinsic())
+      continue;
+    Function *AotF = M.getFunction(F.getName());
+    if (!AotF)
+      continue;
+    std::string AotName = makeAotFallbackName(M, F.getName());
+    F.setMetadata(MD_EJIT_AOT_SYMBOL,
+                  MDNode::get(F.getContext(), MDString::get(F.getContext(),
+                                                            AotName)));
+    Function *Fallback = AotF;
+    if (hasMDStringEntry(AotF->getMetadata(MD_EJIT_METADATA),
+                         TAG_EJIT_ENTRY))
+      Fallback = createEntryAotFallback(*AotF, AotName);
+    Result.AotFallbacks.push_back({std::move(AotName), Fallback});
+  }
+
   // Specialization diagnostics on the post-preOptimize extracted module (the
   // exact bitcode the JIT will specialize). Must run before the extern
   // conversion below so GV definitions (and their !ejit.metadata) are intact.
@@ -637,29 +655,6 @@ static std::string extractAndSerialize(Module &M,
     GV.setInitializer(nullptr);
     GV.setLinkage(GlobalValue::ExternalLinkage);
   }
-  // Pre-internalize non-entry definitions so the JIT's IRMaterializationUnit
-  // does not advertise them in MR->getSymbols().  The JIT-side
-  // runInterproceduralPropagation also internalizes them (for IPSCCP), but
-  // that runs inside the IR transform callback — after the MU has already
-  // been created with the original symbol claim set.  If a helper is
-  // advertised as an external definition in the MU but codegen emits it as
-  // STB_LOCAL (because the JIT-side internalize ran after the MU was fixed),
-  // JITLink maps STB_LOCAL to Scope::Local and excludes it from
-  // InternedResult, breaking the ORC invariant that every claimed symbol has
-  // a matching definition.  Doing it here, before serialization, makes the
-  // embedded bitcode self-consistent: the MU only claims entry-point symbols
-  // (which still have external linkage), and the JIT-side internalize pass
-  // becomes a no-op for helpers (they already have local linkage).
-  for (Function &F : Extracted->functions()) {
-    if (F.isDeclaration() || F.hasLocalLinkage())
-      continue;
-    if (hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY))
-      continue;
-    F.setVisibility(GlobalValue::DefaultVisibility);
-    F.setLinkage(GlobalValue::InternalLinkage);
-  }
-
-
   logEJitGlobalMeta("extract-after-extern", *Extracted);
 
   // Optionally dump the extracted module for debugging (e.g. to confirm an
@@ -668,11 +663,10 @@ static std::string extractAndSerialize(Module &M,
   if (!EJitDumpBitcodeDir.empty())
     dumpExtractedBitcode(*Extracted, EJitDumpBitcodeDir);
 
-  std::string Bitcode;
-  raw_string_ostream OS(Bitcode);
+  raw_string_ostream OS(Result.Data);
   WriteBitcodeToFile(*Extracted, OS);
   OS.flush();
-  return Bitcode;
+  return Result;
 }
 
 static GlobalVariable *embedBitcode(Module &M, const std::string &Bitcode) {
@@ -702,6 +696,7 @@ static void generateSymbolRegisters(
     Module &M,
     const SetVector<Function *> &ClosureFuncs,
     const SetVector<GlobalVariable *> &ClosureGlobals,
+    const SmallVectorImpl<AotFallbackSymbol> &AotFallbacks,
     Function *AutoReg) {
   LLVMContext &Ctx = M.getContext();
   const DataLayout &DL = M.getDataLayout();
@@ -719,6 +714,18 @@ static void generateSymbolRegisters(
 
   BasicBlock *BB = &AutoReg->getEntryBlock();
   Instruction *InsertBefore = BB->getTerminator();
+
+  // Every definition that survived AOT inlining may become a declaration when
+  // another entry is specialized. Register it under its TU-unique fallback
+  // name, including static helpers and other ejit_entry functions.
+  for (const AotFallbackSymbol &Sym : AotFallbacks) {
+    if (!Sym.AotFunction || !registered.insert(Sym.JitName).second)
+      continue;
+    IRBuilder<> Builder(InsertBefore);
+    Builder.CreateCall(M.getFunction(FN_REGISTER_SYMBOL),
+                       {Builder.CreateGlobalString(Sym.JitName),
+                        Builder.CreateBitCast(Sym.AotFunction, PtrTy)});
+  }
 
   for (Function *F : ClosureFuncs) {
     for (BasicBlock &Blk : *F) {
@@ -812,12 +819,14 @@ static void
 generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
                       const SetVector<Function *> &ClosureFuncs,
                       const SetVector<GlobalVariable *> &ClosureGlobals,
+                      const SmallVectorImpl<AotFallbackSymbol> &AotFallbacks,
                       GlobalVariable *BitcodeGV);
 
 static void generateRegisterCall(Module &M, GlobalVariable *BitcodeGV,
                                  const SmallVectorImpl<Function *> &EntryFuncs,
                                  const SetVector<Function *> &ClosureFuncs,
-                                 const SetVector<GlobalVariable *> &ClosureGlobals) {
+                                 const SetVector<GlobalVariable *> &ClosureGlobals,
+                                 const SmallVectorImpl<AotFallbackSymbol> &AotFallbacks) {
   LLVMContext &Ctx = M.getContext();
   auto *VoidTy = Type::getVoidTy(Ctx);
   auto *PtrTy = PointerType::getUnqual(Ctx);
@@ -850,13 +859,15 @@ static void generateRegisterCall(Module &M, GlobalVariable *BitcodeGV,
 
   // Auto-register external symbols referenced by the closure so the JIT
   // can resolve them without manual ejit_register_symbol calls.
-  generateSymbolRegisters(M, ClosureFuncs, ClosureGlobals, AutoReg);
+  generateSymbolRegisters(M, ClosureFuncs, ClosureGlobals, AotFallbacks,
+                          AutoReg);
 
   if (EnableEJitGlobalCtors)
     appendToGlobalCtors(M, AutoReg, EJIT_CTOR_PRIORITY);
 
   // Always build the static registry table for bare-metal / testing fallback.
-  generateRegistryTable(M, EntryFuncs, ClosureFuncs, ClosureGlobals, BitcodeGV);
+  generateRegistryTable(M, EntryFuncs, ClosureFuncs, ClosureGlobals,
+                        AotFallbacks, BitcodeGV);
 }
 
 /// Emit this translation unit's bitcode registry entries as a private array in
@@ -868,6 +879,7 @@ static void
 generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
                       const SetVector<Function *> &ClosureFuncs,
                       const SetVector<GlobalVariable *> &ClosureGlobals,
+                      const SmallVectorImpl<AotFallbackSymbol> &AotFallbacks,
                       GlobalVariable *BitcodeGV) {
   LLVMContext &Ctx = M.getContext();
   auto *I32Ty = Type::getInt32Ty(Ctx);
@@ -896,30 +908,36 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
     }));
   }
 
-  // Symbol entries for external references
-  SmallPtrSet<const Function *, 8> SymbolsDone;
-  auto addSymbol = [&](const Function *F) {
-    if (!F->isIntrinsic() && F->isDeclaration()) {
-      if (SymbolsDone.insert(F).second) {
-        Constant *NameStr = ConstantDataArray::getString(Ctx, F->getName(), true);
-        auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
-            GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
-        Entries.push_back(ConstantStruct::get(EntryTy, {
-            ConstantInt::get(I32Ty, EJIT_REG_SYMBOL),                      // EJIT_REG_SYMBOL
-            ConstantExpr::getBitCast(NameGV, PtrTy),         // name1 string
-            ConstantPointerNull::get(PtrTy),
-            ConstantExpr::getBitCast(const_cast<Function *>(F), PtrTy),
-            ConstantInt::get(I64Ty, 0),
-        }));
-      }
-    }
+  // Function symbols: TU-unique AOT fallbacks for retained definitions, plus
+  // ordinary names for pre-existing external declarations.
+  std::set<std::string> SymbolsDone;
+  auto addNamedSymbol = [&](StringRef Name, const Function *F) {
+    if (!F || F->isIntrinsic() || Name.empty() ||
+        !SymbolsDone.insert(Name.str()).second)
+      return;
+    Constant *NameStr = ConstantDataArray::getString(Ctx, Name, true);
+    auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
+        GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
+    Entries.push_back(ConstantStruct::get(EntryTy, {
+        ConstantInt::get(I32Ty, EJIT_REG_SYMBOL),
+        ConstantExpr::getBitCast(NameGV, PtrTy),
+        ConstantPointerNull::get(PtrTy),
+        ConstantExpr::getBitCast(const_cast<Function *>(F), PtrTy),
+        ConstantInt::get(I64Ty, 0),
+    }));
   };
+  auto addExternalSymbol = [&](const Function *F) {
+    if (F && F->isDeclaration())
+      addNamedSymbol(F->getName(), F);
+  };
+  for (const AotFallbackSymbol &Sym : AotFallbacks)
+    addNamedSymbol(Sym.JitName, Sym.AotFunction);
   for (Function *F : ClosureFuncs) {
     for (const BasicBlock &BB : *F) {
       for (const Instruction &I : BB) {
         if (const CallBase *CB = dyn_cast<CallBase>(&I))
           if (Function *Callee = CB->getCalledFunction())
-            addSymbol(Callee);
+            addExternalSymbol(Callee);
       }
     }
   }
@@ -934,7 +952,7 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
     SmallPtrSet<Function *, 8> FuncsInInit;
     collectFunctionsFromConstant(GV->getInitializer(), FuncsInInit);
     for (Function *F : FuncsInInit)
-      addSymbol(F);
+      addExternalSymbol(F);
   }
 
   // Global variable symbol entries. Resolve through bitcasts/GEPs via
@@ -1015,10 +1033,11 @@ EJitRegisterBitcodePass::run(Module &M, ModuleAnalysisManager &) {
   if (ClosureFuncs.empty())
     return PreservedAnalyses::all();
 
-  std::string Bitcode =
+  ExtractedBitcode Bitcode =
       extractAndSerialize(M, ClosureFuncs, ClosureGlobals, EntryFuncs);
-  GlobalVariable *BitcodeGV = embedBitcode(M, Bitcode);
-  generateRegisterCall(M, BitcodeGV, EntryFuncs, ClosureFuncs, ClosureGlobals);
+  GlobalVariable *BitcodeGV = embedBitcode(M, Bitcode.Data);
+  generateRegisterCall(M, BitcodeGV, EntryFuncs, ClosureFuncs, ClosureGlobals,
+                       Bitcode.AotFallbacks);
 
   return PreservedAnalyses::none();
 }

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-few-mayconst.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-few-mayconst.ll
@@ -4,14 +4,14 @@
 ; RUN: opt -passes=ejit-register-bitcode -ejit-warn-few-mayconst=0 -S %s 2>&1 \
 ; RUN:     | FileCheck %s --check-prefix=OFF
 
-; #3: warn when the specialization closure has fewer than N ejit_may_const
+; #3: warn when the post-inline entry body has fewer than N ejit_may_const
 ; reads. N=4 means 0..3 reads trigger the warning.
 
 ; 1 read → warn (below threshold 4).
 ; CHECK: EJit warning: ejit_entry function 'entry_one' has only 1 ejit_may_const read
 
-; 3 reads in the closure (direct + callee) → warn.
-; CHECK: EJit warning: ejit_entry function 'entry_three_via_helper' has only 3 ejit_may_const reads
+; The noinline AOT callee's 2 reads do not count; only 1 entry-body read → warn.
+; CHECK: EJit warning: ejit_entry function 'entry_three_via_helper' has only 1 ejit_may_const read
 
 ; 0 reads → warn (below threshold 4).
 ; CHECK: EJit warning: ejit_entry function 'entry_zero' has only 0 ejit_may_const reads
@@ -79,7 +79,7 @@ define i32 @entry_five(i32 %c) !ejit.metadata !20 {
   ret i32 %s3
 }
 
-; ── 3 reads in closure (1 direct + 2 in callee) → below threshold → warn ──
+; ── 1 entry-body read; 2 noinline AOT-callee reads do not count → warn ──
 define i32 @entry_three_via_helper(i32 %c) !ejit.metadata !20 {
   %v = call i32 @helper_two(i32 %c)
   %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %c
@@ -87,7 +87,7 @@ define i32 @entry_three_via_helper(i32 %c) !ejit.metadata !20 {
   %sum = add i32 %v, %direct
   ret i32 %sum
 }
-define internal i32 @helper_two(i32 %c) {
+define internal i32 @helper_two(i32 %c) #0 {
   %p0 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 0
   %v0 = load i32, ptr %p0, !ejit.may_const !{}
   %p1 = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 1
@@ -117,3 +117,5 @@ exit:
 
 !10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}, !{!"ejit_may_const_field", i32 0}}
 !20 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+
+attributes #0 = { noinline }

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-no-specialization.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-no-specialization.ll
@@ -1,15 +1,15 @@
 ; RUN: opt -passes=ejit-register-bitcode -S %s 2>&1 | FileCheck %s
 
-; #1: ejit_entry whose specialization closure reads no ejit_may_const field
+; #1: ejit_entry whose post-inline body reads no ejit_may_const field
 ; has no JIT specialization value -> warn.
 
-; CHECK: EJit warning: ejit_entry function 'entry_plain' reads no ejit_may_const field in its specialization closure
-; CHECK: EJit warning: ejit_entry function 'entry_external_only' reads no ejit_may_const field in its specialization closure
+; CHECK: EJit warning: ejit_entry function 'entry_plain' reads no ejit_may_const field in its post-inline body
+; CHECK: EJit warning: ejit_entry function 'entry_via_helper' reads no ejit_may_const field in its post-inline body
+; CHECK: EJit warning: ejit_entry function 'entry_external_only' reads no ejit_may_const field in its post-inline body
 
-; #1 must NOT fire for entries that do read ejit_may_const, whether directly or
-; via an internal helper that the closure covers.
+; #1 must NOT fire for entries that read ejit_may_const directly or through a
+; helper that AOT pre-inlining places in the entry body.
 ; CHECK-NOT: EJit warning: ejit_entry function 'entry_direct' reads no ejit_may_const
-; CHECK-NOT: EJit warning: ejit_entry function 'entry_via_helper' reads no ejit_may_const
 
 @cell_data = global [16 x i32] zeroinitializer, !ejit.metadata !10
 
@@ -26,13 +26,13 @@ define i32 @entry_direct(i32 %c) !ejit.metadata !20 {
   ret i32 %v
 }
 
-; ejit_may_const read hidden in an internal helper. The closure covers it, so
-; the entry still has specialization value -> no warning.
+; A noinline helper executes through its AOT fallback. Its may_const read does
+; not give the JIT entry body specialization value -> warn.
 define i32 @entry_via_helper(i32 %c) !ejit.metadata !20 {
   %r = call i32 @helper_reads_mc(i32 %c)
   ret i32 %r
 }
-define internal i32 @helper_reads_mc(i32 %c) {
+define internal i32 @helper_reads_mc(i32 %c) #0 {
   %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %c
   %v = load i32, ptr %p, !ejit.may_const !{}
   ret i32 %v
@@ -49,3 +49,5 @@ declare void @external_fn(i32)
 !10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}, !{!"ejit_may_const_field", i32 0}}
 !20 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
 !30 = distinct !{!{!"ejit_entry"}}
+
+attributes #0 = { noinline }

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-report-mayconst.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-report-mayconst.ll
@@ -4,7 +4,7 @@
 ; RUN:     -S %s 2>&1 | FileCheck %s
 
 ; Option A: an info-level (non-gating) report of per-ejit_entry ejit_may_const
-; read counts over the specialization closure: K total, J inside loops.
+; read counts in the post-inline body: K total, J inside loops.
 
 ; A single may_const read inside a self-loop -> 1 total, 1 in loops.
 ; CHECK: EJit info: ejit_entry function 'entry_loop': 1 ejit_may_const read (1 in loops)

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-unused-dim.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-unused-dim.ll
@@ -1,10 +1,10 @@
 ; RUN: opt -passes=ejit-register-bitcode -S %s 2>&1 | FileCheck %s
 ; RUN: opt -passes=ejit-register-bitcode -ejit-warn-unused-dim=false -S %s 2>&1 | FileCheck %s --check-prefix=OFF
 
-; #2: an ejit_entry that declares ejit_period_arr_ind(P) but whose closure
+; #2: an ejit_entry that declares ejit_period_arr_ind(P) but whose post-inline body
 ; never indexes an ejit_period_arr(P) has an unused specialization dimension.
 
-; CHECK: EJit warning: ejit_entry function 'entry_unused_cell' declares ejit_period_arr_ind('cell') but its specialization closure never indexes an ejit_period_arr('cell')
+; CHECK: EJit warning: ejit_entry function 'entry_unused_cell' declares ejit_period_arr_ind('cell') but its post-inline body never indexes an ejit_period_arr('cell')
 
 ; The used dim (trp) on the same function must NOT warn, and an entry that does
 ; index its declared dim must NOT warn.

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-register-aot-fallback-symbols.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-register-aot-fallback-symbols.ll
@@ -1,0 +1,24 @@
+; RUN: opt -passes=ejit-register-bitcode -S %s | FileCheck %s
+;
+; Every definition that survives AOT inlining is registered under the same
+; TU-unique name stored in the embedded bitcode. This includes static helpers
+; and other entries, allowing the JIT loader to externalize every non-active
+; body without name collisions across translation units.
+
+; CHECK-DAG: c"__ejit_aot_{{[0-9a-f]+}}\00"
+; CHECK-DAG: call void @ejit_register_symbol(ptr {{.*}}, ptr @static_helper)
+; CHECK-DAG: call void @ejit_register_symbol(ptr {{.*}}, ptr @__ejit_aot_{{[0-9a-f]+}}.body)
+; CHECK: define internal i32 @__ejit_aot_{{[0-9a-f]+}}.body(i32 %x)
+
+define internal i32 @static_helper(i32 %x) #0 {
+  %r = mul i32 %x, 3
+  ret i32 %r
+}
+
+define i32 @function_entry(i32 %x) #0 !ejit.metadata !0 {
+  %r = call i32 @static_helper(i32 %x)
+  ret i32 %r
+}
+
+attributes #0 = { noinline }
+!0 = distinct !{!{!"ejit_entry"}}

--- a/llvm/test/Transforms/EmbeddedJIT/internalize-non-entry-definitions.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/internalize-non-entry-definitions.ll
@@ -2,25 +2,22 @@
 ; RUN: opt -passes=ejit-register-bitcode -ejit-dump-bitcode-dir=%t-dump -S <%s >/dev/null
 ; RUN: opt -S %t-dump/*.bc | FileCheck --check-prefix=EXTRACTED %s
 ;
-; This test verifies that non-ejit_entry function definitions in the extracted
-; bitcode are internalized (set to InternalLinkage) at AOT time, before
-; serialization.  This prevents the JIT's IRMaterializationUnit from claiming
-; them in MR->getSymbols(), avoiding spurious "Missing definitions" errors
-; when the JIT-side runInterproceduralPropagation later internalizes them
-; inside the transform callback (after the MU claim set is already fixed).
+; AOT inlining runs before extraction is finalized. Definitions that survive
+; remain available in the embedded bitcode, tagged with a TU-unique AOT symbol.
+; The ORC loader later converts every non-active definition to that external
+; declaration before creating the IRMaterializationUnit.
 ;
 ; Entry functions that carry !ejit.metadata !{!"ejit_entry"} must keep their
 ; external linkage so the JIT can look them up.
 
-; A helper function that the entry calls — should be internalized in the
-; extracted bitcode.
-define i32 @helper_add(i32 %a, i32 %b) {
+; noinline keeps these calls present after AOT pre-optimization.
+define i32 @helper_add(i32 %a, i32 %b) #0 {
   %sum = add i32 %a, %b
   ret i32 %sum
 }
 
 ; A second helper called by the first helper — transitive internalization.
-define i32 @helper_mul(i32 %a, i32 %b) {
+define i32 @helper_mul(i32 %a, i32 %b) #0 {
   %prod = mul i32 %a, %b
   ret i32 %prod
 }
@@ -41,9 +38,11 @@ define void @ejit_entry_ext() !ejit.metadata !3 {
   ret void
 }
 
-; Check that helpers become internal in the extracted bitcode.
-; EXTRACTED: define internal i32 @helper_add(
-; EXTRACTED: define internal i32 @helper_mul(
+; Helpers retain definitions for now and carry unique fallback names.
+; EXTRACTED: define i32 @helper_add({{.*}} !ejit.aot_symbol ![[ADD:[0-9]+]]
+; EXTRACTED: define i32 @helper_mul({{.*}} !ejit.aot_symbol ![[MUL:[0-9]+]]
+; EXTRACTED-DAG: ![[ADD]] = !{!"__ejit_aot_{{[0-9a-f]+}}"}
+; EXTRACTED-DAG: ![[MUL]] = !{!"__ejit_aot_{{[0-9a-f]+}}"}
 
 ; Entry functions must keep their original linkage (not internal).
 ; EXTRACTED: define{{.*}} i32 @ejit_entry_calc(
@@ -56,3 +55,5 @@ define void @ejit_entry_ext() !ejit.metadata !3 {
 !1 = !{!0}
 !2 = !{!0}
 !3 = !{!0}
+
+attributes #0 = { noinline }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -36,11 +36,14 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/EmbeddedJIT/EJitPasses.h"
+#include "llvm/Transforms/Utils/Cloning.h"
 #include "gtest/gtest.h"
 #ifndef EJIT_FREESTANDING
 #include <thread>
@@ -86,6 +89,10 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
     auto *FT = FunctionType::get(I32, {I32}, false);
     for (StringRef Name : {"dump_a", "dump_b", "dump_c"}) {
       auto *F = Function::Create(FT, Function::ExternalLinkage, Name, &M);
+      F->setMetadata(MD_EJIT_AOT_SYMBOL,
+                     MDNode::get(Ctx, MDString::get(
+                                          Ctx, (Twine("__ejit_aot_test_") +
+                                                Name).str())));
       IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
       B.CreateRet(B.CreateAdd(F->getArg(0), B.getInt32(Name.back())));
     }
@@ -123,6 +130,56 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
   }
 }
 
+static int functionOnlyAotHelper(int X) { return X + 1000; }
+
+TEST(EJitFunctionIsolation, OrcCallsAotForResidualCall) {
+  std::string Bitcode;
+  {
+    LLVMContext Ctx;
+    SMDiagnostic Err;
+    auto M = parseAssemblyString(R"(
+      define internal i32 @module_helper(i32 %x) !ejit.aot_symbol !0 {
+        %r = add i32 %x, 1
+        ret i32 %r
+      }
+      define i32 @function_only_entry(i32 %x) {
+        %r = call i32 @module_helper(i32 %x)
+        ret i32 %r
+      }
+      !0 = !{!"__ejit_aot_function_only_test"}
+    )",
+                                 Err, Ctx);
+    ASSERT_NE(M, nullptr);
+    raw_string_ostream OS(Bitcode);
+    WriteBitcodeToFile(*M, OS);
+    OS.flush();
+  }
+
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  EJitRuntimeState State;
+  Config Cfg;
+  auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
+  ASSERT_TRUE(static_cast<bool>(EngineOrErr));
+  auto Engine = std::move(*EngineOrErr);
+  Engine->addUserSymbol("__ejit_aot_function_only_test",
+                        reinterpret_cast<void *>(&functionOnlyAotHelper));
+
+  constexpr uint64_t Key = 0xf001;
+  SpecializationContext SpecCtx;
+  SpecCtx.fnName = "function_only_entry";
+  SpecCtx.cacheKey = Key;
+  Engine->setActiveContext(&SpecCtx);
+  ASSERT_FALSE(errorToBool(
+      Engine->loadBitcodeModule(Bitcode, Key, SpecCtx.fnName)));
+  auto FnOrErr = Engine->lookup(Key, SpecCtx.fnName);
+  ASSERT_TRUE(static_cast<bool>(FnOrErr));
+  using FnTy = int (*)(int);
+  auto Fn = reinterpret_cast<FnTy>(*FnOrErr);
+  EXPECT_EQ(Fn(5), 1005) << "residual call executed the JIT helper body";
+  Engine->setActiveContext(nullptr);
+}
+
 namespace llvm {
 namespace ejit {
 // Test-only accessor. EJitOptimizer deliberately keeps its individual pipeline
@@ -135,7 +192,6 @@ struct EJitOptimizerTestAccess : EJitOptimizer {
   using EJitOptimizer::EJitOptimizer;
   using EJitOptimizer::preReplacePeriodIndices;
   using EJitOptimizer::runInstCombine;
-  using EJitOptimizer::runInterproceduralPropagation;
   using EJitOptimizer::runOptimizationPipeline;
   using EJitOptimizer::runStructFieldPass;
 };
@@ -2571,137 +2627,130 @@ TEST(EJitEndToEnd, PipelineFoldsMayConstBranchAtAllLevels) {
 }
 
 //===----------------------------------------------------------------------===//
-// Interprocedural propagation (phase 1d)
+// Function-only specialization boundary
 //===----------------------------------------------------------------------===//
 
-// The AOT inliner keeps a call edge wherever it chose not to inline, so a
-// specialization used to stop at every such edge: the entry's substituted
-// dims arrive at the callee as ordinary constant arguments, but the callee
-// body still indexes the period array with a runtime value and re-tests
-// guards. These tests pin phase 1d (internalize + IPSCCP): the constants
-// cross the edge, the callee's may_const load becomes substitutable, and the
-// callee folds to a constant return like the entry does.
-namespace {
-
-/// Entry (has ejit_entry metadata) calls a callee with a constant cell index
-/// — the shape phase 1a leaves behind. The callee loads field 1 of
-/// g_ipcfg[cell] (may_const) and branches on it.
-std::unique_ptr<Module> parseInterprocModule(LLVMContext &Ctx) {
+TEST(EJitFunctionIsolation, NonInlineCalleeBecomesUniqueAotDeclaration) {
+  LLVMContext Ctx;
   SMDiagnostic Err;
   auto M = parseAssemblyString(R"(
-    target datalayout = "e-m:e-i64:64-i128:128-n32:64-S128"
-    %S = type { i32, i32 }
-    @g_ipcfg = external global [4 x %S], !ejit.metadata !0
-
-    define i32 @ip_callee(i8 noundef %cell) {
-      %idx = zext i8 %cell to i64
-      %gep = getelementptr inbounds [4 x %S], ptr @g_ipcfg, i64 0, i64 %idx, i32 1
-      %v = load i32, ptr %gep, align 4, !ejit.may_const !2
-      %c = icmp eq i32 %v, 7
-      br i1 %c, label %then, label %else
-    then:
-      ret i32 100
-    else:
-      ret i32 200
-    }
-
-    define i32 @ip_entry() !ejit.metadata !3 {
-      %r = call i32 @ip_callee(i8 noundef 2)
+    define internal i32 @slow_helper(i32 %x) !ejit.aot_symbol !0 {
+      %r = mul i32 %x, 9
       ret i32 %r
     }
 
-    !0 = !{!1}
-    !1 = !{!"ejit_period_arr", !"cell", i32 4}
-    !2 = !{}
-    !3 = !{!4}
-    !4 = !{!"ejit_entry"}
+    define i32 @active_entry(i32 %x) !ejit.metadata !1 !ejit.aot_symbol !4 {
+      %inlined = add i32 %x, 7
+      %r = call i32 @slow_helper(i32 %inlined)
+      ret i32 %r
+    }
+
+    define i32 @other_entry(i32 %x) !ejit.metadata !1 !ejit.aot_symbol !2 {
+      %r = sub i32 %x, 1
+      ret i32 %r
+    }
+
+    !0 = !{!"__ejit_aot_tu_slow_helper"}
+    !1 = !{!3}
+    !2 = !{!"__ejit_aot_tu_other_entry"}
+    !3 = !{!"ejit_entry"}
+    !4 = !{!"__ejit_aot_tu_active_entry"}
   )",
                               Err, Ctx);
   if (!M)
-    Err.print("parseInterprocModule", errs());
-  return M;
-}
-
-/// Per-cell mock backing for @g_ipcfg; cell 2 has field 1 == 7 → callee
-/// returns 100 when specialized for cell 2.
-struct IpMockElem {
-  int32_t a, b;
-};
-
-unsigned countLoadsIn(const Function &F) {
-  unsigned n = 0;
-  for (const BasicBlock &BB : F)
-    for (const Instruction &I : BB)
-      n += isa<LoadInst>(&I);
-  return n;
-}
-
-} // anonymous namespace
-
-// Without phase 1d the callee is untouched: its load survives the whole
-// pipeline because the cell index stays a runtime argument inside it. This is
-// the baseline that motivates the pass.
-TEST(EJitInterprocedural, ConstantsStopAtCallEdgeWithoutIPSCCP) {
-  LLVMContext Ctx;
-  auto M = parseInterprocModule(Ctx);
+    Err.print("EJitFunctionIsolation", errs());
   ASSERT_NE(M, nullptr);
+  auto OtherModule = CloneModule(*M);
+  auto InvalidModule = CloneModule(*M);
 
-  IpMockElem mock[4] = {{0, 1}, {0, 3}, {0, 7}, {0, 9}};
-  PeriodArrayRegistry reg;
-  reg.registerArray("cell", "g_ipcfg", mock, 4);
-
-  EJitOptimizerTestAccess opt(reg);
-  opt.runInstCombine(*M);
-  opt.runStructFieldPass(*M);
-  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
-
-  Function *Callee = M->getFunction("ip_callee");
-  ASSERT_NE(Callee, nullptr);
-  EXPECT_EQ(countLoadsIn(*Callee), 1u)
-      << "callee folded without IPSCCP — baseline assumption changed";
-}
-
-// With phase 1d in its pipeline position (after 1c, before the 1e/1f
-// re-fold), the constant argument crosses the edge, the callee's may_const
-// load folds against cell 2's runtime value, and the guard collapses: the
-// callee body becomes `ret i32 100`.
-TEST(EJitInterprocedural, IPSCCPPropagatesDimsIntoCallee) {
-  LLVMContext Ctx;
-  auto M = parseInterprocModule(Ctx);
-  ASSERT_NE(M, nullptr);
-
-  IpMockElem mock[4] = {{0, 1}, {0, 3}, {0, 7}, {0, 9}};
-  PeriodArrayRegistry reg;
-  reg.registerArray("cell", "g_ipcfg", mock, 4);
-
-  EJitOptimizerTestAccess opt(reg);
-  // Same order as runPipeline: 1b InstCombine, 1c StructField, 1d IPSCCP,
-  // 1e/1f re-fold, phases 2-4.
-  opt.runInstCombine(*M);
-  opt.runStructFieldPass(*M);
-  opt.runInterproceduralPropagation(*M);
-  opt.runInstCombine(*M);
-  opt.runStructFieldPass(*M);
-  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
-
-  Function *Callee = M->getFunction("ip_callee");
-  Function *Entry = M->getFunction("ip_entry");
-  ASSERT_NE(Callee, nullptr);
+  ASSERT_TRUE(llvm::ejit::detail::isolateFunctionForSpecialization(
+      *M, "active_entry"));
+  Function *Entry = M->getFunction("active_entry");
+  Function *Helper = M->getFunction("__ejit_aot_tu_slow_helper");
+  Function *Other = M->getFunction("__ejit_aot_tu_other_entry");
   ASSERT_NE(Entry, nullptr);
+  ASSERT_NE(Helper, nullptr);
+  ASSERT_NE(Other, nullptr);
+  EXPECT_FALSE(Entry->isDeclaration());
+  EXPECT_TRUE(Helper->isDeclaration());
+  EXPECT_TRUE(Other->isDeclaration());
+  EXPECT_TRUE(Helper->hasExternalLinkage());
+  EXPECT_TRUE(Other->hasExternalLinkage());
 
-  // The callee was internalized so IPSCCP could trust its call-site set; the
-  // entry must stay externally visible — it is the symbol the JIT looks up.
-  EXPECT_TRUE(Callee->hasLocalLinkage());
-  EXPECT_FALSE(Entry->hasLocalLinkage());
+  auto *Call = dyn_cast<CallInst>(&*std::next(Entry->front().begin()));
+  ASSERT_NE(Call, nullptr);
+  EXPECT_EQ(Call->getCalledFunction(), Helper);
+  EXPECT_FALSE(verifyModule(*M, &errs()));
 
-  // The callee's period load and guard folded to the constant return.
-  EXPECT_EQ(countLoadsIn(*Callee), 0u) << "callee may_const load survived";
-  ASSERT_EQ(Callee->size(), 1u) << "callee guard branch survived";
-  auto *Ret = dyn_cast<ReturnInst>(Callee->getEntryBlock().getTerminator());
-  ASSERT_NE(Ret, nullptr);
-  auto *RetVal = dyn_cast<ConstantInt>(Ret->getReturnValue());
-  ASSERT_NE(RetVal, nullptr) << "callee return did not fold";
-  EXPECT_EQ(RetVal->getSExtValue(), 100); // mock[2].b == 7 → then-branch
+  ASSERT_TRUE(llvm::ejit::detail::isolateFunctionForSpecialization(
+      *OtherModule, "other_entry"));
+  EXPECT_FALSE(OtherModule->getFunction("other_entry")->isDeclaration());
+  EXPECT_TRUE(OtherModule->getFunction("__ejit_aot_tu_active_entry")
+                  ->isDeclaration());
+  EXPECT_TRUE(OtherModule->getFunction("__ejit_aot_tu_slow_helper")
+                  ->isDeclaration());
+  EXPECT_FALSE(verifyModule(*OtherModule, &errs()));
+
+  Function *InvalidHelper = InvalidModule->getFunction("slow_helper");
+  InvalidHelper->setMetadata(MD_EJIT_AOT_SYMBOL, nullptr);
+  EXPECT_FALSE(llvm::ejit::detail::isolateFunctionForSpecialization(
+      *InvalidModule, "active_entry"));
+  EXPECT_FALSE(InvalidHelper->isDeclaration())
+      << "failed validation partially modified the module";
+  EXPECT_FALSE(llvm::ejit::detail::isolateFunctionForSpecialization(
+      *M, "missing"));
+}
+
+TEST(EJitFunctionIsolation, EntryFallbackBypassesDispatcherWrapper) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    define internal i32 @slow_helper(i32 %x) #0 {
+      %r = mul i32 %x, 9
+      ret i32 %r
+    }
+
+    define i32 @function_entry(i32 %x) #0 !ejit.metadata !0 {
+      %r = call i32 @slow_helper(i32 %x)
+      ret i32 %r
+    }
+
+    attributes #0 = { noinline }
+    !0 = distinct !{!{!"ejit_entry"}}
+  )",
+                               Err, Ctx);
+  if (!M)
+    Err.print("EntryFallbackBypassesDispatcherWrapper", errs());
+  ASSERT_NE(M, nullptr);
+
+  ModuleAnalysisManager MAM;
+  EJitRegisterBitcodePass().run(*M, MAM);
+
+  Function *AotBody = nullptr;
+  for (Function &F : *M)
+    if (F.getName().starts_with("__ejit_aot_") &&
+        F.getName().ends_with(".body")) {
+      ASSERT_EQ(AotBody, nullptr) << "multiple AOT entry bodies were emitted";
+      AotBody = &F;
+    }
+  ASSERT_NE(AotBody, nullptr);
+  EXPECT_TRUE(AotBody->hasLocalLinkage());
+  EXPECT_FALSE(AotBody->isDeclaration());
+  EXPECT_EQ(AotBody->getMetadata(MD_EJIT_METADATA), nullptr);
+
+  Function *AutoReg = M->getFunction(FN_AUTO_REGISTER);
+  ASSERT_NE(AutoReg, nullptr);
+  bool RegisteredDirectBody = false;
+  for (BasicBlock &BB : *AutoReg)
+    for (Instruction &I : BB)
+      if (auto *CB = dyn_cast<CallBase>(&I))
+        if (Function *Callee = CB->getCalledFunction())
+          if (Callee->getName() == FN_REGISTER_SYMBOL &&
+              CB->getArgOperand(1)->stripPointerCasts() == AotBody)
+            RegisteredDirectBody = true;
+  EXPECT_TRUE(RegisteredDirectBody)
+      << "entry fallback still points at the function that PASS3 wraps";
+  EXPECT_FALSE(verifyModule(*M, &errs()));
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

- keep only the requested `ejit_entry` body in each JIT specialization module
- convert every residual non-inlined definition into a TU-unique AOT declaration
- preserve direct AOT bodies for calls to other `ejit_entry` functions, bypassing their dispatcher wrappers
- remove JIT-time IPSCCP and interprocedural helper optimization
- make specialization diagnostics describe the post-inline entry body

## Root cause

The extracted bitcode retained the full direct-call closure. The JIT optimizer internalized those definitions and ran interprocedural propagation, so every specialization could optimize and code-generate non-inlined callees as part of a module. This increased compile scope and allowed specialized callees to diverge from the requested function boundary.

AOT pre-inlining is still retained. After those inline decisions, every remaining call is resolved to the corresponding AOT implementation. Static helpers use TU-unique registration names to avoid cross-TU collisions. Another `ejit_entry` gets a dedicated internal AOT body so the fallback does not recurse through its dispatcher.

## Compatibility

This adds AOT fallback metadata to embedded bitcode. The clang/AOT package and EJIT runtime must be rebuilt together; old embedded bitcode is intentionally rejected by the strict isolation validation.

This PR is intentionally independent from #155. If both are selected, #155 should be applied first so its pre-inliner cleanup determines which callees are inlined; this PR then sends every remaining call to AOT.

## Validation

- compiled all modified C++ translation units with the existing Windows release build configuration
- `EJitFunctionIsolation.NonInlineCalleeBecomesUniqueAotDeclaration`
- `EJitFunctionIsolation.EntryFallbackBypassesDispatcherWrapper`
- all 11 existing `EJitOptimizer.*` tests
- `git diff --check`

The focused test run passed 13/13. Full release lit and board validation remain pending.