### PR TITLE
[EJIT] Add AOT/JIT function-body cycle profiler

### DIFF
--- a/jit_design_doc/EJIT_FUNCTION_BODY_TIMING.md
+++ b/jit_design_doc/EJIT_FUNCTION_BODY_TIMING.md
@@ -1,8 +1,10 @@
-# EJIT function-body cycle timing
+# EJIT function-body and wrapper cycle timing
 
-This diagnostic mode compares the executed AOT and JIT bodies without charging
-taskpool lookup, inline-cache probing, dispatch, read-token release, or timing
-aggregation to the sample.
+This diagnostic mode compares executed AOT and JIT bodies and reports the
+enclosing wrapper cost from the same invocation. The body interval excludes
+taskpool lookup, inline-cache probing, dispatch, read-token release, and timing
+aggregation. The wrapper interval includes everything from the generated
+wrapper's entry through read-token release, but still excludes aggregation.
 
 ## Build
 
@@ -29,13 +31,20 @@ Example output on SRE:
 
 ```text
 function_body_cycles: unit=cycles slots=128 dropped=0
-  func=process_cell path=AOT count=1000 avg=842 min=790 max=1201 total=842000
-  func=process_cell path=JIT count=1000 avg=516 min=488 max=901 total=516000
+  func=process_cell path=AOT count=1000 body_avg=842 body_min=790 body_max=1201 body_total=842000 wrapper_avg=1010 wrapper_min=940 wrapper_max=1410 wrapper_total=1010000 overhead_avg=168 overhead_min=130 overhead_max=240 overhead_total=168000
+  func=process_cell path=JIT count=1000 body_avg=516 body_min=488 body_max=901 body_total=516000 wrapper_avg=590 wrapper_min=554 wrapper_max=980 wrapper_total=590000 overhead_avg=74 overhead_min=61 overhead_max=110 overhead_total=74000
 ```
 
 Use `ejit_function_body_cycles_reset()` immediately before a measurement window
 to exclude warm-up. `ejit_function_body_cycles_get()` provides the same
-`count/total/min/max` data without parsing logs; `avg` is `total / count`.
+body `count/total/min/max` plus `wrapper_*` and `overhead_*` data without
+parsing logs. Each average is its corresponding total divided by `count`.
+`overhead` is calculated per invocation as the two intervals outside the body,
+so it can be compared directly without subtracting unrelated sample windows.
+
+With the inline cache enabled, the wrapper timestamp is captured before the
+probe. On a miss it is passed into the internal slow-path function, so both AOT
+fallback and slow-path JIT samples include the failed probe and full lookup.
 
 SRE samples use `SRE_CycleCountGet64()`. Host builds use steady-clock
 nanoseconds for structural tests and must not be compared numerically with SRE
@@ -43,10 +52,11 @@ cycles. The fixed-capacity table does not allocate. `dropped` reports samples
 lost to table capacity or a nested/concurrent recorder; the hot recorder uses a
 single try-lock and never waits in the measured workload's return path.
 
-The interval necessarily contains the cost of reading the ending cycle counter.
+The intervals necessarily contain cycle-counter read costs. Wrapper timing also
+disables the frame-less `musttail` form while the diagnostic option is enabled.
 Use identical instrumentation for AOT and JIT, compare averages over many
-samples, and treat very small functions near the two-read measurement floor
-with caution.
+samples, and treat very small functions near the measurement floor with
+caution. Production builds with the option off retain the original wrapper.
 
 Only normal returns are sampled. An AOT exit consisting of a `musttail` call and
 its required adjacent return is left untouched and is not reported, because

--- a/jit_design_doc/EJIT_FUNCTION_BODY_TIMING.md
+++ b/jit_design_doc/EJIT_FUNCTION_BODY_TIMING.md
@@ -1,0 +1,54 @@
+# EJIT function-body cycle timing
+
+This diagnostic mode compares the executed AOT and JIT bodies without charging
+taskpool lookup, inline-cache probing, dispatch, read-token release, or timing
+aggregation to the sample.
+
+## Build
+
+Pass the hidden AOT option when compiling translation units that contain
+`ejit_entry` functions:
+
+```text
+-mllvm -ejit-function-body-timing
+```
+
+The option is off by default. With it off, no timestamp or recorder calls are
+emitted and the inline-cache hit path keeps its frame-less `musttail` shape.
+
+## Read results
+
+After the workload has reached the window to compare, print the accumulated
+samples on each participating core:
+
+```c
+ejit_function_body_cycles_print();
+```
+
+Example output on SRE:
+
+```text
+function_body_cycles: unit=cycles slots=128 dropped=0
+  func=process_cell path=AOT count=1000 avg=842 min=790 max=1201 total=842000
+  func=process_cell path=JIT count=1000 avg=516 min=488 max=901 total=516000
+```
+
+Use `ejit_function_body_cycles_reset()` immediately before a measurement window
+to exclude warm-up. `ejit_function_body_cycles_get()` provides the same
+`count/total/min/max` data without parsing logs; `avg` is `total / count`.
+
+SRE samples use `SRE_CycleCountGet64()`. Host builds use steady-clock
+nanoseconds for structural tests and must not be compared numerically with SRE
+cycles. The fixed-capacity table does not allocate. `dropped` reports samples
+lost to table capacity or a nested/concurrent recorder; the hot recorder uses a
+single try-lock and never waits in the measured workload's return path.
+
+The interval necessarily contains the cost of reading the ending cycle counter.
+Use identical instrumentation for AOT and JIT, compare averages over many
+samples, and treat very small functions near the two-read measurement floor
+with caution.
+
+Only normal returns are sampled. An AOT exit consisting of a `musttail` call and
+its required adjacent return is left untouched and is not reported, because
+inserting a recorder there would invalidate the IR or change tail-call
+behaviour.

--- a/jit_design_doc/EJIT_FUNCTION_BODY_TIMING.md
+++ b/jit_design_doc/EJIT_FUNCTION_BODY_TIMING.md
@@ -61,4 +61,7 @@ caution. Production builds with the option off retain the original wrapper.
 Only normal returns are sampled. An AOT exit consisting of a `musttail` call and
 its required adjacent return is left untouched and is not reported, because
 inserting a recorder there would invalidate the IR or change tail-call
-behaviour.
+behaviour. With the inline cache enabled, any function containing such an exit
+keeps an ABI-identical internal miss function and disables AOT fallback samples
+for that function. Its slow-path JIT sample starts the wrapper interval inside
+the miss function; inline-cache JIT hits retain the full pre-probe interval.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -114,6 +114,10 @@ constexpr const char *FN_TASKPOOL_RELEASE_READ = "ejit_taskpool_release_read";
 constexpr const char *FN_TASKPOOL_TRACE_NOW = "ejit_taskpool_trace_now";
 constexpr const char *FN_TASKPOOL_TRACE_WRAPPER =
     "ejit_taskpool_trace_wrapper";
+constexpr const char *FN_FUNCTION_BODY_CYCLES_RECORD =
+    "ejit_function_body_cycles_record";
+constexpr uint32_t kEJitFunctionBodyPathAOT = 0u;
+constexpr uint32_t kEJitFunctionBodyPathJIT = 1u;
 // Wrapper-timing sentinel status passed to ejit_taskpool_trace_wrapper for
 // icache-hit samples so they aggregate as their own report line (get_fn_avg =
 // probe cost, release_avg = 0), separate from the slow-path compile_or_get

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -255,6 +255,32 @@ void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
                                  uint64_t tAfterFn,
                                  uint64_t tAfterRelease);
 
+// Function-body-only cycle profiler. AOT wrappers emit calls to the recorder
+// only when built with -ejit-function-body-timing. The two timestamps tightly
+// bracket the original AOT body or the selected JIT function call; taskpool
+// lookup, dispatch, read-token release, and aggregation are outside the
+// measured interval. SRE builds report SRE_CycleCountGet64() cycles; host tests
+// use steady_clock nanoseconds. Storage is fixed-capacity and allocation-free.
+typedef enum {
+  EJIT_FUNCTION_BODY_AOT = 0,
+  EJIT_FUNCTION_BODY_JIT = 1
+} ejit_function_body_path_t;
+
+typedef struct {
+  uint64_t count;
+  uint64_t total;
+  uint64_t min;
+  uint64_t max;
+} ejit_function_body_cycles_t;
+
+void ejit_function_body_cycles_record(const char *funcName, uint32_t path,
+                                      uint64_t begin, uint64_t end);
+// Returns 1 and copies a snapshot when samples exist, otherwise returns 0.
+unsigned ejit_function_body_cycles_get(const char *funcName, uint32_t path,
+                                       ejit_function_body_cycles_t *out);
+void ejit_function_body_cycles_print(void);
+void ejit_function_body_cycles_reset(void);
+
 #ifdef EJIT_SRE_TASKPOOL_TESTING
 unsigned ejit_taskpool_poll_one(void);
 unsigned ejit_taskpool_poll_budget(unsigned maxItems);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -250,17 +250,16 @@ unsigned ejit_taskpool_pending_count(void);
 uint64_t ejit_taskpool_trace_now(void);
 void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
                                  void *fnPtr, uint32_t bucketIndex,
-                                 uint64_t tBeforeLookup,
-                                 uint64_t tAfterLookup,
-                                 uint64_t tAfterFn,
-                                 uint64_t tAfterRelease);
+                                 uint64_t tBeforeLookup, uint64_t tAfterLookup,
+                                 uint64_t tAfterFn, uint64_t tAfterRelease);
 
-// Function-body-only cycle profiler. AOT wrappers emit calls to the recorder
-// only when built with -ejit-function-body-timing. The two timestamps tightly
-// bracket the original AOT body or the selected JIT function call; taskpool
-// lookup, dispatch, read-token release, and aggregation are outside the
-// measured interval. SRE builds report SRE_CycleCountGet64() cycles; host tests
-// use steady_clock nanoseconds. Storage is fixed-capacity and allocation-free.
+// Function-body and wrapper cycle profiler. AOT wrappers emit calls to the
+// recorder only when built with -ejit-function-body-timing. Body timestamps
+// tightly bracket the original AOT body or selected JIT function call. Wrapper
+// timestamps additionally include lookup, dispatch, and read-token release;
+// aggregation remains outside both measured intervals. SRE builds report
+// SRE_CycleCountGet64() cycles; host tests use steady_clock nanoseconds.
+// Storage is fixed-capacity and allocation-free.
 typedef enum {
   EJIT_FUNCTION_BODY_AOT = 0,
   EJIT_FUNCTION_BODY_JIT = 1
@@ -271,10 +270,17 @@ typedef struct {
   uint64_t total;
   uint64_t min;
   uint64_t max;
+  uint64_t wrapper_total;
+  uint64_t wrapper_min;
+  uint64_t wrapper_max;
+  uint64_t overhead_total;
+  uint64_t overhead_min;
+  uint64_t overhead_max;
 } ejit_function_body_cycles_t;
 
 void ejit_function_body_cycles_record(const char *funcName, uint32_t path,
-                                      uint64_t begin, uint64_t end);
+                                      uint64_t wrapperBegin, uint64_t bodyBegin,
+                                      uint64_t bodyEnd, uint64_t wrapperEnd);
 // Returns 1 and copies a snapshot when samples exist, otherwise returns 0.
 unsigned ejit_function_body_cycles_get(const char *funcName, uint32_t path,
                                        ejit_function_body_cycles_t *out);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -91,6 +91,12 @@ static_assert(kEJitIcacheHitTimingStatus != static_cast<uint32_t>(EJIT_OK) &&
               "kEJitIcacheHitTimingStatus (0xFE) collides with a real "
               "ejit_status_t value.");
 
+static_assert(kEJitFunctionBodyPathAOT ==
+                      static_cast<uint32_t>(EJIT_FUNCTION_BODY_AOT) &&
+                  kEJitFunctionBodyPathJIT ==
+                      static_cast<uint32_t>(EJIT_FUNCTION_BODY_JIT),
+              "function-body timing path constants must match the C ABI");
+
 // Registry entry ABI: {i32 type; ptr; ptr; ptr; u64 size}, 8-byte aligned,
 // 40 bytes on 64-bit. The AOT passes emit these as constant structs and the
 // runtime walks them in EJit.cpp; the linker scripts (ejit_registry.ld,
@@ -160,6 +166,10 @@ extern "C" int SRE_printf(const char *fmt, ...);
 namespace {
 class TimingSpinLock {
 public:
+  bool tryLock() {
+    uint32_t expected = 0;
+    return flag_.compareExchange(expected, 1u);
+  }
   void lock() {
     uint32_t expected = 0;
     while (!flag_.compareExchange(expected, 1u))
@@ -183,6 +193,68 @@ struct WrapperTimingSlot {
   uint64_t ReleaseSum = 0;
   uint64_t TotalSum = 0;
 };
+
+#ifndef EJIT_FUNCTION_BODY_TIMING_SLOTS
+#define EJIT_FUNCTION_BODY_TIMING_SLOTS 128u
+#endif
+static_assert(EJIT_FUNCTION_BODY_TIMING_SLOTS > 0,
+              "function-body timing table must contain at least one slot");
+
+struct FunctionBodyTimingSlot {
+  bool Valid = false;
+  const char *Name = nullptr;
+  uint32_t Path = 0;
+  uint64_t Count = 0;
+  uint64_t Total = 0;
+  uint64_t Min = UINT64_MAX;
+  uint64_t Max = 0;
+};
+
+static TimingSpinLock gFunctionBodyTimingLock;
+static FunctionBodyTimingSlot
+    gFunctionBodyTimingSlots[EJIT_FUNCTION_BODY_TIMING_SLOTS];
+static EJitAtomicU64 gFunctionBodyTimingDropped;
+
+static uint32_t functionBodyNameHash(const char *Name, uint32_t Path) {
+  uint32_t H = 2166136261u ^ Path;
+  for (const unsigned char *P = reinterpret_cast<const unsigned char *>(Name);
+       *P; ++P)
+    H = (H ^ *P) * 16777619u;
+  return H;
+}
+
+static bool functionBodyNameEqual(const char *A, const char *B) {
+  if (A == B)
+    return true;
+  if (!A || !B)
+    return false;
+  while (*A && *A == *B) {
+    ++A;
+    ++B;
+  }
+  return *A == *B;
+}
+
+static FunctionBodyTimingSlot *
+findFunctionBodyTimingSlot(const char *Name, uint32_t Path, bool Create) {
+  const uint32_t Capacity = EJIT_FUNCTION_BODY_TIMING_SLOTS;
+  uint32_t Start = functionBodyNameHash(Name, Path) % Capacity;
+  for (uint32_t Probe = 0; Probe < Capacity; ++Probe) {
+    FunctionBodyTimingSlot &S =
+        gFunctionBodyTimingSlots[(Start + Probe) % Capacity];
+    if (!S.Valid) {
+      if (!Create)
+        return nullptr;
+      S.Valid = true;
+      S.Name = Name;
+      S.Path = Path;
+      return &S;
+    }
+    if (S.Path == Path && functionBodyNameEqual(S.Name, Name))
+      return &S;
+  }
+  return nullptr;
+}
 
 static TimingSpinLock gWrapperTimingLock;
 static WrapperTimingSlot gWrapperTimingSlots[32];
@@ -1267,6 +1339,90 @@ void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
 #else
   (void)tAfterRelease;
 #endif
+}
+
+void ejit_function_body_cycles_record(const char *funcName, uint32_t path,
+                                      uint64_t begin, uint64_t end) {
+  if (!funcName || !*funcName || path > kEJitFunctionBodyPathJIT)
+    return;
+
+  const uint64_t Cycles = end - begin;
+  // Never spin in an instrumented function's return path. A nested/preempting
+  // sample on the same core is diagnostic-only and is safer to drop than to
+  // wait for a recorder that cannot run until the nested call returns.
+  if (!gFunctionBodyTimingLock.tryLock()) {
+    gFunctionBodyTimingDropped.fetchAdd(1);
+    return;
+  }
+  FunctionBodyTimingSlot *S =
+      findFunctionBodyTimingSlot(funcName, path, /*Create=*/true);
+  if (!S) {
+    gFunctionBodyTimingDropped.fetchAdd(1);
+    gFunctionBodyTimingLock.unlock();
+    return;
+  }
+  ++S->Count;
+  S->Total += Cycles;
+  if (Cycles < S->Min)
+    S->Min = Cycles;
+  if (Cycles > S->Max)
+    S->Max = Cycles;
+  gFunctionBodyTimingLock.unlock();
+}
+
+unsigned ejit_function_body_cycles_get(const char *funcName, uint32_t path,
+                                       ejit_function_body_cycles_t *out) {
+  if (!funcName || !*funcName || !out || path > kEJitFunctionBodyPathJIT)
+    return 0;
+
+  gFunctionBodyTimingLock.lock();
+  FunctionBodyTimingSlot *S =
+      findFunctionBodyTimingSlot(funcName, path, /*Create=*/false);
+  if (!S || S->Count == 0) {
+    gFunctionBodyTimingLock.unlock();
+    return 0;
+  }
+  out->count = S->Count;
+  out->total = S->Total;
+  out->min = S->Min;
+  out->max = S->Max;
+  gFunctionBodyTimingLock.unlock();
+  return 1;
+}
+
+void ejit_function_body_cycles_print(void) {
+  gFunctionBodyTimingLock.lock();
+  EJIT_DIAG_RAW("function_body_cycles: unit=%s slots=%u dropped=%llu",
+#ifdef EJIT_FREESTANDING
+                "cycles",
+#else
+                "host-ns",
+#endif
+                static_cast<unsigned>(EJIT_FUNCTION_BODY_TIMING_SLOTS),
+                static_cast<unsigned long long>(
+                    gFunctionBodyTimingDropped.loadRelaxed()));
+  for (const FunctionBodyTimingSlot &S : gFunctionBodyTimingSlots) {
+    if (!S.Valid || S.Count == 0)
+      continue;
+    EJIT_DIAG_RAW("  func=%s path=%s count=%llu avg=%llu min=%llu max=%llu "
+                  "total=%llu",
+                  S.Name, S.Path == kEJitFunctionBodyPathAOT ? "AOT" : "JIT",
+                  static_cast<unsigned long long>(S.Count),
+                  static_cast<unsigned long long>(S.Total / S.Count),
+                  static_cast<unsigned long long>(S.Min),
+                  static_cast<unsigned long long>(S.Max),
+                  static_cast<unsigned long long>(S.Total));
+    ejitDiagPrintThrottle();
+  }
+  gFunctionBodyTimingLock.unlock();
+}
+
+void ejit_function_body_cycles_reset(void) {
+  gFunctionBodyTimingLock.lock();
+  for (FunctionBodyTimingSlot &S : gFunctionBodyTimingSlots)
+    S = FunctionBodyTimingSlot{};
+  gFunctionBodyTimingDropped.storeRelaxed(0);
+  gFunctionBodyTimingLock.unlock();
 }
 
 ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -208,6 +208,12 @@ struct FunctionBodyTimingSlot {
   uint64_t Total = 0;
   uint64_t Min = UINT64_MAX;
   uint64_t Max = 0;
+  uint64_t WrapperTotal = 0;
+  uint64_t WrapperMin = UINT64_MAX;
+  uint64_t WrapperMax = 0;
+  uint64_t OverheadTotal = 0;
+  uint64_t OverheadMin = UINT64_MAX;
+  uint64_t OverheadMax = 0;
 };
 
 static TimingSpinLock gFunctionBodyTimingLock;
@@ -1342,11 +1348,17 @@ void ejit_taskpool_trace_wrapper(uint32_t funcIndex, uint32_t status,
 }
 
 void ejit_function_body_cycles_record(const char *funcName, uint32_t path,
-                                      uint64_t begin, uint64_t end) {
+                                      uint64_t wrapperBegin, uint64_t bodyBegin,
+                                      uint64_t bodyEnd, uint64_t wrapperEnd) {
   if (!funcName || !*funcName || path > kEJitFunctionBodyPathJIT)
     return;
 
-  const uint64_t Cycles = end - begin;
+  const uint64_t BodyCycles = bodyEnd - bodyBegin;
+  const uint64_t WrapperCycles = wrapperEnd - wrapperBegin;
+  // Use the two non-body intervals instead of subtracting aggregate values so
+  // counter wraparound remains well-defined for each individual sample.
+  const uint64_t OverheadCycles =
+      (bodyBegin - wrapperBegin) + (wrapperEnd - bodyEnd);
   // Never spin in an instrumented function's return path. A nested/preempting
   // sample on the same core is diagnostic-only and is safer to drop than to
   // wait for a recorder that cannot run until the nested call returns.
@@ -1362,11 +1374,21 @@ void ejit_function_body_cycles_record(const char *funcName, uint32_t path,
     return;
   }
   ++S->Count;
-  S->Total += Cycles;
-  if (Cycles < S->Min)
-    S->Min = Cycles;
-  if (Cycles > S->Max)
-    S->Max = Cycles;
+  S->Total += BodyCycles;
+  if (BodyCycles < S->Min)
+    S->Min = BodyCycles;
+  if (BodyCycles > S->Max)
+    S->Max = BodyCycles;
+  S->WrapperTotal += WrapperCycles;
+  if (WrapperCycles < S->WrapperMin)
+    S->WrapperMin = WrapperCycles;
+  if (WrapperCycles > S->WrapperMax)
+    S->WrapperMax = WrapperCycles;
+  S->OverheadTotal += OverheadCycles;
+  if (OverheadCycles < S->OverheadMin)
+    S->OverheadMin = OverheadCycles;
+  if (OverheadCycles > S->OverheadMax)
+    S->OverheadMax = OverheadCycles;
   gFunctionBodyTimingLock.unlock();
 }
 
@@ -1386,6 +1408,12 @@ unsigned ejit_function_body_cycles_get(const char *funcName, uint32_t path,
   out->total = S->Total;
   out->min = S->Min;
   out->max = S->Max;
+  out->wrapper_total = S->WrapperTotal;
+  out->wrapper_min = S->WrapperMin;
+  out->wrapper_max = S->WrapperMax;
+  out->overhead_total = S->OverheadTotal;
+  out->overhead_min = S->OverheadMin;
+  out->overhead_max = S->OverheadMax;
   gFunctionBodyTimingLock.unlock();
   return 1;
 }
@@ -1404,14 +1432,25 @@ void ejit_function_body_cycles_print(void) {
   for (const FunctionBodyTimingSlot &S : gFunctionBodyTimingSlots) {
     if (!S.Valid || S.Count == 0)
       continue;
-    EJIT_DIAG_RAW("  func=%s path=%s count=%llu avg=%llu min=%llu max=%llu "
-                  "total=%llu",
+    EJIT_DIAG_RAW("  func=%s path=%s count=%llu body_avg=%llu body_min=%llu "
+                  "body_max=%llu body_total=%llu wrapper_avg=%llu "
+                  "wrapper_min=%llu wrapper_max=%llu wrapper_total=%llu "
+                  "overhead_avg=%llu overhead_min=%llu overhead_max=%llu "
+                  "overhead_total=%llu",
                   S.Name, S.Path == kEJitFunctionBodyPathAOT ? "AOT" : "JIT",
                   static_cast<unsigned long long>(S.Count),
                   static_cast<unsigned long long>(S.Total / S.Count),
                   static_cast<unsigned long long>(S.Min),
                   static_cast<unsigned long long>(S.Max),
-                  static_cast<unsigned long long>(S.Total));
+                  static_cast<unsigned long long>(S.Total),
+                  static_cast<unsigned long long>(S.WrapperTotal / S.Count),
+                  static_cast<unsigned long long>(S.WrapperMin),
+                  static_cast<unsigned long long>(S.WrapperMax),
+                  static_cast<unsigned long long>(S.WrapperTotal),
+                  static_cast<unsigned long long>(S.OverheadTotal / S.Count),
+                  static_cast<unsigned long long>(S.OverheadMin),
+                  static_cast<unsigned long long>(S.OverheadMax),
+                  static_cast<unsigned long long>(S.OverheadTotal));
     ejitDiagPrintThrottle();
   }
   gFunctionBodyTimingLock.unlock();

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -13,8 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
+#include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
@@ -31,7 +34,6 @@
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 #include <map>
 #include <string>
-#include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 
 // Hard-lock the AOT-side contract constants against each other (the runtime
 // side locks its own copies in EJitRuntime.cpp / EJitSharedTaskPool.cpp):
@@ -66,6 +68,11 @@ static cl::opt<bool> EJitWrapperTiming(
     "ejit-wrapper-timing", cl::init(false), cl::Hidden,
     cl::desc("Emit diagnostic timing probes around taskpool lookup, indirect "
              "JIT call, and read-token release in ejit_entry wrappers"));
+
+static cl::opt<bool> EJitFunctionBodyTiming(
+    "ejit-function-body-timing", cl::init(false), cl::Hidden,
+    cl::desc("Measure only the selected AOT/JIT function body using the SRE "
+             "cycle counter, excluding wrapper lookup and dispatch overhead"));
 
 // Emit a per-function inline-cache probe DIRECTLY in the ejit_entry wrapper
 // (not a call). On a hit the wrapper loads its cell out of the per-function
@@ -692,18 +699,82 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     auto *I64Ty = Type::getInt64Ty(Ctx);
     bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2;
 
+    SmallVector<ReturnInst *, 8> OriginalReturns;
+    for (BasicBlock &BB : *F)
+      if (auto *RI = dyn_cast<ReturnInst>(BB.getTerminator()))
+        OriginalReturns.push_back(RI);
+
     // Timing callees (shared by hit and slow paths).
     FunctionCallee TraceNow{};
     FunctionCallee TraceWrapper{};
-    if (EJitWrapperTiming) {
+    FunctionCallee TraceFunctionBody{};
+    Constant *FunctionName = nullptr;
+    if (EJitWrapperTiming || EJitFunctionBodyTiming) {
       TraceNow = M.getOrInsertFunction(FN_TASKPOOL_TRACE_NOW,
                                        FunctionType::get(I64Ty, false));
+    }
+    if (EJitWrapperTiming) {
       SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty, I64Ty,
                                          I64Ty, I64Ty, I64Ty};
       TraceWrapper = M.getOrInsertFunction(
           FN_TASKPOOL_TRACE_WRAPPER,
           FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
     }
+    if (EJitFunctionBodyTiming) {
+      TraceFunctionBody = M.getOrInsertFunction(
+          FN_FUNCTION_BODY_CYCLES_RECORD,
+          FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, I32Ty, I64Ty, I64Ty},
+                            false));
+      IRBuilder<> NameBuilder(Ctx);
+      FunctionName = NameBuilder.CreateGlobalString(
+          F->getName(), ".ejit.function_body_name", 0, &M);
+    }
+
+    auto emitFunctionBodyRecord = [&](IRBuilder<> &B, uint32_t Path,
+                                      Value *Begin) {
+      if (!EJitFunctionBodyTiming)
+        return;
+      Value *End = B.CreateCall(TraceNow, {}, "ejit_body_end");
+      B.CreateCall(TraceFunctionBody,
+                   {FunctionName, ConstantInt::get(I32Ty, Path), Begin, End});
+    };
+
+    auto instrumentAotBody = [&](BasicBlock *FallbackEntry) {
+      if (!EJitFunctionBodyTiming)
+        return;
+
+      SmallPtrSet<BasicBlock *, 16> Reachable;
+      SmallVector<BasicBlock *, 16> Worklist{FallbackEntry};
+      while (!Worklist.empty()) {
+        BasicBlock *BB = Worklist.pop_back_val();
+        if (!Reachable.insert(BB).second)
+          continue;
+        llvm::append_range(Worklist, successors(BB));
+      }
+
+      SmallVector<ReturnInst *, 8> TimedReturns;
+      for (ReturnInst *RI : OriginalReturns) {
+        if (!Reachable.contains(RI->getParent()))
+          continue;
+        // A musttail call must remain immediately adjacent to its return. Keep
+        // such an uncommon AOT exit valid rather than changing its ABI/stack
+        // behaviour for a diagnostic option.
+        if (auto *CI = dyn_cast_or_null<CallInst>(RI->getPrevNode());
+            CI && CI->isMustTailCall())
+          continue;
+        TimedReturns.push_back(RI);
+      }
+      if (TimedReturns.empty())
+        return;
+
+      IRBuilder<> StartBuilder(&*FallbackEntry->getFirstInsertionPt());
+      Value *Begin =
+          StartBuilder.CreateCall(TraceNow, {}, "ejit_aot_body_begin");
+      for (ReturnInst *RI : TimedReturns) {
+        IRBuilder<> EndBuilder(RI);
+        emitFunctionBodyRecord(EndBuilder, kEJitFunctionBodyPathAOT, Begin);
+      }
+    };
 
     // emitSlowPath: emit the funcIndex guard (EntryBB) + compile_or_get
     // (CallBB) + dispatch (DispatchBB) into Fn, using Fn's args. FallbackBB
@@ -795,7 +866,11 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       SmallVector<Value *, 8> Args;
       for (auto &A : Fn.args())
         Args.push_back(&A);
+      Value *BodyBegin = nullptr;
+      if (EJitFunctionBodyTiming)
+        BodyBegin = B.CreateCall(TraceNow, {}, "ejit_jit_body_begin");
       auto releaseAndTrace = [&]() {
+        emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, BodyBegin);
         if (EJitWrapperTiming) {
           Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
           Value *Bucket = B.CreateLoad(I32Ty, OutBucketAlloca);
@@ -885,6 +960,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
           B.CreateRet(PoisonValue::get(F->getReturnType()));
       }
       emitSlowPath(*MissFn, MissEntry, MissCall, MissDispatch, MissFallback);
+      instrumentAotBody(MissFallback);
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
@@ -942,8 +1018,13 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       B.SetInsertPoint(JitIcacheDispatch);
       SmallVector<Value *, 8> ICArgs;
       for (auto &A : F->args()) ICArgs.push_back(&A);
+      Value *BodyBegin = nullptr;
+      if (EJitFunctionBodyTiming)
+        BodyBegin = B.CreateCall(TraceNow, {}, "ejit_jit_body_begin");
       auto emitHitTiming = [&]() {
-        if (!EJitWrapperTiming) return;
+        emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, BodyBegin);
+        if (!EJitWrapperTiming)
+          return;
         Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
         B.CreateCall(TraceWrapper,
                      {FuncIdxForTiming,
@@ -953,13 +1034,13 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       };
       if (F->getReturnType()->isVoidTy()) {
         CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming)
+        if (!EJitWrapperTiming && !EJitFunctionBodyTiming)
           CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
         emitHitTiming();
         B.CreateRetVoid();
       } else {
         CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming)
+        if (!EJitWrapperTiming && !EJitFunctionBodyTiming)
           CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
         emitHitTiming();
         B.CreateRet(CI);
@@ -999,6 +1080,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         else B.CreateRet(PoisonValue::get(F->getReturnType()));
       }
       emitSlowPath(*F, JitEntry, JitCall, JitDispatch, JitFallback);
+      instrumentAotBody(JitFallback);
     }
 
     Changed = true;

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -71,8 +71,8 @@ static cl::opt<bool> EJitWrapperTiming(
 
 static cl::opt<bool> EJitFunctionBodyTiming(
     "ejit-function-body-timing", cl::init(false), cl::Hidden,
-    cl::desc("Measure only the selected AOT/JIT function body using the SRE "
-             "cycle counter, excluding wrapper lookup and dispatch overhead"));
+    cl::desc("Measure the selected AOT/JIT function body and its enclosing "
+             "wrapper overhead using the SRE cycle counter"));
 
 // Emit a per-function inline-cache probe DIRECTLY in the ejit_entry wrapper
 // (not a call). On a hit the wrapper loads its cell out of the per-function
@@ -714,8 +714,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
                                        FunctionType::get(I64Ty, false));
     }
     if (EJitWrapperTiming) {
-      SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty, I64Ty,
-                                         I64Ty, I64Ty, I64Ty};
+      SmallVector<Type *, 8> TraceTys = {I32Ty, I32Ty, PtrTy, I32Ty,
+                                         I64Ty, I64Ty, I64Ty, I64Ty};
       TraceWrapper = M.getOrInsertFunction(
           FN_TASKPOOL_TRACE_WRAPPER,
           FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
@@ -723,23 +723,25 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     if (EJitFunctionBodyTiming) {
       TraceFunctionBody = M.getOrInsertFunction(
           FN_FUNCTION_BODY_CYCLES_RECORD,
-          FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, I32Ty, I64Ty, I64Ty},
-                            false));
+          FunctionType::get(Type::getVoidTy(Ctx),
+                            {PtrTy, I32Ty, I64Ty, I64Ty, I64Ty, I64Ty}, false));
       IRBuilder<> NameBuilder(Ctx);
       FunctionName = NameBuilder.CreateGlobalString(
           F->getName(), ".ejit.function_body_name", 0, &M);
     }
 
     auto emitFunctionBodyRecord = [&](IRBuilder<> &B, uint32_t Path,
-                                      Value *Begin) {
+                                      Value *WrapperBegin, Value *BodyBegin,
+                                      Value *BodyEnd, Value *WrapperEnd) {
       if (!EJitFunctionBodyTiming)
         return;
-      Value *End = B.CreateCall(TraceNow, {}, "ejit_body_end");
       B.CreateCall(TraceFunctionBody,
-                   {FunctionName, ConstantInt::get(I32Ty, Path), Begin, End});
+                   {FunctionName, ConstantInt::get(I32Ty, Path), WrapperBegin,
+                    BodyBegin, BodyEnd, WrapperEnd});
     };
 
-    auto instrumentAotBody = [&](BasicBlock *FallbackEntry) {
+    auto instrumentAotBody = [&](BasicBlock *FallbackEntry,
+                                 Value *WrapperBegin) {
       if (!EJitFunctionBodyTiming)
         return;
 
@@ -772,7 +774,12 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
           StartBuilder.CreateCall(TraceNow, {}, "ejit_aot_body_begin");
       for (ReturnInst *RI : TimedReturns) {
         IRBuilder<> EndBuilder(RI);
-        emitFunctionBodyRecord(EndBuilder, kEJitFunctionBodyPathAOT, Begin);
+        Value *BodyEnd =
+            EndBuilder.CreateCall(TraceNow, {}, "ejit_aot_body_end");
+        Value *WrapperEnd =
+            EndBuilder.CreateCall(TraceNow, {}, "ejit_wrapper_end");
+        emitFunctionBodyRecord(EndBuilder, kEJitFunctionBodyPathAOT,
+                               WrapperBegin, Begin, BodyEnd, WrapperEnd);
       }
     };
 
@@ -782,22 +789,28 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     // icache-off (in F) and icache-on (in MissFn).
     auto emitSlowPath = [&](Function &Fn, BasicBlock *EntryBB,
                             BasicBlock *CallBB, BasicBlock *DispatchBB,
-                            BasicBlock *FallbackBB) {
+                            BasicBlock *FallbackBB,
+                            Value *WrapperBegin) -> Value * {
       IRBuilder<> B(EntryBB);
       // Allocas live in the entry block so they dominate the call/dispatch
       // blocks (and match the original layout: allocas precede the funcidx
       // guard).
-      Value *DimsAlloca = UseFixed ? nullptr
-                                   : B.CreateAlloca(ArrayType::get(DimPairTy, 4),
-                                                    nullptr, "ejit_dims");
+      Value *DimsAlloca = UseFixed
+                              ? nullptr
+                              : B.CreateAlloca(ArrayType::get(DimPairTy, 4),
+                                               nullptr, "ejit_dims");
       Value *OutFnAlloca = B.CreateAlloca(PtrTy, nullptr, "ejit_out_fn");
-      Value *OutBucketAlloca = B.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
+      Value *OutBucketAlloca =
+          B.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
       Value *OutFnArg = B.CreatePointerCast(OutFnAlloca, PtrTy);
       Value *OutBucketArg = B.CreatePointerCast(OutBucketAlloca, PtrTy);
-      Value *FuncIdx = B.CreateLoad(
-          I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx");
+      if (EJitFunctionBodyTiming && !WrapperBegin)
+        WrapperBegin = B.CreateCall(TraceNow, {}, "ejit_wrapper_begin");
+      Value *FuncIdx = B.CreateLoad(I32Ty, FuncIndexGlobals[F->getName().str()],
+                                    "ejit_funcidx");
       Value *IdxValid = B.CreateICmpNE(
-          FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex), "ejit_idx_ok");
+          FuncIdx, ConstantInt::get(I32Ty, kEJitInvalidFuncIndex),
+          "ejit_idx_ok");
       B.CreateCondBr(IdxValid, CallBB, FallbackBB);
 
       B.SetInsertPoint(CallBB);
@@ -808,8 +821,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       auto emitInstanceVal = [&](unsigned I) -> Value * {
         Value *ArgVal = Fn.getArg(PeriodInds[I].ArgIndex);
         unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
-        if (BW > 32) return B.CreateTrunc(ArgVal, I32Ty);
-        if (BW < 32) return B.CreateZExt(ArgVal, I32Ty);
+        if (BW > 32)
+          return B.CreateTrunc(ArgVal, I32Ty);
+        if (BW < 32)
+          return B.CreateZExt(ArgVal, I32Ty);
         return ArgVal;
       };
       Value *TBeforeLookup = nullptr, *TAfterLookup = nullptr;
@@ -840,20 +855,23 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         Status = B.CreateCall(FixedFn, Args);
       } else {
         for (unsigned I = 0; I < DimCount; ++I) {
-          Value *Idxs[] = {ConstantInt::get(I32Ty, 0), ConstantInt::get(I32Ty, I)};
+          Value *Idxs[] = {ConstantInt::get(I32Ty, 0),
+                           ConstantInt::get(I32Ty, I)};
           Value *PairPtr = B.CreateInBoundsGEP(ArrayType::get(DimPairTy, 4),
                                                DimsAlloca, Idxs);
-          B.CreateStore(emitDimTypeVal(I), B.CreateStructGEP(DimPairTy, PairPtr,
-                                                              0, "dim_type_ptr"));
-          B.CreateStore(emitInstanceVal(I),
-                        B.CreateStructGEP(DimPairTy, PairPtr, 1, "instance_ptr"));
+          B.CreateStore(
+              emitDimTypeVal(I),
+              B.CreateStructGEP(DimPairTy, PairPtr, 0, "dim_type_ptr"));
+          B.CreateStore(
+              emitInstanceVal(I),
+              B.CreateStructGEP(DimPairTy, PairPtr, 1, "instance_ptr"));
         }
         Value *DimsPtr = DimCount > 0 ? B.CreatePointerCast(DimsAlloca, PtrTy)
                                       : ConstantPointerNull::get(PtrTy);
-        Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
-                              {FuncIdx, DimsPtr,
-                               ConstantInt::get(I32Ty, DimCount), OutFnArg,
-                               OutBucketArg});
+        Status =
+            B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
+                         {FuncIdx, DimsPtr, ConstantInt::get(I32Ty, DimCount),
+                          OutFnArg, OutBucketArg});
       }
       if (EJitWrapperTiming)
         TAfterLookup = B.CreateCall(TraceNow, {}, "ejit_t_after_lookup");
@@ -864,24 +882,37 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       B.SetInsertPoint(DispatchBB);
       SmallVector<Value *, 8> Args;
-      for (auto &A : Fn.args())
-        Args.push_back(&A);
+      for (unsigned I = 0; I < F->arg_size(); ++I)
+        Args.push_back(Fn.getArg(I));
       Value *BodyBegin = nullptr;
       if (EJitFunctionBodyTiming)
         BodyBegin = B.CreateCall(TraceNow, {}, "ejit_jit_body_begin");
       auto releaseAndTrace = [&]() {
-        emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, BodyBegin);
+        Value *BodyEnd = nullptr;
+        if (EJitFunctionBodyTiming)
+          BodyEnd = B.CreateCall(TraceNow, {}, "ejit_jit_body_end");
+        Value *TAfterFn = nullptr;
         if (EJitWrapperTiming) {
-          Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+          TAfterFn =
+              BodyEnd ? BodyEnd : B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
           Value *Bucket = B.CreateLoad(I32Ty, OutBucketAlloca);
           B.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
-          Value *TAfterRelease = B.CreateCall(TraceNow, {}, "ejit_t_after_release");
-          B.CreateCall(TraceWrapper, {FuncIdx, Status, OutFn, Bucket,
-                                      TBeforeLookup, TAfterLookup, TAfterFn,
-                                      TAfterRelease});
+          Value *TAfterRelease =
+              B.CreateCall(TraceNow, {}, "ejit_t_after_release");
+          B.CreateCall(TraceWrapper,
+                       {FuncIdx, Status, OutFn, Bucket, TBeforeLookup,
+                        TAfterLookup, TAfterFn, TAfterRelease});
+          if (EJitFunctionBodyTiming)
+            emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, WrapperBegin,
+                                   BodyBegin, BodyEnd, TAfterRelease);
         } else {
           Value *Bucket = B.CreateLoad(I32Ty, OutBucketAlloca);
           B.CreateCall(M.getFunction(FN_TASKPOOL_RELEASE_READ), {Bucket});
+          if (EJitFunctionBodyTiming) {
+            Value *WrapperEnd = B.CreateCall(TraceNow, {}, "ejit_wrapper_end");
+            emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, WrapperBegin,
+                                   BodyBegin, BodyEnd, WrapperEnd);
+          }
         }
       };
       if (F->getReturnType()->isVoidTy()) {
@@ -893,6 +924,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         releaseAndTrace();
         B.CreateRet(RetVal);
       }
+      return WrapperBegin;
     };
 
     // Helper: splice the original body into Dst, fixing PHI/uses, then erase
@@ -910,17 +942,24 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       // MissFn on miss) -- no allocas, no calls, no frame. MissFn holds the
       // funcidx guard + compile_or_get + dispatch + the AOT fallback (original
       // body), with its own frame. Miss is rare, so the call overhead is fine.
-      Function *MissFn = Function::Create(F->getFunctionType(),
-                                          GlobalValue::InternalLinkage,
-                                          F->getName() + "_miss", &M);
-      // Function::Create only inherits module-default uwtable/frame-pointer from
-      // the context, NOT F's target-cpu/target-features/tune-cpu. Without those,
-      // TTI::areInlineCompatible(Caller=MissFn, Callee=helper) fails the subtarget
-      // feature-bit superset check, so InlinerPass rejects every cost-based
-      // inlining into MissFn with "conflicting attributes" (always_inline still
-      // inlines via the InlineCost.cpp AlwaysInline short-circuit). The AOT
-      // fallback body then loses ~all helper inlining vs the original function.
-      // Copy F's attributes so MissFn matches F's subtarget; re-affirm NoInline.
+      FunctionType *MissFnTy = F->getFunctionType();
+      if (EJitFunctionBodyTiming) {
+        SmallVector<Type *, 8> MissParamTys(F->getFunctionType()->params());
+        MissParamTys.push_back(I64Ty);
+        MissFnTy =
+            FunctionType::get(F->getReturnType(), MissParamTys, F->isVarArg());
+      }
+      Function *MissFn = Function::Create(
+          MissFnTy, GlobalValue::InternalLinkage, F->getName() + "_miss", &M);
+      // Function::Create only inherits module-default uwtable/frame-pointer
+      // from the context, NOT F's target-cpu/target-features/tune-cpu. Without
+      // those, TTI::areInlineCompatible(Caller=MissFn, Callee=helper) fails the
+      // subtarget feature-bit superset check, so InlinerPass rejects every
+      // cost-based inlining into MissFn with "conflicting attributes"
+      // (always_inline still inlines via the InlineCost.cpp AlwaysInline
+      // short-circuit). The AOT fallback body then loses ~all helper inlining
+      // vs the original function. Copy F's attributes so MissFn matches F's
+      // subtarget; re-affirm NoInline.
       MissFn->setAttributes(F->getAttributes());
       MissFn->addFnAttr(Attribute::NoInline);
       if (EJitMissFnCold)
@@ -948,8 +987,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       // Create the slow-path entry (funcidx guard) BEFORE MissFallback so it
       // becomes MissFn's entry block.
-      auto *MissEntry = BasicBlock::Create(Ctx, "miss_entry", MissFn,
-                                            MissFallback);
+      auto *MissEntry =
+          BasicBlock::Create(Ctx, "miss_entry", MissFn, MissFallback);
       auto *MissCall = BasicBlock::Create(Ctx, "miss_call", MissFn);
       auto *MissDispatch = BasicBlock::Create(Ctx, "miss_dispatch", MissFn);
       if (!MissFallback->getTerminator()) {
@@ -959,20 +998,28 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         else
           B.CreateRet(PoisonValue::get(F->getReturnType()));
       }
-      emitSlowPath(*MissFn, MissEntry, MissCall, MissDispatch, MissFallback);
-      instrumentAotBody(MissFallback);
+      Value *MissWrapperBegin =
+          EJitFunctionBodyTiming ? MissFn->getArg(F->arg_size()) : nullptr;
+      emitSlowPath(*MissFn, MissEntry, MissCall, MissDispatch, MissFallback,
+                   MissWrapperBegin);
+      instrumentAotBody(MissFallback, MissWrapperBegin);
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
-      auto *JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
+      auto *JitIcacheDispatch =
+          BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
       auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
       IRBuilder<> B(JitEntry);
+      Value *WrapperBegin = nullptr;
+      if (EJitFunctionBodyTiming)
+        WrapperBegin = B.CreateCall(TraceNow, {}, "ejit_wrapper_begin");
       Value *TBeforeIcache = nullptr, *FuncIdxForTiming = nullptr;
       if (EJitWrapperTiming) {
-        TBeforeIcache = B.CreateCall(TraceNow, {}, "ejit_t_before_icache");
-        FuncIdxForTiming = B.CreateLoad(I32Ty,
-                                        FuncIndexGlobals[F->getName().str()],
-                                        "ejit_funcidx_t");
+        TBeforeIcache =
+            WrapperBegin ? WrapperBegin
+                         : B.CreateCall(TraceNow, {}, "ejit_t_before_icache");
+        FuncIdxForTiming = B.CreateLoad(
+            I32Ty, FuncIndexGlobals[F->getName().str()], "ejit_funcidx_t");
       }
       GlobalVariable *IcacheSlot = IcacheIt->second.GV;
       unsigned NumDims = IcacheIt->second.NumDims;
@@ -984,8 +1031,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
           Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
           unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
           Value *Idx = ArgVal;
-          if (BW > 32) Idx = B.CreateTrunc(ArgVal, I32Ty);
-          else if (BW < 32) Idx = B.CreateZExt(ArgVal, I32Ty);
+          if (BW > 32)
+            Idx = B.CreateTrunc(ArgVal, I32Ty);
+          else if (BW < 32)
+            Idx = B.CreateZExt(ArgVal, I32Ty);
           Indices.push_back(Idx);
         }
         SlotPtr = B.CreateInBoundsGEP(IcacheSlot->getValueType(), IcacheSlot,
@@ -1011,26 +1060,37 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       // With -ejit-wrapper-timing the wrapper is NOT frame-less (JitEntry emits
       // bl @ejit_taskpool_trace_now), so the hit path cannot be a musttail tail
       // call: emitHitTiming() inserts calls BETWEEN the call and the ret, which
-      // would violate the musttail rule ("musttail call must precede a ret") and
-      // yield broken IR -> codegen silently drops the function -> boot
+      // would violate the musttail rule ("musttail call must precede a ret")
+      // and yield broken IR -> codegen silently drops the function -> boot
       // translation fault. Use a plain (framed) call + trace + ret instead; the
       // frame-less musttail fast path is reserved for the no-timing case.
       B.SetInsertPoint(JitIcacheDispatch);
       SmallVector<Value *, 8> ICArgs;
-      for (auto &A : F->args()) ICArgs.push_back(&A);
+      for (auto &A : F->args())
+        ICArgs.push_back(&A);
       Value *BodyBegin = nullptr;
       if (EJitFunctionBodyTiming)
         BodyBegin = B.CreateCall(TraceNow, {}, "ejit_jit_body_begin");
       auto emitHitTiming = [&]() {
-        emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, BodyBegin);
-        if (!EJitWrapperTiming)
-          return;
-        Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
-        B.CreateCall(TraceWrapper,
-                     {FuncIdxForTiming,
-                      ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
-                      ICSlotLoad, ConstantInt::get(I32Ty, 0), TBeforeIcache,
-                      TAfterIcache, TAfterFn, TAfterFn});
+        Value *BodyEnd = nullptr;
+        if (EJitFunctionBodyTiming)
+          BodyEnd = B.CreateCall(TraceNow, {}, "ejit_jit_body_end");
+        Value *WrapperEnd = nullptr;
+        if (EJitFunctionBodyTiming)
+          WrapperEnd = B.CreateCall(TraceNow, {}, "ejit_wrapper_end");
+        if (EJitWrapperTiming) {
+          Value *TAfterFn =
+              BodyEnd ? BodyEnd : B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+          B.CreateCall(TraceWrapper,
+                       {FuncIdxForTiming,
+                        ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
+                        ICSlotLoad, ConstantInt::get(I32Ty, 0), TBeforeIcache,
+                        TAfterIcache, TAfterFn, TAfterFn});
+        }
+        if (EJitFunctionBodyTiming) {
+          emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, WrapperBegin,
+                                 BodyBegin, BodyEnd, WrapperEnd);
+        }
       };
       if (F->getReturnType()->isVoidTy()) {
         CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
@@ -1049,14 +1109,21 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       // Miss: tail-call MissFn (which does compile_or_get + dispatch/fallback).
       B.SetInsertPoint(JitMiss);
       SmallVector<Value *, 8> MissArgs;
-      for (auto &A : F->args()) MissArgs.push_back(&A);
+      for (auto &A : F->args())
+        MissArgs.push_back(&A);
+      if (EJitFunctionBodyTiming)
+        MissArgs.push_back(WrapperBegin);
       if (F->getReturnType()->isVoidTy()) {
-        CallInst *CI = B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
-        CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        CallInst *CI =
+            B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+        if (!EJitFunctionBodyTiming)
+          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
         B.CreateRetVoid();
       } else {
-        CallInst *CI = B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
-        CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        CallInst *CI =
+            B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+        if (!EJitFunctionBodyTiming)
+          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
         B.CreateRet(CI);
       }
 
@@ -1076,11 +1143,14 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       spliceOriginalBody(JitFallback);
       if (!JitFallback->getTerminator()) {
         IRBuilder<> B(JitFallback);
-        if (F->getReturnType()->isVoidTy()) B.CreateRetVoid();
-        else B.CreateRet(PoisonValue::get(F->getReturnType()));
+        if (F->getReturnType()->isVoidTy())
+          B.CreateRetVoid();
+        else
+          B.CreateRet(PoisonValue::get(F->getReturnType()));
       }
-      emitSlowPath(*F, JitEntry, JitCall, JitDispatch, JitFallback);
-      instrumentAotBody(JitFallback);
+      Value *WrapperBegin = emitSlowPath(*F, JitEntry, JitCall, JitDispatch,
+                                         JitFallback, nullptr);
+      instrumentAotBody(JitFallback, WrapperBegin);
     }
 
     Changed = true;

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -703,6 +703,18 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     for (BasicBlock &BB : *F)
       if (auto *RI = dyn_cast<ReturnInst>(BB.getTerminator()))
         OriginalReturns.push_back(RI);
+    bool HasMustTailAotExit = false;
+    for (BasicBlock &BB : *F) {
+      for (Instruction &I : BB) {
+        auto *CI = dyn_cast<CallInst>(&I);
+        if (CI && CI->isMustTailCall()) {
+          HasMustTailAotExit = true;
+          break;
+        }
+      }
+      if (HasMustTailAotExit)
+        break;
+    }
 
     // Timing callees (shared by hit and slow paths).
     FunctionCallee TraceNow{};
@@ -942,8 +954,14 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       // MissFn on miss) -- no allocas, no calls, no frame. MissFn holds the
       // funcidx guard + compile_or_get + dispatch + the AOT fallback (original
       // body), with its own frame. Miss is rare, so the call overhead is fine.
+      // Moving a musttail AOT exit into a function with one extra fixed
+      // parameter would invalidate its caller/callee ABI match. Such entries
+      // keep an ABI-identical MissFn; their slow JIT path starts timing locally
+      // and their AOT fallback is deliberately left uninstrumented.
+      const bool ThreadWrapperBegin =
+          EJitFunctionBodyTiming && !HasMustTailAotExit;
       FunctionType *MissFnTy = F->getFunctionType();
-      if (EJitFunctionBodyTiming) {
+      if (ThreadWrapperBegin) {
         SmallVector<Type *, 8> MissParamTys(F->getFunctionType()->params());
         MissParamTys.push_back(I64Ty);
         MissFnTy =
@@ -999,10 +1017,11 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
           B.CreateRet(PoisonValue::get(F->getReturnType()));
       }
       Value *MissWrapperBegin =
-          EJitFunctionBodyTiming ? MissFn->getArg(F->arg_size()) : nullptr;
+          ThreadWrapperBegin ? MissFn->getArg(F->arg_size()) : nullptr;
       emitSlowPath(*MissFn, MissEntry, MissCall, MissDispatch, MissFallback,
                    MissWrapperBegin);
-      instrumentAotBody(MissFallback, MissWrapperBegin);
+      if (!HasMustTailAotExit)
+        instrumentAotBody(MissFallback, MissWrapperBegin);
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
@@ -1111,7 +1130,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       SmallVector<Value *, 8> MissArgs;
       for (auto &A : F->args())
         MissArgs.push_back(&A);
-      if (EJitFunctionBodyTiming)
+      if (ThreadWrapperBegin)
         MissArgs.push_back(WrapperBegin);
       if (F->getReturnType()->isVoidTy()) {
         CallInst *CI =

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing-musttail.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing-musttail.ll
@@ -1,0 +1,79 @@
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s | FileCheck %s --check-prefix=OFF
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=TIMED
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=AOTSAFE
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=MIXED
+
+; Moving an AOT body with a musttail exit into an augmented MissFn would make
+; the caller and callee parameter counts differ. Keep MissFn ABI-identical,
+; preserve every original musttail, and time only JIT execution for this entry.
+;
+; OFF-LABEL: define i32 @musttail_entry(
+; OFF-LABEL: jit_icache_dispatch:
+; OFF: musttail call i32 %ejit_ic_fn
+; OFF-LABEL: jit_miss:
+; OFF: musttail call i32 @musttail_entry_miss(i32 %cell)
+; OFF-LABEL: define internal i32 @musttail_entry_miss(i32 %0)
+; OFF: musttail call i32 @helper(i32 %0)
+;
+; TIMED-LABEL: define i32 @musttail_entry(
+; TIMED: %ejit_wrapper_begin = call i64 @ejit_taskpool_trace_now()
+; TIMED-LABEL: jit_miss:
+; TIMED: call i32 @musttail_entry_miss(i32 %cell)
+; TIMED-LABEL: define internal i32 @musttail_entry_miss(i32 %0)
+; TIMED-LABEL: miss_entry:
+; TIMED: %ejit_wrapper_begin = call i64 @ejit_taskpool_trace_now()
+; TIMED-LABEL: miss_dispatch:
+; TIMED: call void @ejit_function_body_cycles_record({{.*}}i32 1
+;
+; AOTSAFE-LABEL: define internal i32 @musttail_entry_miss(i32 %0)
+; AOTSAFE-LABEL: miss_fallback:
+; AOTSAFE-NOT: call void @ejit_function_body_cycles_record
+; AOTSAFE: musttail call i32 @helper(i32 %0)
+
+; A mixed normal/musttail AOT CFG also suppresses all AOT samples rather than
+; reporting a biased subset of its exits.
+;
+; MIXED-LABEL: define internal i32 @mixed_entry_miss(i32 %0, i32 %1)
+; MIXED-LABEL: miss_fallback:
+; MIXED-NOT: ejit_aot_body_begin
+; MIXED-NOT: call void @ejit_function_body_cycles_record({{.*}}i32 0
+; MIXED: mixed.normal:
+; MIXED: ret i32 %1
+; MIXED: mixed.tail:
+; MIXED: musttail call i32 @mixed_helper(i32 %0, i32 %1)
+
+define i32 @helper(i32 %cell) {
+entry:
+  ret i32 %cell
+}
+
+define i32 @mixed_helper(i32 %cell, i32 %value) {
+entry:
+  %sum = add i32 %cell, %value
+  ret i32 %sum
+}
+
+define i32 @musttail_entry(i32 %cell) !ejit.metadata !0 {
+entry:
+  %r = musttail call i32 @helper(i32 %cell)
+  ret i32 %r
+}
+
+define i32 @mixed_entry(i32 %cell, i32 %value) !ejit.metadata !1 {
+entry:
+  %take.tail = icmp eq i32 %value, 0
+  br i1 %take.tail, label %mixed.tail, label %mixed.normal
+
+mixed.normal:
+  ret i32 %value
+
+mixed.tail:
+  %r = musttail call i32 @mixed_helper(i32 %cell, i32 %value)
+  ret i32 %r
+}
+
+@data = global [16 x i32] zeroinitializer, !ejit.metadata !10
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing.ll
@@ -2,6 +2,7 @@
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=JIT
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=AOT
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=ICACHE
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-wrapper-timing -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=BOTH
 
 ; OFF-NOT: @ejit_function_body_cycles_record
 
@@ -54,6 +55,17 @@
 ; ICACHE: %ejit_aot_body_begin = call i64 @ejit_taskpool_trace_now()
 ; ICACHE: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %[[WRAPPER_BEGIN]], i64 %ejit_aot_body_begin,
 
+; Wrapper and body timing coexist for multiple entries, including void returns.
+; BOTH-LABEL: define i32 @timed_body(
+; BOTH: call void @ejit_taskpool_trace_wrapper(
+; BOTH: call void @ejit_function_body_cycles_record(
+; BOTH-LABEL: define void @timed_void(
+; BOTH-LABEL: jit_icache_dispatch:
+; BOTH: call void %ejit_ic_fn
+; BOTH: call void @ejit_taskpool_trace_wrapper(
+; BOTH: call void @ejit_function_body_cycles_record(
+; BOTH-NEXT: ret void
+
 define i32 @timed_body(i32 %cell, i32 %value) !ejit.metadata !0 {
 entry:
   %positive = icmp sgt i32 %value, 0
@@ -68,7 +80,14 @@ aot.nonpositive:
   ret i32 %neg
 }
 
+define void @timed_void(i32 %cell, ptr %out) !ejit.metadata !1 {
+entry:
+  store i32 %cell, ptr %out
+  ret void
+}
+
 @data = global [16 x i32] zeroinitializer, !ejit.metadata !10
 
 !0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
 !10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing.ll
@@ -1,0 +1,62 @@
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s --check-prefix=OFF
+; RUN: opt -passes=ejit-wrapper-gen -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=JIT
+; RUN: opt -passes=ejit-wrapper-gen -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=AOT
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-function-body-timing -S %s | FileCheck %s --check-prefix=ICACHE
+
+; OFF-NOT: @ejit_function_body_cycles_record
+
+; The JIT interval starts after lookup/dispatch and ends immediately after the
+; selected function call. Read-token release and aggregation are outside it.
+; JIT-LABEL: define i32 @timed_body(
+; JIT-LABEL: jit_dispatch:
+; JIT: %ejit_jit_body_begin = call i64 @ejit_taskpool_trace_now()
+; JIT-NEXT: {{.*}}call i32 %ejit_fn
+; JIT-NEXT: %ejit_body_end = call i64 @ejit_taskpool_trace_now()
+; JIT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 1, i64 %ejit_jit_body_begin, i64 %ejit_body_end)
+; JIT: call void @ejit_taskpool_release_read
+
+; The original AOT CFG is bracketed independently. Both return sites report an
+; AOT sample, including fallback caused by an invalid funcIndex or cache miss.
+; AOT-LABEL: aot.positive:
+; AOT: %ejit_body_end{{.*}} = call i64 @ejit_taskpool_trace_now()
+; AOT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %ejit_aot_body_begin, i64 %ejit_body_end{{.*}})
+; AOT-NEXT: ret i32
+; AOT-LABEL: aot.nonpositive:
+; AOT: %ejit_body_end{{.*}} = call i64 @ejit_taskpool_trace_now()
+; AOT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %ejit_aot_body_begin, i64 %ejit_body_end{{.*}})
+; AOT-NEXT: ret i32
+; AOT-LABEL: jit_fallback:
+; AOT: %ejit_aot_body_begin = call i64 @ejit_taskpool_trace_now()
+
+; Inline-cache JIT hits use the same JIT path label and are no longer musttail
+; while instrumentation is enabled, because the end timestamp follows the call.
+; ICACHE-LABEL: define i32 @timed_body(
+; ICACHE-LABEL: jit_icache_dispatch:
+; ICACHE: %ejit_jit_body_begin = call i64 @ejit_taskpool_trace_now()
+; ICACHE-NOT: musttail
+; ICACHE-NEXT: {{.*}}call i32 %ejit_ic_fn
+; ICACHE-NEXT: %ejit_body_end = call i64 @ejit_taskpool_trace_now()
+; ICACHE-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 1, i64 %ejit_jit_body_begin, i64 %ejit_body_end)
+; ICACHE-NEXT: ret i32
+; ICACHE-LABEL: define internal i32 @timed_body_miss(
+; ICACHE-LABEL: miss_fallback:
+; ICACHE: %ejit_aot_body_begin = call i64 @ejit_taskpool_trace_now()
+
+define i32 @timed_body(i32 %cell, i32 %value) !ejit.metadata !0 {
+entry:
+  %positive = icmp sgt i32 %value, 0
+  br i1 %positive, label %aot.positive, label %aot.nonpositive
+
+aot.positive:
+  %sum = add i32 %value, 7
+  ret i32 %sum
+
+aot.nonpositive:
+  %neg = sub i32 0, %value
+  ret i32 %neg
+}
+
+@data = global [16 x i32] zeroinitializer, !ejit.metadata !10
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing.ll
@@ -5,25 +5,30 @@
 
 ; OFF-NOT: @ejit_function_body_cycles_record
 
-; The JIT interval starts after lookup/dispatch and ends immediately after the
-; selected function call. Read-token release and aggregation are outside it.
+; The JIT body interval starts after lookup/dispatch and ends immediately after
+; the selected function call. The wrapper interval starts before dispatch and
+; ends after read-token release; aggregation is outside both intervals.
 ; JIT-LABEL: define i32 @timed_body(
+; JIT: %ejit_wrapper_begin = call i64 @ejit_taskpool_trace_now()
 ; JIT-LABEL: jit_dispatch:
 ; JIT: %ejit_jit_body_begin = call i64 @ejit_taskpool_trace_now()
 ; JIT-NEXT: {{.*}}call i32 %ejit_fn
-; JIT-NEXT: %ejit_body_end = call i64 @ejit_taskpool_trace_now()
-; JIT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 1, i64 %ejit_jit_body_begin, i64 %ejit_body_end)
+; JIT-NEXT: %ejit_jit_body_end = call i64 @ejit_taskpool_trace_now()
 ; JIT: call void @ejit_taskpool_release_read
+; JIT-NEXT: %ejit_wrapper_end = call i64 @ejit_taskpool_trace_now()
+; JIT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 1, i64 %ejit_wrapper_begin, i64 %ejit_jit_body_begin, i64 %ejit_jit_body_end, i64 %ejit_wrapper_end)
 
 ; The original AOT CFG is bracketed independently. Both return sites report an
 ; AOT sample, including fallback caused by an invalid funcIndex or cache miss.
 ; AOT-LABEL: aot.positive:
-; AOT: %ejit_body_end{{.*}} = call i64 @ejit_taskpool_trace_now()
-; AOT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %ejit_aot_body_begin, i64 %ejit_body_end{{.*}})
+; AOT: %ejit_aot_body_end{{.*}} = call i64 @ejit_taskpool_trace_now()
+; AOT-NEXT: %ejit_wrapper_end{{.*}} = call i64 @ejit_taskpool_trace_now()
+; AOT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %ejit_wrapper_begin, i64 %ejit_aot_body_begin, i64 %ejit_aot_body_end{{.*}}, i64 %ejit_wrapper_end{{.*}})
 ; AOT-NEXT: ret i32
 ; AOT-LABEL: aot.nonpositive:
-; AOT: %ejit_body_end{{.*}} = call i64 @ejit_taskpool_trace_now()
-; AOT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %ejit_aot_body_begin, i64 %ejit_body_end{{.*}})
+; AOT: %ejit_aot_body_end{{.*}} = call i64 @ejit_taskpool_trace_now()
+; AOT-NEXT: %ejit_wrapper_end{{.*}} = call i64 @ejit_taskpool_trace_now()
+; AOT-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %ejit_wrapper_begin, i64 %ejit_aot_body_begin, i64 %ejit_aot_body_end{{.*}}, i64 %ejit_wrapper_end{{.*}})
 ; AOT-NEXT: ret i32
 ; AOT-LABEL: jit_fallback:
 ; AOT: %ejit_aot_body_begin = call i64 @ejit_taskpool_trace_now()
@@ -31,16 +36,23 @@
 ; Inline-cache JIT hits use the same JIT path label and are no longer musttail
 ; while instrumentation is enabled, because the end timestamp follows the call.
 ; ICACHE-LABEL: define i32 @timed_body(
+; ICACHE: %ejit_wrapper_begin = call i64 @ejit_taskpool_trace_now()
 ; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE: %ejit_jit_body_begin = call i64 @ejit_taskpool_trace_now()
 ; ICACHE-NOT: musttail
 ; ICACHE-NEXT: {{.*}}call i32 %ejit_ic_fn
-; ICACHE-NEXT: %ejit_body_end = call i64 @ejit_taskpool_trace_now()
-; ICACHE-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 1, i64 %ejit_jit_body_begin, i64 %ejit_body_end)
+; ICACHE-NEXT: %ejit_jit_body_end = call i64 @ejit_taskpool_trace_now()
+; ICACHE-NEXT: %ejit_wrapper_end = call i64 @ejit_taskpool_trace_now()
+; ICACHE-NEXT: call void @ejit_function_body_cycles_record({{.*}}i32 1, i64 %ejit_wrapper_begin, i64 %ejit_jit_body_begin, i64 %ejit_jit_body_end, i64 %ejit_wrapper_end)
 ; ICACHE-NEXT: ret i32
+; The miss helper receives the outer wrapper timestamp, so its AOT/JIT samples
+; include the failed inline-cache probe rather than starting late.
+; ICACHE: call i32 @timed_body_miss(i32 %cell, i32 %value, i64 %ejit_wrapper_begin)
 ; ICACHE-LABEL: define internal i32 @timed_body_miss(
+; ICACHE-SAME: i64 %[[WRAPPER_BEGIN:[0-9]+]])
 ; ICACHE-LABEL: miss_fallback:
 ; ICACHE: %ejit_aot_body_begin = call i64 @ejit_taskpool_trace_now()
+; ICACHE: call void @ejit_function_body_cycles_record({{.*}}i32 0, i64 %[[WRAPPER_BEGIN]], i64 %ejit_aot_body_begin,
 
 define i32 @timed_body(i32 %cell, i32 %value) !ejit.metadata !0 {
 entry:

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -749,6 +749,12 @@ typedef struct {
   uint64_t total;
   uint64_t min;
   uint64_t max;
+  uint64_t wrapper_total;
+  uint64_t wrapper_min;
+  uint64_t wrapper_max;
+  uint64_t overhead_total;
+  uint64_t overhead_min;
+  uint64_t overhead_max;
 } ejit_function_body_cycles_test_t;
 extern ejit_status_test_t ejit_init(const void *config);
 extern void ejit_shutdown(void);
@@ -774,7 +780,7 @@ extern void ejit_print_code_pool_stats(void);
 extern void ejit_print_active(void);
 extern void ejit_print_version(void);
 extern void ejit_function_body_cycles_record(const char *, uint32_t, uint64_t,
-                                             uint64_t);
+                                             uint64_t, uint64_t, uint64_t);
 extern unsigned
 ejit_function_body_cycles_get(const char *, uint32_t,
                               ejit_function_body_cycles_test_t *);
@@ -934,9 +940,12 @@ namespace {
 TEST(EJitFunctionBodyCyclesTest, AggregatesAotAndJitIndependently) {
   ejit_function_body_cycles_reset();
 
-  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyAot, 100, 130);
-  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyAot, 200, 250);
-  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyJit, 300, 311);
+  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyAot, 90, 100,
+                                   130, 140);
+  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyAot, 180, 200,
+                                   250, 270);
+  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyJit, 290, 300,
+                                   311, 321);
 
   ejit_function_body_cycles_test_t Aot{};
   ASSERT_EQ(
@@ -946,6 +955,12 @@ TEST(EJitFunctionBodyCyclesTest, AggregatesAotAndJitIndependently) {
   EXPECT_EQ(Aot.total, 80u);
   EXPECT_EQ(Aot.min, 30u);
   EXPECT_EQ(Aot.max, 50u);
+  EXPECT_EQ(Aot.wrapper_total, 140u);
+  EXPECT_EQ(Aot.wrapper_min, 50u);
+  EXPECT_EQ(Aot.wrapper_max, 90u);
+  EXPECT_EQ(Aot.overhead_total, 60u);
+  EXPECT_EQ(Aot.overhead_min, 20u);
+  EXPECT_EQ(Aot.overhead_max, 40u);
 
   ejit_function_body_cycles_test_t Jit{};
   ASSERT_EQ(
@@ -955,6 +970,12 @@ TEST(EJitFunctionBodyCyclesTest, AggregatesAotAndJitIndependently) {
   EXPECT_EQ(Jit.total, 11u);
   EXPECT_EQ(Jit.min, 11u);
   EXPECT_EQ(Jit.max, 11u);
+  EXPECT_EQ(Jit.wrapper_total, 31u);
+  EXPECT_EQ(Jit.wrapper_min, 31u);
+  EXPECT_EQ(Jit.wrapper_max, 31u);
+  EXPECT_EQ(Jit.overhead_total, 20u);
+  EXPECT_EQ(Jit.overhead_min, 20u);
+  EXPECT_EQ(Jit.overhead_max, 20u);
 
   ejit_function_body_cycles_reset();
   EXPECT_EQ(

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -744,6 +744,12 @@ TEST(EJit, TaskpoolRegistrationFrozenAfterConstruction) {
 
 extern "C" {
 typedef enum { EJIT_OK_C = 0 } ejit_status_test_t;
+typedef struct {
+  uint64_t count;
+  uint64_t total;
+  uint64_t min;
+  uint64_t max;
+} ejit_function_body_cycles_test_t;
 extern ejit_status_test_t ejit_init(const void *config);
 extern void ejit_shutdown(void);
 extern ejit_status_test_t ejit_activate(const char *, uint32_t);
@@ -767,7 +773,16 @@ extern int ejit_get_code_pool_stats(void *out);
 extern void ejit_print_code_pool_stats(void);
 extern void ejit_print_active(void);
 extern void ejit_print_version(void);
+extern void ejit_function_body_cycles_record(const char *, uint32_t, uint64_t,
+                                             uint64_t);
+extern unsigned
+ejit_function_body_cycles_get(const char *, uint32_t,
+                              ejit_function_body_cycles_test_t *);
+extern void ejit_function_body_cycles_reset(void);
 }
+
+static constexpr uint32_t kEjitFunctionBodyAot = 0;
+static constexpr uint32_t kEjitFunctionBodyJit = 1;
 
 // The "runtime-dynamic cellIdx" C-API tests below exercise the LEGACY model:
 // dynamic period-array registration AFTER ejit_init, then period-name activate.
@@ -915,6 +930,37 @@ TEST(EJitCApi, ActivationCycleWithRuntimeIndex) {
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+TEST(EJitFunctionBodyCyclesTest, AggregatesAotAndJitIndependently) {
+  ejit_function_body_cycles_reset();
+
+  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyAot, 100, 130);
+  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyAot, 200, 250);
+  ejit_function_body_cycles_record("body_cost", kEjitFunctionBodyJit, 300, 311);
+
+  ejit_function_body_cycles_test_t Aot{};
+  ASSERT_EQ(
+      ejit_function_body_cycles_get("body_cost", kEjitFunctionBodyAot, &Aot),
+      1u);
+  EXPECT_EQ(Aot.count, 2u);
+  EXPECT_EQ(Aot.total, 80u);
+  EXPECT_EQ(Aot.min, 30u);
+  EXPECT_EQ(Aot.max, 50u);
+
+  ejit_function_body_cycles_test_t Jit{};
+  ASSERT_EQ(
+      ejit_function_body_cycles_get("body_cost", kEjitFunctionBodyJit, &Jit),
+      1u);
+  EXPECT_EQ(Jit.count, 1u);
+  EXPECT_EQ(Jit.total, 11u);
+  EXPECT_EQ(Jit.min, 11u);
+  EXPECT_EQ(Jit.max, 11u);
+
+  ejit_function_body_cycles_reset();
+  EXPECT_EQ(
+      ejit_function_body_cycles_get("body_cost", kEjitFunctionBodyAot, &Aot),
+      0u);
+}
 // Reset process-global registration state so each taskpool test starts clean:
 // no live gEJIT, no staged data, no staged error, empty name registries. This
 // is essential because the C ABI / registries are process singletons that leak


### PR DESCRIPTION
## English

### Summary
- Add opt-in `-mllvm -ejit-function-body-timing` instrumentation for every wrapped `ejit_entry` function.
- Measure only the selected function body: the original AOT fallback body or the indirect JIT specialization call. Wrapper lookup, dispatch, read-token release, and wrapper aggregation are excluded.
- Use `SRE_CycleCountGet64()` on SRE targets (`steady_clock` nanoseconds on host tests), with independent AOT/JIT count, total, average, minimum, and maximum statistics per function.
- Add allocation-free, fixed-capacity runtime storage and non-blocking recording. Contended/full-table samples are dropped and reported instead of stalling a realtime path.
- Add public get/print/reset APIs, documentation, runtime unit coverage, and IR checks for slow dispatch, AOT fallback, and inline-cache hits.
- The feature is disabled by default, preserving the existing musttail inline-cache fast path and adding no instrumentation calls.

### Validation
- Production-style shared taskpool configuration built `opt` and all changed EJIT sources successfully.
- `EJitFunctionBodyCyclesTest.AggregatesAotAndJitIndependently` passed.
- New IR checks passed for OFF, AOT, JIT, and inline-cache modes.
- Existing `ejit-wrapper-timing.ll` and `ejit-wrapper-gen-icache.ll` checks passed.

Board-only SRE cycle values were not exercised locally; the host validates placement and aggregation, while the documented board path reports real SRE cycles.

## 中文

### 说明
- 新增可选开关 `-mllvm -ejit-function-body-timing`，对每个被包装的 `ejit_entry` 函数统计本体开销。
- AOT 只覆盖原始 fallback 函数体，JIT 只覆盖选中的特化函数间接调用；缓存查询、dispatcher、read-token release 和 wrapper 汇总均不计入。
- 板端使用 `SRE_CycleCountGet64()`，按函数及 AOT/JIT 路径分别汇总次数、总 cycles、平均值、最小值和最大值。
- 统计表固定容量、无动态分配；热路径采用 try-lock，竞争或表满时丢弃样本并计数，避免调测代码阻塞实时路径。
- 提供查询、打印、清零接口，并补充文档、运行时单测以及 AOT/JIT/inline-cache IR 测试。
- 默认关闭，不影响原有 inline-cache musttail 快路径，也不会插入任何计时代码。

### 验证
- 共享 taskpool 生产配置下，`opt` 和本次修改的 EJIT 源码均构建成功。
- AOT/JIT 独立聚合单测通过。
- 新增 OFF/AOT/JIT/inline-cache IR 检查全部通过。
- 原有 wrapper timing 和 inline-cache 回归检查通过。

本地未运行真实板端 cycles 数值测试；本机已验证插桩边界和聚合逻辑，板端按文档运行时会输出 SRE cycles。