### PR TITLE
[EJIT] Experiment with split 1D inline-cache dispatch

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -804,6 +804,14 @@ set(EJIT_ICACHE_SECTION ".mc_shared" CACHE STRING
   "Section for the EJIT inline-cache cell table; must be inter-core shared on a multi-core target")
 message(STATUS "EmbeddedJIT: inline-cache cell table section=${EJIT_ICACHE_SECTION}")
 
+# Optional experiment for one-dimensional cell/trp entries. Instead of one
+# indirect JIT callsite serving every instance, emit a direct conditional branch
+# tree with one indirect callsite per instance [0, 15]. This trades a larger AOT
+# dispatcher for a monomorphic indirect-branch PC per active instance.
+option(EJIT_ICACHE_SPLIT_DISPATCH_1D
+  "Split 1D cell/trp inline-cache dispatch into 16 instance-specific callsites" OFF)
+message(STATUS "EmbeddedJIT: split 1D cell/trp dispatch=${EJIT_ICACHE_SPLIT_DISPATCH_1D}")
+
 #===-- EmbeddedJIT SRE taskpool compile scheduler -------------------------===#
 # Route ejit_compile_or_get through a unified taskpool (cache + dedup + queue)
 # instead of calling the synchronous compile driver directly. Sync and async

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -91,7 +91,8 @@
         "EJIT_SRE_DIAG": "ON",
         "EJIT_DUMP_ASM": "ON",
         "EJIT_STATS_ENABLE": "ON",
-        "EJIT_ICACHE_DIM_SIZE": "16"
+        "EJIT_ICACHE_DIM_SIZE": "16",
+        "EJIT_ICACHE_SPLIT_DISPATCH_1D": "ON"
       }
     },
     {

--- a/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
+++ b/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
@@ -27,3 +27,8 @@ add_llvm_component_library(LLVMEmbeddedJIT
 target_compile_definitions(LLVMEmbeddedJIT PRIVATE
   EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE}
   EJIT_ICACHE_SECTION="${EJIT_ICACHE_SECTION}")
+
+if(EJIT_ICACHE_SPLIT_DISPATCH_1D)
+  target_compile_definitions(LLVMEmbeddedJIT PRIVATE
+    EJIT_ICACHE_SPLIT_DISPATCH_1D=1)
+endif()

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -88,6 +88,15 @@ static cl::opt<bool> EJitInlineCache(
              "cached specialization pointer) before the taskpool "
              "compile_or_get call in ejit_entry wrappers"));
 
+#ifndef EJIT_ICACHE_SPLIT_DISPATCH_1D
+#define EJIT_ICACHE_SPLIT_DISPATCH_1D 0
+#endif
+static cl::opt<bool> EJitIcacheSplitDispatch1D(
+    "ejit-icache-split-dispatch-1d",
+    cl::init(EJIT_ICACHE_SPLIT_DISPATCH_1D != 0), cl::Hidden,
+    cl::desc("Split eligible one-dimensional cell/trp inline-cache dispatch "
+             "into 16 instance-specific indirect callsites"));
+
 // Section for the per-function @__ejit_icache_fn_<name> cell table. In the
 // inter-core SHARED section (.mc_shared, where the taskpool state blob also
 // lives) the table is ONE object every core reads, so a deactivate zeroes a
@@ -888,8 +897,6 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
-      auto *JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
-      auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
       IRBuilder<> B(JitEntry);
       Value *TBeforeIcache = nullptr, *FuncIdxForTiming = nullptr;
       if (EJitWrapperTiming) {
@@ -900,69 +907,134 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       }
       GlobalVariable *IcacheSlot = IcacheIt->second.GV;
       unsigned NumDims = IcacheIt->second.NumDims;
-      Value *SlotPtr = IcacheSlot;
-      if (NumDims > 0) {
-        SmallVector<Value *, 5> Indices;
-        Indices.push_back(ConstantInt::get(I32Ty, 0));
-        for (unsigned I = 0; I < NumDims; ++I) {
-          Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
-          unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
-          Value *Idx = ArgVal;
-          if (BW > 32) Idx = B.CreateTrunc(ArgVal, I32Ty);
-          else if (BW < 32) Idx = B.CreateZExt(ArgVal, I32Ty);
-          Indices.push_back(Idx);
-        }
-        SlotPtr = B.CreateInBoundsGEP(IcacheSlot->getValueType(), IcacheSlot,
-                                      Indices, "ejit_ic_slot");
-      }
-      LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
-      ICSlotLoad->setAlignment(Align(8));
-      // Monotonic, nothing stronger: the cell is shared, so a peer's drain can
-      // store 0 concurrently and the atomic makes that a defined race (old
-      // pointer or 0) instead of UB. The value is self-contained and the call
-      // below carries a data dependency on it, so acquire would buy nothing and
-      // cost an LDAR per hit. Lowers to the same LDR on AArch64.
-      ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
-      Value *TAfterIcache = nullptr;
-      if (EJitWrapperTiming)
-        TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
-      Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
-      IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
-                               {IHit, ConstantInt::getTrue(Ctx)});
-      B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
-
-      // Hit: tail-call the cached specialization directly (no release_read).
-      // With -ejit-wrapper-timing the wrapper is NOT frame-less (JitEntry emits
-      // bl @ejit_taskpool_trace_now), so the hit path cannot be a musttail tail
-      // call: emitHitTiming() inserts calls BETWEEN the call and the ret, which
-      // would violate the musttail rule ("musttail call must precede a ret") and
-      // yield broken IR -> codegen silently drops the function -> boot
-      // translation fault. Use a plain (framed) call + trace + ret instead; the
-      // frame-less musttail fast path is reserved for the no-timing case.
-      B.SetInsertPoint(JitIcacheDispatch);
       SmallVector<Value *, 8> ICArgs;
       for (auto &A : F->args()) ICArgs.push_back(&A);
-      auto emitHitTiming = [&]() {
-        if (!EJitWrapperTiming) return;
-        Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
-        B.CreateCall(TraceWrapper,
-                     {FuncIdxForTiming,
-                      ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
-                      ICSlotLoad, ConstantInt::get(I32Ty, 0), TBeforeIcache,
-                      TAfterIcache, TAfterFn, TAfterFn});
+      auto emitIcacheDispatch = [&](IRBuilder<> &DB, Value *FnPtr,
+                                    Value *TAfterIcache) {
+        // Hit: tail-call the cached specialization directly (no release_read).
+        // Timing inserts calls between the indirect call and return, so only
+        // the uninstrumented path may use musttail.
+        CallInst *CI = DB.CreateCall(F->getFunctionType(), FnPtr, ICArgs);
+        if (!EJitWrapperTiming)
+          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        if (EJitWrapperTiming) {
+          Value *TAfterFn = DB.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+          DB.CreateCall(TraceWrapper,
+                        {FuncIdxForTiming,
+                         ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
+                         FnPtr, ConstantInt::get(I32Ty, 0), TBeforeIcache,
+                         TAfterIcache, TAfterFn, TAfterFn});
+        }
+        if (F->getReturnType()->isVoidTy())
+          DB.CreateRetVoid();
+        else
+          DB.CreateRet(CI);
       };
-      if (F->getReturnType()->isVoidTy()) {
-        CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        emitHitTiming();
-        B.CreateRetVoid();
+
+      const bool IsSplitLifecycle =
+          NumDims == 1 && (PeriodInds[0].PeriodName == "cell" ||
+                           PeriodInds[0].PeriodName == "trp");
+      const bool UseSplitDispatch = EJitIcacheSplitDispatch1D &&
+                                    IsSplitLifecycle &&
+                                    EJIT_ICACHE_DIM_SIZE >= 16;
+      BasicBlock *JitIcacheDispatch = nullptr;
+      if (!UseSplitDispatch)
+        JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
+      auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
+
+      if (UseSplitDispatch) {
+        constexpr unsigned SplitInstances = 16;
+        Value *ArgVal = F->getArg(PeriodInds[0].ArgIndex);
+        unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
+        Value *Instance = ArgVal;
+        if (BW > 32)
+          Instance = B.CreateTrunc(ArgVal, I32Ty, "ejit_split_instance");
+        else if (BW < 32)
+          Instance = B.CreateZExt(ArgVal, I32Ty, "ejit_split_instance");
+
+        SmallVector<BasicBlock *, SplitInstances> ProbeBlocks;
+        SmallVector<BasicBlock *, SplitInstances> DispatchBlocks;
+        for (unsigned I = 0; I < SplitInstances; ++I) {
+          ProbeBlocks.push_back(
+              BasicBlock::Create(Ctx, "jit_icache_probe_" + Twine(I), F));
+          DispatchBlocks.push_back(
+              BasicBlock::Create(Ctx, "jit_icache_dispatch_" + Twine(I), F));
+        }
+
+        for (unsigned I = 0; I < SplitInstances; ++I) {
+          IRBuilder<> PB(ProbeBlocks[I]);
+          Value *SlotPtr = PB.CreateInBoundsGEP(
+              IcacheSlot->getValueType(), IcacheSlot,
+              {ConstantInt::get(I32Ty, 0), ConstantInt::get(I32Ty, I)},
+              "ejit_ic_slot_" + Twine(I));
+          LoadInst *FnPtr =
+              PB.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn_" + Twine(I));
+          FnPtr->setAlignment(Align(8));
+          FnPtr->setAtomic(AtomicOrdering::Monotonic);
+          Value *TAfterIcache = nullptr;
+          if (EJitWrapperTiming)
+            TAfterIcache = PB.CreateCall(TraceNow, {}, "ejit_t_after_icache");
+          Value *IHit = PB.CreateIsNotNull(FnPtr, "ejit_icache_hit");
+          IHit = PB.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
+                                    {IHit, ConstantInt::getTrue(Ctx)});
+          PB.CreateCondBr(IHit, DispatchBlocks[I], JitMiss);
+
+          IRBuilder<> DB(DispatchBlocks[I]);
+          emitIcacheDispatch(DB, FnPtr, TAfterIcache);
+        }
+
+        auto BuildTree = [&](auto &&Self, unsigned Lo,
+                             unsigned Hi) -> BasicBlock * {
+          if (Hi - Lo == 1)
+            return ProbeBlocks[Lo];
+          unsigned Mid = Lo + (Hi - Lo) / 2;
+          BasicBlock *Left = Self(Self, Lo, Mid);
+          BasicBlock *Right = Self(Self, Mid, Hi);
+          BasicBlock *Node = BasicBlock::Create(
+              Ctx, "jit_icache_select_" + Twine(Lo) + "_" + Twine(Hi), F);
+          IRBuilder<> NB(Node);
+          Value *GoLeft = NB.CreateICmpULT(
+              Instance, ConstantInt::get(I32Ty, Mid), "ejit_split_left");
+          NB.CreateCondBr(GoLeft, Left, Right);
+          return Node;
+        };
+        BasicBlock *TreeRoot = BuildTree(BuildTree, 0, SplitInstances);
+        Value *InRange =
+            B.CreateICmpULT(Instance, ConstantInt::get(I32Ty, SplitInstances),
+                            "ejit_split_in_range");
+        B.CreateCondBr(InRange, TreeRoot, JitMiss);
       } else {
-        CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        emitHitTiming();
-        B.CreateRet(CI);
+        Value *SlotPtr = IcacheSlot;
+        if (NumDims > 0) {
+          SmallVector<Value *, 5> Indices;
+          Indices.push_back(ConstantInt::get(I32Ty, 0));
+          for (unsigned I = 0; I < NumDims; ++I) {
+            Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
+            unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
+            Value *Idx = ArgVal;
+            if (BW > 32)
+              Idx = B.CreateTrunc(ArgVal, I32Ty);
+            else if (BW < 32)
+              Idx = B.CreateZExt(ArgVal, I32Ty);
+            Indices.push_back(Idx);
+          }
+          SlotPtr = B.CreateInBoundsGEP(IcacheSlot->getValueType(), IcacheSlot,
+                                        Indices, "ejit_ic_slot");
+        }
+        LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
+        ICSlotLoad->setAlignment(Align(8));
+        // Monotonic lowers to the same LDR on AArch64 while making a concurrent
+        // shared-table drain a defined race.
+        ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
+        Value *TAfterIcache = nullptr;
+        if (EJitWrapperTiming)
+          TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
+        Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
+        IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
+                                 {IHit, ConstantInt::getTrue(Ctx)});
+        B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
+        B.SetInsertPoint(JitIcacheDispatch);
+        emitIcacheDispatch(B, ICSlotLoad, TAfterIcache);
       }
 
       // Miss: tail-call MissFn (which does compile_or_get + dispatch/fallback).

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
@@ -1,0 +1,68 @@
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=false -S %s | FileCheck %s --check-prefix=DEFAULT
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=true -S %s | FileCheck %s --check-prefix=SPLIT
+
+; The default remains the compact, single indirect callsite.
+; DEFAULT-NOT: jit_icache_probe_0:
+; DEFAULT-COUNT-4: jit_icache_dispatch:
+
+; Eligible one-dimensional cell entries use a direct conditional branch tree.
+; Values outside [0, 15] bypass the inline table and take the existing miss path.
+; Every in-range instance has a distinct constant slot load and indirect call PC.
+; SPLIT-LABEL: define i32 @cell_entry(
+; SPLIT: %ejit_split_in_range = icmp ult i32 %cell, 16
+; SPLIT: br i1 %ejit_split_in_range, label %jit_icache_select_0_16, label %jit_miss
+; SPLIT-NOT: switch
+; SPLIT: jit_icache_probe_0:
+; SPLIT: load atomic ptr, ptr @__ejit_icache_fn_cell_entry monotonic
+; SPLIT: jit_icache_dispatch_0:
+; SPLIT-COUNT-16: musttail call i32 %ejit_ic_fn_
+
+; trp is the other supported one-dimensional lifecycle name.
+; SPLIT-LABEL: define i32 @trp_entry(
+; SPLIT: %ejit_split_in_range = icmp ult i32 %trp, 16
+; SPLIT: jit_icache_dispatch_0:
+; SPLIT: jit_icache_dispatch_15:
+
+; Two-dimensional entries deliberately retain the existing compact dispatcher.
+; SPLIT-LABEL: define i32 @two_dim_entry(
+; SPLIT-NOT: jit_icache_probe_0:
+; SPLIT: jit_icache_dispatch:
+
+; Other one-dimensional lifecycle names also retain the compact dispatcher.
+; SPLIT-LABEL: define i32 @other_entry(
+; SPLIT-NOT: jit_icache_probe_0:
+; SPLIT: jit_icache_dispatch:
+
+define i32 @cell_entry(i32 %cell, i32 %value) !ejit.metadata !0 {
+entry:
+  %r = add i32 %value, 1
+  ret i32 %r
+}
+
+define i32 @trp_entry(i32 %trp) !ejit.metadata !1 {
+entry:
+  ret i32 %trp
+}
+
+define i32 @two_dim_entry(i32 %cell, i32 %trp) !ejit.metadata !2 {
+entry:
+  %r = add i32 %cell, %trp
+  ret i32 %r
+}
+
+define i32 @other_entry(i32 %slot) !ejit.metadata !3 {
+entry:
+  ret i32 %slot
+}
+
+@cell_data = global i32 0, !ejit.metadata !10
+@trp_data = global i32 0, !ejit.metadata !11
+@other_data = global i32 0, !ejit.metadata !12
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"trp", i32 0}}
+!2 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
+!3 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"slot", i32 0}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
+!11 = distinct !{!{!"ejit_period_arr", !"trp", i32 16}}
+!12 = distinct !{!{!"ejit_period_arr", !"slot", i32 16}}


### PR DESCRIPTION
## Summary

- add an opt-in `EJIT_ICACHE_SPLIT_DISPATCH_1D` experiment for one-dimensional `cell`/`trp` entries with indices 0..15
- replace the shared indirect dispatch PC with a balanced direct-branch selector and 16 constant-slot, instance-specific indirect tail-call PCs
- keep 2D entries, other lifecycle names, and out-of-range values on the existing compact/slow paths
- keep the option OFF by default

## Why

The current inline-cache wrapper uses one indirect branch PC for all specialized targets. When multiple cell versions are active, that PC may become polymorphic and contribute to the observed branch-mispredict/front-end-stall increase. This experiment gives each cell/trp value its own indirect branch PC so each site can become monomorphic.

## Validation

- new IR regression covers cell, trp, 2D fallback, other-name fallback, and the default-off path
- existing inline-cache, timing, idempotency, dispatcher layout, and section tests pass
- default-off IR is byte-for-byte identical to the previous implementation
- AArch64 O2 object contains exactly 16 indirect `br` instructions at distinct PCs for `cell_entry`, with no jump table
- sample wrapper code size grows from 24 B to 448 B

## Board A/B required

This is deliberately a draft and default-off. The extra direct branches and code size can themselves increase front-end pressure. Please compare IPC, `BR_MIS_PRED / BR_RETIRED`, `STALL_FRONTEND / CPU_CYCLES`, and I-cache metrics before deciding whether to enable it.

## 中文说明

该实验只处理一维 `cell/trp` 且索引小于 16 的场景：将原先一个间接跳转点面对多个 JIT 目标，拆成 16 个固定槽位和 16 个独立间接跳转点。二维、其他生命周期名以及越界值仍走旧路径，宏默认关闭。AArch64 机器码已确认没有被后端重新合并成 jump table；代价是示例 wrapper 从 24B 增长到 448B，因此必须以上板 PMU A/B 结果判断是否有效。