### PR TITLE
[EJIT] Preserve nested entry specialization boundaries

### DIFF
--- a/jit_design_doc/EJIT_BITCODE_SLIMMING.md
+++ b/jit_design_doc/EJIT_BITCODE_SLIMMING.md
@@ -83,6 +83,13 @@ inliner 的 cost 分析就是"哪些函数值得保留函数体"的决策;内联
 - static 的 entry 也能被 JIT 强制外链(EJitOrcEngine.cpp:903-905)
 - 多 entry 闭包并集提取、嵌套特化(E 的 JIT 代码调 AOT 的 H,H 的 wrapper 分派到自己的 JIT 版本)
 
+多 entry 仍共用一份 bitcode，但每次加载 specialization 时只保留当前
+entry 的 definition；同一 TU 中的其他 entry 会在 ORC 建立符号声明前转为
+declaration，并解析到 PASS1 登记的最终 AOT wrapper 地址。因此 A 的特化上下文
+不会顺带改写 B 的 body，调用路径固定为 `A_JIT -> B_wrapper -> B_JIT/AOT`。
+这个裁剪必须发生在 `addIRModule` 之前，否则 ORC 的 symbol claim 会与最终
+codegen 输出不一致。
+
 ### 4.3 注册机制:确定性改名 key
 
 spec JITDylib 隔离(见 §1)意味着**每个外链化的 helper(static 或 external、host 或 bare-metal)都必须显式注册**。而 `userSymbols` 是进程级扁平表(EJitOrcEngine.cpp:106),static 函数名只在模块内唯一——两个 TU 的同名 `static helper` 注册会互相覆盖,静默错绑。

--- a/jit_design_doc/EJIT_BITCODE_SLIMMING.md
+++ b/jit_design_doc/EJIT_BITCODE_SLIMMING.md
@@ -90,6 +90,12 @@ declaration，并解析到 PASS1 登记的最终 AOT wrapper 地址。因此 A �
 这个裁剪必须发生在 `addIRModule` 之前，否则 ORC 的 symbol claim 会与最终
 codegen 输出不一致。
 
+local-linkage entry 的自身 bitcode/funcIndex lookup 仍使用源码函数名；PASS1 另外
+生成 `ejit_static.<module>.<hash>.<name>` wrapper key，并作为 function attribute
+写进 embedded bitcode。只有当该 entry 作为 nested callee 被转成 declaration 时，
+ORC 才把声明改成这个唯一 key，避免不同 TU 的同名 static entry 在进程级
+`userSymbols` 表中互相覆盖。
+
 ### 4.3 注册机制:确定性改名 key
 
 spec JITDylib 隔离(见 §1)意味着**每个外链化的 helper(static 或 external、host 或 bare-metal)都必须显式注册**。而 `userSymbols` 是进程级扁平表(EJitOrcEngine.cpp:106),static 函数名只在模块内唯一——两个 TU 的同名 `static helper` 注册会互相覆盖,静默错绑。

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -65,6 +65,12 @@ constexpr const char *TAG_EJIT_PERIOD_ARR = "ejit_period_arr";
 constexpr const char *TAG_EJIT_PERIOD = "ejit_period";
 constexpr const char *TAG_EJIT_MAY_CONST_FIELD = "ejit_may_const_field";
 
+// PASS1 records the process-unique AOT wrapper symbol for local ejit_entry
+// functions on the embedded-bitcode clone. The JIT uses it only when that
+// entry is externalized as a nested specialization boundary; compiling the
+// entry itself continues to use its original source-level name.
+constexpr const char *ATTR_EJIT_WRAPPER_SYMBOL = "ejit.wrapper_symbol";
+
 //===----------------------------------------------------------------------===//
 // Global variable and section names
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -97,10 +97,16 @@ static void isolateSpecializationEntry(Module &M, StringRef EntryName) {
     // bind A -> B directly inside the specialization module. Make every other
     // entry an external call instead; its registered AOT wrapper performs B's
     // own specialization lookup.
+    Attribute WrapperSymbol = F.getFnAttribute(ATTR_EJIT_WRAPPER_SYMBOL);
+    std::string WrapperName = WrapperSymbol.isValid()
+                                  ? WrapperSymbol.getValueAsString().str()
+                                  : std::string();
     F.deleteBody();
     F.setVisibility(GlobalValue::DefaultVisibility);
     F.setLinkage(GlobalValue::ExternalLinkage);
     F.setDSOLocal(false);
+    if (!WrapperName.empty())
+      F.setName(WrapperName);
   }
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -86,6 +86,24 @@ static void collectReferencedExternalDecls(
   }
 }
 
+static void isolateSpecializationEntry(Module &M, StringRef EntryName) {
+  for (Function &F : M.functions()) {
+    if (F.getName() == EntryName || F.isDeclaration() ||
+        !hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY))
+      continue;
+
+    // A shared TU bitcode payload can contain several ejit_entry definitions.
+    // Keeping them would let A's specialization context rewrite B's body and
+    // bind A -> B directly inside the specialization module. Make every other
+    // entry an external call instead; its registered AOT wrapper performs B's
+    // own specialization lookup.
+    F.deleteBody();
+    F.setVisibility(GlobalValue::DefaultVisibility);
+    F.setLinkage(GlobalValue::ExternalLinkage);
+    F.setDSOLocal(false);
+  }
+}
+
 struct EJitOrcEngine::Impl {
 #ifdef EJIT_SRE_CODE_POOL
   /// Dedicated 2MiB code pools backing all JIT machine code. Declared before
@@ -872,6 +890,10 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error", cacheKey);
     return ModuleOrErr.takeError();
   }
+
+  // Do this before addIRModule so ORC's materialization-unit symbol claims
+  // match the definitions that codegen will actually emit.
+  isolateSpecializationEntry(**ModuleOrErr, origFnName);
 
   Triple TT((*ModuleOrErr)->getTargetTriple());
   if (TT.isAArch64() && TT.isOSBinFormatELF()) {

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -651,6 +651,17 @@ static std::string extractAndSerialize(Module &M,
     const SetVector<Function *> &ToExternalize) {
 
   auto Extracted = CloneModule(M);
+
+  // Preserve the original entry name for its own funcIndex/bitcode lookup,
+  // but carry a process-unique wrapper key for local entries. The JIT applies
+  // this key only when another entry's specialization externalizes this one.
+  for (Function *F : EntryFuncs) {
+    if (!F->hasLocalLinkage())
+      continue;
+    if (Function *Cur = Extracted->getFunction(F->getName()))
+      Cur->addFnAttr(ATTR_EJIT_WRAPPER_SYMBOL, ejitRegistrationKey(M, *F));
+  }
+
   DenseSet<StringRef> FuncNames;
   for (Function *F : Funcs)
     FuncNames.insert(F->getName());
@@ -824,7 +835,7 @@ static void generateSymbolRegisters(
   // externalizes every entry except the one currently being specialized and
   // resolves calls to those declarations through this table.
   for (Function *F : EntryFuncs) {
-    std::string Name = F->getName().str();
+    std::string Name = ejitRegistrationKey(M, *F);
     if (registered.insert(Name).second) {
       IRBuilder<> Builder(InsertBefore);
       Builder.CreateCall(M.getFunction(FN_REGISTER_SYMBOL),
@@ -1029,10 +1040,13 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
 
   // Symbol entries for external references
   SmallPtrSet<const Function *, 8> SymbolsDone;
-  auto addSymbol = [&](const Function *F, bool RequireDeclaration = true) {
+  auto addSymbol = [&](const Function *F, bool RequireDeclaration = true,
+                       StringRef RegistrationName = {}) {
     if (!F->isIntrinsic() && (!RequireDeclaration || F->isDeclaration())) {
       if (SymbolsDone.insert(F).second) {
-        Constant *NameStr = ConstantDataArray::getString(Ctx, F->getName(), true);
+        StringRef Name = RegistrationName.empty() ? F->getName()
+                                                   : RegistrationName;
+        Constant *NameStr = ConstantDataArray::getString(Ctx, Name, true);
         auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
             GlobalValue::PrivateLinkage, NameStr, ".ejit.str.");
         Entries.push_back(ConstantStruct::get(EntryTy, {
@@ -1049,7 +1063,7 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
   // PASS3 later turns these functions into wrappers in place, so these
   // constants resolve to wrapper addresses in the final AOT object.
   for (Function *F : EntryFuncs)
-    addSymbol(F, /*RequireDeclaration=*/false);
+    addSymbol(F, /*RequireDeclaration=*/false, ejitRegistrationKey(M, *F));
   for (Function *F : ClosureFuncs) {
     for (const BasicBlock &BB : *F) {
       for (const Instruction &I : BB) {

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -796,6 +796,7 @@ static void collectFunctionsFromConstant(Constant *C,
 /// them without dlsym — suitable for bare-metal embedded environments.
 static void generateSymbolRegisters(
     Module &M,
+    const SmallVectorImpl<Function *> &EntryFuncs,
     const SetVector<Function *> &ClosureFuncs,
     const SetVector<GlobalVariable *> &ClosureGlobals,
     const SetVector<Function *> &ToExternalize,
@@ -816,6 +817,21 @@ static void generateSymbolRegisters(
 
   BasicBlock *BB = &AutoReg->getEntryBlock();
   Instruction *InsertBefore = BB->getTerminator();
+
+  // Nested ejit_entry calls are specialization boundaries. PASS3 rewrites
+  // these Function objects in place into their AOT wrappers after this pass,
+  // so the addresses recorded here ultimately point at the wrappers. The JIT
+  // externalizes every entry except the one currently being specialized and
+  // resolves calls to those declarations through this table.
+  for (Function *F : EntryFuncs) {
+    std::string Name = F->getName().str();
+    if (registered.insert(Name).second) {
+      IRBuilder<> Builder(InsertBefore);
+      Builder.CreateCall(M.getFunction(FN_REGISTER_SYMBOL),
+                         {Builder.CreateGlobalString(Name),
+                          Builder.CreateBitCast(F, PtrTy)});
+    }
+  }
 
   for (Function *F : ClosureFuncs) {
     for (BasicBlock &Blk : *F) {
@@ -962,8 +978,8 @@ static void generateRegisterCall(Module &M, GlobalVariable *BitcodeGV,
 
   // Auto-register external symbols referenced by the closure so the JIT
   // can resolve them without manual ejit_register_symbol calls.
-  generateSymbolRegisters(M, ClosureFuncs, ClosureGlobals, ToExternalize,
-                          AutoReg);
+  generateSymbolRegisters(M, EntryFuncs, ClosureFuncs, ClosureGlobals,
+                          ToExternalize, AutoReg);
 
   if (EnableEJitGlobalCtors)
     appendToGlobalCtors(M, AutoReg, EJIT_CTOR_PRIORITY);
@@ -1013,8 +1029,8 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
 
   // Symbol entries for external references
   SmallPtrSet<const Function *, 8> SymbolsDone;
-  auto addSymbol = [&](const Function *F) {
-    if (!F->isIntrinsic() && F->isDeclaration()) {
+  auto addSymbol = [&](const Function *F, bool RequireDeclaration = true) {
+    if (!F->isIntrinsic() && (!RequireDeclaration || F->isDeclaration())) {
       if (SymbolsDone.insert(F).second) {
         Constant *NameStr = ConstantDataArray::getString(Ctx, F->getName(), true);
         auto *NameGV = new GlobalVariable(M, NameStr->getType(), true,
@@ -1029,6 +1045,11 @@ generateRegistryTable(Module &M, const SmallVectorImpl<Function *> &EntryFuncs,
       }
     }
   };
+
+  // PASS3 later turns these functions into wrappers in place, so these
+  // constants resolve to wrapper addresses in the final AOT object.
+  for (Function *F : EntryFuncs)
+    addSymbol(F, /*RequireDeclaration=*/false);
   for (Function *F : ClosureFuncs) {
     for (const BasicBlock &BB : *F) {
       for (const Instruction &I : BB) {

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
@@ -178,7 +178,7 @@ entry:
 }
 
 ; an entry above the threshold must never be externalized
-define i32 @entry_big(i32 %idx) !ejit.metadata !21 {
+define internal i32 @entry_big(i32 %idx) !ejit.metadata !21 {
 entry:
   %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %idx
   %v = load i32, ptr %p, !ejit.may_const !{}
@@ -219,6 +219,7 @@ attributes #1 = { inlinehint }
 ; MOD: [48 x i8] c"ejit_static._stdin_.{{0x[0-9a-f]+}}.hint_big\00"
 ; MOD: c"ext_helper_big\00"
 ; MOD: [53 x i8] c"ejit_static._stdin_.{{0x[0-9a-f]+}}.st_helper_big\00"
+; MOD: c"ejit_static._stdin_.{{0x[0-9a-f]+}}.entry_big\00"
 ; MOD: { i32 3, ptr @{{.*}}, ptr null, ptr @boundary_helper, i64 0 }
 ; MOD: { i32 3, ptr @{{.*}}, ptr null, ptr @hint_big, i64 0 }
 ; MOD: { i32 3, ptr @{{.*}}, ptr null, ptr @ext_helper_big, i64 0 }
@@ -254,7 +255,8 @@ attributes #1 = { inlinehint }
 ; EXT: tail call i32 @ext_helper_small(i32 %r3)
 ; EXT: tail call i32 @boundary_helper(i32 {{.*}})
 ; EXT: tail call i32 @kept_15inst(i32 {{.*}})
-; EXT: define i32 @entry_big(i32 %idx) {{.*}} {
+; EXT: define internal i32 @entry_big(i32 %idx) #[[ENTRY_ATTR:[0-9]+]] {{.*}} {
+; EXT: attributes #[[ENTRY_ATTR]] = { {{.*}}"ejit.wrapper_symbol"="ejit_static._stdin_.{{0x[0-9a-f]+}}.entry_big"{{.*}} }
 ; EXT-NOT: @st_helper_big
 ; EXT-NOT: @hint_big
 

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
@@ -227,6 +227,8 @@ attributes #1 = { inlinehint }
 ; MOD-NOT: ptr @ext_helper_small
 ; MOD-NOT: ptr @kept_15inst
 ; MOD: define internal void @ejit_auto_register() {
+; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @entry)
+; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @entry_big)
 ; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @st_helper_big)
 ; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @ext_helper_big)
 ; MOD-DAG: call void @ejit_register_symbol(ptr @{{.*}}, ptr @hint_big)
@@ -234,7 +236,6 @@ attributes #1 = { inlinehint }
 ; MOD-NOT: @st_helper_small
 ; MOD-NOT: @ext_helper_small
 ; MOD-NOT: @kept_15inst
-; MOD-NOT: @entry_big
 ; MOD: }
 
 ; EXT side: the extracted bitcode. Big helpers are declarations (the static

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -124,6 +124,7 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
 }
 
 static int nestedEntryWrapper(int X) { return X + 100; }
+static int wrongNestedEntryWrapper(int X) { return X + 1000; }
 
 TEST(EJitOrcEngine, NestedEntryResolvesThroughRegisteredWrapper) {
   std::string Bitcode;
@@ -139,9 +140,11 @@ TEST(EJitOrcEngine, NestedEntryResolvesThroughRegisteredWrapper) {
       return MDNode::getDistinct(Ctx, {Entry});
     };
 
-    auto *Nested = Function::Create(FT, Function::ExternalLinkage,
+    auto *Nested = Function::Create(FT, Function::InternalLinkage,
                                     "nested_entry_b", &M);
     Nested->setMetadata(MD_EJIT_METADATA, EntryMD());
+    Nested->addFnAttr(ATTR_EJIT_WRAPPER_SYMBOL,
+                      "ejit_static.nested_entries.test.nested_entry_b");
     IRBuilder<> B(BasicBlock::Create(Ctx, "entry", Nested));
     B.CreateRet(B.CreateAdd(Nested->getArg(0), B.getInt32(1)));
 
@@ -164,6 +167,8 @@ TEST(EJitOrcEngine, NestedEntryResolvesThroughRegisteredWrapper) {
   ASSERT_TRUE(static_cast<bool>(EngineOrErr));
   auto Engine = std::move(*EngineOrErr);
   Engine->addUserSymbol("nested_entry_b",
+                        reinterpret_cast<void *>(&wrongNestedEntryWrapper));
+  Engine->addUserSymbol("ejit_static.nested_entries.test.nested_entry_b",
                         reinterpret_cast<void *>(&nestedEntryWrapper));
 
   SpecializationContext Ctx;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -123,6 +123,77 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
   }
 }
 
+static int nestedEntryWrapper(int X) { return X + 100; }
+
+TEST(EJitOrcEngine, NestedEntryResolvesThroughRegisteredWrapper) {
+  std::string Bitcode;
+  {
+    LLVMContext Ctx;
+    Module M("nested_entries", Ctx);
+    M.setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+    auto *I32 = Type::getInt32Ty(Ctx);
+    auto *FT = FunctionType::get(I32, {I32}, false);
+    auto EntryMD = [&]() {
+      Metadata *Entry =
+          MDNode::get(Ctx, MDString::get(Ctx, TAG_EJIT_ENTRY));
+      return MDNode::getDistinct(Ctx, {Entry});
+    };
+
+    auto *Nested = Function::Create(FT, Function::ExternalLinkage,
+                                    "nested_entry_b", &M);
+    Nested->setMetadata(MD_EJIT_METADATA, EntryMD());
+    IRBuilder<> B(BasicBlock::Create(Ctx, "entry", Nested));
+    B.CreateRet(B.CreateAdd(Nested->getArg(0), B.getInt32(1)));
+
+    auto *Root = Function::Create(FT, Function::ExternalLinkage,
+                                  "nested_entry_a", &M);
+    Root->setMetadata(MD_EJIT_METADATA, EntryMD());
+    B.SetInsertPoint(BasicBlock::Create(Ctx, "entry", Root));
+    B.CreateRet(B.CreateCall(Nested, {Root->getArg(0)}));
+
+    raw_string_ostream OS(Bitcode);
+    WriteBitcodeToFile(M, OS);
+    OS.flush();
+  }
+
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  EJitRuntimeState State;
+  Config Cfg;
+  auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
+  ASSERT_TRUE(static_cast<bool>(EngineOrErr));
+  auto Engine = std::move(*EngineOrErr);
+  Engine->addUserSymbol("nested_entry_b",
+                        reinterpret_cast<void *>(&nestedEntryWrapper));
+
+  SpecializationContext Ctx;
+  Ctx.fnName = "nested_entry_a";
+  Ctx.cacheKey = 0xea01;
+  Engine->setActiveContext(&Ctx);
+  ASSERT_FALSE(errorToBool(
+      Engine->loadBitcodeModule(Bitcode, Ctx.cacheKey, Ctx.fnName)));
+  auto FnOrErr = Engine->lookup(Ctx.cacheKey, Ctx.fnName);
+  ASSERT_TRUE(static_cast<bool>(FnOrErr));
+  Engine->setActiveContext(nullptr);
+
+  using FnTy = int (*)(int);
+  auto Fn = reinterpret_cast<FnTy>(*FnOrErr);
+  EXPECT_EQ(Fn(5), 105);
+
+  // B remains a normal specialization target when B itself is compiled; its
+  // own body must win over the registered wrapper symbol.
+  Ctx.fnName = "nested_entry_b";
+  Ctx.cacheKey = 0xeb01;
+  Engine->setActiveContext(&Ctx);
+  ASSERT_FALSE(errorToBool(
+      Engine->loadBitcodeModule(Bitcode, Ctx.cacheKey, Ctx.fnName)));
+  FnOrErr = Engine->lookup(Ctx.cacheKey, Ctx.fnName);
+  ASSERT_TRUE(static_cast<bool>(FnOrErr));
+  Engine->setActiveContext(nullptr);
+  Fn = reinterpret_cast<FnTy>(*FnOrErr);
+  EXPECT_EQ(Fn(5), 6);
+}
+
 namespace llvm {
 namespace ejit {
 // Test-only accessor. EJitOptimizer deliberately keeps its individual pipeline


### PR DESCRIPTION
## Summary

- register every `ejit_entry` AOT wrapper as a resolvable JIT symbol
- before ORC creates a specialization materialization unit, keep only the requested entry definition and turn other entry definitions into external declarations
- add an executable A -> B regression test that verifies A's JIT calls B through the registered wrapper, while compiling B itself still uses B's own body
- document the nested-entry boundary in the PR156 bitcode-slimming design

## Why

A translation unit currently embeds one shared bitcode module for all of its `ejit_entry` functions. For a same-TU call such as `A -> B`, specializing A could therefore leave B's definition in A's JIT module. The specialization pipeline can then rewrite B using A's context and bind the call directly to that in-module body, bypassing B's own wrapper and specialization identity.

The fix establishes this invariant:

```text
specialize A: define A, declare B
specialize B: declare A, define B
```

The declaration resolves to the final AOT wrapper address emitted by PASS3, so the runtime path becomes:

```text
A_JIT -> B_wrapper -> B_JIT (when ready) / B_AOT
```

Isolation happens before `addIRModule`, so ORC symbol claims remain consistent with codegen output. The shared bitcode representation is retained; no per-entry bitcode duplication is introduced.

## 中文说明

同一 TU 的多个 `ejit_entry` 当前共用一份 bitcode。特化 A 时如果 B 的函数体仍保留在模块内，A 的特化上下文可能顺带改写 B，并让 `A_JIT` 直接调用该模块内的 B，绕过 B 自己的 wrapper 和 specialization key。

本修复在 ORC 建立模块前只保留当前目标 entry 的定义，把其他 entry 转为 declaration，并解析到 PASS3 最终生成的 AOT wrapper。这样固定得到：

```text
A_JIT -> B_wrapper -> B_JIT（ready 时）/ B_AOT
```

仍然复用同一份 embedded bitcode，不增加每个 entry 一份 bitcode 的存储开销。

## Validation

- added `EJitOrcEngine.NestedEntryResolvesThroughRegisteredWrapper`
- extended PASS1 FileCheck coverage for entry-wrapper symbol registration
- `git diff --check` passes
- local LLVM binaries/build tree are unavailable on this machine, so the new LLVM tests were not executed locally