### PR TITLE
[EJIT] Specialize pointer-form period roots

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -3,6 +3,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
@@ -222,6 +223,86 @@ static Constant *createConstantFromMemory(const void *addr, Type *Ty,
   return nullptr;
 }
 
+/// Replace a load of a pointer-valued period global with the registered
+/// pointee address. Pointer-form ejit_period/ejit_period_arr globals are
+/// registered by the address of their pointer slot, so resolveBase() returns
+/// the slot and createConstantFromMemory() performs the required dereference.
+///
+/// This load is intentionally not required to carry !ejit.may_const: the
+/// pointer is the address root of the period object, while the annotation
+/// belongs to fields inside that object. Materializing the root lets IPSCCP
+/// propagate it through a non-inlined helper, after which the normal
+/// may_const-field replacement can resolve the field load.
+static Constant *
+tryReplacePeriodPointerBase(LoadInst *LI, const GVPeriodMap &gvMap,
+                            PeriodArrayRegistry &reg, const DataLayout &DL) {
+  if (LI->isVolatile() || LI->isAtomic() || !LI->getType()->isPointerTy())
+    return nullptr;
+
+  auto *GV = dyn_cast<GlobalVariable>(
+      LI->getPointerOperand()->stripPointerCasts());
+  if (!GV || !GV->getValueType()->isPointerTy())
+    return nullptr;
+
+  auto It = gvMap.find(GV);
+  if (It == gvMap.end())
+    return nullptr;
+
+  void *PointerSlot = resolveBase(GV, It->second, reg);
+  if (!PointerSlot)
+    return nullptr;
+  return createConstantFromMemory(PointerSlot, LI->getType(), DL);
+}
+
+/// Resolve a may_const load after IPSCCP/InstCombine has propagated a period
+/// pointer into a callee and folded its GEP into an absolute address. Accept
+/// the address only when it matches a declared may_const field of a registered
+/// pointer-form period object; arbitrary inttoptr loads must remain untouched.
+static Constant *tryReplacePeriodAbsoluteAddress(
+    LoadInst *LI, const GVPeriodMap &gvMap,
+    const MayConstOffsetMap &mayConstFieldMap, PeriodArrayRegistry &reg,
+    const DataLayout &DL) {
+  const Value *Ptr = LI->getPointerOperand();
+  APInt ExtraOffset(DL.getIndexTypeSizeInBits(Ptr->getType()), 0);
+  const Value *Base = Ptr->stripAndAccumulateConstantOffsets(
+      DL, ExtraOffset, /*AllowNonInbounds=*/true);
+
+  auto *IntToPtr = dyn_cast<ConstantExpr>(Base);
+  if (!IntToPtr || IntToPtr->getOpcode() != Instruction::IntToPtr)
+    return nullptr;
+  auto *AddressInt = dyn_cast<ConstantInt>(IntToPtr->getOperand(0));
+  if (!AddressInt)
+    return nullptr;
+
+  APInt Absolute = AddressInt->getValue().zextOrTrunc(ExtraOffset.getBitWidth());
+  Absolute += ExtraOffset;
+  uintptr_t Target = static_cast<uintptr_t>(Absolute.getZExtValue());
+
+  for (const auto &[GV, Info] : gvMap) {
+    if (!GV->getValueType()->isPointerTy())
+      continue;
+    auto FieldIt = mayConstFieldMap.find(GV);
+    if (FieldIt == mayConstFieldMap.end())
+      continue;
+
+    void *PointerSlot = resolveBase(GV, Info, reg);
+    if (!PointerSlot)
+      continue;
+    void *Pointee = nullptr;
+    std::memcpy(&Pointee, PointerSlot, sizeof(Pointee));
+    uintptr_t ObjectBase = reinterpret_cast<uintptr_t>(Pointee);
+    if (!ObjectBase || Target < ObjectBase)
+      continue;
+
+    uint64_t FieldOffset = Target - ObjectBase;
+    if (!llvm::is_contained(FieldIt->second, FieldOffset))
+      continue;
+    return createConstantFromMemory(reinterpret_cast<const void *>(Target),
+                                    LI->getType(), DL);
+  }
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 // Load replacement helpers — one per access pattern
 //===----------------------------------------------------------------------===//
@@ -423,6 +504,16 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
       ++totalLoads;
 #endif
 
+      // A pointer-form period global is itself the root needed to reach nested
+      // may_const fields. It has no may_const marker of its own, but replacing
+      // it here exposes a concrete address to IPSCCP and later StructFieldPass
+      // rounds, including when the field access lives in a non-inlined helper.
+      if (Constant *C = tryReplacePeriodPointerBase(
+              LI, gvPeriodMap_, registry_, DL)) {
+        replacements.push_back({LI, C});
+        continue;
+      }
+
       if (!isMayConstLoad(LI, mayConstFieldMap_, DL))
         continue;
 #ifdef EJIT_DIAG_ENABLE
@@ -432,11 +523,14 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
       Value *PtrOp = LI->getPointerOperand();
 
       // Try each access pattern in order.
-      Constant *C = nullptr;
+      Constant *C = tryReplacePeriodAbsoluteAddress(
+          LI, gvPeriodMap_, mayConstFieldMap_, registry_, DL);
 
       // Pattern 1: direct GlobalVariable load (scalar static variable).
-      if (auto *GV = dyn_cast<GlobalVariable>(PtrOp->stripPointerCasts()))
-        C = tryReplaceDirectGV(LI, GV, gvPeriodMap_, registry_, DL);
+      if (!C) {
+        if (auto *GV = dyn_cast<GlobalVariable>(PtrOp->stripPointerCasts()))
+          C = tryReplaceDirectGV(LI, GV, gvPeriodMap_, registry_, DL);
+      }
 
       // Pattern 2: GEP-based access (array or struct field).
       if (!C)

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -2050,6 +2050,97 @@ TEST(EJitStructFieldPass, MissingPerLoadMetadataGVOffsetFallback) {
   EXPECT_EQ(RetVal->getSExtValue(), 30);
 }
 
+// A pointer-form period array is registered by the address of its pointer
+// slot. The root pointer load has no !ejit.may_const marker: only the nested
+// BBB field does. Specializing the root address is nevertheless required when
+// the field access sits behind a non-inlined helper, because the field pass
+// cannot otherwise trace the helper argument back to @aaa.
+TEST(EJitStructFieldPass, PointerPeriodRootFeedsNestedMayConstHelper) {
+  LLVMContext Ctx;
+  auto M = std::make_unique<Module>("pointer_period_nested", Ctx);
+  M->setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+  M->setDataLayout("e-p:64:64");
+
+  IRBuilder<> B(Ctx);
+  Type *I32Ty = B.getInt32Ty();
+  auto *BBBTy = StructType::create(Ctx, {I32Ty, I32Ty}, "BBB");
+  auto *CCCTy = StructType::create(Ctx, {I32Ty}, "CCC");
+  auto *AAATy = StructType::create(
+      Ctx, {BBBTy, ArrayType::get(CCCTy, 10)}, "AAA");
+
+  auto *AAA = new GlobalVariable(
+      *M, B.getPtrTy(), false, GlobalValue::ExternalLinkage,
+      ConstantPointerNull::get(B.getPtrTy()), "aaa");
+  Metadata *PeriodOps[] = {
+      MDString::get(Ctx, TAG_EJIT_PERIOD_ARR), MDString::get(Ctx, "xxx"),
+      ConstantAsMetadata::get(ConstantInt::get(I32Ty, 0))};
+  // Offset zero belongs to BBB::mayConstValue. AAA and AAA::bbb themselves are
+  // deliberately not may_const.
+  Metadata *FieldOps[] = {
+      MDString::get(Ctx, TAG_EJIT_MAY_CONST_FIELD),
+      ConstantAsMetadata::get(ConstantInt::get(I32Ty, 0))};
+  AAA->setMetadata(
+      MD_EJIT_METADATA,
+      MDNode::get(Ctx,
+                  {MDNode::get(Ctx, PeriodOps), MDNode::get(Ctx, FieldOps)}));
+
+  auto *HelperTy = FunctionType::get(I32Ty, {B.getPtrTy()}, false);
+  auto *Helper = Function::Create(HelperTy, GlobalValue::InternalLinkage,
+                                  "read_bbb_may_const", M.get());
+  Helper->addFnAttr(Attribute::NoInline);
+  BasicBlock *HelperEntry = BasicBlock::Create(Ctx, "entry", Helper);
+  B.SetInsertPoint(HelperEntry);
+  Value *NestedField = B.CreateStructGEP(AAATy, Helper->getArg(0), 0,
+                                         "bbb");
+  NestedField = B.CreateStructGEP(BBBTy, NestedField, 0, "may_const");
+  auto *NestedLoad = B.CreateLoad(I32Ty, NestedField, "value");
+  NestedLoad->setMetadata(MD_EJIT_MAY_CONST, MDNode::get(Ctx, {}));
+  B.CreateRet(NestedLoad);
+
+  auto *EntryTy = FunctionType::get(I32Ty, {}, false);
+  auto *Entry = Function::Create(EntryTy, GlobalValue::ExternalLinkage,
+                                 "read_aaa", M.get());
+  BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", Entry);
+  B.SetInsertPoint(EntryBB);
+  // This load has no may_const metadata. It is the address root that must be
+  // materialized before interprocedural propagation can expose the field GEP.
+  Value *Base = B.CreateLoad(B.getPtrTy(), AAA, "aaa.base");
+  B.CreateRet(B.CreateCall(Helper, {Base}));
+
+  struct MockAAA {
+    struct {
+      int32_t mayConstValue;
+      int32_t mutableValue;
+    } bbb;
+    struct {
+      int32_t value;
+    } ccc[10];
+  } Mock = {{73, 9}, {}};
+  MockAAA *CurrentAAA = &Mock;
+
+  PeriodArrayRegistry Reg;
+  // Pointer-form period arrays are registered with &aaa, not aaa.
+  Reg.registerArray("xxx", "aaa", &CurrentAAA, 0);
+  EJitOptimizerTestAccess Opt(Reg);
+
+  Opt.runStructFieldPass(*M);
+  EXPECT_EQ(countLoads(*Entry), 0u)
+      << "the unannotated period pointer root should become an address";
+
+  Opt.runInterproceduralPropagation(*M);
+  Opt.runInstCombine(*M);
+  Opt.runStructFieldPass(*M);
+  Opt.runInstCombine(*M);
+
+  EXPECT_EQ(countLoads(*Helper), 0u)
+      << "the nested BBB may_const load should be specialized";
+  auto *Ret = dyn_cast_or_null<ReturnInst>(&Helper->back().back());
+  ASSERT_NE(Ret, nullptr);
+  auto *RetValue = dyn_cast<ConstantInt>(Ret->getReturnValue());
+  ASSERT_NE(RetValue, nullptr);
+  EXPECT_EQ(RetValue->getSExtValue(), 73);
+}
+
 // 3. A load WITHOUT per-load metadata whose offset is NOT in the GV offset list
 //    must be left alone. Confirms the fallback does not over-fire.
 TEST(EJitStructFieldPass, MissingPerLoadMetadataWrongOffsetNoReplace) {


### PR DESCRIPTION
## Summary / 概要

- Specialize an unannotated pointer load from a pointer-form `ejit_period` / `ejit_period_arr` global so nested `may_const` fields remain reachable across a non-inlined helper.
- 在 pointer 形式的 period 全局变量上，先将未标记 `may_const` 的根指针 load 固化为已注册对象地址，使非内联 helper 内的嵌套 `may_const` 字段可以继续特化。
- After IPSCCP/InstCombine folds the propagated GEP into an absolute address, resolve it only when it matches both a registered pointer-period object and a declared `ejit_may_const_field` offset.
- IPSCCP/InstCombine 将 GEP 折叠为绝对地址后，仅当地址同时匹配已注册 pointer-period 对象和声明过的 `ejit_may_const_field` 偏移时才读取替换，避免影响普通指针。

## Root cause / 原因

`EJitStructFieldPass` previously considered only the final `may_const` load. The root `load ptr, ptr @aaa` is intentionally unannotated because `aaa` and its `bbb` parent are mutable. When the field access lives in a non-inlined helper, the pass sees only a function argument and cannot trace it back to the registered period global.

原 PASS 只处理末端 `may_const` load。由于 `aaa` 和父字段 `bbb` 本身可变，根节点 `load ptr, ptr @aaa` 不带 `may_const`；字段访问位于非内联 helper 时，PASS 只能看到函数参数，无法回溯到 period 注册信息。

## Safety / 安全边界

- Volatile and atomic root pointer loads are not replaced.
- Non-period pointer globals are not replaced.
- Absolute-address field loads require a registered pointer object and an exact declared may-const byte offset.

## Tests / 验证

- Added `PointerPeriodRootFeedsNestedMayConstHelper`, modeling `AAA { BBB bbb; CCC ccc[10]; }` where only `BBB::mayConstValue` is may-const.
- Compiled the changed pass and the updated EJIT unit-test translation unit.
- Ran an isolated production-order pipeline: StructField -> IPSCCP -> InstCombine -> StructField. Final IR removed `load @aaa`, removed the nested field load, and produced `ret i32 73` in the noinline helper.