### PR TITLE
[EJIT] Close JIT optimization gap vs AOT O2: module cleanup + vectorization

### DIFF
--- a/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
+++ b/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
@@ -177,7 +177,7 @@ EJitOrcEngine::Create(const EJitConfig& config) {
 
     // 步骤 3: 注册 IRTransformLayer 回调
     // 完整的 JIT Pipeline: 参数替换 → InstCombine → StructFieldPass → IPSCCP →
-    //   InstCombine → StructFieldPass → 标准优化 (详见 §2.4)
+    //   InstCombine → StructFieldPass → 模块清理 → 标准优化 → 向量化 (详见 §2.4)
     // 注意: IRTransformLayer::TransformFunction 签名为
     //   Expected<ThreadSafeModule>(ThreadSafeModule, MaterializationResponsibility&)
     // withModuleDo 的回调签名为 Expected<Error>(Module&)，原地修改 Module
@@ -201,8 +201,11 @@ EJitOrcEngine::Create(const EJitConfig& config) {
                 //   1c EJitStructFieldPass      —— may_const load → 常量
                 //   1d runInterproceduralPropagation —— 内部化非 entry 定义 + IPSCCP
                 //   1e/1f runInstCombine + EJitStructFieldPass（对 callee 再做一轮）
+                //   1g runModuleCleanup —— RPO attrs + DAE + GlobalDCE（模块级清理）
                 //   2-4 LowerExpect + buildFunctionSimplificationPipeline(O1/O2/O3)
                 //        + 二次 StructFieldPass + cleanup(InstCombine/SCCP/SimplifyCFG/ADCE)
+                //   5   向量化（仅 L2/L3，见 §2.4.3）：L2 = SLP + 部分展开；
+                //        L3 加 LoopVectorize + LoopLoadElimination
                 engine->P->optimizer->runPipeline(M, *ctx);
 
                 return Error::success();
@@ -802,6 +805,8 @@ void runInstCombine(Module& M) {
 
 **`runInterproceduralPropagation`** — 内部化所有非 `ejit_entry` 定义后运行 IPSCCP，把 1a–1c 在每个调用点变成常量的实参推进 callee 函数体（并把常量返回值推回调用点）。JIT 侧**不再单独运行 Inline**：callee 已在 AOT 预优化（`EJitRegisterBitcodePass`：AlwaysInline + ModuleInliner(O2)）内联。
 
+**`runModuleCleanup`** — 特化后的模块级清理（Phase 1g，所有档位都跑）：`ReversePostOrderFunctionAttrsPass` 推断函数属性供下游折叠，`DeadArgumentEliminationPass` 删除被 IPSCCP 常量化的参数（只改写 local-linkage 函数，外部 `ejit_entry` 不受影响），`GlobalDCEPass` 删除守卫折叠后失去调用点的函数——缩小 JIT 后端需编译的代码量。
+
 ```cpp
 void EJitOptimizer::runInterproceduralPropagation(Module& M) {
     // IPSCCP 仅能推理 local linkage 且未被取地址函数的实参；
@@ -823,11 +828,13 @@ void EJitOptimizer::runInterproceduralPropagation(Module& M) {
 
 ### 2.4.3 优化 Pipeline (L1/L2/L3) — 第二次 StructFieldPass 之后
 
-后特化清理直接复用 **真实的 LLVM 函数级简化流水线** `PassBuilder::buildFunctionSimplificationPipeline`（O1/O2/O3 各预建一份并缓存），而不是手工拼装的 pass 序列。`ctx.optLevel`（L1→O1、L2→O2、L3→O3）只选择这三条已缓存的 FPM 之一；它**不改变**流水线其余部分。注意这是**函数级**简化流水线，并非完整的 `clang -O2` module 流水线——除 phase 1d 的 IPSCCP 外，不含 GlobalOpt、CalledValuePropagation、ArgumentPromotion 等 module/CGSCC pass。
+后特化清理直接复用 **真实的 LLVM 函数级简化流水线** `PassBuilder::buildFunctionSimplificationPipeline`（O1/O2/O3 各预建一份并缓存），而不是手工拼装的 pass 序列。`ctx.optLevel`（L1→O1、L2→O2、L3→O3）选择这三条已缓存的 FPM 之一，并**门控 Phase 5 向量化**（L2/L3 运行、L1 跳过）；Phase 1a–1g 与 Phase 2/4 对所有档位一致。注意这是**函数级**简化流水线，并非完整的 `clang -O2` module 流水线——除 phase 1d 的 IPSCCP 和 phase 1g 的模块清理（RPO attrs + DAE + GlobalDCE）外，不含 GlobalOpt、CalledValuePropagation、ArgumentPromotion 等 module/CGSCC pass。
 
 ```cpp
 // 构造时预建（EJitOptimizer 构造函数）
-PassBuilder PB;
+// TM 由引擎用同一个 JTMB createTargetMachine 后传入（EJitOrcEngine::Create）；
+// 无 TM 时 TTI 退化为 32-bit 基线，向量化永不触发（见本节约末的注）。
+PassBuilder PB(TM);
 PB.registerModuleAnalyses(MAM_);   PB.registerCGSCCAnalyses(CGAM_);
 PB.registerFunctionAnalyses(FAM_); PB.registerLoopAnalyses(LAM_);
 PB.crossRegisterProxies(LAM_, FAM_, CGAM_, MAM_);
@@ -837,6 +844,11 @@ simplifyO2_ = PB.buildFunctionSimplificationPipeline(O2, ThinOrFullLTOPhase::Non
 simplifyO3_ = PB.buildFunctionSimplificationPipeline(O3, ThinOrFullLTOPhase::None);
 cleanupFPM_.addPass(InstCombinePass());  cleanupFPM_.addPass(SCCPPass());
 cleanupFPM_.addPass(SimplifyCFGPass());  cleanupFPM_.addPass(ADCEPass());
+cleanupMPM_.addPass(ReversePostOrderFunctionAttrsPass());   // Phase 1g
+cleanupMPM_.addPass(DeadArgumentEliminationPass());
+cleanupMPM_.addPass(GlobalDCEPass());
+vectorizeL2_ = buildVectorizeFPM(PTO, /*SpeedupLevel=*/2, /*EnableLoopVectorize=*/false); // Phase 5
+vectorizeL3_ = buildVectorizeFPM(PTO, /*SpeedupLevel=*/3, /*EnableLoopVectorize=*/true);
 
 void EJitOptimizer::runOptimizationPipeline(Module& M, ejit::OptimizationLevel level) {
     FunctionPassManager& simplifyFPM = simplifyFPMForLevel(level); // L1→O1 / L2→O2 / L3→O3
@@ -850,10 +862,14 @@ void EJitOptimizer::runOptimizationPipeline(Module& M, ejit::OptimizationLevel l
     for (Function& F : M.functions())
         if (!F.isDeclaration())
             cleanupFPM_.run(F, FAM_);
+    // Phase 5: 特化后向量化（仅 L2/L3）。L2 = SLP + 部分展开；L3 加 LoopVectorize。
+    // 在最终 StructFieldPass 之后运行，向量化器看到的是完全特化的循环。
+    if (level >= L2)
+        runVectorization(M, level);
 }
 ```
 
-> **注**：`buildFunctionSimplificationPipeline` 包含 SROA、InstCombine、SCCP、GVN、CorrelatedValuePropagation、BDCE、DSE、loop-rotate、LICM、loop-unroll 等，但**不含向量化**。首次 Inline 由 AOT 预优化完成；JIT 侧不再做二次 Inline。
+> **注**：`buildFunctionSimplificationPipeline` 包含 SROA、InstCombine、SCCP、GVN、CorrelatedValuePropagation、BDCE、DSE、loop-rotate、LICM、loop-unroll 等，但**不含向量化**——向量化由 Phase 5 在最终 StructFieldPass 之后按档位追加（L1 跳过，对齐 `clang -O1`）。Phase 5 的 SLP 在 L2+ 无条件运行（宿主侧由 cl::opt 门控，嵌入式运行时无此概念）——以 JIT 编译时延换代码质量，属有意取舍，实测编译时延应顺带评估。首次 Inline 由 AOT 预优化完成；JIT 侧不再做二次 Inline。
 
 ---
 

--- a/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
+++ b/jit_design_doc/PASS7_EJitRuntime_OrcJITLink.md
@@ -206,6 +206,8 @@ EJitOrcEngine::Create(const EJitConfig& config) {
                 //        + 二次 StructFieldPass + cleanup(InstCombine/SCCP/SimplifyCFG/ADCE)
                 //   5   向量化（仅 L2/L3，见 §2.4.3）：L2 = SLP + 部分展开；
                 //        L3 加 LoopVectorize + LoopLoadElimination
+                //   6   最终 GlobalDCE：2-5 阶段折叠 expect 守卫、删除调用点后
+                //        清扫失去引用者的 callee（1g 时这些调用点尚未死）
                 engine->P->optimizer->runPipeline(M, *ctx);
 
                 return Error::success();
@@ -805,7 +807,7 @@ void runInstCombine(Module& M) {
 
 **`runInterproceduralPropagation`** — 内部化所有非 `ejit_entry` 定义后运行 IPSCCP，把 1a–1c 在每个调用点变成常量的实参推进 callee 函数体（并把常量返回值推回调用点）。JIT 侧**不再单独运行 Inline**：callee 已在 AOT 预优化（`EJitRegisterBitcodePass`：AlwaysInline + ModuleInliner(O2)）内联。
 
-**`runModuleCleanup`** — 特化后的模块级清理（Phase 1g，所有档位都跑）：`ReversePostOrderFunctionAttrsPass` 推断函数属性供下游折叠，`DeadArgumentEliminationPass` 删除被 IPSCCP 常量化的参数（只改写 local-linkage 函数，外部 `ejit_entry` 不受影响），`GlobalDCEPass` 删除守卫折叠后失去调用点的函数——缩小 JIT 后端需编译的代码量。
+**`runModuleCleanup`** — 特化后的模块级清理（Phase 1g，所有档位都跑）：`ReversePostOrderFunctionAttrsPass` 推断函数属性供下游折叠，`DeadArgumentEliminationPass` 删除被 IPSCCP 常量化的参数（只改写 local-linkage 函数，外部 `ejit_entry` 不受影响），`GlobalDCEPass` 删除失去调用点的函数——缩小 JIT 后端需编译的代码量。注意：此轮 DCE 看不到 expect 守卫（`__builtin_expect`）的死半边——守卫要到 Phase 2（LowerExpect）才折叠；那些调用点在 Phase 2-5 才死掉的 callee 由 Phase 6 的最终 GlobalDCE 清扫（见 §2.4.3）。
 
 ```cpp
 void EJitOptimizer::runInterproceduralPropagation(Module& M) {
@@ -849,6 +851,7 @@ cleanupMPM_.addPass(DeadArgumentEliminationPass());
 cleanupMPM_.addPass(GlobalDCEPass());
 vectorizeL2_ = buildVectorizeFPM(PTO, /*SpeedupLevel=*/2, /*EnableLoopVectorize=*/false); // Phase 5
 vectorizeL3_ = buildVectorizeFPM(PTO, /*SpeedupLevel=*/3, /*EnableLoopVectorize=*/true);
+finalDCEMPM_.addPass(GlobalDCEPass());  // Phase 6: 最终死代码清扫
 
 void EJitOptimizer::runOptimizationPipeline(Module& M, ejit::OptimizationLevel level) {
     FunctionPassManager& simplifyFPM = simplifyFPMForLevel(level); // L1→O1 / L2→O2 / L3→O3
@@ -866,10 +869,12 @@ void EJitOptimizer::runOptimizationPipeline(Module& M, ejit::OptimizationLevel l
     // 在最终 StructFieldPass 之后运行，向量化器看到的是完全特化的循环。
     if (level >= L2)
         runVectorization(M, level);
+    // Phase 6 在 runPipeline 中：runOptimizationPipeline 之后对模块跑一次
+    // 最终 GlobalDCE（finalDCEMPM_）。
 }
 ```
 
-> **注**：`buildFunctionSimplificationPipeline` 包含 SROA、InstCombine、SCCP、GVN、CorrelatedValuePropagation、BDCE、DSE、loop-rotate、LICM、loop-unroll 等，但**不含向量化**——向量化由 Phase 5 在最终 StructFieldPass 之后按档位追加（L1 跳过，对齐 `clang -O1`）。Phase 5 的 SLP 在 L2+ 无条件运行（宿主侧由 cl::opt 门控，嵌入式运行时无此概念）——以 JIT 编译时延换代码质量，属有意取舍，实测编译时延应顺带评估。首次 Inline 由 AOT 预优化完成；JIT 侧不再做二次 Inline。
+> **注**：`buildFunctionSimplificationPipeline` 包含 SROA、InstCombine、SCCP、GVN、CorrelatedValuePropagation、BDCE、DSE、loop-rotate、LICM、loop-unroll 等，但**不含向量化**——向量化由 Phase 5 在最终 StructFieldPass 之后按档位追加（L1 跳过，对齐 `clang -O1`）。Phase 5 的 SLP 在 L2+ 无条件运行（宿主侧由 cl::opt 门控，嵌入式运行时无此概念）——以 JIT 编译时延换代码质量，属有意取舍，实测编译时延应顺带评估。UnrollAndJam 则**不启用**：宿主把它挂在 `-enable-unroll-and-jam`（cl::opt，默认 OFF）后面，L2/L3 都跑它会使 JIT 比对应的 AOT O2/O3 更激进，代码体积也不利嵌入式缓存。Phase 6 的最终 GlobalDCE 有必要性：expect 守卫（`__builtin_expect`）要到 Phase 2（LowerExpect）折叠后才能删掉守卫死半边的调用，而 Phase 1g 的 DCE 在此之前已运行——Phase 2-5 新死掉的 callee 只有靠这最后一扫才不会被 JIT 后端编译。首次 Inline 由 AOT 预优化完成；JIT 侧不再做二次 Inline。
 
 ---
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -45,6 +45,7 @@ public:
   ///   4. IPSCCP (push constants across call edges) + re-substitution
   ///   5. Module cleanup (RPO attrs + dead-arg elimination + GlobalDCE)
   ///   6. Core optimization pipeline (L1/L2/L3) + vectorization (L2+)
+  ///      + final GlobalDCE sweep (callees freed by phases 2-5)
   void runPipeline(Module &M, const SpecializationContext &ctx);
 
   /// Clear all cached analysis results. Must be called between compilations
@@ -117,6 +118,10 @@ private:
   //   cleanupMPM_     RPO attrs + DAE + GlobalDCE module cleanup (Phase 1g).
   //   vectorizeL2/3_  post-specialization vectorization (Phase 5); L2 has SLP +
   //                   partial unrolling, L3 adds the loop vectorizer.
+  //   finalDCEMPM_    final GlobalDCE (Phase 6): phases 2-5 delete call sites
+  //                   (expect-guard folding, unrolled-loop leftovers) that
+  //                   phase 1g's DCE could not yet see as dead, so sweep the
+  //                   now-unreferenced callees before the backend compiles.
   FunctionPassManager lowerExpectFPM_;
   FunctionPassManager simplifyO1_;
   FunctionPassManager simplifyO2_;
@@ -125,6 +130,7 @@ private:
   ModulePassManager cleanupMPM_;
   FunctionPassManager vectorizeL2_;
   FunctionPassManager vectorizeL3_;
+  ModulePassManager finalDCEMPM_;
 
   // Grant the unit-test accessor visibility into the private pipeline steps.
   // runPipeline() remains the only production entry point; this friend keeps

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -19,6 +19,9 @@
 #include "llvm/ExecutionEngine/EJIT/EJitPassBuilder.h"
 
 namespace llvm {
+
+class TargetMachine;
+
 namespace ejit {
 
 /// JIT optimization pipeline. Runs on the extracted bitcode module during
@@ -27,14 +30,21 @@ namespace ejit {
 /// every compilation.
 class EJitOptimizer {
 public:
-  EJitOptimizer(PeriodArrayRegistry &reg);
+  /// \p TM feeds PassBuilder's TargetIRAnalysis: with it, TTI is
+  /// backend-accurate (real vector register widths) and the Phase 5
+  /// vectorizers can fire; without it the default TTI reports a 32-bit
+  /// baseline, which disables vectorization (and skews loop-unroll cost
+  /// models). The engine passes the same JITTargetMachineBuilder-derived TM
+  /// the JIT compiles with.
+  EJitOptimizer(PeriodArrayRegistry &reg, TargetMachine *TM = nullptr);
 
   /// Run the full JIT specialization pipeline:
   ///   1. Parameter substitution (ejit_period_arr_ind → constants)
   ///   2. InstCombine (fold GEP chains from substituted params)
-  ///   3. Inline (L2+: expand callee bodies so may_const GEPs are traceable)
-  ///   4. StructFieldPass (may_const loads → runtime constants)
-  ///   5. Core optimization pipeline (L1/L2/L3)
+  ///   3. StructFieldPass (may_const loads → runtime constants)
+  ///   4. IPSCCP (push constants across call edges) + re-substitution
+  ///   5. Module cleanup (RPO attrs + dead-arg elimination + GlobalDCE)
+  ///   6. Core optimization pipeline (L1/L2/L3) + vectorization (L2+)
   void runPipeline(Module &M, const SpecializationContext &ctx);
 
   /// Clear all cached analysis results. Must be called between compilations
@@ -62,12 +72,28 @@ private:
   /// constant returns back to call sites.
   void runInterproceduralPropagation(Module &M);
 
+  /// Module-level cleanup after specialization (Phase 1g). Runs on every tier:
+  /// RPO function-attribute inference feeds downstream folds, dead-argument
+  /// elimination drops parameters IPSCCP replaced with constants (their call
+  /// sites stop computing them), and GlobalDCE deletes functions whose call
+  /// sites the folded guards deleted — shrinking what the JIT backend must
+  /// compile. DAE only rewrites local-linkage functions, so the external
+  /// ejit_entry is untouched.
+  void runModuleCleanup(Module &M);
+
+  /// Post-specialization vectorization (Phase 5). Runs after the final
+  /// StructFieldPass so the vectorizers see the fully-specialized loops.
+  /// L2: SLP + partial loop unrolling; L3 adds the loop vectorizer. L1 skips
+  /// vectorization entirely.
+  void runVectorization(Module &M, OptimizationLevel level);
+
   /// Run the EJIT optimization pipeline: a single fused sequence that exploits
   /// the just-substituted period-index / may_const constants to their fixed
   /// point (scalar fold/propagate/simplify), folds loops whose bounds became
   /// constant, re-specializes the array accesses that unrolling turns into
-  /// constant-index GEPs, then does a final cleanup. `level` is accepted for ABI
-  /// compatibility and does not affect the pipeline.
+  /// constant-index GEPs, then does a final cleanup. `level` selects the
+  /// function-simplification tier (L1→O1, L2→O2, L3→O3) and gates the
+  /// Phase 5 vectorization (L2+).
   void runOptimizationPipeline(Module &M, OptimizationLevel level);
 
   /// Pick the cached function-simplification FPM for an EJIT optimization tier.
@@ -87,12 +113,18 @@ private:
   //                   Pipeline); runs before the O2 pipeline (Phase 2).
   //   simplifyO1/2/3_ the real LLVM -O1/-O2/-O3 function-simplification pipeline
   //                   (Phase 3), one per tier; NO vectorization.
-  //   cleanupFPM_     light fold after the second StructFieldPass (Phase 5).
+  //   cleanupFPM_     light fold after the second StructFieldPass (Phase 4).
+  //   cleanupMPM_     RPO attrs + DAE + GlobalDCE module cleanup (Phase 1g).
+  //   vectorizeL2/3_  post-specialization vectorization (Phase 5); L2 has SLP +
+  //                   partial unrolling, L3 adds the loop vectorizer.
   FunctionPassManager lowerExpectFPM_;
   FunctionPassManager simplifyO1_;
   FunctionPassManager simplifyO2_;
   FunctionPassManager simplifyO3_;
   FunctionPassManager cleanupFPM_;
+  ModulePassManager cleanupMPM_;
+  FunctionPassManager vectorizeL2_;
+  FunctionPassManager vectorizeL3_;
 
   // Grant the unit-test accessor visibility into the private pipeline steps.
   // runPipeline() remains the only production entry point; this friend keeps

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -39,13 +39,15 @@ public:
   EJitOptimizer(PeriodArrayRegistry &reg, TargetMachine *TM = nullptr);
 
   /// Run the full JIT specialization pipeline:
-  ///   1. Parameter substitution (ejit_period_arr_ind → constants)
-  ///   2. InstCombine (fold GEP chains from substituted params)
-  ///   3. StructFieldPass (may_const loads → runtime constants)
-  ///   4. IPSCCP (push constants across call edges) + re-substitution
-  ///   5. Module cleanup (RPO attrs + dead-arg elimination + GlobalDCE)
-  ///   6. Core optimization pipeline (L1/L2/L3) + vectorization (L2+)
-  ///      + final GlobalDCE sweep (callees freed by phases 2-5)
+  ///   1a. Parameter substitution (ejit_period_arr_ind → constants)
+  ///   1b. InstCombine (fold GEP chains from substituted params)
+  ///   1c. StructFieldPass (may_const loads → runtime constants)
+  ///   1d. IPSCCP (push constants across call edges)
+  ///   1e/1f. InstCombine + StructFieldPass for callees
+  ///   1g. Module cleanup (RPO attrs + dead-arg elimination + GlobalDCE)
+  ///   2-4. LowerExpect → O1/O2/O3 simplification → re-substitution + cleanup
+  ///   5. Vectorization (L2+)
+  ///   6. Final GlobalDCE sweep (callees freed by phases 2-5)
   void runPipeline(Module &M, const SpecializationContext &ctx);
 
   /// Clear all cached analysis results. Must be called between compilations

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -371,8 +371,7 @@ void EJitOptimizer::runOptimizationPipeline(Module &M,
   // Phase 5: vectorization + partial unrolling, L2+. Runs after the final
   // StructFieldPass so the vectorizers see the fully-specialized loops. L1
   // skips vectorization entirely (matching clang -O1).
-  if (static_cast<int>(level) >=
-      static_cast<int>(ejit::OptimizationLevel::L2)) {
+  if (level >= ejit::OptimizationLevel::L2) {
     runVectorization(M, level);
     EJIT_DIAG_DEBUG("pipeline phase5 done: vectorization opt=%d",
                     static_cast<int>(level));

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -12,8 +12,9 @@
 // The post-specialization cleanup is the real LLVM -O2 function-simplification
 // pipeline (PassBuilder::buildFunctionSimplificationPipeline); hand-added on
 // top of it are the LowerExpect prefix, the light cleanupFPM_, the Phase 1g
-// module cleanup (RPO attrs + DAE + GlobalDCE), and the Phase 5 vectorization
-// FPMs (SLP + partial unroll at L2, loop vectorizer at L3).
+// module cleanup (RPO attrs + DAE + GlobalDCE), the Phase 5 vectorization FPMs
+// (SLP + partial unroll at L2, loop vectorizer at L3), and the Phase 6 final
+// GlobalDCE sweep.
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include "llvm/Transforms/IPO/DeadArgumentElimination.h"
 #include "llvm/Transforms/IPO/FunctionAttrs.h"
@@ -25,7 +26,6 @@
 #include "llvm/Transforms/Scalar/LICM.h"
 #include "llvm/Transforms/Scalar/LoopLoadElimination.h"
 #include "llvm/Transforms/Scalar/LoopPassManager.h"
-#include "llvm/Transforms/Scalar/LoopUnrollAndJamPass.h"
 #include "llvm/Transforms/Scalar/LoopUnrollPass.h"
 #include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
@@ -43,18 +43,22 @@ using namespace llvm::ejit;
 /// Build the post-specialization vectorization FPM. Mirrors the non-LTO path
 /// of PassBuilder::addVectorPasses (PassBuilderPipelines.cpp): loop
 /// vectorization (L3 only), SLP for parallel scalar chains, trip-count-based
-/// partial unrolling + unroll-and-jam to hide backedge latency, and a late
-/// LICM. SpeedupLevel feeds the unroll cost model (2 = O2, 3 = O3).
+/// partial unrolling to hide backedge latency, and a late LICM. SpeedupLevel
+/// feeds the unroll cost model (2 = O2, 3 = O3).
 ///
 /// Deliberate deviations from the host path, all compile-time tradeoffs:
 /// SLP runs unconditionally at L2+ (the host gates it on a cl::opt that has
-/// no meaning for an embedded runtime); the aggressive SimplifyCFG before
-/// SLP, WarnMissedTransformations, InferAlignment, AlignmentFromAssumptions
-/// and the unswitch/LICM part of the ExtraVectorizerPasses block are skipped
-/// (LICM still runs at the end of this FPM).
-static FunctionPassManager
-buildVectorizeFPM(const PipelineTuningOptions &PTO, unsigned SpeedupLevel,
-                  bool EnableLoopVectorize) {
+/// no meaning for an embedded runtime); UnrollAndJam is skipped (the host
+/// gates it on -enable-unroll-and-jam, cl::opt default OFF, so running it
+/// would make the JIT more aggressive than the AOT O2/O3 it matches, at code
+/// size that matters for an embedded cache); the aggressive SimplifyCFG
+/// before SLP, WarnMissedTransformations, InferAlignment,
+/// AlignmentFromAssumptions and the unswitch/LICM part of the
+/// ExtraVectorizerPasses block are skipped (LICM still runs at the end of
+/// this FPM).
+static FunctionPassManager buildVectorizeFPM(const PipelineTuningOptions &PTO,
+                                             unsigned SpeedupLevel,
+                                             bool EnableLoopVectorize) {
   FunctionPassManager FPM;
   if (EnableLoopVectorize) {
     FPM.addPass(LoopVectorizePass(LoopVectorizeOptions()));
@@ -73,9 +77,10 @@ buildVectorizeFPM(const PipelineTuningOptions &PTO, unsigned SpeedupLevel,
   FPM.addPass(InstCombinePass());
   // Partial unrolling: LoopFullUnroll (inside the simplification pipeline)
   // only fully unrolls; partial trip-count unrolling hides backedge latency.
-  // UnrollAndJam first, as in the host pipeline.
-  FPM.addPass(createFunctionToLoopPassAdaptor(
-      LoopUnrollAndJamPass(static_cast<int>(SpeedupLevel))));
+  // The host would insert UnrollAndJam before this, but it gates it on
+  // -enable-unroll-and-jam (default OFF), so we skip it: running it would
+  // make the JIT more aggressive than the AOT O2/O3 it matches, at code-size
+  // cost that matters for an embedded cache.
   FPM.addPass(LoopUnrollPass(LoopUnrollOptions(static_cast<int>(SpeedupLevel),
                                                /*OnlyWhenForced=*/false,
                                                /*ForgetSCEV=*/false)));
@@ -167,6 +172,15 @@ EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg, TargetMachine *TM)
                                    /*EnableLoopVectorize=*/false);
   vectorizeL3_ = buildVectorizeFPM(PTO, /*SpeedupLevel=*/3,
                                    /*EnableLoopVectorize=*/true);
+
+  // finalDCEMPM_ — Phase 6, final module-level dead-code sweep. Phase 1g's
+  // GlobalDCE runs before the expect guards fold: a may_const load feeding an
+  // llvm.expect condition only becomes a constant-foldable branch after
+  // Phase 2 (LowerExpect), so callees called only from the guard's dead half
+  // survive 1g with a live call site. Phases 2-5 then delete those call sites;
+  // this last sweep drops the now-unreferenced callees so the JIT backend
+  // never compiles them.
+  finalDCEMPM_.addPass(GlobalDCEPass());
 }
 
 void EJitOptimizer::clearAnalyses() {
@@ -224,6 +238,14 @@ void EJitOptimizer::runPipeline(Module &M,
   // re-specialize → cleanup → vectorize). ctx.optLevel selects the
   // function-simplification tier and gates Phase 5 vectorization (L2+).
   runOptimizationPipeline(M, ctx.optLevel);
+
+  // Phase 6 — final GlobalDCE. Phases 2-5 folded expect-guarded branches and
+  // deleted call sites (and unrolled-loop leftovers) that phase 1g's DCE
+  // could not see as dead; sweep the now-unreferenced callees before the JIT
+  // backend compiles them.
+  finalDCEMPM_.run(M, MAM_);
+  EJIT_DIAG_DEBUG("pipeline phase6 done: final GlobalDCE");
+
   EJIT_DIAG_VERBOSE("pipeline done func=%s key=0x%016lx", ctx.fnName.c_str(),
                     ctx.cacheKey);
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -10,26 +10,99 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Debug.h"
 // The post-specialization cleanup is the real LLVM -O2 function-simplification
-// pipeline (PassBuilder::buildFunctionSimplificationPipeline); only the light
-// cleanupFPM_ and the LowerExpect prefix are hand-added below.
+// pipeline (PassBuilder::buildFunctionSimplificationPipeline); hand-added on
+// top of it are the LowerExpect prefix, the light cleanupFPM_, the Phase 1g
+// module cleanup (RPO attrs + DAE + GlobalDCE), and the Phase 5 vectorization
+// FPMs (SLP + partial unroll at L2, loop vectorizer at L3).
 #include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/IPO/DeadArgumentElimination.h"
+#include "llvm/Transforms/IPO/FunctionAttrs.h"
+#include "llvm/Transforms/IPO/GlobalDCE.h"
 #include "llvm/Transforms/IPO/SCCP.h"
 #include "llvm/Transforms/Scalar/ADCE.h"
+#include "llvm/Transforms/Scalar/CorrelatedValuePropagation.h"
+#include "llvm/Transforms/Scalar/EarlyCSE.h"
+#include "llvm/Transforms/Scalar/LICM.h"
+#include "llvm/Transforms/Scalar/LoopLoadElimination.h"
+#include "llvm/Transforms/Scalar/LoopPassManager.h"
+#include "llvm/Transforms/Scalar/LoopUnrollAndJamPass.h"
+#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
 #include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
+#include "llvm/Transforms/Scalar/SROA.h"
+#include "llvm/Transforms/Vectorize/LoopVectorize.h"
+#include "llvm/Transforms/Vectorize/SLPVectorizer.h"
+#include "llvm/Transforms/Vectorize/VectorCombine.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
 
 #define DEBUG_TYPE "ejit-optimizer"
 
-EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
+/// Build the post-specialization vectorization FPM. Mirrors the non-LTO path
+/// of PassBuilder::addVectorPasses (PassBuilderPipelines.cpp): loop
+/// vectorization (L3 only), SLP for parallel scalar chains, trip-count-based
+/// partial unrolling + unroll-and-jam to hide backedge latency, and a late
+/// LICM. SpeedupLevel feeds the unroll cost model (2 = O2, 3 = O3).
+///
+/// Deliberate deviations from the host path, all compile-time tradeoffs:
+/// SLP runs unconditionally at L2+ (the host gates it on a cl::opt that has
+/// no meaning for an embedded runtime); the aggressive SimplifyCFG before
+/// SLP, WarnMissedTransformations, InferAlignment, AlignmentFromAssumptions
+/// and the unswitch/LICM part of the ExtraVectorizerPasses block are skipped
+/// (LICM still runs at the end of this FPM).
+static FunctionPassManager
+buildVectorizeFPM(const PipelineTuningOptions &PTO, unsigned SpeedupLevel,
+                  bool EnableLoopVectorize) {
+  FunctionPassManager FPM;
+  if (EnableLoopVectorize) {
+    FPM.addPass(LoopVectorizePass(LoopVectorizeOptions()));
+    // Eliminate loads by forwarding stores from the previous iteration.
+    FPM.addPass(LoopLoadEliminationPass());
+    FPM.addPass(InstCombinePass());
+    // Scalar part of the host's ExtraVectorizerPasses block: fold and hoist
+    // the runtime alignment/overlap checks the vectorizer inserted.
+    FPM.addPass(EarlyCSEPass());
+    FPM.addPass(CorrelatedValuePropagationPass());
+    FPM.addPass(InstCombinePass());
+  }
+  // Optimize parallel scalar instruction chains into SIMD instructions.
+  FPM.addPass(SLPVectorizerPass());
+  FPM.addPass(VectorCombinePass());
+  FPM.addPass(InstCombinePass());
+  // Partial unrolling: LoopFullUnroll (inside the simplification pipeline)
+  // only fully unrolls; partial trip-count unrolling hides backedge latency.
+  // UnrollAndJam first, as in the host pipeline.
+  FPM.addPass(createFunctionToLoopPassAdaptor(
+      LoopUnrollAndJamPass(static_cast<int>(SpeedupLevel))));
+  FPM.addPass(LoopUnrollPass(LoopUnrollOptions(static_cast<int>(SpeedupLevel),
+                                               /*OnlyWhenForced=*/false,
+                                               /*ForgetSCEV=*/false)));
+  // Unrolling can turn variable-offset GEPs into alloca into constant-offset
+  // ones; promote them. PreserveCFG: no CFG cleanup is scheduled after us.
+  FPM.addPass(SROAPass(SROAOptions::PreserveCFG));
+  FPM.addPass(InstCombinePass());
+  // Late LICM after the unroll/vectorize cleanup, as in the host pipeline.
+  // Caps come from PipelineTuningOptions, exactly as the host uses them.
+  FPM.addPass(createFunctionToLoopPassAdaptor(
+      LICMPass(PTO.LicmMssaOptCap, PTO.LicmMssaNoAccForPromotionCap,
+               /*AllowSpeculation=*/true),
+      /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/false));
+  return FPM;
+}
+
+EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg, TargetMachine *TM)
     : registry_(reg) {
   // Use the real llvm::PassBuilder to register the FULL analysis set. The O2
   // function-simplification pipeline (GVN, CorrelatedValuePropagation, etc.)
   // needs analyses the minimal EJitPassBuilder does not register (~13 vs ~40).
-  PassBuilder PB;
+  // With a TargetMachine (the engine passes the same JTMB-derived TM the JIT
+  // compiles with), TargetIRAnalysis is backend-accurate — real vector
+  // register widths, so Phase 5 vectorization can fire. Without one it falls
+  // back to the 32-bit baseline TTI, which disables the vectorizers (and
+  // skews the loop-unroll cost models).
+  PassBuilder PB(TM);
   PB.registerFunctionAnalyses(FAM_);
   PB.registerLoopAnalyses(LAM_);
   PB.registerCGSCCAnalyses(CGAM_);
@@ -70,6 +143,30 @@ EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg)
   cleanupFPM_.addPass(SCCPPass());
   cleanupFPM_.addPass(SimplifyCFGPass());
   cleanupFPM_.addPass(ADCEPass());
+
+  // cleanupMPM_ — Phase 1g, module-level cleanup of the specialized IR, run on
+  // every tier. RPO attribute inference feeds downstream folds, DAE drops
+  // parameters IPSCCP replaced with constants (DAE only rewrites
+  // local-linkage functions, so the external ejit_entry is untouched), and
+  // GlobalDCE deletes callees whose call sites the folded guards deleted —
+  // shrinking what the JIT backend must compile.
+  cleanupMPM_.addPass(ReversePostOrderFunctionAttrsPass());
+  cleanupMPM_.addPass(DeadArgumentEliminationPass());
+  cleanupMPM_.addPass(GlobalDCEPass());
+
+  // vectorizeL2/L3_ — Phase 5, post-specialization vectorization. Runs after
+  // the final StructFieldPass so the vectorizers see the fully-specialized
+  // loops (Phase 3 unrolling exposed constant-index accesses that Phase 4
+  // substituted). L2: SLP + partial unrolling; L3 adds the loop vectorizer.
+  // The Phase 5 unrolling itself runs after that last substitution: safe,
+  // because it only creates variable-index GEPs for runtime-trip-count loops
+  // (constant-trip loops were already fully unrolled in Phase 3), and
+  // vectorizer-synthesized loads never carry !ejit.may_const.
+  PipelineTuningOptions PTO;
+  vectorizeL2_ = buildVectorizeFPM(PTO, /*SpeedupLevel=*/2,
+                                   /*EnableLoopVectorize=*/false);
+  vectorizeL3_ = buildVectorizeFPM(PTO, /*SpeedupLevel=*/3,
+                                   /*EnableLoopVectorize=*/true);
 }
 
 void EJitOptimizer::clearAnalyses() {
@@ -117,10 +214,15 @@ void EJitOptimizer::runPipeline(Module &M,
   runInstCombine(M);
   runStructFieldPass(M);
   EJIT_DIAG_DEBUG("pipeline phase1ef done: callee InstCombine+StructFieldPass");
+  //   (g) Module-level cleanup: RPO attrs, dead-argument elimination, and
+  //       GlobalDCE shrink the specialized module before the expensive
+  //       per-function phases run on it.
+  runModuleCleanup(M);
+  EJIT_DIAG_DEBUG("pipeline phase1g done: module cleanup (RPO attrs + DAE + GlobalDCE)");
 
-  // Phases 2-4 — exploit those constants (scalar fixed point → loops →
-  // re-specialize → cleanup). ctx.optLevel is accepted for ABI compatibility
-  // and does not affect the pipeline.
+  // Phases 2-5 — exploit those constants (scalar fixed point → loops →
+  // re-specialize → cleanup → vectorize). ctx.optLevel selects the
+  // function-simplification tier and gates Phase 5 vectorization (L2+).
   runOptimizationPipeline(M, ctx.optLevel);
   EJIT_DIAG_VERBOSE("pipeline done func=%s key=0x%016lx", ctx.fnName.c_str(),
                     ctx.cacheKey);
@@ -243,5 +345,27 @@ void EJitOptimizer::runOptimizationPipeline(Module &M,
   for (Function &F : M.functions())
     if (!F.isDeclaration())
       cleanupFPM_.run(F, FAM_);
+
+  // Phase 5: vectorization + partial unrolling, L2+. Runs after the final
+  // StructFieldPass so the vectorizers see the fully-specialized loops. L1
+  // skips vectorization entirely (matching clang -O1).
+  if (static_cast<int>(level) >=
+      static_cast<int>(ejit::OptimizationLevel::L2)) {
+    runVectorization(M, level);
+    EJIT_DIAG_DEBUG("pipeline phase5 done: vectorization opt=%d",
+                    static_cast<int>(level));
+  }
+}
+
+void EJitOptimizer::runModuleCleanup(Module &M) {
+  cleanupMPM_.run(M, MAM_);
+}
+
+void EJitOptimizer::runVectorization(Module &M, ejit::OptimizationLevel level) {
+  FunctionPassManager &FPM =
+      (level == ejit::OptimizationLevel::L3) ? vectorizeL3_ : vectorizeL2_;
+  for (Function &F : M.functions())
+    if (!F.isDeclaration())
+      FPM.run(F, FAM_);
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -106,6 +106,10 @@ struct EJitOrcEngine::Impl {
   std::map<std::string, void *> userSymbols;
   /// If non-empty, dump JIT-optimized IR to this directory.
   std::string dumpJITDir;
+  /// TargetMachine feeding the optimizer's TargetIRAnalysis. Declared BEFORE
+  /// the optimizer so it is destroyed AFTER it (reverse declaration order).
+  /// Created from the same JITTargetMachineBuilder the JIT compiles with.
+  std::unique_ptr<TargetMachine> optimizerTM;
   /// Persistent optimizer — analysis managers are registered once and reused.
   std::unique_ptr<EJitOptimizer> optimizer;
   /// TargetMachine used for the name-filtered ASM diagnostic dump (created
@@ -708,8 +712,18 @@ EJitOrcEngine::Create(const Config &config,
       });
 
   // Create persistent optimizer — analysis managers are registered once here
-  // and reused across compilations (cleared between runs).
-  engine->P->optimizer = std::make_unique<EJitOptimizer>(periodReg);
+  // and reused across compilations (cleared between runs). Give it a real
+  // TargetMachine (same JTMB the JIT compiles with) so its TargetIRAnalysis is
+  // backend-accurate: without one, TTI falls back to a 32-bit baseline in
+  // which the vectorizers see no vector registers and never fire.
+  if (auto TMOrErr = JTMBOrErr->createTargetMachine())
+    engine->P->optimizerTM = std::move(*TMOrErr);
+  else
+    EJIT_DIAG("optimizer: createTargetMachine failed (%s); TTI falls back to "
+              "the 32-bit baseline and vectorization is disabled",
+              toString(TMOrErr.takeError()).c_str());
+  engine->P->optimizer =
+      std::make_unique<EJitOptimizer>(periodReg, engine->P->optimizerTM.get());
 
   // Register all known global variable addresses from the PeriodArrayRegistry
   // so that external global references in any loaded bitcode module resolve

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -36,11 +36,16 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Target/TargetOptions.h"
+#include "llvm/TargetParser/Host.h"
 #include "gtest/gtest.h"
 #ifndef EJIT_FREESTANDING
 #include <thread>
@@ -86,6 +91,15 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
     auto *FT = FunctionType::get(I32, {I32}, false);
     for (StringRef Name : {"dump_a", "dump_b", "dump_c"}) {
       auto *F = Function::Create(FT, Function::ExternalLinkage, Name, &M);
+      // Tag as an ejit_entry, as the AOT pass does for every looked-up
+      // function. The pipeline keeps tagged entries external; an untagged
+      // defined function is internalized in phase 1d (IPSCCP preparation) and
+      // phase 1g's GlobalDCE then deletes it as unreferenced — removing an
+      // independently-compiled entry that the lookup expects to find.
+      F->setMetadata(
+          MD_EJIT_METADATA,
+          MDNode::get(
+              Ctx, {MDNode::get(Ctx, {MDString::get(Ctx, TAG_EJIT_ENTRY)})}));
       IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
       B.CreateRet(B.CreateAdd(F->getArg(0), B.getInt32(Name.back())));
     }
@@ -136,8 +150,10 @@ struct EJitOptimizerTestAccess : EJitOptimizer {
   using EJitOptimizer::preReplacePeriodIndices;
   using EJitOptimizer::runInstCombine;
   using EJitOptimizer::runInterproceduralPropagation;
+  using EJitOptimizer::runModuleCleanup;
   using EJitOptimizer::runOptimizationPipeline;
   using EJitOptimizer::runStructFieldPass;
+  using EJitOptimizer::runVectorization;
 };
 } // namespace ejit
 } // namespace llvm
@@ -1155,6 +1171,27 @@ static std::unique_ptr<Module> createTestModule(LLVMContext &Ctx,
   return M;
 }
 
+/// Create a TargetMachine for the host target so the optimizer's
+/// TargetIRAnalysis is backend-accurate (real vector register widths). Without
+/// a TM the default TTI reports no vector registers and the vectorizers never
+/// fire. Uses the host's default triple — not a hardcoded x86-64 one — so the
+/// tests run on whatever native target this build registers (x86-64 SSE2,
+/// AArch64 NEON, ...); returns nullptr if the host target is not registered.
+static std::unique_ptr<TargetMachine> createNativeTargetMachine() {
+  // Register the native target (idempotent); there is no global fixture for
+  // this in EJITTests, individual tests call it themselves.
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  Triple HostTriple(sys::getDefaultTargetTriple());
+  std::string Err;
+  const Target *T = TargetRegistry::lookupTarget(HostTriple, Err);
+  if (!T)
+    return nullptr;
+  TargetOptions Options;
+  return std::unique_ptr<TargetMachine>(T->createTargetMachine(
+      HostTriple, "generic", "", Options, Reloc::PIC_));
+}
+
 /// Create a simple function with a period-array-index argument metadata.
 static Function *createPeriodIndFunc(LLVMContext &Ctx, Module &M,
                                      const std::string &name) {
@@ -1340,6 +1377,188 @@ TEST(EJitOptimizer, FoldsExpectGuardedConstantBranch) {
   auto *RetVal = dyn_cast<ConstantInt>(Ret->getReturnValue());
   ASSERT_NE(RetVal, nullptr);
   EXPECT_EQ(RetVal->getZExtValue(), 0u);
+}
+
+/// Create an internal callee whose body ignores its i32 argument — the state
+/// IPSCCP leaves behind after replacing a callee's parameter uses with a
+/// constant. DAE should drop the parameter; GlobalDCE should delete the
+/// function if it has no callers.
+static Function *createDeadArgCallee(LLVMContext &Ctx, Module &M,
+                                     const std::string &Name) {
+  IRBuilder<> B(Ctx);
+  auto *F = Function::Create(
+      FunctionType::get(B.getInt32Ty(), {B.getInt32Ty()}, false),
+      GlobalValue::InternalLinkage, Name, &M);
+  BasicBlock *BB = BasicBlock::Create(Ctx, "entry", F);
+  B.SetInsertPoint(BB);
+  B.CreateRet(B.getInt32(1));
+  return F;
+}
+
+TEST(EJitOptimizer, ModuleCleanupDropsDeadArgAndDeadCallee) {
+  LLVMContext Ctx;
+  auto M = createTestModule(Ctx, "moduleCleanup");
+
+  // A callee whose argument specialization made dead, called by the entry.
+  Function *Callee = createDeadArgCallee(Ctx, *M, "dead_arg_callee");
+
+  // A defined-but-unreferenced callee: guard folding deleted its last call
+  // site, leaving it dead.
+  createDeadArgCallee(Ctx, *M, "dead_callee");
+
+  IRBuilder<> B(Ctx);
+  auto *Entry =
+      Function::Create(FunctionType::get(B.getInt32Ty(), {}, false),
+                       GlobalValue::ExternalLinkage, "entry", M.get());
+  BasicBlock *BB = BasicBlock::Create(Ctx, "entry", Entry);
+  B.SetInsertPoint(BB);
+  B.CreateRet(B.CreateCall(Callee, {B.getInt32(7)}));
+
+  PeriodArrayRegistry reg;
+  EJitOptimizerTestAccess opt(reg);
+  opt.runModuleCleanup(*M);
+
+  // DAE removed the dead parameter from the callee and rewrote the call site.
+  EXPECT_EQ(Callee->arg_size(), 0u);
+  CallInst *CI = nullptr;
+  for (BasicBlock &BB : *Entry)
+    for (Instruction &I : BB)
+      if (auto *C = dyn_cast<CallInst>(&I)) {
+        CI = C;
+        break;
+      }
+  ASSERT_NE(CI, nullptr);
+  EXPECT_EQ(CI->arg_size(), 0u);
+
+  // GlobalDCE deleted the unreferenced callee.
+  EXPECT_EQ(M->getFunction("dead_callee"), nullptr);
+}
+
+/// Create a function storing four i32 constants to consecutive elements of an
+/// internal global array — the classic SLP pattern (parallel scalar stores).
+static Function *createSLPStoreFunc(LLVMContext &Ctx, Module &M,
+                                    const std::string &Name) {
+  IRBuilder<> B(Ctx);
+  Type *I32Ty = B.getInt32Ty();
+  auto *F = Function::Create(FunctionType::get(B.getVoidTy(), {}, false),
+                             GlobalValue::ExternalLinkage, Name, &M);
+  auto *Arr = new GlobalVariable(
+      M, ArrayType::get(I32Ty, 4), /*isConstant=*/false,
+      GlobalValue::InternalLinkage,
+      Constant::getNullValue(ArrayType::get(I32Ty, 4)), "arr");
+  BasicBlock *BB = BasicBlock::Create(Ctx, "entry", F);
+  B.SetInsertPoint(BB);
+  for (unsigned I = 0; I < 4; ++I) {
+    Value *GEP = B.CreateConstGEP2_64(ArrayType::get(I32Ty, 4), Arr, 0, I);
+    B.CreateStore(B.getInt32(I * 3 + 1), GEP);
+  }
+  B.CreateRetVoid();
+  return F;
+}
+
+/// Scan a function for any vector-typed value (instruction result or operand).
+static bool hasVectorType(const Function &F) {
+  for (const BasicBlock &BB : F)
+    for (const Instruction &I : BB) {
+      if (I.getType()->isVectorTy())
+        return true;
+      for (const Use &U : I.operands())
+        if (U->getType()->isVectorTy())
+          return true;
+    }
+  return false;
+}
+
+TEST(EJitOptimizer, L2SlpVectorizesStoresButL1DoesNot) {
+  LLVMContext Ctx;
+  auto M = createTestModule(Ctx, "slpTier");
+  Function *F = createSLPStoreFunc(Ctx, *M, "store4");
+
+  auto TM = createNativeTargetMachine();
+  if (!TM)
+    GTEST_SKIP() << "host target not registered in this build";
+  PeriodArrayRegistry reg;
+  EJitOptimizerTestAccess opt(reg, TM.get());
+
+  // L1: no vectorization passes run — the four stores stay scalar.
+  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L1);
+  EXPECT_FALSE(hasVectorType(*F)) << "L1 must not vectorize";
+
+  // Rebuild with a fresh module and clear the cached analyses, mirroring the
+  // production clearAnalyses() between compilations.
+  opt.clearAnalyses();
+  M = createTestModule(Ctx, "slpTier2");
+  F = createSLPStoreFunc(Ctx, *M, "store4");
+
+  // L2: SLP fuses the four scalar stores into one <4 x i32> store.
+  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
+  EXPECT_TRUE(hasVectorType(*F)) << "L2 SLP did not vectorize the stores";
+}
+
+/// Create a function with a runtime-trip-count reduction loop:
+///   int sum(ptr %a, i32 %n) { int acc = 0; for (i = 0; i < n; ++i) acc +=
+///   a[i]; }
+/// Runtime bounds keep the loop alive through full unrolling, so only the loop
+/// vectorizer (L3) can turn it into SIMD.
+static Function *createLoopSumFunc(LLVMContext &Ctx, Module &M,
+                                   const std::string &Name) {
+  IRBuilder<> B(Ctx);
+  Type *I32Ty = B.getInt32Ty();
+  auto *F =
+      Function::Create(FunctionType::get(I32Ty, {B.getPtrTy(), I32Ty}, false),
+                       GlobalValue::ExternalLinkage, Name, &M);
+  auto &Ptr = *F->arg_begin();
+  auto &N = *F->getArg(1);
+
+  BasicBlock *Entry = BasicBlock::Create(Ctx, "entry", F);
+  BasicBlock *Loop = BasicBlock::Create(Ctx, "loop", F);
+  BasicBlock *Exit = BasicBlock::Create(Ctx, "exit", F);
+  B.SetInsertPoint(Entry);
+  B.CreateBr(Loop);
+
+  B.SetInsertPoint(Loop);
+  PHINode *I = B.CreatePHI(I32Ty, 2, "i");
+  PHINode *Acc = B.CreatePHI(I32Ty, 2, "acc");
+  I->addIncoming(B.getInt32(0), Entry);
+  Acc->addIncoming(B.getInt32(0), Entry);
+  Value *GEP = B.CreateGEP(I32Ty, &Ptr, I);
+  Value *V = B.CreateLoad(I32Ty, GEP, "v");
+  Value *AccNext = B.CreateAdd(Acc, V, "acc.next");
+  Value *INext = B.CreateAdd(I, B.getInt32(1), "i.next");
+  Value *Cmp = B.CreateICmpULT(INext, &N, "cmp");
+  I->addIncoming(INext, Loop);
+  Acc->addIncoming(AccNext, Loop);
+  B.CreateCondBr(Cmp, Loop, Exit);
+
+  B.SetInsertPoint(Exit);
+  B.CreateRet(AccNext);
+  return F;
+}
+
+TEST(EJitOptimizer, L3LoopVectorizesButL2DoesNot) {
+  LLVMContext Ctx;
+  auto M = createTestModule(Ctx, "loopVecTier");
+  Function *F = createLoopSumFunc(Ctx, *M, "sum");
+
+  auto TM = createNativeTargetMachine();
+  if (!TM)
+    GTEST_SKIP() << "host target not registered in this build";
+  PeriodArrayRegistry reg;
+  EJitOptimizerTestAccess opt(reg, TM.get());
+
+  // L2: partial unrolling only — the loop stays scalar.
+  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L2);
+  EXPECT_FALSE(hasVectorType(*F)) << "L2 must not loop-vectorize";
+
+  // Rebuild with a fresh module and clear the cached analyses, mirroring the
+  // production clearAnalyses() between compilations.
+  opt.clearAnalyses();
+  M = createTestModule(Ctx, "loopVecTier2");
+  F = createLoopSumFunc(Ctx, *M, "sum");
+
+  // L3: the loop vectorizer turns the reduction into SIMD.
+  opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L3);
+  EXPECT_TRUE(hasVectorType(*F)) << "L3 loop vectorizer did not fire";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -1418,7 +1418,12 @@ TEST(EJitOptimizer, ModuleCleanupDropsDeadArgAndDeadCallee) {
   EJitOptimizerTestAccess opt(reg);
   opt.runModuleCleanup(*M);
 
-  // DAE removed the dead parameter from the callee and rewrote the call site.
+  // DAE replaced the callee with a new zero-arg function, ERASING the old one
+  // (DeadArgumentElimination.cpp takeName/eraseFromParent), and rebuilt the
+  // call site too — both pointers captured above dangle after the cleanup.
+  // Re-fetch by name / re-scan before asserting.
+  Callee = M->getFunction("dead_arg_callee");
+  ASSERT_NE(Callee, nullptr);
   EXPECT_EQ(Callee->arg_size(), 0u);
   CallInst *CI = nullptr;
   for (BasicBlock &BB : *Entry)
@@ -1456,6 +1461,14 @@ static Function *createSLPStoreFunc(LLVMContext &Ctx, Module &M,
   return F;
 }
 
+/// Apply the TM's target triple and DataLayout to a test module so the
+/// vectorizers see the same backend-accurate TTI/cost models the optimizer's
+/// TargetIRAnalysis uses — not the module defaults (no DL at all).
+static void setTargetAttrsFromTM(Module &M, const TargetMachine &TM) {
+  M.setTargetTriple(TM.getTargetTriple());
+  M.setDataLayout(TM.createDataLayout());
+}
+
 /// Scan a function for any vector-typed value (instruction result or operand).
 static bool hasVectorType(const Function &F) {
   for (const BasicBlock &BB : F)
@@ -1477,6 +1490,7 @@ TEST(EJitOptimizer, L2SlpVectorizesStoresButL1DoesNot) {
   auto TM = createNativeTargetMachine();
   if (!TM)
     GTEST_SKIP() << "host target not registered in this build";
+  setTargetAttrsFromTM(*M, *TM);
   PeriodArrayRegistry reg;
   EJitOptimizerTestAccess opt(reg, TM.get());
 
@@ -1488,6 +1502,7 @@ TEST(EJitOptimizer, L2SlpVectorizesStoresButL1DoesNot) {
   // production clearAnalyses() between compilations.
   opt.clearAnalyses();
   M = createTestModule(Ctx, "slpTier2");
+  setTargetAttrsFromTM(*M, *TM);
   F = createSLPStoreFunc(Ctx, *M, "store4");
 
   // L2: SLP fuses the four scalar stores into one <4 x i32> store.
@@ -1543,6 +1558,7 @@ TEST(EJitOptimizer, L3LoopVectorizesButL2DoesNot) {
   auto TM = createNativeTargetMachine();
   if (!TM)
     GTEST_SKIP() << "host target not registered in this build";
+  setTargetAttrsFromTM(*M, *TM);
   PeriodArrayRegistry reg;
   EJitOptimizerTestAccess opt(reg, TM.get());
 
@@ -1554,11 +1570,107 @@ TEST(EJitOptimizer, L3LoopVectorizesButL2DoesNot) {
   // production clearAnalyses() between compilations.
   opt.clearAnalyses();
   M = createTestModule(Ctx, "loopVecTier2");
+  setTargetAttrsFromTM(*M, *TM);
   F = createLoopSumFunc(Ctx, *M, "sum");
 
   // L3: the loop vectorizer turns the reduction into SIMD.
   opt.runOptimizationPipeline(*M, llvm::ejit::OptimizationLevel::L3);
   EXPECT_TRUE(hasVectorType(*F)) << "L3 loop vectorizer did not fire";
+}
+
+/// Build the Phase 2-4 dead-callee scenario: a may_const load feeding an
+/// llvm.expect guard whose dead half calls an internal helper. Phase 1c
+/// substitutes the load, but the expect intrinsic blocks branch folding until
+/// Phase 2 (LowerExpect) — so the call is still live when Phase 1g's GlobalDCE
+/// runs, and only phases 2-3 delete it. The helper's last call site dies AFTER
+/// 1g, so without a final DCE sweep it survives to the backend compile.
+static void createExpectGuardDeadCalleeFunc(LLVMContext &Ctx, Module &M) {
+  IRBuilder<> B(Ctx);
+  Type *I32Ty = B.getInt32Ty();
+  Type *I64Ty = B.getInt64Ty();
+
+  // int32_t g_cfg[4], tagged as the period array the registry knows as "cell".
+  auto *ArrTy = ArrayType::get(I32Ty, 4);
+  auto *GVar = new GlobalVariable(M, ArrTy, /*isConstant=*/false,
+                                  GlobalValue::InternalLinkage,
+                                  Constant::getNullValue(ArrTy), "g_cfg");
+  Metadata *ArrMDOps[] = {
+      MDString::get(Ctx, TAG_EJIT_PERIOD_ARR),
+      MDString::get(Ctx, "cell"),
+      ConstantAsMetadata::get(ConstantInt::get(I32Ty, 4)),
+  };
+  GVar->setMetadata(MD_EJIT_METADATA,
+                    MDNode::get(Ctx, {MDNode::get(Ctx, ArrMDOps)}));
+
+  // void dead_helper() — its only call site dies when the guard folds.
+  auto *Helper =
+      Function::Create(FunctionType::get(B.getVoidTy(), {}, false),
+                       GlobalValue::InternalLinkage, "dead_helper", &M);
+  BasicBlock *HBB = BasicBlock::Create(Ctx, "entry", Helper);
+  B.SetInsertPoint(HBB);
+  B.CreateRetVoid();
+
+  FunctionCallee ExpectFn = M.getOrInsertFunction(
+      "llvm.expect.i64", FunctionType::get(I64Ty, {I64Ty, I64Ty}, false));
+
+  // entry: %v = load i32 (may_const) @g_cfg[2]  — 42 after phase 1c
+  //        %e = expect(zext %v, 1)
+  //        %c = icmp eq %e, 0                    — false: 42 != 0
+  //        br %c, guard, fast
+  // guard: call dead_helper(); ret 0             — the v==0 case, folded away
+  // fast:  ret 1                                 — survives
+  auto *F = Function::Create(FunctionType::get(I32Ty, {}, false),
+                             GlobalValue::ExternalLinkage, "entry", &M);
+  // Tag it as the ejit_entry so phase 1d's internalization skips it.
+  F->setMetadata(
+      MD_EJIT_METADATA,
+      MDNode::get(Ctx,
+                  {MDNode::get(Ctx, {MDString::get(Ctx, TAG_EJIT_ENTRY)})}));
+  BasicBlock *EntryBB = BasicBlock::Create(Ctx, "entry", F);
+  BasicBlock *Guard = BasicBlock::Create(Ctx, "guard", F);
+  BasicBlock *Fast = BasicBlock::Create(Ctx, "fast", F);
+
+  B.SetInsertPoint(EntryBB);
+  Value *GEP = B.CreateConstGEP2_64(ArrTy, GVar, 0, 2, "gep");
+  auto *Load = B.CreateLoad(I32Ty, GEP, "v");
+  Load->setMetadata("ejit.may_const",
+                    MDNode::get(Ctx, MDString::get(Ctx, "ejit")));
+  auto *E = B.CreateCall(ExpectFn,
+                         {B.CreateZExt(Load, I64Ty, "z"), B.getInt64(1)}, "e");
+  auto *C = B.CreateICmpEQ(E, B.getInt64(0), "c");
+  B.CreateCondBr(C, Guard, Fast);
+
+  B.SetInsertPoint(Fast);
+  B.CreateRet(B.getInt32(1));
+
+  B.SetInsertPoint(Guard);
+  B.CreateCall(Helper, {});
+  B.CreateRet(B.getInt32(0));
+}
+
+TEST(EJitOptimizer, FinalGlobalDceDropsExpectGuardFreedHelper) {
+  LLVMContext Ctx;
+  auto M = createTestModule(Ctx, "finalDce");
+
+  // Runtime value for the may_const load: g_cfg[2] = 42.
+  int32_t cfg[4] = {0, 0, 42, 0};
+  PeriodArrayRegistry reg;
+  reg.registerArray("cell", "g_cfg", cfg, 4);
+  createExpectGuardDeadCalleeFunc(Ctx, *M);
+
+  SpecializationContext ctx;
+  ctx.fnName = "entry";
+  ctx.dimensions.push_back({"cell", 2});
+  ctx.optLevel = llvm::ejit::OptimizationLevel::L3;
+
+  EJitOptimizerTestAccess opt(reg);
+  opt.runPipeline(*M, ctx);
+
+  // Phases 2-3 folded the guard and deleted its dead half — and with it the
+  // call to dead_helper — only AFTER phase 1g's GlobalDCE ran. The final
+  // sweep must delete the helper so the backend never compiles it.
+  EXPECT_EQ(M->getFunction("dead_helper"), nullptr)
+      << "helper whose only call site died in phases 2-3 survived the pipeline";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -1650,25 +1650,38 @@ static void createExpectGuardDeadCalleeFunc(LLVMContext &Ctx, Module &M) {
 
 TEST(EJitOptimizer, FinalGlobalDceDropsExpectGuardFreedHelper) {
   LLVMContext Ctx;
-  auto M = createTestModule(Ctx, "finalDce");
-
   // Runtime value for the may_const load: g_cfg[2] = 42.
   int32_t cfg[4] = {0, 0, 42, 0};
   PeriodArrayRegistry reg;
   reg.registerArray("cell", "g_cfg", cfg, 4);
-  createExpectGuardDeadCalleeFunc(Ctx, *M);
 
   SpecializationContext ctx;
   ctx.fnName = "entry";
   ctx.dimensions.push_back({"cell", 2});
   ctx.optLevel = llvm::ejit::OptimizationLevel::L3;
 
+  // Pin the phase-6 necessity premise: phase 1g's GlobalDCE runs while the
+  // helper's only call is still live behind the expect guard (which folds
+  // only in phase 2) — so the helper must survive 1g. If this assertion ever
+  // fails, the guard folded earlier than the pipeline claims and the final
+  // sweep below would be dead code.
+  {
+    auto M = createTestModule(Ctx, "finalDce");
+    createExpectGuardDeadCalleeFunc(Ctx, *M);
+    EJitOptimizerTestAccess opt(reg);
+    opt.runModuleCleanup(*M);
+    EXPECT_NE(M->getFunction("dead_helper"), nullptr)
+        << "guard-held call must keep the helper alive at phase 1g";
+  }
+
+  // The full pipeline then folds the guard (phases 2-3, after LowerExpect)
+  // and deletes its dead half — and with it the call to dead_helper — only
+  // AFTER phase 1g's GlobalDCE ran. The final sweep must delete the helper
+  // so the backend never compiles it.
+  auto M = createTestModule(Ctx, "finalDce");
+  createExpectGuardDeadCalleeFunc(Ctx, *M);
   EJitOptimizerTestAccess opt(reg);
   opt.runPipeline(*M, ctx);
-
-  // Phases 2-3 folded the guard and deleted its dead half — and with it the
-  // call to dead_helper — only AFTER phase 1g's GlobalDCE ran. The final
-  // sweep must delete the helper so the backend never compiles it.
   EXPECT_EQ(M->getFunction("dead_helper"), nullptr)
       << "helper whose only call site died in phases 2-3 survived the pipeline";
 }


### PR DESCRIPTION
Three-way pipeline comparison showed the ejit_entry JIT path lacked two capabilities the AOT O2 path has: module-level cleanup and vectorization (no vectorizer pass ever ran; and without a TargetMachine, TTI reports a 32-bit baseline so the vectorizers could not fire anyway).

- Phase 1g: module cleanup on every tier — RPO function attrs + dead-argument elimination + GlobalDCE. DAE drops parameters IPSCCP replaced with constants; GlobalDCE deletes functions whose call sites folded guards removed. DAE only rewrites local-linkage functions, so the external ejit_entry is untouched.
- Phase 5: post-specialization vectorization, gated by tier. L2 runs SLP
  + partial loop unrolling (+ VectorCombine, LICM); L3 adds the loop vectorizer + loop-load elimination. L1 skips vectorization, matching clang -O1. Runs after the final StructFieldPass so the vectorizers see fully-specialized loops.
- Plumb the engine's JTMB-derived TargetMachine into EJitOptimizer so PassBuilder's TargetIRAnalysis is backend-accurate; without it TTI falls back to the 32-bit baseline and vectorization never triggers.
- Re-inlining is intentionally not added: the embedded bitcode is closure-trimmed with externalized helpers, so there is nothing to inline; DAE covers the dead-parameter win instead.
- Tests: 3 new gtests (module cleanup, L2 SLP, L3 loop vectorization) using a native-host TargetMachine; tag the dump test's independent entries with ejit_entry metadata, since the pipeline internalizes and DCEs untagged defined functions. Also fix include order and use the host default triple with GTEST_SKIP for portability.
- Sync PASS7 design doc: phase list gains 1g + phase 5, optLevel now gates vectorization, ctor snippet feeds the TM.