### PR TITLE
[EJIT] Add dimension-bound pointer snapshots

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -5257,6 +5257,14 @@ def EjitPeriodArrInd : InheritableParamAttr {
   let Documentation = [EjitPeriodArrIndDocs];
 }
 
+// Binds a pointer parameter's pointee to one specialization dimension.
+def EjitBoundPtr : InheritableParamAttr {
+  let Spellings = [Clang<"ejit_bound_ptr">];
+  let Args = [StringArgument<"PeriodName">];
+  let Subjects = SubjectList<[ParmVar]>;
+  let Documentation = [EjitBoundPtrDocs];
+}
+
 // Marks a function for JIT optimization
 def EjitEntry : InheritableAttr {
   let Spellings = [Clang<"ejit_entry">];

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9511,6 +9511,28 @@ may be marked with this attribute.
   }];
 }
 
+def EjitBoundPtrDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+EmbeddedJIT: binds a pointer parameter's pointee to a specialization dimension.
+
+On a JIT cache miss, the runtime snapshots the complete pointee before the
+call returns. Loads of ``ejit_may_const`` fields through the parameter may then
+be specialized from that snapshot. The function must also have exactly one
+``ejit_period_arr_ind`` parameter with the same period name.
+
+Only a pointer to a complete object type is accepted. The first implementation
+supports one bound pointer per function and performs a shallow object copy;
+pointers contained inside the object are not followed.
+
+.. code-block:: c
+
+  __attribute__((ejit_entry))
+  void process(__attribute__((ejit_period_arr_ind("cell"))) unsigned cellIdx,
+               __attribute__((ejit_bound_ptr("cell"))) const CellConfig *cfg);
+  }];
+}
+
 def EjitEntryDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13499,6 +13499,13 @@ def err_ejit_period_arr_ind_invalid_type : Error<
 def err_ejit_period_arr_ind_too_many : Error<
   "function %0 has %1 ejit_period_arr_ind parameters, "
   "which exceeds the maximum of 4">;
+def err_ejit_bound_ptr_invalid_type : Error<
+  "ejit_bound_ptr parameter %0 must be a pointer to a complete object type">;
+def err_ejit_bound_ptr_missing_dim : Error<
+  "ejit_bound_ptr(%0) requires exactly one matching "
+  "ejit_period_arr_ind(%0) parameter">;
+def err_ejit_bound_ptr_too_many : Error<
+  "function %0 has %1 ejit_bound_ptr parameters; at most one is supported">;
 def err_ejit_entry_recursive : Error<
   "ejit_entry function %0 cannot be recursive">;
 def err_ejit_period_lc_no_index : Error<

--- a/clang/lib/CodeGen/CGEJIT.cpp
+++ b/clang/lib/CodeGen/CGEJIT.cpp
@@ -24,6 +24,10 @@ using namespace clang;
 using namespace CodeGen;
 using namespace llvm::ejit;
 
+static void collectBoundMayConstFields(
+    ASTContext &Ctx, const RecordDecl *RD, uint64_t BaseOffset,
+    SmallVectorImpl<std::pair<uint64_t, uint64_t>> &Fields);
+
 /// Emit !ejit.metadata for an ejit_entry or ejit_period_lc function.
 void clang::CodeGen::emitEjitFunctionMetadata(CodeGenModule &CGM,
                                               const FunctionDecl *FD,
@@ -78,6 +82,36 @@ void clang::CodeGen::emitEjitFunctionMetadata(CodeGenModule &CGM,
     }
   }
 
+  // ejit_bound_ptr (on pointer parameters). The pointee size is part of the
+  // metadata so the AOT wrapper can snapshot it before an async request
+  // outlives the call and its pointer.
+  for (unsigned I = 0; I < FD->getNumParams(); ++I) {
+    const ParmVarDecl *PD = FD->getParamDecl(I);
+    if (const auto *BoundAttr = PD->getAttr<EjitBoundPtrAttr>()) {
+      QualType Pointee = PD->getType()->getPointeeType();
+      uint64_t Size =
+          CGM.getContext().getTypeSizeInChars(Pointee).getQuantity();
+      SmallVector<llvm::Metadata *, 8> BoundOps = {
+          llvm::MDString::get(Ctx, TAG_EJIT_BOUND_PTR),
+          llvm::MDString::get(Ctx, BoundAttr->getPeriodName()),
+          llvm::ConstantAsMetadata::get(
+              llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), I)),
+          llvm::ConstantAsMetadata::get(
+              llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), Size))};
+      if (const auto *RD = Pointee->getAsRecordDecl()) {
+        SmallVector<std::pair<uint64_t, uint64_t>, 8> Fields;
+        collectBoundMayConstFields(CGM.getContext(), RD, 0, Fields);
+        for (const auto &[Offset, FieldSize] : Fields)
+          BoundOps.push_back(llvm::MDNode::get(
+              Ctx, {llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
+                        llvm::Type::getInt64Ty(Ctx), Offset)),
+                    llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
+                        llvm::Type::getInt64Ty(Ctx), FieldSize))}));
+      }
+      Entries.push_back(llvm::MDNode::get(Ctx, BoundOps));
+    }
+  }
+
   if (!Entries.empty()) {
     llvm::MDNode *MD = llvm::MDNode::getDistinct(Ctx, Entries);
     F->setMetadata(MD_EJIT_METADATA, MD);
@@ -107,6 +141,26 @@ static void collectMayConstFieldOffsets(ASTContext &Ctx, const RecordDecl *RD,
       Offsets.push_back(FieldOff);
     if (const auto *InnerRD = FD->getType()->getAsRecordDecl())
       collectMayConstFieldOffsets(Ctx, InnerRD, FieldOff, Offsets);
+  }
+}
+
+static void collectBoundMayConstFields(
+    ASTContext &Ctx, const RecordDecl *RD, uint64_t BaseOffset,
+    SmallVectorImpl<std::pair<uint64_t, uint64_t>> &Fields) {
+  if (RD->isUnion())
+    return;
+  const ASTRecordLayout &Layout = Ctx.getASTRecordLayout(RD);
+  for (const FieldDecl *FD : RD->fields()) {
+    if (FD->isBitField())
+      continue;
+    uint64_t Offset =
+        BaseOffset + Layout.getFieldOffset(FD->getFieldIndex()) / 8;
+    QualType FieldType = FD->getType();
+    if (FD->hasAttr<EjitMayConstAttr>() && !FieldType.isVolatileQualified())
+      Fields.push_back(
+          {Offset, Ctx.getTypeSizeInChars(FieldType).getQuantity()});
+    if (const auto *InnerRD = FieldType->getAsRecordDecl())
+      collectBoundMayConstFields(Ctx, InnerRD, Offset, Fields);
   }
 }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -75,6 +75,7 @@ using namespace sema;
 // Forward declaration for EmbeddedJIT deferred parameter check.
 // Defined in SemaEJIT.cpp.
 void checkEjitPeriodArrIndLimit(Sema &S, const FunctionDecl *FD);
+void checkEjitBoundPtrIndex(Sema &S, const FunctionDecl *FD);
 
 // Forward declaration for EmbeddedJIT always_inline conflict check.
 // Defined in SemaEJIT.cpp.
@@ -12306,6 +12307,7 @@ bool Sema::CheckFunctionDeclaration(Scope *S, FunctionDecl *NewFD,
   // declaration's parameter (propagated by the merge), so this runs here
   // rather than at attribute-handling time.
   checkEjitPeriodLcIndex(*this, NewFD);
+  checkEjitBoundPtrIndex(*this, NewFD);
 
   // A function defined without ejit_entry / ejit_period_lc even though a
   // prior declaration carries the attribute is not JIT-specialized: warn and

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -78,6 +78,7 @@ void handleEjitMayConstAttr(Sema &S, Decl *D, const ParsedAttr &AL);
 void handleEjitPeriodAttr(Sema &S, Decl *D, const ParsedAttr &AL);
 void handleEjitPeriodArrAttr(Sema &S, Decl *D, const ParsedAttr &AL);
 void handleEjitPeriodArrIndAttr(Sema &S, Decl *D, const ParsedAttr &AL);
+void handleEjitBoundPtrAttr(Sema &S, Decl *D, const ParsedAttr &AL);
 void handleEjitEntryAttr(Sema &S, Decl *D, const ParsedAttr &AL);
 void handleEjitPeriodLcAttr(Sema &S, Decl *D, const ParsedAttr &AL);
 
@@ -7903,6 +7904,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     break;
   case ParsedAttr::AT_EjitPeriodArrInd:
     handleEjitPeriodArrIndAttr(S, D, AL);
+    break;
+  case ParsedAttr::AT_EjitBoundPtr:
+    handleEjitBoundPtrAttr(S, D, AL);
     break;
   case ParsedAttr::AT_EjitEntry:
     handleEjitEntryAttr(S, D, AL);

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -219,6 +219,30 @@ void handleEjitPeriodArrIndAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
       EjitPeriodArrIndAttr(S.Context, AL, PeriodName));
 }
 
+void handleEjitBoundPtrAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+  auto *PVD = dyn_cast<ParmVarDecl>(D);
+  if (!PVD) {
+    S.Diag(AL.getLoc(), diag::warn_attribute_wrong_decl_type_str)
+        << AL << AL.isRegularKeywordAttribute() << "function parameters";
+    return;
+  }
+
+  QualType PT = PVD->getType();
+  QualType Pointee;
+  if (PT->isPointerType())
+    Pointee = PT->getPointeeType();
+  if (Pointee.isNull() || !Pointee->isObjectType() ||
+      Pointee->isIncompleteType()) {
+    S.Diag(AL.getLoc(), diag::err_ejit_bound_ptr_invalid_type) << PVD;
+    return;
+  }
+
+  StringRef PeriodName;
+  if (!S.checkStringLiteralArgumentAttr(AL, 0, PeriodName))
+    return;
+  PVD->addAttr(::new (S.Context) EjitBoundPtrAttr(S.Context, AL, PeriodName));
+}
+
 /// handleEjitEntryAttr - Process the ejit_entry attribute.
 /// Checks:
 ///   1. Applies only to FunctionDecl
@@ -293,6 +317,36 @@ void checkEjitPeriodArrIndLimit(Sema &S, const FunctionDecl *FD) {
           << FD << Count;
     }
   }
+}
+
+void checkEjitBoundPtrIndex(Sema &S, const FunctionDecl *FD) {
+  if (!FD)
+    return;
+
+  unsigned BoundCount = 0;
+  const EjitBoundPtrAttr *LastBound = nullptr;
+  for (const ParmVarDecl *P : FD->parameters())
+    if (const auto *A = P->getAttr<EjitBoundPtrAttr>()) {
+      ++BoundCount;
+      LastBound = A;
+    }
+
+  if (BoundCount > 1 && LastBound) {
+    S.Diag(LastBound->getLocation(), diag::err_ejit_bound_ptr_too_many)
+        << FD << BoundCount;
+    return;
+  }
+
+  if (!LastBound)
+    return;
+  unsigned MatchingDims = 0;
+  for (const ParmVarDecl *P : FD->parameters())
+    if (const auto *D = P->getAttr<EjitPeriodArrIndAttr>())
+      if (D->getPeriodName() == LastBound->getPeriodName())
+        ++MatchingDims;
+  if (MatchingDims != 1)
+    S.Diag(LastBound->getLocation(), diag::err_ejit_bound_ptr_missing_dim)
+        << LastBound->getPeriodName();
 }
 
 /// checkEjitEntryLcConflict - ejit_entry and ejit_period_lc are mutually

--- a/clang/test/CodeGen/ejit_metadata.c
+++ b/clang/test/CodeGen/ejit_metadata.c
@@ -27,6 +27,14 @@ void lc_func(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx) {
   g_cellCfg[cellIdx].xx = 42; // modify non-may_const field
 }
 
+// CHECK: define {{.*}}i32 @bound_entry({{.*}} !ejit.metadata ![[BOUND_META:[0-9]+]]
+__attribute__((ejit_entry))
+int bound_entry(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx,
+                __attribute__((ejit_bound_ptr("cell")))
+                const struct CellConfig *cfg) {
+  return cfg->cellType + cfg->xx;
+}
+
 // CHECK-DAG: ![[MAYCONST_FIELD:[0-9]+]] = !{!"ejit_may_const_field", i32 0}
 // CHECK-DAG: ![[PERIOD_META]] = distinct !{![[PERIOD:[0-9]+]], ![[MAYCONST_FIELD]]}
 // CHECK-DAG: ![[PERIOD]] = !{!"ejit_period", !"static"}
@@ -38,3 +46,6 @@ void lc_func(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx) {
 // CHECK-DAG: ![[LC]] = !{!"ejit_period_lc", !"cell"}
 // CHECK-DAG: ![[IND]] = !{!"ejit_period_arr_ind", !"cell", i32 0}
 // CHECK-DAG: ![[MAYCONST]] = !{}
+// CHECK-DAG: ![[BOUND_META]] = distinct !{![[ENTRY]], ![[IND]], ![[BOUND:[0-9]+]]}
+// CHECK-DAG: ![[BOUND]] = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, ![[BOUND_FIELD:[0-9]+]]}
+// CHECK-DAG: ![[BOUND_FIELD]] = !{i64 0, i64 4}

--- a/clang/test/Sema/ejit_bound_ptr.c
+++ b/clang/test/Sema/ejit_bound_ptr.c
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+struct Cfg { int value; };
+
+__attribute__((ejit_entry))
+void good(__attribute__((ejit_period_arr_ind("cell"))) int cell,
+          __attribute__((ejit_bound_ptr("cell"))) const struct Cfg *cfg);
+
+__attribute__((ejit_entry))
+void not_pointer(__attribute__((ejit_period_arr_ind("cell"))) int cell,
+                 __attribute__((ejit_bound_ptr("cell"))) int cfg);
+// expected-error@-1 {{ejit_bound_ptr parameter 'cfg' must be a pointer to a complete object type}}
+
+struct Incomplete;
+__attribute__((ejit_entry))
+void incomplete(__attribute__((ejit_period_arr_ind("cell"))) int cell,
+                __attribute__((ejit_bound_ptr("cell"))) struct Incomplete *cfg);
+// expected-error@-1 {{ejit_bound_ptr parameter 'cfg' must be a pointer to a complete object type}}
+
+__attribute__((ejit_entry))
+void missing_dim(__attribute__((ejit_period_arr_ind("trp"))) int trp,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *cfg);
+// expected-error@-1 {{ejit_bound_ptr(cell) requires exactly one matching ejit_period_arr_ind(cell) parameter}}
+
+__attribute__((ejit_entry))
+void two_bound(__attribute__((ejit_period_arr_ind("cell"))) int cell,
+               __attribute__((ejit_bound_ptr("cell"))) struct Cfg *a,
+               __attribute__((ejit_bound_ptr("cell"))) struct Cfg *b);
+// expected-error@-1 {{function 'two_bound' has 2 ejit_bound_ptr parameters; at most one is supported}}

--- a/ejit_test/README.md
+++ b/ejit_test/README.md
@@ -46,6 +46,21 @@ Integration tests for the EmbeddedJIT JIT compilation system.
 | `ejit_ptr_period_test` | Pointer-type ejit_period_arr and ejit_period (NEW) |
 | `ejit_trace_test` | Runtime trace: JIT dispatch, fallback, lifecycle hooks |
 
+### Board-only Multicore Demo
+
+`ejit_bound_ptr_sre_multicore_test.c` provides the SRE `test_ejit_period`
+entry for validating dimension-bound pointer snapshots across cores:
+
+1. Core 8 runs `test_ejit_period` to start the shared worker and arm capture.
+2. Core 18 runs `test_ejit_period` to enqueue independent cell 1 (`scale=5`)
+   and cell 2 (`scale=9`) stack snapshots, then verifies both JIT versions.
+3. Core 8 runs `test_ejit_bound_ptr_print` to print the optimized function.
+
+The expected AOT/JIT pairs are `153/253` for cell 1 and `194/294` for cell 2.
+The compiled list must contain both cell instances. The latest function dump
+(cell 2) must have no loads for `algorithm` or `scale`, while the `runtimeBias`
+load remains.
+
 ### External Dependency Tests (not in build.sh)
 
 | Test | Dependency | Description |

--- a/ejit_test/ejit_bound_ptr_sre_multicore_test.c
+++ b/ejit_test/ejit_bound_ptr_sre_multicore_test.c
@@ -1,0 +1,287 @@
+//===-- ejit_bound_ptr_sre_multicore_test.c - cross-core snapshot demo ----===//
+//
+// Board flow after a reset:
+//   1. Core 8:  test_ejit_period
+//      Initializes EJIT, owns the shared compile worker, and arms the dump.
+//   2. Core 18: test_ejit_period
+//      Enqueues compilation from a stack-local bound object, destroys that
+//      object, waits for publication, then verifies a JIT cache hit using a
+//      second object whose dynamic field has a different value.
+//   3. Core 8:  test_ejit_bound_ptr_print
+//      Prints the worker-local optimized IR/ASM.
+//
+// Do not call ejit_shutdown(): the owner worker and facade must survive across
+// shell invocations.
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+#include <string.h>
+
+#include "ejit_test_helpers.h"
+
+extern void SRE_printf(const char *format, ...);
+extern uint32_t SRE_TaskDelay(uint32_t tick);
+extern void call_init_array_functions(void);
+extern uint8_t g_ucLocalCoreID;
+
+#ifndef EJIT_SHARED_SECTION_ATTR
+#define EJIT_SHARED_SECTION_ATTR __attribute__((section(".mc_shared")))
+#endif
+
+#define BOUND_PTR_WORKER_CORE 8u
+#define BOUND_PTR_PRODUCER_CORE 18u
+#define BOUND_PTR_CELL_A 1u
+#define BOUND_PTR_CELL_B 2u
+#define BOUND_PTR_TRP 2u
+#define BOUND_PTR_WAIT_ROUNDS 6000u
+#define BOUND_PTR_WAIT_TICKS 10u
+
+enum BoundPtrDemoStage {
+  BOUND_PTR_DEMO_RESET = 0,
+  BOUND_PTR_DEMO_WORKER_READY = 1,
+  BOUND_PTR_DEMO_COMPILED = 2,
+  BOUND_PTR_DEMO_PRINTED = 3,
+};
+
+struct CellRelated {
+  ejit_may_const uint32_t algorithm;
+  ejit_may_const uint32_t scale;
+  uint32_t runtimeBias;
+};
+
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(cell)
+uint32_t g_bound_cells[8];
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(trp)
+uint32_t g_bound_trps[8];
+EJIT_SHARED_SECTION_ATTR volatile uint32_t g_bound_ptr_demo_stage;
+EJIT_SHARED_SECTION_ATTR volatile uint64_t g_bound_ptr_demo_sink;
+
+ejit_entry uint32_t
+bound_cell_config_mc(ejit_period_arr_ind(cell) uint8_t cellIndex,
+                     ejit_period_arr_ind(trp) uint8_t trpIndex,
+                     EJIT_BOUND_PTR(cell) const struct CellRelated *cellRelated,
+                     uint32_t input) {
+  if (cellRelated->algorithm == 7u)
+    return input * cellRelated->scale + cellRelated->runtimeBias + cellIndex +
+           trpIndex;
+  return input + cellRelated->runtimeBias;
+}
+
+__attribute__((noinline)) static uint32_t
+enqueue_from_stack(uint8_t cell, uint32_t scale, uint32_t runtimeBias) {
+  struct CellRelated local = {7u, scale, runtimeBias};
+  return bound_cell_config_mc(cell, BOUND_PTR_TRP, &local, 10u);
+}
+
+// Encourage reuse of the caller stack after enqueue_from_stack has returned.
+// Correctness must not depend on whether this happens to overlap its old slot.
+__attribute__((noinline)) static void clobber_producer_stack(void) {
+  volatile uint8_t bytes[512];
+  for (uint32_t i = 0; i < sizeof(bytes); ++i)
+    bytes[i] = (uint8_t)(0xa5u ^ i);
+  __asm__ volatile("" : : "r"(&bytes[0]) : "memory");
+}
+
+static int wait_for_two_compiles(uint64_t baseline) {
+  for (uint32_t round = 0; round < BOUND_PTR_WAIT_ROUNDS; ++round) {
+    ejit_taskpool_stats_t stats;
+    memset(&stats, 0, sizeof(stats));
+    (void)ejit_taskpool_get_stats(&stats);
+    if (stats.compileFailed || stats.publishFailed) {
+      SRE_printf("[BOUND-PTR-MC] FAIL compile=%llu publish=%llu\n",
+                 (unsigned long long)stats.compileFailed,
+                 (unsigned long long)stats.publishFailed);
+      return 0;
+    }
+    if (stats.asyncCompiles >= baseline + 2u &&
+        ejit_taskpool_pending_count() == 0)
+      return 1;
+    if ((round % 500u) == 0)
+      SRE_printf("[BOUND-PTR-MC] waiting compiles=%llu/2 pending=%u\n",
+                 (unsigned long long)(stats.asyncCompiles - baseline),
+                 ejit_taskpool_pending_count());
+    (void)SRE_TaskDelay(BOUND_PTR_WAIT_TICKS);
+  }
+  return 0;
+}
+
+static int run_producer(void) {
+  uint32_t stage = __atomic_load_n(&g_bound_ptr_demo_stage, __ATOMIC_ACQUIRE);
+  if (stage != BOUND_PTR_DEMO_WORKER_READY) {
+    SRE_printf("[BOUND-PTR-MC][core=18] FAIL stage=%u; run core 8 first\n",
+               stage);
+    return -3;
+  }
+
+  if (ejit_activate("cell", BOUND_PTR_CELL_A) != EJIT_OK ||
+      ejit_activate("cell", BOUND_PTR_CELL_B) != EJIT_OK ||
+      ejit_activate("trp", BOUND_PTR_TRP) != EJIT_OK) {
+    SRE_printf("[BOUND-PTR-MC][core=18] FAIL activate\n");
+    return -4;
+  }
+
+  ejit_clear_cache();
+  ejit_taskpool_stats_t before;
+  memset(&before, 0, sizeof(before));
+  (void)ejit_taskpool_get_stats(&before);
+
+  // The first call returns AOT while the worker is pending. The local object
+  // is dead before this producer starts waiting. Stack clobbering strengthens
+  // the lifetime stress, while the taskpool unit test supplies the
+  // deterministic enqueue-before-poll ownership proof.
+  uint32_t aotA = enqueue_from_stack(BOUND_PTR_CELL_A, 5u, 100u);
+  clobber_producer_stack();
+  uint32_t aotB = enqueue_from_stack(BOUND_PTR_CELL_B, 9u, 100u);
+  clobber_producer_stack();
+  const uint32_t expectedAotA = 153u;
+  const uint32_t expectedAotB = 194u;
+  if (aotA != expectedAotA || aotB != expectedAotB) {
+    SRE_printf("[BOUND-PTR-MC][core=18] FAIL AOT cell1=%u/%u cell2=%u/%u\n",
+               aotA, expectedAotA, aotB, expectedAotB);
+    return -5;
+  }
+
+  if (!wait_for_two_compiles(before.asyncCompiles)) {
+    SRE_printf("[BOUND-PTR-MC][core=18] FAIL compile timeout\n");
+    ejit_taskpool_print_stats();
+    return -6;
+  }
+
+  ejit_taskpool_stats_t compiled;
+  memset(&compiled, 0, sizeof(compiled));
+  (void)ejit_taskpool_get_stats(&compiled);
+
+  // Each cell keeps its own stable scale, while runtimeBias deliberately
+  // changes. Reusing cell 1's scale=5 specialization for cell 2 would return
+  // 254 instead of 294 and fail this check.
+  uint32_t jitA = enqueue_from_stack(BOUND_PTR_CELL_A, 5u, 200u);
+  uint32_t jitB = enqueue_from_stack(BOUND_PTR_CELL_B, 9u, 200u);
+  const uint32_t expectedJitA = 253u;
+  const uint32_t expectedJitB = 294u;
+  ejit_taskpool_stats_t after;
+  memset(&after, 0, sizeof(after));
+  (void)ejit_taskpool_get_stats(&after);
+  if (jitA != expectedJitA || jitB != expectedJitB) {
+    SRE_printf("[BOUND-PTR-MC][core=18] FAIL JIT cell1=%u/%u cell2=%u/%u\n",
+               jitA, expectedJitA, jitB, expectedJitB);
+    return -7;
+  }
+  if (after.cacheHits < compiled.cacheHits + 2u) {
+    SRE_printf("[BOUND-PTR-MC][core=18] FAIL no cache hit before=%llu "
+               "after=%llu; check shared code-pointer support\n",
+               (unsigned long long)compiled.cacheHits,
+               (unsigned long long)after.cacheHits);
+    return -8;
+  }
+
+  __atomic_store_n(&g_bound_ptr_demo_sink,
+                   ((uint64_t)jitA << 32) | (uint64_t)jitB, __ATOMIC_RELEASE);
+  __atomic_store_n(&g_bound_ptr_demo_stage, BOUND_PTR_DEMO_COMPILED,
+                   __ATOMIC_RELEASE);
+  SRE_printf("[BOUND-PTR-MC][core=18] PASS cell1 AOT/JIT=%u/%u cell2 "
+             "AOT/JIT=%u/%u compiles=2 hits=%llu; run "
+             "test_ejit_bound_ptr_print on core 8\n",
+             aotA, jitA, aotB, jitB,
+             (unsigned long long)(after.cacheHits - compiled.cacheHits));
+  return 0;
+}
+
+static int run_worker(void) {
+  uint32_t stage = __atomic_load_n(&g_bound_ptr_demo_stage, __ATOMIC_ACQUIRE);
+  if (stage == BOUND_PTR_DEMO_RESET) {
+    __atomic_store_n(&g_bound_ptr_demo_sink, 0u, __ATOMIC_RELEASE);
+    ejit_dump_func("bound_cell_config_mc");
+    __atomic_store_n(&g_bound_ptr_demo_stage, BOUND_PTR_DEMO_WORKER_READY,
+                     __ATOMIC_RELEASE);
+    SRE_printf("[BOUND-PTR-MC][core=8] worker ready; run test_ejit_period on "
+               "core 18\n");
+    return 0;
+  }
+
+  SRE_printf("[BOUND-PTR-MC][core=8] worker already initialized stage=%u; "
+             "use test_ejit_bound_ptr_print for output\n",
+             stage);
+  return 0;
+}
+
+int test_ejit_bound_ptr_print(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  if (core != BOUND_PTR_WORKER_CORE) {
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL: dump is worker-local; run "
+               "test_ejit_bound_ptr_print on core 8\n",
+               core);
+    return -9;
+  }
+
+  uint32_t stage = __atomic_load_n(&g_bound_ptr_demo_stage, __ATOMIC_ACQUIRE);
+  if (stage < BOUND_PTR_DEMO_COMPILED) {
+    SRE_printf("[BOUND-PTR-MC][core=8] FAIL stage=%u; run test_ejit_period "
+               "on core 18 first\n",
+               stage);
+    return -10;
+  }
+  if (stage == BOUND_PTR_DEMO_PRINTED) {
+    SRE_printf("[BOUND-PTR-MC][core=8] dump already printed\n");
+    return 0;
+  }
+
+  ejit_dump_func("");
+  SRE_printf("\n[BOUND-PTR-MC] === COMPILED VERSIONS ===\n");
+  ejit_taskpool_print_compiled();
+  SRE_printf("\n[BOUND-PTR-MC] === OPTIMIZED FUNCTION ===\n");
+  ejit_print_dumped("bound_cell_config_mc");
+  SRE_printf("[BOUND-PTR-MC][core=8] expect: algorithm/scale loads and "
+             "branch removed; runtimeBias load retained. The function dump "
+             "is the latest capture (cell=2, scale=9).\n");
+  SRE_printf("[BOUND-PTR-MC][core=8] PASS sink=0x%llx\n",
+             (unsigned long long)__atomic_load_n(&g_bound_ptr_demo_sink,
+                                                 __ATOMIC_ACQUIRE));
+  __atomic_store_n(&g_bound_ptr_demo_stage, BOUND_PTR_DEMO_PRINTED,
+                   __ATOMIC_RELEASE);
+  return 0;
+}
+
+int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  SRE_printf("\n=== EJIT bound-pointer multicore demo (core=%u) ===\n", core);
+  call_init_array_functions();
+
+  ejit_config_t cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.compileMode = EJIT_COMPILE_ASYNC;
+  cfg.optLevel = EJIT_OPT_L2;
+  cfg.enableLogger = true;
+  cfg.forceStaticRegistry = true;
+
+  ejit_status_t rc = ejit_init(&cfg);
+  uint32_t worker = ejit_taskpool_get_worker_core();
+  SRE_printf("[BOUND-PTR-MC][core=%u] init rc=%d worker=%u stage=%u\n", core,
+             (int)rc, worker,
+             __atomic_load_n(&g_bound_ptr_demo_stage, __ATOMIC_ACQUIRE));
+  if (rc != EJIT_OK)
+    return -1;
+  if (worker != BOUND_PTR_WORKER_CORE) {
+    SRE_printf("[BOUND-PTR-MC] FAIL worker=%u; reset and run core 8 first\n",
+               worker);
+    return -2;
+  }
+
+  if (core == BOUND_PTR_WORKER_CORE)
+    return run_worker();
+  if (core == BOUND_PTR_PRODUCER_CORE)
+    return run_producer();
+
+  SRE_printf("[BOUND-PTR-MC][core=%u] skip: use core 8 or core 18\n", core);
+  return 0;
+}

--- a/ejit_test/ejit_bound_ptr_sre_multicore_test.c
+++ b/ejit_test/ejit_bound_ptr_sre_multicore_test.c
@@ -15,10 +15,82 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <stdint.h>
-#include <string.h>
+// Kept self-contained for direct board integration: no project or libc
+// headers are required by this file.
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef unsigned long size_t;
+typedef _Bool bool;
 
-#include "ejit_test_helpers.h"
+#define true 1
+#define false 0
+
+#define EJIT_PERIOD_CONST __attribute__((ejit_period_const))
+#define EJIT_IN_PERIOD_ARRAY(x) __attribute__((ejit_in_period_array(#x)))
+#define EJIT_DIM(x) __attribute__((ejit_dim(#x)))
+#define EJIT_BOUND_PTR(x) __attribute__((ejit_bound_ptr(#x)))
+#define EJIT_ENTRY __attribute__((ejit_entry))
+
+#define ejit_may_const EJIT_PERIOD_CONST
+#define ejit_period_arr(x) EJIT_IN_PERIOD_ARRAY(x)
+#define ejit_period_arr_ind(x) EJIT_DIM(x)
+#define ejit_entry EJIT_ENTRY
+
+typedef enum {
+  EJIT_OK = 0,
+  EJIT_COMPILE_ERROR = -3,
+} ejit_status_t;
+
+typedef enum {
+  EJIT_COMPILE_SYNC = 0,
+  EJIT_COMPILE_ASYNC = 1,
+} ejit_compile_mode_t;
+
+typedef enum {
+  EJIT_OPT_L1 = 1,
+  EJIT_OPT_L2 = 2,
+  EJIT_OPT_L3 = 3,
+} ejit_opt_level_t;
+
+typedef struct {
+  ejit_compile_mode_t compileMode;
+  ejit_opt_level_t optLevel;
+  size_t maxCodeMemory;
+  size_t maxDataMemory;
+  size_t maxCacheEntries;
+  size_t maxCacheSize;
+  bool enableLogger;
+  bool forceStaticRegistry;
+  const char *dumpJITDir;
+} ejit_config_t;
+
+typedef struct {
+  uint64_t cacheHits;
+  uint64_t asyncCompiles;
+  uint64_t asyncEnqueues;
+  uint64_t alreadyPending;
+  uint64_t queueFull;
+  uint64_t compileFailed;
+  uint64_t publishFailed;
+  uint64_t instanceDisabled;
+  uint64_t instanceDisabledPreActivate;
+  uint32_t readyEntries;
+  uint32_t pendingEntries;
+  uint32_t queueApproxSize;
+  uint32_t reserved;
+} ejit_taskpool_stats_t;
+
+extern ejit_status_t ejit_init(const ejit_config_t *config);
+extern ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx);
+extern void ejit_clear_cache(void);
+extern unsigned ejit_taskpool_pending_count(void);
+extern ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out);
+extern void ejit_taskpool_print_stats(void);
+extern void ejit_taskpool_print_compiled(void);
+extern uint32_t ejit_taskpool_get_worker_core(void);
+extern void ejit_dump_func(const char *name);
+extern void ejit_print_dumped(const char *name);
 
 extern void SRE_printf(const char *format, ...);
 extern uint32_t SRE_TaskDelay(uint32_t tick);
@@ -85,8 +157,7 @@ __attribute__((noinline)) static void clobber_producer_stack(void) {
 
 static int wait_for_two_compiles(uint64_t baseline) {
   for (uint32_t round = 0; round < BOUND_PTR_WAIT_ROUNDS; ++round) {
-    ejit_taskpool_stats_t stats;
-    memset(&stats, 0, sizeof(stats));
+    ejit_taskpool_stats_t stats = {0};
     (void)ejit_taskpool_get_stats(&stats);
     if (stats.compileFailed || stats.publishFailed) {
       SRE_printf("[BOUND-PTR-MC] FAIL compile=%llu publish=%llu\n",
@@ -122,8 +193,7 @@ static int run_producer(void) {
   }
 
   ejit_clear_cache();
-  ejit_taskpool_stats_t before;
-  memset(&before, 0, sizeof(before));
+  ejit_taskpool_stats_t before = {0};
   (void)ejit_taskpool_get_stats(&before);
 
   // The first call returns AOT while the worker is pending. The local object
@@ -148,8 +218,7 @@ static int run_producer(void) {
     return -6;
   }
 
-  ejit_taskpool_stats_t compiled;
-  memset(&compiled, 0, sizeof(compiled));
+  ejit_taskpool_stats_t compiled = {0};
   (void)ejit_taskpool_get_stats(&compiled);
 
   // Each cell keeps its own stable scale, while runtimeBias deliberately
@@ -159,8 +228,7 @@ static int run_producer(void) {
   uint32_t jitB = enqueue_from_stack(BOUND_PTR_CELL_B, 9u, 200u);
   const uint32_t expectedJitA = 253u;
   const uint32_t expectedJitB = 294u;
-  ejit_taskpool_stats_t after;
-  memset(&after, 0, sizeof(after));
+  ejit_taskpool_stats_t after = {0};
   (void)ejit_taskpool_get_stats(&after);
   if (jitA != expectedJitA || jitB != expectedJitB) {
     SRE_printf("[BOUND-PTR-MC][core=18] FAIL JIT cell1=%u/%u cell2=%u/%u\n",
@@ -257,8 +325,7 @@ int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   SRE_printf("\n=== EJIT bound-pointer multicore demo (core=%u) ===\n", core);
   call_init_array_functions();
 
-  ejit_config_t cfg;
-  memset(&cfg, 0, sizeof(cfg));
+  ejit_config_t cfg = {0};
   cfg.compileMode = EJIT_COMPILE_ASYNC;
   cfg.optLevel = EJIT_OPT_L2;
   cfg.enableLogger = true;

--- a/ejit_test/ejit_bound_ptr_test.c
+++ b/ejit_test/ejit_bound_ptr_test.c
@@ -1,0 +1,64 @@
+//===-- ejit_bound_ptr_test.c - Dimension-bound pointee snapshot test -----===//
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "ejit_test_helpers.h"
+
+typedef struct {
+  uint32_t ejit_may_const algorithm;
+  uint32_t ejit_may_const scale;
+  uint32_t runtimeBias;
+} CellRelated;
+
+ejit_period_arr(cell) uint32_t g_cells[8];
+ejit_period_arr(trp) uint32_t g_trps[8];
+
+ejit_entry uint32_t bound_cell_config(ejit_period_arr_ind(cell)
+                                          uint8_t cellIndex,
+                                      ejit_period_arr_ind(trp) uint8_t trpIndex,
+                                      EJIT_BOUND_PTR(cell)
+                                          const CellRelated *cellRelated,
+                                      uint32_t input) {
+  if (cellRelated->algorithm == 7)
+    return input * cellRelated->scale + cellRelated->runtimeBias + cellIndex +
+           trpIndex;
+  return input + cellRelated->runtimeBias;
+}
+
+static uint32_t call_with_stack_instance(uint8_t cellIndex, uint8_t trpIndex,
+                                         uint32_t runtimeBias) {
+  CellRelated Local = {7, 5, runtimeBias};
+  return bound_cell_config(cellIndex, trpIndex, &Local, 10);
+}
+
+int main(void) {
+  const uint8_t Cell = 3;
+  const uint8_t Trp = 2;
+  ejit_config_t Config;
+  ejit_default_config(&Config);
+  if (ejit_init(&Config) != EJIT_OK)
+    return 1;
+  if (ejit_activate("cell", Cell) != EJIT_OK ||
+      ejit_activate("trp", Trp) != EJIT_OK)
+    return 2;
+
+  ejit_dump_func("bound_cell_config");
+  uint32_t Aot = call_with_stack_instance(Cell, Trp, 100);
+  ejit_drain_taskpool();
+
+  // The first stack object is gone. The specialization must have consumed its
+  // owned snapshot, while this call's dynamic field must still be read here.
+  uint32_t Jit = call_with_stack_instance(Cell, Trp, 200);
+  uint32_t ExpectedAot = 10 * 5 + 100 + Cell + Trp;
+  uint32_t ExpectedJit = 10 * 5 + 200 + Cell + Trp;
+  printf("AOT=%u expected=%u JIT=%u expected=%u\n", Aot, ExpectedAot, Jit,
+         ExpectedJit);
+  ejit_print_dumped("bound_cell_config");
+  if (Aot != ExpectedAot || Jit != ExpectedJit) {
+    printf("FAIL\n");
+    return 3;
+  }
+  printf("PASS\n");
+  return 0;
+}

--- a/jit_design_doc/EJIT_BOUND_PTR.md
+++ b/jit_design_doc/EJIT_BOUND_PTR.md
@@ -1,0 +1,48 @@
+# EJIT dimension-bound pointer snapshots
+
+`EJIT_BOUND_PTR(period)` associates one pointer parameter with an existing
+`EJIT_DIM(period)` parameter. It lets EJIT specialize fields whose values are
+stable for that period instance without requiring a global array name.
+
+```c
+typedef struct {
+  uint32_t ejit_may_const algorithm;
+  uint32_t ejit_may_const scale;
+  uint32_t runtime_bias;
+} CellConfig;
+
+EJIT_ENTRY uint32_t process(
+    EJIT_DIM(cell) uint8_t cell,
+    EJIT_BOUND_PTR(cell) const CellConfig *config,
+    uint32_t input) {
+  return input * config->scale + config->runtime_bias;
+}
+```
+
+On a real JIT cache miss, the wrapper copies the complete `CellConfig` object
+into the compile request before returning. The asynchronous worker therefore
+never retains or dereferences the caller's pointer. Stack-local objects are
+safe to destroy immediately after the entry call.
+
+Only loads of `ejit_may_const` fields are replaced from the snapshot. Other
+fields, such as `runtime_bias` above, remain ordinary loads through the pointer
+passed to each invocation of the JIT function.
+
+## Contract and limits
+
+- The function must have exactly one matching `EJIT_DIM(period)` parameter.
+- The first implementation supports one `EJIT_BOUND_PTR` parameter per entry.
+- The copy is shallow. Pointer fields inside the object are not followed.
+- An `ejit_may_const` field must remain stable while its period instance is
+  active. Change it only as part of the normal deactivate/update/reactivate
+  lifecycle so the period version invalidates old specialized code.
+- The default snapshot cap is 256 bytes. Configure
+  `EJIT_BOUND_PTR_MAX_BYTES` to a positive multiple of 8 when a larger object
+  is required. An oversize request falls back to AOT without queuing work.
+- Volatile, atomic, bit-field, union, dynamically indexed, and unmarked field
+  loads are never folded from the snapshot.
+
+The snapshot is carried inline in `EJitCompileRequest`. This increases shared
+queue storage by `EJIT_BOUND_PTR_MAX_BYTES * queue capacity`, but avoids heap
+allocation, ownership handoff, cleanup races, and dangling-pointer failure
+paths on the worker side.

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -823,6 +823,8 @@ set(EJIT_SRE_TASKPOOL_BUCKETS "32" CACHE STRING
 # Async work-queue capacity (rounded up to a power of two).
 set(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY "1024" CACHE STRING
   "EmbeddedJIT SRE taskpool async queue capacity (power of two)")
+set(EJIT_BOUND_PTR_MAX_BYTES "256" CACHE STRING
+  "Maximum shallow pointee snapshot carried by one EJIT compile request")
 # Flat dedup table capacity = max dense funcIndex (spec §3.5 inFlight_[]).
 set(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX "4096" CACHE STRING
   "EmbeddedJIT SRE taskpool flat dedup capacity (max dense funcIndex)")
@@ -830,6 +832,7 @@ set(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX "4096" CACHE STRING
 # value fails at `cmake` time with a clear message instead of mid-build.
 ejit_require_numeric(EJIT_SRE_TASKPOOL_BUCKETS)
 ejit_require_numeric(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY)
+ejit_require_numeric(EJIT_BOUND_PTR_MAX_BYTES)
 ejit_require_numeric(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX)
 if(EJIT_SRE_TASKPOOL_BUCKETS LESS 1 OR EJIT_SRE_TASKPOOL_BUCKETS GREATER 254)
   message(FATAL_ERROR
@@ -843,6 +846,18 @@ if(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY LESS 2 OR NOT _ejit_queue_pow2 EQUAL 0)
     "EJIT_SRE_TASKPOOL_QUEUE_CAPACITY (${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}) "
     "must be a power of two >= 2 (the ring queue indexes with a mask).")
 endif()
+if(EJIT_BOUND_PTR_MAX_BYTES LESS 1 OR EJIT_BOUND_PTR_MAX_BYTES GREATER 65536)
+  message(FATAL_ERROR
+    "EJIT_BOUND_PTR_MAX_BYTES must be in [1, 65536], got ${EJIT_BOUND_PTR_MAX_BYTES}")
+endif()
+math(EXPR _ejit_bound_ptr_rem "${EJIT_BOUND_PTR_MAX_BYTES} % 8")
+if(NOT _ejit_bound_ptr_rem EQUAL 0)
+  message(FATAL_ERROR
+    "EJIT_BOUND_PTR_MAX_BYTES must be a multiple of 8, got ${EJIT_BOUND_PTR_MAX_BYTES}")
+endif()
+unset(_ejit_bound_ptr_rem)
+add_definitions(-DEJIT_BOUND_PTR_MAX_BYTES=${EJIT_BOUND_PTR_MAX_BYTES})
+message(STATUS "EmbeddedJIT: bound-pointer snapshot cap=${EJIT_BOUND_PTR_MAX_BYTES} bytes")
 unset(_ejit_queue_pow2)
 if(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX LESS 1)
   message(FATAL_ERROR

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -61,6 +61,7 @@ constexpr const char *MD_EJIT_MAY_CONST = "ejit.may_const";
 constexpr const char *TAG_EJIT_ENTRY = "ejit_entry";
 constexpr const char *TAG_EJIT_PERIOD_LC = "ejit_period_lc";
 constexpr const char *TAG_EJIT_PERIOD_ARR_IND = "ejit_period_arr_ind";
+constexpr const char *TAG_EJIT_BOUND_PTR = "ejit_bound_ptr";
 constexpr const char *TAG_EJIT_PERIOD_ARR = "ejit_period_arr";
 constexpr const char *TAG_EJIT_PERIOD = "ejit_period";
 constexpr const char *TAG_EJIT_MAY_CONST_FIELD = "ejit_may_const_field";
@@ -98,6 +99,8 @@ constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_BOUND =
+    "ejit_taskpool_compile_or_get_bound";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper
 // when -ejit-wrapper-fixed-dim-entry is enabled and the entry has <= 4 dims.
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_0D =

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -19,6 +19,7 @@
 #ifdef EJIT_SRE_PGO_VALUE_PROFILE
 #include "llvm/ExecutionEngine/EJIT/EJitVpCollector.h"
 #endif
+#include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h"
 #ifdef EJIT_SRE_TASKPOOL
 #include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h"
 #endif
@@ -178,7 +179,8 @@ private:
   /// \p tier is the CompileTier (uint32_t, EJitOrcEngine.h) decoded from
   /// the request's funcIndex high bits (EJitSreQueue.h); gated by
   /// Config::enablePgo (off => Baseline regardless).
-  void *compileCold(uint64_t cacheKey, uint32_t tier, bool storeLru);
+  void *compileCold(uint64_t cacheKey, uint32_t tier, bool storeLru,
+                    const EJitCompileRequest *request = nullptr);
 
   /// PGO: Tier-1 captured counter refs per cacheKey (EJIT_ONLINE_PGO.md
   /// §5.2). Filled after a Tier-1 compile (ORC lookup of __profc_/__profd_

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -109,6 +109,7 @@ private:
 
   /// Run EJitStructFieldPass on all functions.
   void runStructFieldPass(Module &M);
+  void runStructFieldPass(Module &M, const SpecializationContext &ctx);
 
   /// Push the specialized constants across call edges. The AOT inliner keeps a
   /// call edge wherever it chose not to inline, so after phase 1 every call

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -87,6 +87,8 @@ struct SpecializationContext {
     uint8_t cellIdx;
   };
   SmallVector<DimInfo, 4> dimensions;
+  uint32_t boundArgIndex = 0;
+  SmallVector<uint8_t, 256> boundData;
   OptimizationLevel optLevel = OptimizationLevel::L2;
   /// PGO tier (Baseline when PGO is disabled or for the first compile).
   CompileTier tier = CompileTier::Baseline;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -37,6 +37,7 @@
 #define EJIT_IN_PERIOD_ARRAY(x)
 #define ejit_period_arr(x)
 #define EJIT_DIM(x)
+#define EJIT_BOUND_PTR(x)
 #define ejit_period_arr_ind(x)
 #define EJIT_ENTRY
 #define ejit_entry
@@ -48,6 +49,7 @@
 #define EJIT_IN_PERIOD(x)       __attribute__((ejit_in_period(#x)))
 #define EJIT_IN_PERIOD_ARRAY(x) __attribute__((ejit_in_period_array(#x)))
 #define EJIT_DIM(x)             __attribute__((ejit_dim(#x)))
+#define EJIT_BOUND_PTR(x) __attribute__((ejit_bound_ptr(#x)))
 #define EJIT_ENTRY              __attribute__((ejit_entry))
 #define EJIT_PERIOD_GUARD(x)    __attribute__((ejit_period_guard(#x)))
 // Old names (aliases — use new macros to avoid double expansion)
@@ -213,6 +215,14 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                                            const ejit_dim_pair_t *dims,
                                            uint32_t numDims, void **outFn,
                                            uint32_t *outBucket);
+
+// Slow-path variant used by wrappers with EJIT_BOUND_PTR. The runtime copies
+// snapshotData before returning; asynchronous compilation never retains the
+// caller's pointer. Oversize/null snapshots fail cleanly and execute AOT.
+ejit_status_t ejit_taskpool_compile_or_get_bound(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const void *snapshotData, uint32_t snapshotSize, uint32_t boundArgIndex,
+    void **outFn, uint32_t *outBucket);
 
 // Fixed-dimension fast paths (0-4 dims). Additive alternatives to
 // ejit_taskpool_compile_or_get that pass the dim identity as scalar arguments

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -98,7 +98,8 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// the shared blob also records completed-function and deferred-miss counts.
 /// v13: non-owner cores can post a may_const-ranking diagnostic request to the
 /// owner worker and wait for its completion without sharing optimizer objects.
-constexpr uint32_t kEJitSharedAbiVersion = 13u;
+/// v14: EJitCompileRequest owns an inline bound-pointer snapshot.
+constexpr uint32_t kEJitSharedAbiVersion = 14u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -835,7 +835,10 @@ public:
 
   //--- producer path ----------------------------------------------------------
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                                  uint32_t numDims, void *fallback);
+                                  uint32_t numDims, void *fallback,
+                                  const void *boundData = nullptr,
+                                  uint32_t boundSize = 0,
+                                  uint32_t boundArgIndex = 0);
   /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
   /// terminal front half of compileOrGet(): the Ready check, the
   /// instance-enabled check, and the cache lookup, then classifies the outcome:

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
@@ -33,6 +33,12 @@
 #ifndef EJIT_SRE_TASKPOOL_QUEUE_CAPACITY
 #define EJIT_SRE_TASKPOOL_QUEUE_CAPACITY 1024u
 #endif
+#ifndef EJIT_BOUND_PTR_MAX_BYTES
+#define EJIT_BOUND_PTR_MAX_BYTES 256u
+#endif
+static_assert(EJIT_BOUND_PTR_MAX_BYTES > 0 &&
+                  (EJIT_BOUND_PTR_MAX_BYTES % 8u) == 0,
+              "EJIT_BOUND_PTR_MAX_BYTES must be a positive multiple of 8");
 
 namespace llvm {
 namespace ejit {
@@ -64,13 +70,21 @@ struct EJitCompileRequest {
   // cache. Unused (left 0) by the non-shared taskpool. Endianness: a plain
   // fixed-width scalar accessed by value, never byte-parsed.
   uint32_t generation;
+  // Optional shallow pointee snapshot for ejit_bound_ptr. It is stored inline
+  // so an async request owns every byte it needs after the caller returns.
+  // boundSize == 0 means no bound pointer. No raw caller pointer crosses the
+  // queue boundary.
+  uint32_t boundArgIndex;
+  uint32_t boundSize;
+  alignas(uintptr_t) uint8_t boundData[EJIT_BOUND_PTR_MAX_BYTES];
 };
 
 // Size is stable per pointer width: on a 64-bit target the trailing uint32_t
 // generation forces 4 bytes of tail padding (alignof == 8) -> 72; on a 32-bit
 // target everything is 4-aligned with no padding -> 64.
 static_assert(sizeof(EJitCompileRequest) ==
-                  (sizeof(uintptr_t) == 8 ? 72u : 64u),
+                  (sizeof(uintptr_t) == 8 ? 80u + EJIT_BOUND_PTR_MAX_BYTES
+                                          : 72u + EJIT_BOUND_PTR_MAX_BYTES),
               "EJitCompileRequest size must stay stable (incl. generation)");
 static_assert(alignof(EJitCompileRequest) <= 8,
               "EJitCompileRequest alignment must stay <= 8 bytes");

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
@@ -38,7 +38,11 @@ using MayConstOffsetMap =
 /// constants.
 class EJitStructFieldPass : public PassInfoMixin<EJitStructFieldPass> {
 public:
-  EJitStructFieldPass(PeriodArrayRegistry &reg) : registry_(reg) {}
+  EJitStructFieldPass(PeriodArrayRegistry &reg,
+                      const uint8_t *boundData = nullptr,
+                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0)
+      : registry_(reg), boundData_(boundData), boundSize_(boundSize),
+        boundArgIndex_(boundArgIndex) {}
 
   /// Pre-build GV metadata maps from the Module (call once before run()).
   void initFromModule(Module &M);
@@ -65,6 +69,9 @@ public:
 
 private:
   PeriodArrayRegistry &registry_;
+  const uint8_t *boundData_ = nullptr;
+  uint32_t boundSize_ = 0;
+  uint32_t boundArgIndex_ = 0;
 
   // Cached metadata maps — built once per module, reused across functions.
   GVPeriodMap gvPeriodMap_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -366,7 +366,10 @@ public:
   EJitTaskPoolCache &cache() { return cache_; }
 
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                                  uint32_t numDims, void *fallback);
+                                  uint32_t numDims, void *fallback,
+                                  const void *boundData = nullptr,
+                                  uint32_t boundSize = 0,
+                                  uint32_t boundArgIndex = 0);
 
   /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
   /// terminal front half of compileOrGet(): the instance-enabled check and the

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -385,7 +385,8 @@ void EJitCompileDriver::registerSymbol(const std::string &name, void *addr) {
 }
 
 void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
-                                     bool storeLru) {
+                                     bool storeLru,
+                                     const EJitCompileRequest *request) {
   // ── Cold path: decode cacheKey, verify, compile ────────────────────────
   uint32_t funcIdx = static_cast<uint32_t>(cacheKey >> 32);
   uint8_t dims[4] = {
@@ -465,6 +466,16 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
   ctx.optLevel = config_.optLevel;
   for (unsigned i = 0; i < dimCount; ++i)
     ctx.dimensions.push_back({periodNames[i], dims[i]});
+  if (request && request->boundSize) {
+    if (request->boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
+      EJIT_DIAG("compile FAIL key=0x%016lx func=%s: bound snapshot too large",
+                cacheKey, funcName.c_str());
+      return nullptr;
+    }
+    ctx.boundArgIndex = request->boundArgIndex;
+    ctx.boundData.append(request->boundData,
+                         request->boundData + request->boundSize);
+  }
 
   // PGO tier (EJIT_ONLINE_PGO.md §4). Gated by Config::enablePgo: off => the
   // default Baseline (unchanged pipeline). On => first compile is Tier-1
@@ -820,7 +831,7 @@ void *EJitCompileDriver::compileNow(const EJitCompileRequest &req) {
   EJIT_DIAG("compileNow dispatch func=%u key=0x%016lx dims=[%u,%u,%u,%u]",
             funcIdx, cacheKey, packedDims[0], packedDims[1], packedDims[2],
             packedDims[3]);
-  return compileCold(cacheKey, tier, /*storeLru=*/false);
+  return compileCold(cacheKey, tier, /*storeLru=*/false, &req);
 }
 
 void EJitCompileDriver::notifyTaskpoolPublished(const EJitCompileRequest &req,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -151,7 +151,13 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
   // every may_const field into a compile-time constant.
   preReplacePeriodIndices(M, ctx);
   runInstCombine(M);
-  runStructFieldPass(M);
+  EJIT_DIAG_DEBUG("pipeline phase1b done: InstCombine");
+  // Inlining is intentionally not run here: the AOT pre-optimization
+  // (EJitRegisterBitcodePass: AlwaysInline + ModuleInliner(O2)) already expanded
+  // callee bodies in the embedded bitcode, so their may_const GEP chains are
+  // already traceable to the global.
+  //   (c) Replace the may_const loads with their runtime constant values.
+  runStructFieldPass(M, ctx);
   EJIT_DIAG_DEBUG("pipeline phase1c done: StructFieldPass");
   //   (d) Push the constants across call edges. Wherever the AOT inliner kept
   //       a call, the callee still re-derives cell addressing and re-tests
@@ -165,7 +171,7 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
   //       loads they root, so phases 2-4 exploit the constants in every
   //       function, not just the entry.
   runInstCombine(M);
-  runStructFieldPass(M);
+  runStructFieldPass(M, ctx);
   EJIT_DIAG_DEBUG("pipeline phase1ef done: callee InstCombine+StructFieldPass");
 
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
@@ -674,12 +680,20 @@ void EJitOptimizer::runInterproceduralPropagation(Module &M) {
   MPM.run(M, MAM_);
 }
 
-void EJitOptimizer::runStructFieldPass(Module &M) {
-  EJitStructFieldPass structField(registry_);
+void EJitOptimizer::runStructFieldPass(Module &M,
+                                       const SpecializationContext &ctx) {
+  EJitStructFieldPass structField(
+      registry_, ctx.boundData.empty() ? nullptr : ctx.boundData.data(),
+      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex);
   structField.initFromModule(M);
   for (Function &F : M.functions())
     if (!F.isDeclaration())
       structField.run(F, FAM_);
+}
+
+void EJitOptimizer::runStructFieldPass(Module &M) {
+  SpecializationContext Empty;
+  runStructFieldPass(M, Empty);
 }
 
 FunctionPassManager &

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -885,10 +885,11 @@ inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
 }
 } // namespace
 
-ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
-                                           const ejit_dim_pair_t *dims,
-                                           uint32_t numDims, void **outFn,
-                                           uint32_t *outBucket) {
+static ejit_status_t
+taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
+                         uint32_t numDims, const void *snapshotData,
+                         uint32_t snapshotSize, uint32_t boundArgIndex,
+                         void **outFn, uint32_t *outBucket) {
   if (outFn)
     *outFn = nullptr;
   if (outBucket)
@@ -964,7 +965,8 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
   }
 
   auto r = tp->compileOrGet(funcIndex, dimsCast, numDims,
-                            /*fallback=*/nullptr);
+                            /*fallback=*/nullptr, snapshotData, snapshotSize,
+                            boundArgIndex);
   if (outFn)
     *outFn = r.fnPtr;
   if (outBucket)
@@ -975,6 +977,23 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
   if (r.fnPtr)
     tp->l0Fill(funcIndex, r.fnPtr, dimsCast, numDims);
   return taskpoolStatus(r.status);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
+                                           const ejit_dim_pair_t *dims,
+                                           uint32_t numDims, void **outFn,
+                                           uint32_t *outBucket) {
+  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, nullptr, 0, 0,
+                                  outFn, outBucket);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_bound(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const void *snapshotData, uint32_t snapshotSize, uint32_t boundArgIndex,
+    void **outFn, uint32_t *outBucket) {
+  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, snapshotData,
+                                  snapshotSize, boundArgIndex, outFn,
+                                  outBucket);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cstdlib>
+#include <cstring>
 
 // Compile-time guard: if EJIT_ICACHE_FUNC_SLOTS ever falls below
 // EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX (defined in EJitSharedTaskPoolState.h,
@@ -2850,7 +2851,9 @@ EJitSharedTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
 
 EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                                 uint32_t numDims, void *fallback) {
+                                 uint32_t numDims, void *fallback,
+                                 const void *boundData, uint32_t boundSize,
+                                 uint32_t boundArgIndex) {
   EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p",
                     funcIndex, numDims, fallback);
   // Parameter check already done by the C API layer.
@@ -2867,6 +2870,13 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   }
   // True miss: continue the slow path with the caller's fallback.
   R.fnPtr = fallback;
+  if ((boundSize != 0 && !boundData) || boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
+    EJIT_DIAG("shared taskpool bound snapshot reject func=%u size=%u max=%u",
+              funcIndex, boundSize,
+              static_cast<unsigned>(EJIT_BOUND_PTR_MAX_BYTES));
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    return R;
+  }
   // Off mode (§5.2 step 2).
   if (state_->mode.loadAcquire() ==
       static_cast<uint32_t>(EJitCompileMode::Off)) {
@@ -2894,6 +2904,16 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       ReqLocal.dims[i] = dims[i];
       ReqLocal.versions[i] =
           instanceVersion(dims[i].dimType, dims[i].instanceId);
+    }
+    ReqLocal.boundArgIndex = boundArgIndex;
+    ReqLocal.boundSize = boundSize;
+    if (boundSize)
+      std::memcpy(ReqLocal.boundData, boundData, boundSize);
+    if (!versionsCurrent(ReqLocal)) {
+      EJIT_DIAG("shared taskpool sync snapshot drop func=%u: version changed",
+                funcIndex);
+      R.status = EJitCompileOrGetStatus::CompileFailed;
+      return R;
     }
     void *fn = nullptr;
     bool ok = compileFn_(compileCtx_, ReqLocal, &fn);
@@ -2978,6 +2998,16 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   for (uint32_t i = 0; i < numDims; ++i) {
     Req.dims[i] = dims[i];
     Req.versions[i] = instanceVersion(dims[i].dimType, dims[i].instanceId);
+  }
+  Req.boundArgIndex = boundArgIndex;
+  Req.boundSize = boundSize;
+  if (boundSize)
+    std::memcpy(Req.boundData, boundData, boundSize);
+  if (!versionsCurrent(Req) || state_->generation.loadAcquire() != gen) {
+    EJIT_DIAG("shared taskpool async snapshot drop func=%u: lifecycle changed",
+              funcIndex);
+    R.status = EJitCompileOrGetStatus::CompileFailed;
+    return R;
   }
   switch (dedupMark(funcIndex, gen)) {
   case EJitDedupResult::AlreadyPending:

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -99,6 +99,82 @@ static const GlobalVariable *findRootGV(const Value *V) {
   return nullptr;
 }
 
+static const Argument *findRootArgument(const Value *V) {
+  V = V->stripPointerCasts();
+  if (auto *Arg = dyn_cast<Argument>(V))
+    return Arg;
+  if (auto *GEP = dyn_cast<GEPOperator>(V))
+    return findRootArgument(GEP->getPointerOperand());
+  return nullptr;
+}
+
+static bool functionBindsArgument(const Function &F, unsigned ArgIndex) {
+  MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
+  if (!MD)
+    return false;
+  for (const MDOperand &Op : MD->operands()) {
+    auto *Sub = dyn_cast<MDNode>(Op.get());
+    if (!Sub || Sub->getNumOperands() < 3)
+      continue;
+    auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
+    auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
+    if (Tag && Tag->getString() == TAG_EJIT_BOUND_PTR && Idx &&
+        Idx->getZExtValue() == ArgIndex)
+      return true;
+  }
+  return false;
+}
+
+static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
+                                                        const Value *PtrOp,
+                                                        const Argument *Root);
+
+static bool isBoundMayConstLoad(LoadInst *LI, const Function &F,
+                                unsigned ArgIndex, const DataLayout &DL) {
+  if (LI->isVolatile() || LI->isAtomic() || ArgIndex >= F.arg_size())
+    return false;
+  const Argument *Root = findRootArgument(LI->getPointerOperand());
+  if (!Root || Root->getArgNo() != ArgIndex)
+    return false;
+  if (LI->hasMetadata(MD_EJIT_MAY_CONST))
+    return true;
+
+  auto Offset = accumulateArgumentOffset(DL, LI->getPointerOperand(), Root);
+  TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
+  if (!Offset || AccessSize.isScalable())
+    return false;
+
+  MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
+  if (!MD)
+    return false;
+  for (const MDOperand &Op : MD->operands()) {
+    auto *Sub = dyn_cast<MDNode>(Op.get());
+    if (!Sub || Sub->getNumOperands() < 4)
+      continue;
+    auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
+    auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
+    if (!Tag || Tag->getString() != TAG_EJIT_BOUND_PTR || !Idx ||
+        Idx->getZExtValue() != ArgIndex)
+      continue;
+    for (unsigned I = 4; I < Sub->getNumOperands(); ++I) {
+      auto *Field = dyn_cast<MDNode>(Sub->getOperand(I));
+      if (!Field || Field->getNumOperands() != 2)
+        continue;
+      auto *FieldOffset =
+          mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
+      auto *FieldSize = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
+      if (FieldOffset && FieldSize) {
+        uint64_t Begin = FieldOffset->getZExtValue();
+        uint64_t Size = FieldSize->getZExtValue();
+        if (*Offset >= Begin && *Offset - Begin <= Size &&
+            AccessSize.getFixedValue() <= Size - (*Offset - Begin))
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
 /// If all GEP indices are ConstantInt, compute the cumulative byte offset.
 /// Returns std::nullopt if any index is not constant.
 static std::optional<uint64_t>
@@ -137,6 +213,26 @@ accumulateFullOffset(const DataLayout &DL, const Value *PtrOp) {
   }
 
   return total.getZExtValue();
+}
+
+static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
+                                                        const Value *PtrOp,
+                                                        const Argument *Root) {
+  APInt Total(DL.getPointerSizeInBits(0), 0);
+  while (PtrOp) {
+    PtrOp = PtrOp->stripPointerCasts();
+    if (PtrOp == Root)
+      return Total.getZExtValue();
+    auto *GEP = dyn_cast<GEPOperator>(PtrOp);
+    if (!GEP)
+      return std::nullopt;
+    auto Off = computeGEPOffset(GEP, DL);
+    if (!Off)
+      return std::nullopt;
+    Total += APInt(Total.getBitWidth(), *Off);
+    PtrOp = GEP->getPointerOperand();
+  }
+  return std::nullopt;
 }
 
 /// Check whether a load is (or can be treated as) a may_const access.
@@ -408,6 +504,24 @@ static Constant *tryReplacePeriodAbsoluteAddress(
   return nullptr;
 }
 
+static Constant *tryReplaceBoundPointer(LoadInst *LI, const Function &F,
+                                        const uint8_t *Data, uint32_t Size,
+                                        uint32_t ArgIndex,
+                                        const DataLayout &DL) {
+  if (!Data || !Size || ArgIndex >= F.arg_size() ||
+      !functionBindsArgument(F, ArgIndex))
+    return nullptr;
+  const Argument *Root = findRootArgument(LI->getPointerOperand());
+  if (!Root || Root->getArgNo() != ArgIndex)
+    return nullptr;
+  auto Offset = accumulateArgumentOffset(DL, LI->getPointerOperand(), Root);
+  TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
+  if (!Offset || AccessSize.isScalable() || *Offset > Size ||
+      AccessSize.getFixedValue() > Size - *Offset)
+    return nullptr;
+  return createConstantFromMemory(Data + *Offset, LI->getType(), DL);
+}
+
 //===----------------------------------------------------------------------===//
 // Load replacement helpers — one per access pattern
 //===----------------------------------------------------------------------===//
@@ -619,7 +733,8 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
         continue;
       }
 
-      if (!isMayConstLoad(LI, mayConstFieldMap_, DL))
+      bool BoundMayConst = isBoundMayConstLoad(LI, F, boundArgIndex_, DL);
+      if (!BoundMayConst && !isMayConstLoad(LI, mayConstFieldMap_, DL))
         continue;
 #ifdef EJIT_DIAG_ENABLE
       ++mayConstLoads;
@@ -630,6 +745,13 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
       // Try each access pattern in order.
       Constant *C = tryReplacePeriodAbsoluteAddress(
           LI, gvPeriodMap_, mayConstFieldMap_, registry_, DL);
+
+      // Pattern 0: an ejit_bound_ptr parameter. Only the marked load is read
+      // from the owned snapshot; the pointer argument and all dynamic fields
+      // remain live inputs to the specialization.
+      if (!C)
+        C = tryReplaceBoundPointer(LI, F, boundData_, boundSize_,
+                                   boundArgIndex_, DL);
 
       // Pattern 1: direct GlobalVariable load (scalar static variable).
       if (!C) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -4,6 +4,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include <algorithm>
+#include <cstring>
 #include <vector>
 
 using namespace llvm;
@@ -487,7 +488,9 @@ EJitTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
 
 EJitTaskPool::CompileOrGetResult
 EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
-                           uint32_t numDims, void *fallback) {
+                           uint32_t numDims, void *fallback,
+                           const void *boundData, uint32_t boundSize,
+                           uint32_t boundArgIndex) {
   EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex,
                     numDims, fallback);
 
@@ -525,6 +528,14 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   // True miss: continue the slow path with the caller's fallback.
   R.fnPtr = fallback;
 
+  if ((boundSize != 0 && !boundData) || boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
+    EJIT_DIAG("taskpool bound snapshot reject func=%u size=%u max=%u",
+              funcIndex, boundSize,
+              static_cast<unsigned>(EJIT_BOUND_PTR_MAX_BYTES));
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    return R;
+  }
+
   // 3. Off mode (§5.2 step 2) — fall back, never enqueue/compile.
   if (switch_.getMode() == EJitCompileMode::Off) {
     EJIT_DIAG_VERBOSE("taskpool fallback func=%u: mode off", funcIndex);
@@ -548,6 +559,16 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       Req.dims[i] = dims[i];
       Req.versions[i] =
           switch_.getInstanceVersion(dims[i].dimType, dims[i].instanceId);
+    }
+    Req.boundArgIndex = boundArgIndex;
+    Req.boundSize = boundSize;
+    if (boundSize)
+      std::memcpy(Req.boundData, boundData, boundSize);
+    if (!versionsMatch(Req)) {
+      EJIT_DIAG("taskpool sync snapshot drop func=%u: version changed",
+                funcIndex);
+      R.status = EJitCompileOrGetStatus::CompileFailed;
+      return R;
     }
     // Inline compile: checkpoint 1 + compile + checkpoint 2 + commit gate,
     // same logic as runCompile(), executed on the calling thread.
@@ -602,6 +623,16 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     Req.dims[i] = dims[i];
     Req.versions[i] =
         switch_.getInstanceVersion(dims[i].dimType, dims[i].instanceId);
+  }
+  Req.boundArgIndex = boundArgIndex;
+  Req.boundSize = boundSize;
+  if (boundSize)
+    std::memcpy(Req.boundData, boundData, boundSize);
+  if (!versionsMatch(Req)) {
+    EJIT_DIAG("taskpool async snapshot drop func=%u: version changed",
+              funcIndex);
+    R.status = EJitCompileOrGetStatus::CompileFailed;
+    return R;
   }
 
   EJitTaskQueue::EnqueueResult EQ = queue_.tryEnqueue(Req);

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -32,6 +32,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/EmbeddedJIT/EJitPasses.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
+#include <limits>
 #include <map>
 #include <string>
 
@@ -145,6 +146,32 @@ struct PeriodArrIndInfo {
   unsigned ArgIndex;
   uint32_t DimType;
 };
+
+struct BoundPtrInfo {
+  std::string PeriodName;
+  unsigned ArgIndex;
+  uint64_t PointeeSize;
+};
+
+static std::optional<BoundPtrInfo> getBoundPtrInfo(const Function &F) {
+  MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
+  if (!MD)
+    return std::nullopt;
+  for (const MDOperand &Op : MD->operands()) {
+    auto *Sub = dyn_cast<MDNode>(Op.get());
+    if (!Sub || Sub->getNumOperands() < 4)
+      continue;
+    auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
+    auto *PN = dyn_cast<MDString>(Sub->getOperand(1));
+    auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
+    auto *Size = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(3));
+    if (Tag && Tag->getString() == TAG_EJIT_BOUND_PTR && PN && Idx && Size)
+      return BoundPtrInfo{PN->getString().str(),
+                          static_cast<unsigned>(Idx->getZExtValue()),
+                          Size->getZExtValue()};
+  }
+  return std::nullopt;
+}
 
 static SmallVector<PeriodArrIndInfo, 4> getPeriodArrIndInfo(const Function &F) {
   SmallVector<PeriodArrIndInfo, 4> Result;
@@ -508,6 +535,15 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
   M.getOrInsertFunction(
       FN_TASKPOOL_COMPILE_OR_GET,
       FunctionType::get(I32Ty, {I32Ty, PtrTy, I32Ty, PtrTy, PtrTy}, false));
+  bool HasBoundPtr = llvm::any_of(EntryFuncs, [](const Function *F) {
+    return getBoundPtrInfo(*F).has_value();
+  });
+  if (HasBoundPtr)
+    M.getOrInsertFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND,
+                          FunctionType::get(I32Ty,
+                                            {I32Ty, PtrTy, I32Ty, PtrTy, I32Ty,
+                                             I32Ty, PtrTy, PtrTy},
+                                            false));
   M.getOrInsertFunction(
       FN_TASKPOOL_RELEASE_READ,
       FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false));
@@ -632,6 +668,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       F->addFnAttr(Attribute::NoInline);
 
     auto PeriodInds = getPeriodArrIndInfo(*F);
+    auto BoundPtr = getBoundPtrInfo(*F);
     unsigned DimCount = PeriodInds.size();
 
     if (DimCount > EJIT_ICACHE_MAX_DIMS) {
@@ -686,6 +723,22 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     if (Invalid)
       continue;
 
+    if (BoundPtr) {
+      unsigned MatchingDims =
+          llvm::count_if(PeriodInds, [&](const PeriodArrIndInfo &I) {
+            return I.PeriodName == BoundPtr->PeriodName;
+          });
+      if (BoundPtr->ArgIndex >= ArgCount ||
+          !F->getArg(BoundPtr->ArgIndex)->getType()->isPointerTy() ||
+          BoundPtr->PointeeSize == 0 ||
+          BoundPtr->PointeeSize > std::numeric_limits<uint32_t>::max() ||
+          MatchingDims != 1) {
+        F->getContext().emitError(
+            "ejit-wrapper-gen: invalid ejit_bound_ptr metadata");
+        continue;
+      }
+    }
+
     // Save original entry block
     BasicBlock &OrigEntry = F->getEntryBlock();
 
@@ -697,7 +750,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
     auto *I64Ty = Type::getInt64Ty(Ctx);
-    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
+    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2 && !BoundPtr;
 
     SmallVector<ReturnInst *, 8> OriginalReturns;
     for (BasicBlock &BB : *F)
@@ -880,10 +933,20 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         }
         Value *DimsPtr = DimCount > 0 ? B.CreatePointerCast(DimsAlloca, PtrTy)
                                       : ConstantPointerNull::get(PtrTy);
-        Status =
-            B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
-                         {FuncIdx, DimsPtr, ConstantInt::get(I32Ty, DimCount),
-                          OutFnArg, OutBucketArg});
+        if (BoundPtr) {
+          Value *Snapshot = Fn.getArg(BoundPtr->ArgIndex);
+          Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND),
+                                {FuncIdx, DimsPtr,
+                                 ConstantInt::get(I32Ty, DimCount), Snapshot,
+                                 ConstantInt::get(I32Ty, BoundPtr->PointeeSize),
+                                 ConstantInt::get(I32Ty, BoundPtr->ArgIndex),
+                                 OutFnArg, OutBucketArg});
+        } else {
+          Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
+                                {FuncIdx, DimsPtr,
+                                 ConstantInt::get(I32Ty, DimCount), OutFnArg,
+                                 OutBucketArg});
+        }
       }
       if (EJitWrapperTiming)
         TAfterLookup = B.CreateCall(TraceNow, {}, "ejit_t_after_lookup");

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bound-ptr.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bound-ptr.ll
@@ -1,0 +1,24 @@
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s
+
+; A bound pointer uses the generic bound slow-path API even when fixed-dim
+; entries are enabled. The ordinary icache hit path remains outside this call.
+
+; CHECK-LABEL: define i32 @bound_entry(i32 %cell, ptr %cfg, i32 %input)
+; CHECK: jit_call:
+; CHECK: call i32 @ejit_taskpool_compile_or_get_bound(i32 {{.*}}, ptr {{.*}}, i32 1, ptr %cfg, i32 12, i32 1, ptr {{.*}}, ptr {{.*}})
+; CHECK-NOT: call i32 @ejit_taskpool_compile_or_get_1d
+
+define i32 @bound_entry(i32 %cell, ptr %cfg, i32 %input) !ejit.metadata !0 {
+entry:
+  %field = getelementptr { i32, i32, i32 }, ptr %cfg, i32 0, i32 0
+  %v = load i32, ptr %field, !ejit.may_const !4
+  %r = add i32 %v, %input
+  ret i32 %r
+}
+
+!0 = distinct !{!1, !2, !3}
+!1 = !{!"ejit_entry"}
+!2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+!3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 12, !5}
+!4 = !{}
+!5 = !{i64 0, i64 4}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -1594,6 +1594,58 @@ TEST(EJitStructFieldPass, NoMayConstNoChange) {
   EXPECT_TRUE(PA.areAllPreserved());
 }
 
+TEST(EJitStructFieldPass, BoundPointerUsesOwnedSnapshot) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Stable = type { i32, i32 }
+    %Cfg = type { %Stable, i32 }
+    define i32 @bound(i32 %cell, ptr %cfg) !ejit.metadata !0 {
+    entry:
+      %mode.ptr = getelementptr %Cfg, ptr %cfg, i32 0, i32 0, i32 1
+      %mode = load i32, ptr %mode.ptr
+      %dynamic.ptr = getelementptr %Cfg, ptr %cfg, i32 0, i32 1
+      %dynamic = load i32, ptr %dynamic.ptr
+      %sum = add i32 %mode, %dynamic
+      ret i32 %sum
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 12, !4}
+    !4 = !{i64 0, i64 8}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  struct Config {
+    uint32_t stablePrefix;
+    uint32_t mode;
+    uint32_t dynamic;
+  } Snapshot{3, 7, 99};
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&Snapshot),
+                           sizeof(Snapshot), 1);
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Pass.run(*M->getFunction("bound"), FAM);
+
+  unsigned Loads = 0;
+  bool SawSnapshotConstant = false;
+  for (Instruction &I : instructions(*M->getFunction("bound"))) {
+    if (isa<LoadInst>(I))
+      ++Loads;
+    if (auto *Add = dyn_cast<BinaryOperator>(&I))
+      for (Value *Operand : Add->operands())
+        if (auto *C = dyn_cast<ConstantInt>(Operand))
+          SawSnapshotConstant |= C->getZExtValue() == 7;
+  }
+  EXPECT_EQ(Loads, 1u) << "dynamic field must remain a runtime load";
+  EXPECT_TRUE(SawSnapshotConstant);
+}
+
 //===----------------------------------------------------------------------===//
 // EJitStructFieldPass extended tests
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdio>
+#include <cstring>
 #include <memory>
 #include <thread>
 #include <type_traits>
@@ -38,6 +39,22 @@ void *codeFor(uint32_t funcIndex) {
 }
 
 bool mockCompile(void * /*ctx*/, const EJitCompileRequest &req, void **outFn) {
+  *outFn = codeFor(req.funcIndex);
+  return true;
+}
+
+struct BoundSnapshotLog {
+  uint32_t argIndex = 0;
+  uint32_t size = 0;
+  uint32_t value = 0;
+};
+bool mockCompileBoundSnapshot(void *ctx, const EJitCompileRequest &req,
+                              void **outFn) {
+  auto *log = static_cast<BoundSnapshotLog *>(ctx);
+  log->argIndex = req.boundArgIndex;
+  log->size = req.boundSize;
+  if (req.boundSize >= sizeof(log->value))
+    std::memcpy(&log->value, req.boundData, sizeof(log->value));
   *outFn = codeFor(req.funcIndex);
   return true;
 }
@@ -740,6 +757,27 @@ TEST_F(SharedTaskPoolTest, MultiProducerSharedQueue) {
   owner.getDiagnostics(d);
   EXPECT_EQ(d.cacheReadyCount, 3u);
   EXPECT_EQ(d.asyncCompiles, 3u);
+}
+
+TEST_F(SharedTaskPoolTest, BoundSnapshotOwnedAcrossCores) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  BoundSnapshotLog log;
+  owner.setCompiler(&mockCompileBoundSnapshot, &log);
+
+  EJitCoreId::setCurrentForTest(2);
+  uint32_t callerValue = 0x12345678u;
+  auto r = owner.compileOrGet(101, nullptr, 0, codeFor(101), &callerValue,
+                              sizeof(callerValue), 3);
+  ASSERT_EQ(r.status, EJitCompileOrGetStatus::EnqueuedPending);
+
+  // The producer may reuse or destroy its object before the owner runs.
+  callerValue = 0;
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_TRUE(owner.pollOne());
+  EXPECT_EQ(log.argIndex, 3u);
+  EXPECT_EQ(log.size, sizeof(callerValue));
+  EXPECT_EQ(log.value, 0x12345678u);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2329,9 +2367,9 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // one-shot diagnostic mask. Bump this deliberately: the blob is mapped at one
   // address by every core, so a layout change that slips through unversioned is
   // a silent cross-core corruption.
-  // v10 adds shared PGO controls, v11 adds Tier-1 writable ranges, and v12
-  // adds staged concurrent-profile admission and progress counters.
-  EXPECT_EQ(kEJitSharedAbiVersion, 12u);
+  // v10-v13 add PGO controls, writable ranges, staged admission, and audit
+  // requests; v14 adds the owned bound-pointer snapshot.
+  EXPECT_EQ(kEJitSharedAbiVersion, 14u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
@@ -26,6 +26,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitRwLock.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h"
 #include "gtest/gtest.h"
+#include <cstring>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -84,6 +85,24 @@ struct PublishObserver {
   }
 };
 
+struct SnapshotCompiler {
+  uint32_t first = 0;
+  uint32_t second = 0;
+  uint32_t argIndex = 0;
+
+  static bool compile(void *ctx, const EJitCompileRequest &req, void **outFn) {
+    auto *self = static_cast<SnapshotCompiler *>(ctx);
+    if (req.boundSize >= 2 * sizeof(uint32_t)) {
+      std::memcpy(&self->first, req.boundData, sizeof(uint32_t));
+      std::memcpy(&self->second, req.boundData + sizeof(uint32_t),
+                  sizeof(uint32_t));
+    }
+    self->argIndex = req.boundArgIndex;
+    *outFn = reinterpret_cast<void *>(&DummyFn0);
+    return true;
+  }
+};
+
 /// Bounded busy-wait (no sleep) used by the real-worker tests.
 template <typename Pred> bool spinUntil(Pred P, uint64_t MaxIters = 200000000) {
   for (uint64_t i = 0; i < MaxIters; ++i) {
@@ -106,10 +125,11 @@ TEST(EJitTaskPoolLayout, RequestIsFlatPod) {
   static_assert(std::is_standard_layout<EJitCompileRequest>::value,
                 "EJitCompileRequest must be standard layout");
   EXPECT_LE(alignof(EJitCompileRequest), 8u);
-  // funcIndex + numDims + dims[4] + versions[4] + fallbackPtr + generation,
-  // with tail padding to alignof on a 64-bit target (72) and none on 32-bit
-  // (64). See the static_assert in EJitSreQueue.h.
-  EXPECT_EQ(sizeof(EJitCompileRequest), sizeof(uintptr_t) == 8 ? 72u : 64u);
+  // The fixed request owns its optional bound-pointer bytes inline. See the
+  // cross-pointer-width layout assertion in EJitSreQueue.h.
+  EXPECT_EQ(sizeof(EJitCompileRequest), sizeof(uintptr_t) == 8
+                                            ? 80u + EJIT_BOUND_PTR_MAX_BYTES
+                                            : 72u + EJIT_BOUND_PTR_MAX_BYTES);
 }
 
 //===----------------------------------------------------------------------===//
@@ -931,6 +951,41 @@ TEST(EJitTaskPoolTest, InvalidParam) {
   // The C API layer (ejit_taskpool_compile_or_get) performs runtime validation
   // for these invariants; the internal compileOrGet/tryCacheHit assumes
   // already-validated inputs.
+}
+
+TEST(EJitTaskPoolTest, BoundSnapshotOutlivesCallerObject) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  SnapshotCompiler C;
+  P.setCompiler(&SnapshotCompiler::compile, &C);
+  EJitDimPair D[1] = {{0, 3}};
+  struct Config {
+    uint32_t mode;
+    uint32_t scale;
+  };
+
+  {
+    Config Local{7, 5};
+    auto R = P.compileOrGet(17, D, 1, nullptr, &Local, sizeof(Local), 2);
+    ASSERT_EQ(R.status, EJitCompileOrGetStatus::EnqueuedPending);
+    Local.mode = 99;
+    Local.scale = 99;
+  }
+
+  ASSERT_TRUE(P.pollOne());
+  EXPECT_EQ(C.first, 7u);
+  EXPECT_EQ(C.second, 5u);
+  EXPECT_EQ(C.argIndex, 2u);
+}
+
+TEST(EJitTaskPoolTest, OversizeBoundSnapshotFallsBack) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  uint8_t Data[EJIT_BOUND_PTR_MAX_BYTES + 1] = {};
+  EJitDimPair D[1] = {{0, 3}};
+  auto R = P.compileOrGet(18, D, 1, nullptr, Data, sizeof(Data), 1);
+  EXPECT_EQ(R.status, EJitCompileOrGetStatus::InvalidParam);
+  EXPECT_EQ(P.pendingCount(), 0u);
 }
 
 TEST(EJitTaskPoolTest, OutOfRangeFuncIndexRejected) {


### PR DESCRIPTION
## Summary

- add `EJIT_BOUND_PTR(period)` for associating a pointer argument with an existing EJIT specialization dimension
- copy the complete pointee into the compile request on a real cache miss, so asynchronous workers never retain the caller pointer
- specialize only `ejit_may_const` fields from the owned snapshot while leaving unmarked fields as runtime loads
- support both private and shared taskpools with bounded inline storage and clean AOT fallback for invalid or oversized snapshots
- add focused frontend, wrapper, optimizer, taskpool, and shared-taskpool coverage
- add an SRE multicore board demo that builds independent cell 1 and cell 2 versions

## Semantics and lifetime

The first implementation supports one bound-pointer argument per entry. The copy is shallow and defaults to a 256-byte configurable cap. Nested pointer targets are not followed.

The caller's object may be stack-local and may disappear immediately after the entry call returns. Fields marked `ejit_may_const` must still obey the normal period lifecycle contract: update them only through deactivate/update/reactivate so old specializations are invalidated. Volatile, atomic, union, bit-field, dynamically indexed, and unmarked loads are not folded.

## Board demo

The board-only `ejit_bound_ptr_sre_multicore_test.c` uses the established worker-first flow:

```text
core[8]  -> test_ejit_period
core[18] -> test_ejit_period
core[8]  -> test_ejit_bound_ptr_print
```

Core 18 creates two cache identities for the same entry:

- cell 1: `scale=5`, expected AOT/JIT `153/253`
- cell 2: `scale=9`, expected AOT/JIT `194/294`

The test requires two successful compiles and two cache hits. Reusing cell 1's specialization for cell 2 would produce `254` instead of `294` and fail. The worker-side print function lists both compiled identities and dumps the latest optimized function; `algorithm`/`scale` loads and the branch should disappear, while the dynamic `runtimeBias` load remains.

## Validation

- private taskpool request layout, stack-object lifetime, and oversize fallback tests passed
- shared taskpool owned-snapshot cross-core test passed
- struct-field optimizer test confirms the stable field becomes a constant and exactly one dynamic load remains
- new board demo passes host C syntax checking with warnings treated as errors
- `git diff --check` passes

The full Windows LLVM test target was not rebuilt after the final rebase because it triggered a roughly 1200-object rebuild. Real SRE worker/producer execution and IR/ASM output remain to be validated on board.