### PR TITLE
[EJIT] Add patchable direct dispatch pads for 1D cell/trp

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -390,6 +390,7 @@ def doit_gc_merge(args):
         # reachable from this root + ejit_init's .ejit_period walk, no explicit
         # root needed.
         "ejit_register_icache_slot",
+        "ejit_register_icache_pads",
     ]
 
     defined = set()

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -812,6 +812,14 @@ option(EJIT_ICACHE_SPLIT_DISPATCH_1D
   "Split 1D cell/trp inline-cache dispatch into 16 instance-specific callsites" OFF)
 message(STATUS "EmbeddedJIT: split 1D cell/trp dispatch=${EJIT_ICACHE_SPLIT_DISPATCH_1D}")
 
+# Optional second-stage experiment for the split dispatcher above. Each leaf
+# tail-branches to an AOT pad whose single AArch64 B instruction is patched to
+# the JIT body after publication. The split option remains independently useful
+# as the lower-risk indirect-branch A/B baseline.
+option(EJIT_ICACHE_DIRECT_DISPATCH_PADS
+  "Patch split 1D cell/trp dispatch pads to JIT bodies with direct branches" OFF)
+message(STATUS "EmbeddedJIT: direct 1D cell/trp pads=${EJIT_ICACHE_DIRECT_DISPATCH_PADS}")
+
 #===-- EmbeddedJIT SRE taskpool compile scheduler -------------------------===#
 # Route ejit_compile_or_get through a unified taskpool (cache + dedup + queue)
 # instead of calling the synchronous compile driver directly. Sync and async

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -804,6 +804,14 @@ set(EJIT_ICACHE_SECTION ".mc_shared" CACHE STRING
   "Section for the EJIT inline-cache cell table; must be inter-core shared on a multi-core target")
 message(STATUS "EmbeddedJIT: inline-cache cell table section=${EJIT_ICACHE_SECTION}")
 
+# Optional experiment for one-dimensional cell/trp entries. Instead of one
+# indirect JIT callsite serving every instance, emit a direct conditional branch
+# tree with one indirect callsite per instance [0, 15]. This trades a larger AOT
+# dispatcher for a monomorphic indirect-branch PC per active instance.
+option(EJIT_ICACHE_SPLIT_DISPATCH_1D
+  "Split 1D cell/trp inline-cache dispatch into 16 instance-specific callsites" OFF)
+message(STATUS "EmbeddedJIT: split 1D cell/trp dispatch=${EJIT_ICACHE_SPLIT_DISPATCH_1D}")
+
 #===-- EmbeddedJIT SRE taskpool compile scheduler -------------------------===#
 # Route ejit_compile_or_get through a unified taskpool (cache + dedup + queue)
 # instead of calling the synchronous compile driver directly. Sync and async

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -92,7 +92,8 @@
         "EJIT_DUMP_ASM": "ON",
         "EJIT_STATS_ENABLE": "ON",
         "EJIT_ICACHE_DIM_SIZE": "16",
-        "EJIT_ICACHE_SPLIT_DISPATCH_1D": "ON"
+        "EJIT_ICACHE_SPLIT_DISPATCH_1D": "ON",
+        "EJIT_ICACHE_DIRECT_DISPATCH_PADS": "ON"
       }
     },
     {

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -91,7 +91,8 @@
         "EJIT_SRE_DIAG": "ON",
         "EJIT_DUMP_ASM": "ON",
         "EJIT_STATS_ENABLE": "ON",
-        "EJIT_ICACHE_DIM_SIZE": "16"
+        "EJIT_ICACHE_DIM_SIZE": "16",
+        "EJIT_ICACHE_SPLIT_DISPATCH_1D": "ON"
       }
     },
     {

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -75,6 +75,7 @@ constexpr const char *GV_EJIT_BITCODE = "__ejit_bitcode";
 // diagnostic. Keep these constants as the single source for the AOT side.
 constexpr const char *SECT_EJIT_BITCODE = ".ejit_bitcode";
 constexpr const char *SECT_EJIT_PERIOD = ".ejit_period";
+constexpr const char *SECT_EJIT_DIRECT_PADS = ".text.ejit_pads";
 constexpr const char *FN_AUTO_REGISTER = "ejit_auto_register";
 constexpr const char *CTORS_GLOBAL = "llvm.global_ctors";
 
@@ -96,6 +97,8 @@ constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 // ejit_icache_try call - so the hit path is one load + null-check + indirect
 // call. Signature: void ejit_register_icache_slot(const char *name, void *slot).
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
+constexpr const char *FN_REGISTER_ICACHE_PADS = "ejit_register_icache_pads";
+constexpr uint32_t kEJitIcacheDirectPadCount = 16;
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectPad.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectPad.h
@@ -35,7 +35,7 @@ inline bool ejitEncodeAArch64DirectBranch(uintptr_t Site, uintptr_t Target,
   if ((Site & 3u) != 0 || (Target & 3u) != 0 || Delta < MinDelta ||
       Delta > MaxDelta)
     return false;
-  const uint32_t Imm26 = static_cast<uint32_t>(Delta >> 2) & 0x03ffffffu;
+  const uint32_t Imm26 = static_cast<uint32_t>(Delta / 4) & 0x03ffffffu;
   Instruction = 0x14000000u | Imm26;
   return true;
 }

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectPad.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDirectPad.h
@@ -1,0 +1,59 @@
+//===-- EJitDirectPad.h - AArch64 direct-dispatch pad helpers -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITDIRECTPAD_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITDIRECTPAD_H
+
+#include <cstdint>
+
+namespace llvm {
+namespace ejit {
+
+/// Encode `b Target` at Site. AArch64 B carries a signed 26-bit word offset,
+/// hence the byte displacement must be aligned and lie in [-128MiB, 128MiB).
+inline bool ejitEncodeAArch64DirectBranch(uintptr_t Site, uintptr_t Target,
+                                          uint32_t &Instruction) {
+  constexpr int64_t MinDelta = -(int64_t{1} << 27);
+  constexpr int64_t MaxDelta = (int64_t{1} << 27) - 4;
+  int64_t Delta;
+  if (Target >= Site) {
+    const uintptr_t Distance = Target - Site;
+    if (Distance > static_cast<uintptr_t>(MaxDelta))
+      return false;
+    Delta = static_cast<int64_t>(Distance);
+  } else {
+    const uintptr_t Distance = Site - Target;
+    if (Distance > static_cast<uintptr_t>(-MinDelta))
+      return false;
+    Delta = -static_cast<int64_t>(Distance);
+  }
+  if ((Site & 3u) != 0 || (Target & 3u) != 0 || Delta < MinDelta ||
+      Delta > MaxDelta)
+    return false;
+  const uint32_t Imm26 = static_cast<uint32_t>(Delta >> 2) & 0x03ffffffu;
+  Instruction = 0x14000000u | Imm26;
+  return true;
+}
+
+/// A64 instruction bytes are little-endian even in an aarch64_be ELF. Convert
+/// the architectural instruction word to the value a native uint32_t store
+/// must use for the target's data endianness.
+inline uint32_t ejitAArch64InstructionStoreWord(uint32_t Instruction,
+                                                bool DataBigEndian) {
+  if (!DataBigEndian)
+    return Instruction;
+  return ((Instruction & 0x000000ffu) << 24) |
+         ((Instruction & 0x0000ff00u) << 8) |
+         ((Instruction & 0x00ff0000u) >> 8) |
+         ((Instruction & 0xff000000u) >> 24);
+}
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITDIRECTPAD_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
@@ -28,10 +28,11 @@ typedef enum {
   EJIT_REG_PERIOD_ARRAY = 1,
   EJIT_REG_STATIC_VAR = 2,
   EJIT_REG_SYMBOL = 3,
-  EJIT_REG_NONE = 4,      // sentinel (kept at 4 for table ABI stability)
-  EJIT_REG_LIFECYCLE = 5, // lifecycle dimType-slot fixup (additive)
-  EJIT_REG_FUNCINDEX = 6, // function dense-funcIndex fixup (additive)
-  EJIT_REG_ICACHE_SLOT = 7 // function inline-cache slot-pointer fixup (additive)
+  EJIT_REG_NONE = 4,        // sentinel (kept at 4 for table ABI stability)
+  EJIT_REG_LIFECYCLE = 5,   // lifecycle dimType-slot fixup (additive)
+  EJIT_REG_FUNCINDEX = 6,   // function dense-funcIndex fixup (additive)
+  EJIT_REG_ICACHE_SLOT = 7, // inline-cache slot-pointer fixup (additive)
+  EJIT_REG_ICACHE_PADS = 8  // direct-dispatch pad table (additive)
 } ejit_reg_type_t;
 
 typedef struct {
@@ -40,8 +41,10 @@ typedef struct {
       *name1; // funcName / periodName / varName / symbolName / lifecycleName
   const char *name2; // varName (period/static), NULL otherwise
   const void *ptr;   // bitcode data / baseAddr / symbol addr / &i32 slot /
-                     //   &ptr icache slot base (EJIT_REG_ICACHE_SLOT)
-  uint64_t size;     // bitcode size / array size / numDims (EJIT_REG_ICACHE_SLOT)
+                     //   &ptr icache slot base (EJIT_REG_ICACHE_SLOT) /
+                     //   direct-pad pointer table (EJIT_REG_ICACHE_PADS)
+  uint64_t size;     // bitcode size / array size / numDims (ICACHE_SLOT) /
+                     //   pad count (ICACHE_PADS)
                      //   / 0
 } ejit_reg_entry_t;
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -176,6 +176,13 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 void ejit_register_icache_slot(const char *funcName, void *slot,
                                uint32_t numDims);
 
+// Register an AOT direct-dispatch pad table. table points at padCount+1
+// pointers: pad entry addresses [0, padCount), followed by the shared miss
+// target. Unsupported platforms leave the pads targeting miss, so registration
+// is always fail-safe.
+void ejit_register_icache_pads(const char *funcName, const void *table,
+                               uint32_t padCount);
+
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index
 // only; there is no array-pointer dimension in the active state (a period name
 // with multiple arrays is activated as a whole for that instance).

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -227,6 +227,13 @@ enum class EJitIcacheRegResult { Ok, CapacityMiss, Invalid };
 EJitIcacheRegResult ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
                                            uint32_t numDims);
 
+// Register padCount direct-dispatch pad entry addresses followed by one miss
+// target pointer. Direct pads are only emitted for one-dimensional cell/trp
+// wrappers and currently have a fixed count of 16.
+EJitIcacheRegResult ejitIcacheRegisterPads(uint32_t funcIndex,
+                                           const void *table,
+                                           uint32_t padCount);
+
 /// Diagnostic: dump every registered icache slot to the diagnostic log.
 /// Shows funcIndex, base pointer, numDims, the per-slot cell capacity
 /// (16^numDims), and cell[0] (the scalar or [0]...[0] cell) so the caller
@@ -335,6 +342,11 @@ public:
   /// Per-core platform primitive: seal one 4KiB page at \p pageVA to RX in the
   /// CALLING core's translation context (enable_ex). Returns true on success.
   using SealPageCallback = bool (*)(void *ctx, uintptr_t pageVA);
+  /// Patch one AOT direct-dispatch pad to p target and publish the instruction
+  /// to every core. The callback must fail without modifying the pad when the
+  /// target is outside AArch64 B's range or the page cannot be made writable.
+  using IcachePadPatchCallback = bool (*)(void *ctx, void *pad,
+                                          const void *target);
 
   /// Worker loop entry (provided by this class, run on the injected task).
   using WorkerEntryFn = void (*)(void *ctx);
@@ -563,6 +575,10 @@ public:
   void setSealPageCallback(SealPageCallback fn, void *ctx) {
     sealPageFn_ = fn;
     sealPageCtx_ = ctx;
+  }
+  void setIcachePadPatchCallback(IcachePadPatchCallback fn, void *ctx) {
+    icachePadPatchFn_ = fn;
+    icachePadPatchCtx_ = ctx;
   }
   void setWorkerHooks(WorkerStartFn start, WorkerStopFn stop, void *ctx) {
     workerStart_ = start;
@@ -1110,6 +1126,8 @@ private:
   void *splitPoolCtx_ = nullptr;
   SealPageCallback sealPageFn_ = nullptr;
   void *sealPageCtx_ = nullptr;
+  IcachePadPatchCallback icachePadPatchFn_ = nullptr;
+  void *icachePadPatchCtx_ = nullptr;
   bool fourKSeal_ = false;
   WorkerStartFn workerStart_ = nullptr;
   WorkerStopFn workerStop_ = nullptr;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
@@ -52,6 +52,12 @@ bool ejitSreSplitPoolForCurrentCore(uintptr_t PoolBase, uint64_t PoolSize);
 /// success. A no-op returning false when the platform seal symbol is not built.
 bool ejitSreSealPageForCurrentCore(uintptr_t PageVA);
 
+/// Atomically replace the one-instruction AOT pad at p Pad with `b Target`,
+/// preserving W^X and synchronizing instruction caches. Returns false without
+/// modifying the pad when either address is invalid/out of range or the pad
+/// section cannot be made writable.
+bool ejitSrePatchDirectBranch(void *Pad, const void *Target);
+
 } // namespace ejit
 } // namespace llvm
 

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -170,6 +170,11 @@ if(EJIT_SRE_SHARED_TASKPOOL)
   target_compile_definitions(LLVMEJIT PRIVATE EJIT_ICACHE_FUNC_SLOTS=${EJIT_ICACHE_FUNC_SLOTS})
 endif()
 
+if(EJIT_ICACHE_DIRECT_DISPATCH_PADS)
+  target_compile_definitions(LLVMEJIT PRIVATE
+    EJIT_ICACHE_DIRECT_DISPATCH_PADS=1)
+endif()
+
 # EJIT_FREESTANDING must be visible in LLVMJITLink headers so that
 # std::promise / std::future usage is guarded (bare-metal has no <future>).
 if(EJIT_FREESTANDING)

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -247,6 +247,36 @@ EJit::EJit(const Config &config) : config_(config) {
           }
           break;
         }
+        case EJIT_REG_ICACHE_PADS: {
+          if (!e->name1 || !e->ptr) {
+            recordInitError(EJIT_ERR_INVALID_PARAM,
+                            "icache pad registration has a null table",
+                            e->name1 ? e->name1 : "");
+            break;
+          }
+          uint32_t idx = EJitFuncRegistry::instance().resolveAssign(e->name1);
+          if (idx == kEJitInvalidFuncIndex) {
+            recordInitError(EJIT_ERR_CACHE_FULL,
+                            "funcIndex capacity exhausted for icache pads",
+                            e->name1);
+            break;
+          }
+          switch (ejitIcacheRegisterPads(idx, e->ptr,
+                                         static_cast<uint32_t>(e->size))) {
+          case EJitIcacheRegResult::Ok:
+            break;
+          case EJitIcacheRegResult::CapacityMiss:
+            EJIT_DIAG("register_icache_pads name=%s: idx=%u exceeds pad "
+                      "capacity %u; pads remain on miss",
+                      e->name1, idx, EJIT_ICACHE_FUNC_SLOTS);
+            break;
+          case EJitIcacheRegResult::Invalid:
+            recordInitError(EJIT_ERR_INVALID_PARAM,
+                            "invalid icache direct-pad table", e->name1);
+            break;
+          }
+          break;
+        }
         default:
           break;
         }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -120,6 +120,17 @@ bool taskpoolCompileThunk(void *ctx, const EJitCompileRequest &req,
   return false;
 #endif
 }
+
+[[maybe_unused]] bool sharedPatchDirectPadThunk(void * /*ctx*/, void *pad,
+                                                const void *target) {
+#ifdef EJIT_SRE_CODE_POOL
+  return ejitSrePatchDirectBranch(pad, target);
+#else
+  (void)pad;
+  (void)target;
+  return false;
+#endif
+}
 #endif
 } // namespace
 #endif
@@ -196,6 +207,9 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
   // Mirror the owner-core code-pool stats into the shared state so every core's
   // ejit_print_code_pool_stats is consistent (the pools are owner-private).
   sharedPool_.setCodePoolStatsProvider(&sharedCodePoolStatsThunk, this);
+#ifdef EJIT_ICACHE_DIRECT_DISPATCH_PADS
+  sharedPool_.setIcachePadPatchCallback(&sharedPatchDirectPadThunk, this);
+#endif
 #endif
 #ifdef EJIT_SRE_SHARED_CODE_POINTERS
   sharedPool_.setCodeSharingEnabled(true);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -511,6 +511,37 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
   }
 }
 
+void ejit_register_icache_pads(const char *funcName, const void *table,
+                               uint32_t padCount) {
+  if (!funcName || !table) {
+    EJIT_DIAG("register_icache_pads reject: name=%p table=%p",
+              (const void *)funcName, table);
+    return;
+  }
+  uint32_t idx = EJitFuncRegistry::instance().resolveAssign(funcName);
+  if (idx == kEJitInvalidFuncIndex) {
+    EJitRegistrationStore::instance().recordError(
+        EJIT_ERR_CACHE_FULL, "funcIndex capacity exhausted for icache pads",
+        funcName);
+    return;
+  }
+  switch (ejitIcacheRegisterPads(idx, table, padCount)) {
+  case EJitIcacheRegResult::Ok:
+    EJIT_DIAG_VERBOSE("register_icache_pads OK name=%s idx=%u count=%u",
+                      funcName, idx, padCount);
+    break;
+  case EJitIcacheRegResult::CapacityMiss:
+    EJIT_DIAG("register_icache_pads name=%s: idx=%u exceeds pad capacity %u; "
+              "pads remain on miss",
+              funcName, idx, EJIT_ICACHE_FUNC_SLOTS);
+    break;
+  case EJitIcacheRegResult::Invalid:
+    EJitRegistrationStore::instance().recordError(
+        EJIT_ERR_INVALID_PARAM, "invalid icache direct-pad table", funcName);
+    break;
+  }
+}
+
 ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx) {
   if (!gEJIT) {
     EJIT_DIAG("activate(%s,%u) failed: not initialized", periodName, cellIdx);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -17,11 +17,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
-#include <atomic>
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
-#include "llvm/ExecutionEngine/EJIT/EJitStats.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
+#include "llvm/ExecutionEngine/EJIT/EJitStats.h"
+#include <atomic>
 
 // Compile-time guard: if EJIT_ICACHE_FUNC_SLOTS ever falls below
 // EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX (defined in EJitSharedTaskPoolState.h,
@@ -177,6 +178,23 @@ struct EJitIcacheSlotReg {
 };
 EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
 
+// Optional direct-dispatch companions for one-dimensional cell/trp slots.
+// table[0..count) are AOT pad entry addresses; table[count] is the common miss
+// target each pad contains at link time and is restored to on every drain.
+struct EJitIcachePadReg {
+  const uintptr_t *table;
+  uint32_t count;
+};
+EJitIcachePadReg gIcachePads[EJIT_ICACHE_FUNC_SLOTS];
+
+inline void *icachePad(const EJitIcachePadReg &reg, uintptr_t idx) {
+  return reinterpret_cast<void *>(reg.table[idx]);
+}
+
+inline const void *icachePadMiss(const EJitIcachePadReg &reg) {
+  return reinterpret_cast<const void *>(reg.table[reg.count]);
+}
+
 // A cell viewed as the atomic it is: EJitAtomic<uintptr_t> is a standard-layout
 // wrapper over exactly one pointer-sized word, so this overlay on the AOT array
 // is layout-identical and only changes which builtin performs the access.
@@ -246,6 +264,18 @@ EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex,
   return EJitIcacheRegResult::Ok;
 }
 
+EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterPads(uint32_t funcIndex,
+                                                       const void *table,
+                                                       uint32_t padCount) {
+  if (!table || padCount != kEJitIcacheDirectPadCount)
+    return EJitIcacheRegResult::Invalid;
+  if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
+    return EJitIcacheRegResult::CapacityMiss;
+  gIcachePads[funcIndex].table = static_cast<const uintptr_t *>(table);
+  gIcachePads[funcIndex].count = padCount;
+  return EJitIcacheRegResult::Ok;
+}
+
 void llvm::ejit::ejitIcacheClearAll() {
   // Unregister every slot: nulling base makes all probes miss (icacheTry/icacheFill
   // see no base and bail), which is the "empty" state. We do NOT dereference the
@@ -257,6 +287,8 @@ void llvm::ejit::ejitIcacheClearAll() {
   for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
     gIcacheSlots[f].base = nullptr;
     gIcacheSlots[f].numDims = 0;
+    gIcachePads[f].table = nullptr;
+    gIcachePads[f].count = 0;
   }
 }
 
@@ -348,10 +380,19 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
     ++walkedSlots;
 #endif
     for (uintptr_t c = 0; c < cells; ++c) {
+      const uintptr_t oldFn = icacheCell(reg.base, c).loadRelaxed();
 #ifdef EJIT_DIAG_ENABLE
-      if (icacheCell(reg.base, c).loadRelaxed() != 0)
+      if (oldFn != 0)
         ++clearedCells;
 #endif
+      const EJitIcachePadReg &pads = gIcachePads[f];
+      if (oldFn != 0 && pads.table && c < pads.count && icachePadPatchFn_ &&
+          icacheCrossCoreExecutable()) {
+        if (!icachePadPatchFn_(icachePadPatchCtx_, icachePad(pads, c),
+                               icachePadMiss(pads)))
+          EJIT_DIAG("icacheDrain pad restore FAIL: func=%u idx=%llu pad=%p", f,
+                    static_cast<unsigned long long>(c), icachePad(pads, c));
+      }
       icacheCell(reg.base, c).storeRelaxed(0);
     }
   }
@@ -720,6 +761,12 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   const uintptr_t idx = icacheLinearize(dims, numDims);
   EJitAtomicUPtr &cell = icacheCell(reg.base, idx);
   cell.storeRelaxed(reinterpret_cast<uintptr_t>(fnPtr));
+  const EJitIcachePadReg &pads = gIcachePads[funcIndex];
+  bool padPublished = false;
+  if (numDims == 1 && pads.table && idx < pads.count && icachePadPatchFn_ &&
+      icacheCrossCoreExecutable())
+    padPublished =
+        icachePadPatchFn_(icachePadPatchCtx_, icachePad(pads, idx), fnPtr);
 
   // Re-validate AFTER the store and retract on conflict. The checks above only
   // PRECEDE the store: a drain can begin after they pass, zero this cell, and
@@ -730,6 +777,12 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   // fill (disjointness), and a null cell is always safe.
   if (state_->icacheDrainsInFlight.loadAcquire() != 0 ||
       static_cast<uint32_t>(token) != state_->icacheDrainSeq.loadAcquire()) {
+    if (padPublished &&
+        !icachePadPatchFn_(icachePadPatchCtx_, icachePad(pads, idx),
+                           icachePadMiss(pads)))
+      EJIT_DIAG("icacheFill pad retract FAIL: func=%u idx=%llu pad=%p",
+                funcIndex, static_cast<unsigned long long>(idx),
+                icachePad(pads, idx));
     cell.storeRelaxed(0);
     if (!gIcacheFillRejectLogged[kFillRejectRetracted]) {
       gIcacheFillRejectLogged[kFillRejectRetracted] = true;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -182,17 +182,28 @@ EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
 // table[0..count) are AOT pad entry addresses; table[count] is the common miss
 // target each pad contains at link time and is restored to on every drain.
 struct EJitIcachePadReg {
-  const uintptr_t *table;
+  const void *table;
   uint32_t count;
 };
 EJitIcachePadReg gIcachePads[EJIT_ICACHE_FUNC_SLOTS];
 
+inline uintptr_t icachePadWord(const EJitIcachePadReg &reg, uintptr_t idx) {
+  uintptr_t word;
+  const auto *entry = static_cast<const unsigned char *>(reg.table) +
+                      idx * sizeof(uintptr_t);
+  // The AOT object is an LLVM pointer array, not a C++ uintptr_t array. A
+  // fixed-size builtin copy preserves the representation without type-punning
+  // and lowers to one native pointer load on the supported targets.
+  __builtin_memcpy(&word, entry, sizeof(word));
+  return word;
+}
+
 inline void *icachePad(const EJitIcachePadReg &reg, uintptr_t idx) {
-  return reinterpret_cast<void *>(reg.table[idx]);
+  return reinterpret_cast<void *>(icachePadWord(reg, idx));
 }
 
 inline const void *icachePadMiss(const EJitIcachePadReg &reg) {
-  return reinterpret_cast<const void *>(reg.table[reg.count]);
+  return reinterpret_cast<const void *>(icachePadWord(reg, reg.count));
 }
 
 // A cell viewed as the atomic it is: EJitAtomic<uintptr_t> is a standard-layout
@@ -271,7 +282,7 @@ EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterPads(uint32_t funcIndex,
     return EJitIcacheRegResult::Invalid;
   if (funcIndex >= EJIT_ICACHE_FUNC_SLOTS)
     return EJitIcacheRegResult::CapacityMiss;
-  gIcachePads[funcIndex].table = static_cast<const uintptr_t *>(table);
+  gIcachePads[funcIndex].table = table;
   gIcachePads[funcIndex].count = padCount;
   return EJitIcacheRegResult::Ok;
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -26,6 +26,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDirectPad.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h" // seal/split granule contract
 
 #include <cstdint>
@@ -127,6 +128,13 @@ extern const unsigned char __ejit_code_end[] __attribute__((weak));
 extern const unsigned char __ejit_code_start[];
 extern const unsigned char __ejit_code_end[];
 #endif
+}
+#endif
+
+#if defined(EJIT_ICACHE_DIRECT_DISPATCH_PADS)
+extern "C" {
+extern const unsigned char __ejit_pads_start[];
+extern const unsigned char __ejit_pads_end[];
 }
 #endif
 
@@ -386,6 +394,55 @@ bool llvm::ejit::ejitSreSealPageForCurrentCore(uintptr_t PageVA) {
   EJIT_DIAG("sealPageForCurrentCore unsupported config: pageVA=0x%llx",
             static_cast<unsigned long long>(PageVA));
   (void)PageVA;
+  return false;
+#endif
+}
+
+bool llvm::ejit::ejitSrePatchDirectBranch(void *Pad, const void *Target) {
+#if defined(EJIT_FIXED_CODE_POOL) && defined(EJIT_ICACHE_DIRECT_DISPATCH_PADS)
+  if (!Pad || !Target)
+    return false;
+  const uintptr_t Site = reinterpret_cast<uintptr_t>(Pad);
+  const uintptr_t Dest = reinterpret_cast<uintptr_t>(Target);
+  const uintptr_t PadsBegin = reinterpret_cast<uintptr_t>(__ejit_pads_start);
+  const uintptr_t PadsEnd = reinterpret_cast<uintptr_t>(__ejit_pads_end);
+  if (Site < PadsBegin || Site + sizeof(uint32_t) > PadsEnd)
+    return false;
+
+  uint32_t Instruction;
+  if (!ejitEncodeAArch64DirectBranch(Site, Dest, Instruction)) {
+    EJIT_DIAG("patchDirectBranch range FAIL: pad=%p target=%p delta=%lld", Pad,
+              Target, static_cast<long long>(Dest - Site));
+    return false;
+  }
+
+  const uintptr_t Page = Site & ~static_cast<uintptr_t>(k4KiB - 1);
+  const uint32_t OldWord =
+      __atomic_load_n(static_cast<uint32_t *>(Pad), __ATOMIC_RELAXED);
+  if (ejit_sre_enable_rw(1, static_cast<unsigned long long>(Page)) != 0) {
+    EJIT_DIAG("patchDirectBranch enable_rw FAIL: pad=%p page=0x%llx", Pad,
+              static_cast<unsigned long long>(Page));
+    return false;
+  }
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  constexpr bool DataBigEndian = true;
+#else
+  constexpr bool DataBigEndian = false;
+#endif
+  const uint32_t StoreWord =
+      ejitAArch64InstructionStoreWord(Instruction, DataBigEndian);
+  __atomic_store_n(static_cast<uint32_t *>(Pad), StoreWord, __ATOMIC_RELEASE);
+  if (sealAndSyncCache(Page, k4KiB) != 0) {
+    EJIT_DIAG("patchDirectBranch enable_ex FAIL: pad=%p page=0x%llx", Pad,
+              static_cast<unsigned long long>(Page));
+    __atomic_store_n(static_cast<uint32_t *>(Pad), OldWord, __ATOMIC_RELEASE);
+    (void)sealAndSyncCache(Page, k4KiB);
+    return false;
+  }
+  return true;
+#else
+  (void)Pad;
+  (void)Target;
   return false;
 #endif
 }

--- a/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
+++ b/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
@@ -108,6 +108,19 @@ SECTIONS
    * AOT code. REQUIRES the platform to supply enable_rw (symmetric to
    * enable_ex); a missing enable_rw is a hard link error.
    */
+  /* --- EmbeddedJIT patchable direct-dispatch pads ---
+   * Keep these instructions on dedicated 4KiB pages: runtime publication flips
+   * a pad page RX->RW->RX, so sharing it with ordinary AOT text would create an
+   * avoidable execute-permission window. The strong bounds also make a missing
+   * product-linker integration fail at link time when direct pads are enabled. */
+  .text.ejit_pads : ALIGN(4096)
+  {
+    __ejit_pads_start = .;
+    KEEP(*(.text.ejit_pads))
+    . = ALIGN(4096);
+    __ejit_pads_end = .;
+  } > CODE
+
   /* --- EmbeddedJIT frame-less dispatcher clustering ---
    * Tiny (~16-48 bytes each) icache dispatchers grouped together so they share
    * cache lines (spatial locality across ejit_entry switches) and reduce iTLB
@@ -159,6 +172,17 @@ SECTIONS
  *
  * EJIT_FIXED_CODE_POOL also needs a fixed-region INSERT fragment at the FINAL
  * executable link (not merely at an intermediate `clang -r` link):
+ *
+ *   SECTIONS
+ *   {
+ *     .text.ejit_pads : ALIGN(4096)
+ *     {
+ *       __ejit_pads_start = .;
+ *       KEEP(*(.text.ejit_pads))
+ *       . = ALIGN(4096);
+ *       __ejit_pads_end = .;
+ *     }
+ *   } INSERT AFTER .text;
  *
  *   SECTIONS
  *   {

--- a/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
+++ b/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
@@ -32,3 +32,8 @@ if(EJIT_ICACHE_SPLIT_DISPATCH_1D)
   target_compile_definitions(LLVMEmbeddedJIT PRIVATE
     EJIT_ICACHE_SPLIT_DISPATCH_1D=1)
 endif()
+
+if(EJIT_ICACHE_DIRECT_DISPATCH_PADS)
+  target_compile_definitions(LLVMEmbeddedJIT PRIVATE
+    EJIT_ICACHE_DIRECT_DISPATCH_PADS=1)
+endif()

--- a/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
+++ b/llvm/lib/Transforms/EmbeddedJIT/CMakeLists.txt
@@ -27,3 +27,8 @@ add_llvm_component_library(LLVMEmbeddedJIT
 target_compile_definitions(LLVMEmbeddedJIT PRIVATE
   EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE}
   EJIT_ICACHE_SECTION="${EJIT_ICACHE_SECTION}")
+
+if(EJIT_ICACHE_SPLIT_DISPATCH_1D)
+  target_compile_definitions(LLVMEmbeddedJIT PRIVATE
+    EJIT_ICACHE_SPLIT_DISPATCH_1D=1)
+endif()

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -97,6 +97,15 @@ static cl::opt<bool> EJitIcacheSplitDispatch1D(
     cl::desc("Split eligible one-dimensional cell/trp inline-cache dispatch "
              "into 16 instance-specific indirect callsites"));
 
+#ifndef EJIT_ICACHE_DIRECT_DISPATCH_PADS
+#define EJIT_ICACHE_DIRECT_DISPATCH_PADS 0
+#endif
+static cl::opt<bool> EJitIcacheDirectDispatchPads(
+    "ejit-icache-direct-dispatch-pads",
+    cl::init(EJIT_ICACHE_DIRECT_DISPATCH_PADS != 0), cl::Hidden,
+    cl::desc("Tail-branch split 1D cell/trp leaves through patchable AOT "
+             "direct-branch pads"));
+
 // Section for the per-function @__ejit_icache_fn_<name> cell table. In the
 // inter-core SHARED section (.mc_shared, where the taskpool state blob also
 // lives) the table is ONE object every core reads, so a deactivate zeroes a
@@ -481,6 +490,63 @@ emitIcacheSlotRegistration(Module &M,
   appendToUsed(M, {GV});
 }
 
+static void emitIcachePadRegistration(
+    Module &M, const std::map<std::string, GlobalVariable *> &Tables) {
+  if (Tables.empty() || M.getGlobalVariable(".ejit.registry.icache_pads"))
+    return;
+  LLVMContext &Ctx = M.getContext();
+  auto *PtrTy = PointerType::getUnqual(Ctx);
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+  M.getOrInsertFunction(
+      FN_REGISTER_ICACHE_PADS,
+      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy, I32Ty}, false));
+
+  Function *AutoReg = M.getFunction(FN_AUTO_REGISTER);
+  if (!AutoReg) {
+    auto *AutoRegTy = FunctionType::get(Type::getVoidTy(Ctx), false);
+    AutoReg = Function::Create(AutoRegTy, GlobalValue::InternalLinkage,
+                               FN_AUTO_REGISTER, &M);
+    BasicBlock::Create(Ctx, "entry", AutoReg);
+    ReturnInst::Create(Ctx, &AutoReg->getEntryBlock());
+    if (EnableEJitGlobalCtors)
+      appendToGlobalCtors(M, AutoReg, EJIT_CTOR_PRIORITY);
+  }
+  Instruction *Ret = AutoReg->getEntryBlock().getTerminator();
+  FunctionCallee Register = M.getFunction(FN_REGISTER_ICACHE_PADS);
+  for (auto &KV : Tables) {
+    IRBuilder<> Builder(Ret);
+    Value *Name = Builder.CreateGlobalString(KV.first);
+    Builder.CreateCall(Register,
+                       {Name, Builder.CreateBitCast(KV.second, PtrTy),
+                        ConstantInt::get(I32Ty, kEJitIcacheDirectPadCount)});
+  }
+
+  StructType *EntryTy = StructType::get(
+      Ctx, {I32Ty, PtrTy, PtrTy, PtrTy, I64Ty}, /*isPacked=*/false);
+  auto makeStrGV = [&](const std::string &S) -> Constant * {
+    Constant *Str = ConstantDataArray::getString(Ctx, S, true);
+    auto *GV =
+        new GlobalVariable(M, Str->getType(), true, GlobalValue::PrivateLinkage,
+                           Str, ".ejit.str.");
+    return ConstantExpr::getBitCast(GV, PtrTy);
+  };
+  SmallVector<Constant *, 16> Entries;
+  for (auto &KV : Tables)
+    Entries.push_back(ConstantStruct::get(
+        EntryTy, {ConstantInt::get(I32Ty, EJIT_REG_ICACHE_PADS),
+                  makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
+                  ConstantExpr::getBitCast(KV.second, PtrTy),
+                  ConstantInt::get(I64Ty, kEJitIcacheDirectPadCount)}));
+  ArrayType *ArrayTy = ArrayType::get(EntryTy, Entries.size());
+  auto *GV = new GlobalVariable(
+      M, ArrayTy, /*isConstant=*/true, GlobalValue::PrivateLinkage,
+      ConstantArray::get(ArrayTy, Entries), ".ejit.registry.icache_pads");
+  GV->setSection(SECT_EJIT_PERIOD);
+  GV->setAlignment(M.getDataLayout().getABITypeAlign(EntryTy));
+  appendToUsed(M, {GV});
+}
+
 } // anonymous namespace
 
 PreservedAnalyses EJitWrapperGenPass::run(Module &M,
@@ -612,6 +678,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
   LLVM_DEBUG(dbgs() << "ejit-wrapper-gen: " << EntryFuncs.size()
                     << " entry function(s)\n");
+  std::map<std::string, GlobalVariable *> DirectPadTables;
   bool Changed = false;
   for (Function *F : EntryFuncs) {
     LLVM_DEBUG(dbgs() << "ejit-wrapper-gen: wrapping " << F->getName() << "\n");
@@ -713,6 +780,11 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
           FN_TASKPOOL_TRACE_WRAPPER,
           FunctionType::get(Type::getVoidTy(Ctx), TraceTys, false));
     }
+
+    auto applyEntryCallABI = [&](CallInst *CI) {
+      CI->setCallingConv(F->getCallingConv());
+      CI->setAttributes(F->getAttributes());
+    };
 
     // emitSlowPath: emit the funcIndex guard (EntryBB) + compile_or_get
     // (CallBB) + dispatch (DispatchBB) into Fn, using Fn's args. FallbackBB
@@ -819,13 +891,15 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         }
       };
       if (F->getReturnType()->isVoidTy()) {
-        B.CreateCall(F->getFunctionType(), OutFn, Args);
+        CallInst *CI = B.CreateCall(F->getFunctionType(), OutFn, Args);
+        applyEntryCallABI(CI);
         releaseAndTrace();
         B.CreateRetVoid();
       } else {
-        Value *RetVal = B.CreateCall(F->getFunctionType(), OutFn, Args);
+        CallInst *CI = B.CreateCall(F->getFunctionType(), OutFn, Args);
+        applyEntryCallABI(CI);
         releaseAndTrace();
-        B.CreateRet(RetVal);
+        B.CreateRet(CI);
       }
     };
 
@@ -915,6 +989,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         // Timing inserts calls between the indirect call and return, so only
         // the uninstrumented path may use musttail.
         CallInst *CI = DB.CreateCall(F->getFunctionType(), FnPtr, ICArgs);
+        applyEntryCallABI(CI);
         if (!EJitWrapperTiming)
           CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
         if (EJitWrapperTiming) {
@@ -937,13 +1012,16 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       const bool UseSplitDispatch = EJitIcacheSplitDispatch1D &&
                                     IsSplitLifecycle &&
                                     EJIT_ICACHE_DIM_SIZE >= 16;
+      const bool UseDirectPads = UseSplitDispatch &&
+                                 EJitIcacheDirectDispatchPads &&
+                                 !EJitWrapperTiming;
       BasicBlock *JitIcacheDispatch = nullptr;
       if (!UseSplitDispatch)
         JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
       auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
 
       if (UseSplitDispatch) {
-        constexpr unsigned SplitInstances = 16;
+        constexpr unsigned SplitInstances = kEJitIcacheDirectPadCount;
         Value *ArgVal = F->getArg(PeriodInds[0].ArgIndex);
         unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
         Value *Instance = ArgVal;
@@ -952,16 +1030,67 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         else if (BW < 32)
           Instance = B.CreateZExt(ArgVal, I32Ty, "ejit_split_instance");
 
+        SmallVector<Function *, SplitInstances> PadFunctions;
+        if (UseDirectPads) {
+          SmallVector<Constant *, SplitInstances + 1> PadTable;
+          for (unsigned I = 0; I < SplitInstances; ++I) {
+            Function *Pad = Function::Create(
+                F->getFunctionType(), GlobalValue::InternalLinkage,
+                "__ejit_icache_pad_" + F->getName() + "_" + Twine(I), &M);
+            Pad->setCallingConv(F->getCallingConv());
+            Pad->setAttributes(F->getAttributes());
+            Pad->addFnAttr(Attribute::NoInline);
+            Pad->setSection(SECT_EJIT_DIRECT_PADS);
+            Pad->setAlignment(Align(4));
+            BasicBlock *Entry = BasicBlock::Create(Ctx, "entry", Pad);
+            IRBuilder<> PB(Entry);
+            SmallVector<Value *, 8> Args;
+            for (Argument &A : Pad->args())
+              Args.push_back(&A);
+            CallInst *CI =
+                PB.CreateCall(MissFn->getFunctionType(), MissFn, Args);
+            applyEntryCallABI(CI);
+            CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+            if (F->getReturnType()->isVoidTy())
+              PB.CreateRetVoid();
+            else
+              PB.CreateRet(CI);
+            PadFunctions.push_back(Pad);
+            PadTable.push_back(ConstantExpr::getBitCast(Pad, PtrTy));
+          }
+          PadTable.push_back(ConstantExpr::getBitCast(MissFn, PtrTy));
+          ArrayType *TableTy = ArrayType::get(PtrTy, PadTable.size());
+          auto *Table = new GlobalVariable(
+              M, TableTy, /*isConstant=*/true, GlobalValue::PrivateLinkage,
+              ConstantArray::get(TableTy, PadTable),
+              "__ejit_icache_pad_table_" + F->getName());
+          Table->setAlignment(Align(8));
+          DirectPadTables.emplace(F->getName().str(), Table);
+        }
+
+        SmallVector<BasicBlock *, SplitInstances> LeafBlocks;
         SmallVector<BasicBlock *, SplitInstances> ProbeBlocks;
         SmallVector<BasicBlock *, SplitInstances> DispatchBlocks;
         for (unsigned I = 0; I < SplitInstances; ++I) {
-          ProbeBlocks.push_back(
-              BasicBlock::Create(Ctx, "jit_icache_probe_" + Twine(I), F));
-          DispatchBlocks.push_back(
-              BasicBlock::Create(Ctx, "jit_icache_dispatch_" + Twine(I), F));
+          if (UseDirectPads) {
+            DispatchBlocks.push_back(
+                BasicBlock::Create(Ctx, "jit_icache_dispatch_" + Twine(I), F));
+            LeafBlocks.push_back(DispatchBlocks.back());
+          } else {
+            ProbeBlocks.push_back(
+                BasicBlock::Create(Ctx, "jit_icache_probe_" + Twine(I), F));
+            DispatchBlocks.push_back(
+                BasicBlock::Create(Ctx, "jit_icache_dispatch_" + Twine(I), F));
+            LeafBlocks.push_back(ProbeBlocks.back());
+          }
         }
 
         for (unsigned I = 0; I < SplitInstances; ++I) {
+          if (UseDirectPads) {
+            IRBuilder<> DB(DispatchBlocks[I]);
+            emitIcacheDispatch(DB, PadFunctions[I], nullptr);
+            continue;
+          }
           IRBuilder<> PB(ProbeBlocks[I]);
           Value *SlotPtr = PB.CreateInBoundsGEP(
               IcacheSlot->getValueType(), IcacheSlot,
@@ -986,7 +1115,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         auto BuildTree = [&](auto &&Self, unsigned Lo,
                              unsigned Hi) -> BasicBlock * {
           if (Hi - Lo == 1)
-            return ProbeBlocks[Lo];
+            return LeafBlocks[Lo];
           unsigned Mid = Lo + (Hi - Lo) / 2;
           BasicBlock *Left = Self(Self, Lo, Mid);
           BasicBlock *Right = Self(Self, Mid, Hi);
@@ -1043,10 +1172,12 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       for (auto &A : F->args()) MissArgs.push_back(&A);
       if (F->getReturnType()->isVoidTy()) {
         CallInst *CI = B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+        applyEntryCallABI(CI);
         CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
         B.CreateRetVoid();
       } else {
         CallInst *CI = B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+        applyEntryCallABI(CI);
         CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
         B.CreateRet(CI);
       }
@@ -1075,6 +1206,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
     Changed = true;
   }
+
+  emitIcachePadRegistration(M, DirectPadTables);
 
   return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -88,6 +88,15 @@ static cl::opt<bool> EJitInlineCache(
              "cached specialization pointer) before the taskpool "
              "compile_or_get call in ejit_entry wrappers"));
 
+#ifndef EJIT_ICACHE_SPLIT_DISPATCH_1D
+#define EJIT_ICACHE_SPLIT_DISPATCH_1D 0
+#endif
+static cl::opt<bool> EJitIcacheSplitDispatch1D(
+    "ejit-icache-split-dispatch-1d",
+    cl::init(EJIT_ICACHE_SPLIT_DISPATCH_1D != 0), cl::Hidden,
+    cl::desc("Split eligible one-dimensional cell/trp inline-cache dispatch "
+             "into 16 instance-specific indirect callsites"));
+
 // Section for the per-function @__ejit_icache_fn_<name> cell table. In the
 // inter-core SHARED section (.mc_shared, where the taskpool state blob also
 // lives) the table is ONE object every core reads, so a deactivate zeroes a
@@ -888,8 +897,6 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       // Wrapper (F): frame-less probe + tail calls.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
-      auto *JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
-      auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
       IRBuilder<> B(JitEntry);
       Value *TBeforeIcache = nullptr, *FuncIdxForTiming = nullptr;
       if (EJitWrapperTiming) {
@@ -900,69 +907,134 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       }
       GlobalVariable *IcacheSlot = IcacheIt->second.GV;
       unsigned NumDims = IcacheIt->second.NumDims;
-      Value *SlotPtr = IcacheSlot;
-      if (NumDims > 0) {
-        SmallVector<Value *, 5> Indices;
-        Indices.push_back(ConstantInt::get(I32Ty, 0));
-        for (unsigned I = 0; I < NumDims; ++I) {
-          Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
-          unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
-          Value *Idx = ArgVal;
-          if (BW > 32) Idx = B.CreateTrunc(ArgVal, I32Ty);
-          else if (BW < 32) Idx = B.CreateZExt(ArgVal, I32Ty);
-          Indices.push_back(Idx);
-        }
-        SlotPtr = B.CreateInBoundsGEP(IcacheSlot->getValueType(), IcacheSlot,
-                                      Indices, "ejit_ic_slot");
-      }
-      LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
-      ICSlotLoad->setAlignment(Align(8));
-      // Monotonic, nothing stronger: the cell is shared, so a peer's drain can
-      // store 0 concurrently and the atomic makes that a defined race (old
-      // pointer or 0) instead of UB. The value is self-contained and the call
-      // below carries a data dependency on it, so acquire would buy nothing and
-      // cost an LDAR per hit. Lowers to the same LDR on AArch64.
-      ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
-      Value *TAfterIcache = nullptr;
-      if (EJitWrapperTiming)
-        TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
-      Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
-      IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
-                               {IHit, ConstantInt::getTrue(Ctx)});
-      B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
-
-      // Hit: tail-call the cached specialization directly (no release_read).
-      // With -ejit-wrapper-timing the wrapper is NOT frame-less (JitEntry emits
-      // bl @ejit_taskpool_trace_now), so the hit path cannot be a musttail tail
-      // call: emitHitTiming() inserts calls BETWEEN the call and the ret, which
-      // would violate the musttail rule ("musttail call must precede a ret") and
-      // yield broken IR -> codegen silently drops the function -> boot
-      // translation fault. Use a plain (framed) call + trace + ret instead; the
-      // frame-less musttail fast path is reserved for the no-timing case.
-      B.SetInsertPoint(JitIcacheDispatch);
       SmallVector<Value *, 8> ICArgs;
       for (auto &A : F->args()) ICArgs.push_back(&A);
-      auto emitHitTiming = [&]() {
-        if (!EJitWrapperTiming) return;
-        Value *TAfterFn = B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
-        B.CreateCall(TraceWrapper,
-                     {FuncIdxForTiming,
-                      ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
-                      ICSlotLoad, ConstantInt::get(I32Ty, 0), TBeforeIcache,
-                      TAfterIcache, TAfterFn, TAfterFn});
+      auto emitIcacheDispatch = [&](IRBuilder<> &DB, Value *FnPtr,
+                                    Value *TAfterIcache) {
+        // Hit: tail-call the cached specialization directly (no release_read).
+        // Timing inserts calls between the indirect call and return, so only
+        // the uninstrumented path may use musttail.
+        CallInst *CI = DB.CreateCall(F->getFunctionType(), FnPtr, ICArgs);
+        if (!EJitWrapperTiming)
+          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        if (EJitWrapperTiming) {
+          Value *TAfterFn = DB.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+          DB.CreateCall(TraceWrapper,
+                        {FuncIdxForTiming,
+                         ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
+                         FnPtr, ConstantInt::get(I32Ty, 0), TBeforeIcache,
+                         TAfterIcache, TAfterFn, TAfterFn});
+        }
+        if (F->getReturnType()->isVoidTy())
+          DB.CreateRetVoid();
+        else
+          DB.CreateRet(CI);
       };
-      if (F->getReturnType()->isVoidTy()) {
-        CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        emitHitTiming();
-        B.CreateRetVoid();
+
+      const bool IsSplitLifecycle =
+          NumDims == 1 && (PeriodInds[0].PeriodName == "cell" ||
+                           PeriodInds[0].PeriodName == "trp");
+      const bool UseSplitDispatch = EJitIcacheSplitDispatch1D &&
+                                    IsSplitLifecycle &&
+                                    EJIT_ICACHE_DIM_SIZE >= 16;
+      BasicBlock *JitIcacheDispatch = nullptr;
+      if (!UseSplitDispatch)
+        JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
+      auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
+
+      if (UseSplitDispatch) {
+        constexpr unsigned SplitInstances = 16;
+        Value *ArgVal = F->getArg(PeriodInds[0].ArgIndex);
+        unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
+        Value *Instance = ArgVal;
+        if (BW > 32)
+          Instance = B.CreateTrunc(ArgVal, I32Ty, "ejit_split_instance");
+        else if (BW < 32)
+          Instance = B.CreateZExt(ArgVal, I32Ty, "ejit_split_instance");
+
+        SmallVector<BasicBlock *, SplitInstances> ProbeBlocks;
+        SmallVector<BasicBlock *, SplitInstances> DispatchBlocks;
+        for (unsigned I = 0; I < SplitInstances; ++I) {
+          ProbeBlocks.push_back(
+              BasicBlock::Create(Ctx, "jit_icache_probe_" + Twine(I), F));
+          DispatchBlocks.push_back(
+              BasicBlock::Create(Ctx, "jit_icache_dispatch_" + Twine(I), F));
+        }
+
+        for (unsigned I = 0; I < SplitInstances; ++I) {
+          IRBuilder<> PB(ProbeBlocks[I]);
+          Value *SlotPtr = PB.CreateInBoundsGEP(
+              IcacheSlot->getValueType(), IcacheSlot,
+              {ConstantInt::get(I32Ty, 0), ConstantInt::get(I32Ty, I)},
+              "ejit_ic_slot_" + Twine(I));
+          LoadInst *FnPtr =
+              PB.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn_" + Twine(I));
+          FnPtr->setAlignment(Align(8));
+          FnPtr->setAtomic(AtomicOrdering::Monotonic);
+          Value *TAfterIcache = nullptr;
+          if (EJitWrapperTiming)
+            TAfterIcache = PB.CreateCall(TraceNow, {}, "ejit_t_after_icache");
+          Value *IHit = PB.CreateIsNotNull(FnPtr, "ejit_icache_hit");
+          IHit = PB.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
+                                    {IHit, ConstantInt::getTrue(Ctx)});
+          PB.CreateCondBr(IHit, DispatchBlocks[I], JitMiss);
+
+          IRBuilder<> DB(DispatchBlocks[I]);
+          emitIcacheDispatch(DB, FnPtr, TAfterIcache);
+        }
+
+        auto BuildTree = [&](auto &&Self, unsigned Lo,
+                             unsigned Hi) -> BasicBlock * {
+          if (Hi - Lo == 1)
+            return ProbeBlocks[Lo];
+          unsigned Mid = Lo + (Hi - Lo) / 2;
+          BasicBlock *Left = Self(Self, Lo, Mid);
+          BasicBlock *Right = Self(Self, Mid, Hi);
+          BasicBlock *Node = BasicBlock::Create(
+              Ctx, "jit_icache_select_" + Twine(Lo) + "_" + Twine(Hi), F);
+          IRBuilder<> NB(Node);
+          Value *GoLeft = NB.CreateICmpULT(
+              Instance, ConstantInt::get(I32Ty, Mid), "ejit_split_left");
+          NB.CreateCondBr(GoLeft, Left, Right);
+          return Node;
+        };
+        BasicBlock *TreeRoot = BuildTree(BuildTree, 0, SplitInstances);
+        Value *InRange =
+            B.CreateICmpULT(Instance, ConstantInt::get(I32Ty, SplitInstances),
+                            "ejit_split_in_range");
+        B.CreateCondBr(InRange, TreeRoot, JitMiss);
       } else {
-        CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        emitHitTiming();
-        B.CreateRet(CI);
+        Value *SlotPtr = IcacheSlot;
+        if (NumDims > 0) {
+          SmallVector<Value *, 5> Indices;
+          Indices.push_back(ConstantInt::get(I32Ty, 0));
+          for (unsigned I = 0; I < NumDims; ++I) {
+            Value *ArgVal = F->getArg(PeriodInds[I].ArgIndex);
+            unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
+            Value *Idx = ArgVal;
+            if (BW > 32)
+              Idx = B.CreateTrunc(ArgVal, I32Ty);
+            else if (BW < 32)
+              Idx = B.CreateZExt(ArgVal, I32Ty);
+            Indices.push_back(Idx);
+          }
+          SlotPtr = B.CreateInBoundsGEP(IcacheSlot->getValueType(), IcacheSlot,
+                                        Indices, "ejit_ic_slot");
+        }
+        LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
+        ICSlotLoad->setAlignment(Align(8));
+        // Monotonic lowers to the same LDR on AArch64 while making a concurrent
+        // shared-table drain a defined race.
+        ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
+        Value *TAfterIcache = nullptr;
+        if (EJitWrapperTiming)
+          TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
+        Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
+        IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
+                                 {IHit, ConstantInt::getTrue(Ctx)});
+        B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
+        B.SetInsertPoint(JitIcacheDispatch);
+        emitIcacheDispatch(B, ICSlotLoad, TAfterIcache);
       }
 
       // Miss: tail-call MissFn (which does compile_or_get + dispatch/fallback).

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -1022,6 +1022,9 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
       if (UseSplitDispatch) {
         constexpr unsigned SplitInstances = kEJitIcacheDirectPadCount;
+        static_assert((SplitInstances & (SplitInstances - 1)) == 0,
+                      "bit-test dispatch requires a power-of-two "
+                      "instance count");
         Value *ArgVal = F->getArg(PeriodInds[0].ArgIndex);
         unsigned BW = cast<IntegerType>(ArgVal->getType())->getBitWidth();
         Value *Instance = ArgVal;
@@ -1122,9 +1125,18 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
           BasicBlock *Node = BasicBlock::Create(
               Ctx, "jit_icache_select_" + Twine(Lo) + "_" + Twine(Hi), F);
           IRBuilder<> NB(Node);
-          Value *GoLeft = NB.CreateICmpULT(
-              Instance, ConstantInt::get(I32Ty, Mid), "ejit_split_left");
-          NB.CreateCondBr(GoLeft, Left, Right);
+          // The entry range guard makes these low bits a complete instance
+          // key. AArch64 lowers the lower levels to single-instruction TBNZ
+          // branches instead of a CMP plus a conditional branch at each node.
+          unsigned Bit = 0;
+          for (unsigned Width = Hi - Lo; Width > 2; Width >>= 1)
+            ++Bit;
+          Value *SelectedBit = NB.CreateAnd(
+              Instance, ConstantInt::get(I32Ty, 1u << Bit),
+              "ejit_split_bit");
+          Value *GoRight = NB.CreateICmpNE(
+              SelectedBit, ConstantInt::get(I32Ty, 0), "ejit_split_right");
+          NB.CreateCondBr(GoRight, Right, Left);
           return Node;
         };
         BasicBlock *TreeRoot = BuildTree(BuildTree, 0, SplitInstances);

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-bittest-aarch64.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-bittest-aarch64.ll
@@ -1,0 +1,29 @@
+; REQUIRES: aarch64-registered-target
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=true -ejit-icache-direct-dispatch-pads=true -S %s | llc -mtriple=aarch64-unknown-none-elf -O2 | FileCheck %s
+
+; The 1D selector should lower its lower tree levels to single-instruction bit
+; tests. The range guard may let CodeGen retain threshold branches near the
+; root, but the old all-threshold tree emitted no tbz/tbnz at all.
+; CHECK-LABEL: cell_entry:
+; CHECK: cmp w0, #16
+; CHECK: tbnz w0, #2,
+; CHECK: tbnz w0, #1,
+; CHECK: tbnz w0, #0,
+; CHECK-NOT: blr
+; CHECK: .size cell_entry
+; CHECK-LABEL: __ejit_icache_pad_cell_entry_0:
+; CHECK: b cell_entry_miss
+
+target triple = "aarch64-unknown-none-elf"
+
+define i32 @cell_entry(i32 %cell, i32 %value) !ejit.metadata !0 {
+entry:
+  %result = add i32 %value, 1
+  ret i32 %result
+}
+
+@cell_data = global i32 0, !ejit.metadata !1
+
+!0 = distinct !{!{!"ejit_entry"},
+                !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!1 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-direct-pad-attrs.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-direct-pad-attrs.ll
@@ -1,0 +1,23 @@
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=true -ejit-icache-direct-dispatch-pads=true -S %s | FileCheck %s
+
+; Direct pads must preserve ABI-impacting parameter attributes so both musttail
+; edges remain valid for real entry signatures, not only scalar test functions.
+
+%S = type { i64, i64 }
+
+; CHECK-LABEL: define void @cell_sret(
+; CHECK-COUNT-16: musttail call void @__ejit_icache_pad_cell_sret_
+; CHECK-LABEL: define internal void @__ejit_icache_pad_cell_sret_0(ptr noalias sret(%S) align 8 %{{.*}}, i32 %{{.*}})
+; CHECK: musttail call void @cell_sret_miss(ptr noalias sret(%S) align 8 %{{.*}}, i32 %{{.*}})
+
+define void @cell_sret(ptr noalias sret(%S) align 8 %out, i32 %cell) !ejit.metadata !0 {
+entry:
+  %field = getelementptr inbounds %S, ptr %out, i32 0, i32 0
+  store i64 7, ptr %field, align 8
+  ret void
+}
+
+@cell_data = global i32 0, !ejit.metadata !10
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 1}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
@@ -1,5 +1,6 @@
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=false -S %s | FileCheck %s --check-prefix=DEFAULT
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=true -S %s | FileCheck %s --check-prefix=SPLIT
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=true -ejit-icache-direct-dispatch-pads=true -S %s | FileCheck %s --check-prefix=DIRECT
 
 ; The default remains the compact, single indirect callsite.
 ; DEFAULT-NOT: jit_icache_probe_0:
@@ -27,6 +28,25 @@
 ; SPLIT-LABEL: define i32 @two_dim_entry(
 ; SPLIT-NOT: jit_icache_probe_0:
 ; SPLIT: jit_icache_dispatch:
+
+; Direct-pad mode removes the slot load and indirect call from eligible leaves.
+; The AOT pad symbols initially tail-call the common miss function; runtime
+; publication patches that one B instruction to the JIT body.
+; DIRECT-DAG: @__ejit_icache_pad_table_cell_entry = private constant [17 x ptr]
+; DIRECT-DAG: @__ejit_icache_pad_table_trp_entry = private constant [17 x ptr]
+; DIRECT-DAG: @.ejit.registry.icache_pads = private constant {{.*}} i32 8, {{.*}} ptr @__ejit_icache_pad_table_cell_entry, i64 16
+; DIRECT-LABEL: define i32 @cell_entry(
+; DIRECT: %ejit_split_in_range = icmp ult i32 %cell, 16
+; DIRECT-NOT: load atomic ptr
+; DIRECT-COUNT-16: musttail call i32 @__ejit_icache_pad_cell_entry_
+; DIRECT-LABEL: define i32 @trp_entry(
+; DIRECT-NOT: load atomic ptr
+; DIRECT-COUNT-16: musttail call i32 @__ejit_icache_pad_trp_entry_
+; DIRECT-LABEL: define i32 @two_dim_entry(
+; DIRECT: load atomic ptr
+; DIRECT: musttail call i32 %ejit_ic_fn
+; DIRECT-DAG: define internal i32 @__ejit_icache_pad_cell_entry_0({{.*}}) {{.*}}section ".text.ejit_pads" align 4
+; DIRECT-DAG: musttail call i32 @cell_entry_miss(
 
 ; Other one-dimensional lifecycle names also retain the compact dispatcher.
 ; SPLIT-LABEL: define i32 @other_entry(

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
@@ -6,7 +6,7 @@
 ; DEFAULT-NOT: jit_icache_probe_0:
 ; DEFAULT-COUNT-4: jit_icache_dispatch:
 
-; Eligible one-dimensional cell entries use a direct conditional branch tree.
+; Eligible one-dimensional cell entries use a bit-test conditional branch tree.
 ; Values outside [0, 15] bypass the inline table and take the existing miss path.
 ; Every in-range instance has a distinct constant slot load and indirect call PC.
 ; SPLIT-LABEL: define i32 @cell_entry(
@@ -17,6 +17,10 @@
 ; SPLIT: load atomic ptr, ptr @__ejit_icache_fn_cell_entry monotonic
 ; SPLIT: jit_icache_dispatch_0:
 ; SPLIT-COUNT-16: musttail call i32 %ejit_ic_fn_
+; SPLIT-DAG: and i32 %cell, 8
+; SPLIT-DAG: and i32 %cell, 4
+; SPLIT-DAG: and i32 %cell, 2
+; SPLIT-DAG: and i32 %cell, 1
 
 ; trp is the other supported one-dimensional lifecycle name.
 ; SPLIT-LABEL: define i32 @trp_entry(

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-split-1d.ll
@@ -1,0 +1,68 @@
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=false -S %s | FileCheck %s --check-prefix=DEFAULT
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -ejit-icache-split-dispatch-1d=true -S %s | FileCheck %s --check-prefix=SPLIT
+
+; The default remains the compact, single indirect callsite.
+; DEFAULT-NOT: jit_icache_probe_0:
+; DEFAULT-COUNT-4: jit_icache_dispatch:
+
+; Eligible one-dimensional cell entries use a direct conditional branch tree.
+; Values outside [0, 15] bypass the inline table and take the existing miss path.
+; Every in-range instance has a distinct constant slot load and indirect call PC.
+; SPLIT-LABEL: define i32 @cell_entry(
+; SPLIT: %ejit_split_in_range = icmp ult i32 %cell, 16
+; SPLIT: br i1 %ejit_split_in_range, label %jit_icache_select_0_16, label %jit_miss
+; SPLIT-NOT: switch
+; SPLIT: jit_icache_probe_0:
+; SPLIT: load atomic ptr, ptr @__ejit_icache_fn_cell_entry monotonic
+; SPLIT: jit_icache_dispatch_0:
+; SPLIT-COUNT-16: musttail call i32 %ejit_ic_fn_
+
+; trp is the other supported one-dimensional lifecycle name.
+; SPLIT-LABEL: define i32 @trp_entry(
+; SPLIT: %ejit_split_in_range = icmp ult i32 %trp, 16
+; SPLIT: jit_icache_dispatch_0:
+; SPLIT: jit_icache_dispatch_15:
+
+; Two-dimensional entries deliberately retain the existing compact dispatcher.
+; SPLIT-LABEL: define i32 @two_dim_entry(
+; SPLIT-NOT: jit_icache_probe_0:
+; SPLIT: jit_icache_dispatch:
+
+; Other one-dimensional lifecycle names also retain the compact dispatcher.
+; SPLIT-LABEL: define i32 @other_entry(
+; SPLIT-NOT: jit_icache_probe_0:
+; SPLIT: jit_icache_dispatch:
+
+define i32 @cell_entry(i32 %cell, i32 %value) !ejit.metadata !0 {
+entry:
+  %r = add i32 %value, 1
+  ret i32 %r
+}
+
+define i32 @trp_entry(i32 %trp) !ejit.metadata !1 {
+entry:
+  ret i32 %trp
+}
+
+define i32 @two_dim_entry(i32 %cell, i32 %trp) !ejit.metadata !2 {
+entry:
+  %r = add i32 %cell, %trp
+  ret i32 %r
+}
+
+define i32 @other_entry(i32 %slot) !ejit.metadata !3 {
+entry:
+  ret i32 %slot
+}
+
+@cell_data = global i32 0, !ejit.metadata !10
+@trp_data = global i32 0, !ejit.metadata !11
+@other_data = global i32 0, !ejit.metadata !12
+
+!0 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"trp", i32 0}}
+!2 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
+!3 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"slot", i32 0}}
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
+!11 = distinct !{!{!"ejit_period_arr", !"trp", i32 16}}
+!12 = distinct !{!{!"ejit_period_arr", !"slot", i32 16}}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -15,6 +15,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDirectPad.h"
 #include "gtest/gtest.h"
 #include <algorithm>
 #include <atomic>
@@ -71,6 +73,23 @@ struct PrepareLog {
 bool mockPrepareCode(void *ctx, const void * /*fnPtr*/) {
   auto *log = static_cast<PrepareLog *>(ctx);
   log->cores.push_back(EJitCoreId::current());
+  return log->succeed;
+}
+
+struct PadPatchLog {
+  std::vector<std::pair<void *, const void *>> patches;
+  EJitSharedTaskPoolState *raceState = nullptr;
+  const void *missTarget = nullptr;
+  bool raceOnBody = false;
+  bool succeed = true;
+};
+bool mockPatchPad(void *ctx, void *pad, const void *target) {
+  auto *log = static_cast<PadPatchLog *>(ctx);
+  log->patches.push_back({pad, target});
+  if (log->raceOnBody && target != log->missTarget && log->raceState) {
+    log->raceOnBody = false;
+    log->raceState->icacheDrainSeq.fetchAdd(1);
+  }
   return log->succeed;
 }
 
@@ -2917,6 +2936,106 @@ TEST_F(SharedTaskPoolTest, InlineCacheDrainReachesEveryCorePartition) {
   ASSERT_TRUE(pool.setInstanceEnabled(0, 7, true));
   EXPECT_EQ(cells[1], 0u);
   EXPECT_EQ(cells[2], 0u);
+}
+
+TEST_F(SharedTaskPoolTest, DirectPadsPublishAndDrainWithTheirCell) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  constexpr uint32_t kInst = 5;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  uintptr_t pads[kEJitIcacheDirectPadCount + 1] = {};
+  for (uint32_t i = 0; i < kEJitIcacheDirectPadCount; ++i)
+    pads[i] = 0x200000u + i * 4u;
+  pads[kEJitIcacheDirectPadCount] = 0x300000u;
+  registerSlot(kFunc, cells, 1);
+  ASSERT_EQ(ejitIcacheRegisterPads(kFunc, pads, kEJitIcacheDirectPadCount),
+            EJitIcacheRegResult::Ok);
+
+  PadPatchLog log;
+  log.missTarget = reinterpret_cast<void *>(pads[kEJitIcacheDirectPadCount]);
+  pool.setIcachePadPatchCallback(&mockPatchPad, &log);
+  const EJitDimPair d[1] = {{0, kInst}};
+  void *fn = codeFor(kFunc);
+  pool.icacheFill(kFunc, fn, d, 1, pool.icacheBeginResolve());
+
+  ASSERT_EQ(log.patches.size(), 1u);
+  EXPECT_EQ(log.patches[0].first, reinterpret_cast<void *>(pads[kInst]));
+  EXPECT_EQ(log.patches[0].second, fn);
+  EXPECT_EQ(cells[kInst], reinterpret_cast<uintptr_t>(fn));
+
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 7, true));
+  ASSERT_EQ(log.patches.size(), 2u);
+  EXPECT_EQ(log.patches[1].first, reinterpret_cast<void *>(pads[kInst]));
+  EXPECT_EQ(log.patches[1].second, log.missTarget);
+  EXPECT_EQ(cells[kInst], 0u);
+}
+
+TEST_F(SharedTaskPoolTest, DirectPadsStayOnMissWithPerCorePrepare) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  uintptr_t pads[kEJitIcacheDirectPadCount + 1] = {};
+  for (uint32_t i = 0; i < kEJitIcacheDirectPadCount; ++i)
+    pads[i] = 0x200000u + i * 4u;
+  pads[kEJitIcacheDirectPadCount] = 0x300000u;
+  registerSlot(kFunc, cells, 1);
+  ASSERT_EQ(ejitIcacheRegisterPads(kFunc, pads, kEJitIcacheDirectPadCount),
+            EJitIcacheRegResult::Ok);
+  PrepareLog prepare;
+  pool.setPrepareCodeCallback(&mockPrepareCode, &prepare);
+  PadPatchLog log;
+  pool.setIcachePadPatchCallback(&mockPatchPad, &log);
+  const EJitDimPair d[1] = {{0, 2}};
+
+  pool.icacheFill(kFunc, codeFor(kFunc), d, 1, pool.icacheBeginResolve());
+  EXPECT_TRUE(log.patches.empty());
+  EXPECT_NE(cells[2], 0u)
+      << "the ordinary pointer cache keeps its existing dimensioned behavior";
+}
+
+TEST_F(SharedTaskPoolTest, DirectPadFillRetractsAfterRacingDrain) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  constexpr uint32_t kInst = 4;
+  uintptr_t cells[EJIT_ICACHE_DIM_SIZE] = {};
+  uintptr_t pads[kEJitIcacheDirectPadCount + 1] = {};
+  for (uint32_t i = 0; i < kEJitIcacheDirectPadCount; ++i)
+    pads[i] = 0x200000u + i * 4u;
+  pads[kEJitIcacheDirectPadCount] = 0x300000u;
+  registerSlot(kFunc, cells, 1);
+  ASSERT_EQ(ejitIcacheRegisterPads(kFunc, pads, kEJitIcacheDirectPadCount),
+            EJitIcacheRegResult::Ok);
+  PadPatchLog log;
+  log.raceState = state_.get();
+  log.missTarget = reinterpret_cast<void *>(pads[kEJitIcacheDirectPadCount]);
+  log.raceOnBody = true;
+  pool.setIcachePadPatchCallback(&mockPatchPad, &log);
+  const EJitDimPair d[1] = {{0, kInst}};
+
+  pool.icacheFill(kFunc, codeFor(kFunc), d, 1, pool.icacheBeginResolve());
+  ASSERT_EQ(log.patches.size(), 2u);
+  EXPECT_EQ(log.patches[0].second, codeFor(kFunc));
+  EXPECT_EQ(log.patches[1].second, log.missTarget);
+  EXPECT_EQ(cells[kInst], 0u);
+}
+
+TEST(EJitDirectPadEncodingTest, EncodesRangeAndBigEndianStoreWord) {
+  uint32_t instruction = 0;
+  EXPECT_TRUE(ejitEncodeAArch64DirectBranch(0x1000, 0x1004, instruction));
+  EXPECT_EQ(instruction, 0x14000001u);
+  EXPECT_EQ(ejitAArch64InstructionStoreWord(instruction, false), 0x14000001u);
+  EXPECT_EQ(ejitAArch64InstructionStoreWord(instruction, true), 0x01000014u);
+
+  EXPECT_TRUE(ejitEncodeAArch64DirectBranch(0x1004, 0x1000, instruction));
+  EXPECT_EQ(instruction, 0x17ffffffu);
+  EXPECT_TRUE(ejitEncodeAArch64DirectBranch(
+      0x10000000u, 0x10000000u + (uintptr_t{1} << 27) - 4, instruction));
+  EXPECT_FALSE(ejitEncodeAArch64DirectBranch(
+      0x10000000u, 0x10000000u + (uintptr_t{1} << 27), instruction));
+  EXPECT_FALSE(ejitEncodeAArch64DirectBranch(0x1001, 0x1004, instruction));
 }
 
 // The drain runs on EVERY setInstanceEnabled call, not only the one that moves


### PR DESCRIPTION
## 中文说明

基于 #165 的一维 `cell` / `trp` 拆分 dispatcher，进一步把每个叶子的间接调用替换为固定 PC 的 AOT 直跳 pad，用于验证多版本 JIT target 导致 BTB/前端停滞的假设。

- 每个符合条件的 entry 生成 16 个 4-byte AOT pad；初始直接跳到现有 miss/AOT fallback。
- JIT 版本发布后将对应 pad 的单条 AArch64 `B` 原子改写到 JIT body；drain/失效时改回 miss。
- JIT body 仍使用现有 fixed code pool，不要求固定大小或固定槽位。
- 仅支持一维 `cell < 16` / `trp < 16`；二维和其他 lifecycle 保持原 dispatcher。
- 仅在跨核代码立即可执行的模式发布直跳；旧的 per-core prepare 模式保持 miss，失败关闭。
- pad 独占 4 KiB linker section，使用 `enable_rw -> store -> enable_ex + D/I cache sync`，并处理 `aarch64_be` 下指令字节仍为 little-endian 的情况。
- wrapper timing 打开时继续使用 #165 的间接拆分路径。
- 同时补齐 entry 调用的 ABI 属性传播，保证 `sret/byval` 等真实签名的 `musttail` 合法。

### 验证

- WrapperGen FileCheck：默认、split-indirect、direct-pad 三种模式通过。
- 新增复杂 ABI (`sret`) verifier/FileCheck 用例通过。
- SharedTaskPool direct-pad 定向测试 4/4：发布、drain 回拨、发布/drain 竞态、per-core prepare 回退、大端编码。
- AArch64 big-endian 对象检查：每个 pad 恰好 4 bytes / 1 条 `B`，wrapper->pad 与 pad->miss 均为 `R_AARCH64_JUMP26`。
- 关键 runtime TU（EJit/EJitRuntime/EJitCompileDriver/EJitSrePlatform）单独编译通过。

### 板端待验证

- 对比 activate 前后 `BR_MIS_PRED`、`STALL_FRONTEND`、IPC，以及 2/6 核、2/6 个版本组合。
- 压测 publish 与 period-toggle/drain 并发时的 RX/RW 权限切换和跨核 I-cache 可见性。
- 确认产品 linker script 合入 `.text.ejit_pads`，且 pads 与 fixed JIT pool 始终在 AArch64 `B` 的 +/-128 MiB 范围内。

## English

This PR extends #165 with fixed-PC AOT direct-branch pads for eligible 1D `cell`/`trp` dispatch. Each pad starts as a direct branch to the existing miss path, is patched to the published JIT body, and is restored on drain. JIT bodies keep the existing variable-size fixed-code-pool allocation.

The experiment is intentionally limited to one dimension and indices below 16. Two-dimensional/other lifecycle entries retain the existing dispatcher, wrapper timing retains the split-indirect baseline, and legacy per-core execute preparation leaves pads on miss.

This is a draft because board-side PMU and concurrent permission-transition validation are still required.