### PR TITLE
[EJIT] specialization dedup: reuse code for equal-fingerprint compiles

### DIFF
--- a/jit_design_doc/EJIT_SPECIALIZATION_DEDUP.md
+++ b/jit_design_doc/EJIT_SPECIALIZATION_DEDUP.md
@@ -1,0 +1,431 @@
+# EmbeddedJIT 特化版本去重(特化后 IR 指纹合并)设计文档
+
+**版本**: 0.4
+**日期**: 2026-08-21
+**状态**: **v1 已实现**(分支 ejit_spec_dedup;实现状态见 §14)
+**修订**: 0.2 检视修订--v1 合并限定同 funcIdx(StructuralHash 不哈希签名/
+  属性/flags,跨函数可构造碰撞,见 §5.4);新增 releaser 硬门(§5.5);
+  DryRun 计数口径(§9);清理时机修正(ejit_clear_cache 现为 no-op)。
+  0.3 --补指纹存放位置与内存布局(§5.5);新增代码回收与共享指针的
+  三层复杂度拆解及回收路径排序(§13)
+**关联**: EJIT_ICACHE_ANALYSIS.md, EJIT_ICACHE_MULTIVERSION.md, EJIT_ICACHE_SHARED_TABLE.md, EJIT_SRE_CODE_POOL.md, EJIT_SRE_TASKPOOL.md, PASS6_EJitStructFieldPass.md, PASS7_EJitRuntime_OrcJITLink.md
+**目标**: 消除内容等价的特化版本造成的 JIT 代码段膨胀,改善 icache/代码池占用
+
+---
+
+## 1. 背景与问题
+
+多维 `ejit_dim` 特化按 `(funcIndex, dims)` 身份组合出多个特化版本。每个版本独立
+codegen、独立占用 code pool,**当前没有任何去重与回收**:
+
+- 每次特化 = 新建独立 JITDylib(`spec_<cacheKey>`)+ 一次
+  `allocateCode`(EJitOrcEngine.cpp `loadBitcodeModule`);
+- code pool 纯 bump 分配,"Pool memory is not reclaimed in v1"
+  (EJitCodePoolMemoryManager.cpp `FinalizedInfo` / `deallocate` 注释);
+- 生产环境 `setReleaser` 未接线(仅单测使用),驱逐/重编译都不释放代码。
+
+当多个 instance(如 N 个同配置小区/通道)的 period 数组**内容相同**、或特化常量
+实际不影响代码时,产生的多份机器码完全等价,却各占一份代码段。这直接放大了
+`.text.ejit` 的驻留体积与 icache 工作集(问题背景见 EJIT_ICACHE_ANALYSIS.md,
+多版本分发机制见 EJIT_ICACHE_MULTIVERSION.md)。
+
+## 2. 现状关键事实(方案边界由它们决定)
+
+| # | 事实 | 出处 |
+|---|---|---|
+| F1 | 编译严格串行:async 走单一 owner worker `runCompile`;sync 模式也仅 owner 可内联编译 | EJitSharedTaskPool.cpp `runCompile` / `compileOrGet` sync 分支 |
+| F2 | cache slot 按 `(funcIndex, dims)` 身份键控,`fnPtr`/`codeStart`/`codeSize` 只是值;dispatch、inline-cache cell、per-core L0、`executableCoreMask` 全部按身份或 slot 维度工作,无 "fnPtr 反查身份" 假设 | EJitSharedTaskPoolState.h `EJitSharedCacheSlot`;EJitRuntime.cpp L0 路径 |
+| F3 | 特化真实输入 = bitcode(funcIdx) + cellIdx + **运行期数组内容**(StructFieldPass 编译期 `memcpy` 活内存) | EJitOptimizer.cpp `preReplacePeriodIndices`;EJitStructFieldPass.cpp 读值路径 |
+| F4 | 特化 pipeline 挂在 LLJIT IRTransformLayer,`lookup` 触发 materialization 时才执行 | EJitOrcEngine.cpp `setTransform` lambda |
+| F5 | code pool FinalizedRanges append-only,`findRange` 可解析任意已发布指针的区间 | EJitCodePool.h `recordFinalizedRange`/`findRange` |
+| F6 | peer 4K seal 按 slot 独立跟踪(`executableCoreMask`),平台 `enable_ex` 幂等 | EJitSharedTaskPoolState.h;EJitSrePlatform |
+
+## 3. 目标与非目标
+
+**目标**
+
+1. 内容等价的特化版本共享同一份机器码:新身份的 cache slot 发布**已存在版本的
+   fnPtr**,不再为新版本分配 code pool;
+2. 合并判定绝对保守:任何不确定因素都只能导致"不合并",绝不导致"错误合并";
+3. 与现有分发机制零冲突:cache publish、inline-cache、L0、跨核 seal、驱逐/重编译
+   语义全部不变;
+4. 可先测量后启用(DryRun 模式),可配置关闭。
+
+**非目标**
+
+- 不做代码段回收/去分配(仍遵守 v1 "sealed 页不回收" 约束,只是让等价版本
+  **根本不产生**第二份代码);
+- 不追求降低编译时延(去重命中仍需 parse + 特化 pipeline,省的是 codegen +
+  link + seal + pool 分配);
+- 不合并"语义相似但不同"的版本(仅字节级等价判定);
+- 不改共享内存结构 ABI(`EJitSharedTaskPoolState` 不动,abiVersion 不变)。
+
+## 4. 候选方案与选择
+
+| 方案 | 判据 | 判定点 | 需要回收? | 结论 |
+|---|---|---|---|---|
+| A. 编译后比机器码 | 全 allocation 字节相同 | codegen 后、finalize/seal 前 | 需要 pool bump 回滚 API | 备选,暂缓 |
+| B. 特化后 IR 指纹 | post-pipeline IR 结构相同 | pipeline 后、codegen 前 | 不需要(重复代码不产生) | **采用** |
+| C. 编译前按数组内容 hash | 引用 cell 字节相同 | 编译前 | 不需要 | **否决**(见 §5.1) |
+| D. 记录"替换值向量"指纹 | 替换出的常量集合相同 | pipeline 内 | 不需要 | **否决**(见 §5.1) |
+
+确定性的单线程编译下,"post-pipeline IR 相同"与"机器码相同"命中的集合一致
+(同进程、同 TargetMachine、外部符号同地址),B 以更小的机制覆盖了 A 的全部收益,
+且免除 A 的三大负担:pool 回滚、seal 前决策时序、debug 段/模块名字节剔除
+(`spec_<cacheKey>` 名字只影响机器码比对,不影响 IR 指纹,见 §6.2)。
+A 仅在"存在未预见的 codegen 不确定性"时才有兜底价值,留作观察 DryRun 数据后
+的可选项(§12)。
+
+## 5. 关键设计决策
+
+### 5.1 指纹必须取在 pipeline 之后(否决 C/D 的反例)
+
+cellIdx 本身是被 `preReplacePeriodIndices` 烘进 IR 的常量。若函数分支依赖 idx:
+
+```c
+EJIT_ENTRY void f(EJIT_DIM(cell) uint8_t idx) {
+    if (idx == 3) { x = g_arr[idx].a; }   // cell 0 与 cell 5 走不同分支
+    else          { x = g_arr[idx].b; }
+}
+```
+
+cell 0 与 cell 5 即使**全部字段内容相同**,特化结果也在结构上不同(折叠了不同
+分支、读了不同字段)。方案 C(整 cell 内容相同)与方案 D(替换值集合相同,两者
+恰好相等)都会错误合并。
+
+而取 pipeline 之后的 IR 做指纹,idx 常量就在 IR 里:分支折叠不同 ⇒ IR 不同 ⇒
+不合并。**pipeline 输出天然是全部特化输入(F3)的依赖闭包**,无需逐项枚举输入,
+也就没有枚举遗漏。
+
+### 5.2 等价判据与正确性链条
+
+```
+指纹相同 ⇒ 特化后 IR 结构相同
+        ⇒ (编译串行确定、同进程同 TM、外部符号同地址)
+        ⇒ 机器码相同 ⇒ 旧 fnPtr 对新身份语义正确
+```
+
+任一环节的怀疑点都必须往"指纹不同"方向失效(§8)。
+
+### 5.3 判定点前移:重构 compile 链
+
+现状 pipeline 在 IRTransformLayer 里(F4),materialization 内部无法"返回已有
+地址替代发码"。重构为**急切执行**(全部仍在 owner 核串行,F1):
+
+```cpp
+// EJitOrcEngine 新 API,替代 loadBitcodeModule + lookup 两步外部调用
+struct SpecializeResult { void *fnPtr = nullptr; bool deduped = false; };
+
+Expected<SpecializeResult> EJitOrcEngine::specializeAndResolve(
+    StringRef bitcodeData, uint64_t cacheKey, const std::string &fnName) {
+  // 1. parse + 前置修正(dso_local、static entry 外链化)
+  //    -- 今 loadBitcodeModule 开头段原样搬
+  // 2. optimizer->clearAnalyses(); runPipeline(M, ctx)
+  //    -- 从 IRTransformLayer lambda 搬出;dump _pre.ll/_opt.ll、
+  //       captureDump 一并搬(同一 lambda 内的既有逻辑)
+  // 3. fp = hashModuleIR(M)                       // §5.4
+  // 4. if (DedupEntry *E = dedupIndex_.find(cacheKey>>32 /*funcIdx*/, fp))
+  //       return {E->fnPtr, /*deduped=*/true};    // 到此为止:不建 JD、
+  //                                                // 不 codegen、不占 pool
+  // 5. 今 loadBitcodeModule 尾段:收集 globalSymbols、建 spec JD、
+  //    absoluteSymbols、addIRModule(transform 层此时直通,§5.6)
+  // 6. fnPtr = lookup(cacheKey, fnName);          // 现逻辑不变
+  //    dedupIndex_.insert(funcIdx, fp, fnPtr);
+  //    return {fnPtr, false};
+}
+```
+
+- `compileCold`(EJitCompileDriver.cpp)改调这一个 API;dims 校验、isActive
+  检查不动;taskpool 的 `runCompile`/sync 路径**零改动**——`compileFn_`
+  返回旧 fnPtr 后,`codeRangeFn_`、版本门(cp1/cp2)、`cachePublish` 照旧;
+- dedup 命中时该 cacheKey **不创建 JITDylib**:`specDylibs` 无此 key,
+  `ejit_clear_cache`/重编译遍历不到,无需清理,行为一致;
+- legacy 调用方 `compileCold(cacheKey, /*storeLru=*/true)` 走同一 API,
+  行为不变。
+
+### 5.4 指纹构造:`StructuralHash` + initializer 补充哈希
+
+采用 in-tree `llvm::StructuralHash(M, /*DetailedHash=*/true)`
+(llvm/lib/IR/StructuralHash.cpp),已核实其跨编译确定性恰好满足需求:
+
+- GlobalValue(外部函数/全局)按**名字**哈希(`hashGlobalValue`)——两次 parse
+  的不同指针无影响;名字不同 ⇒ 指纹不同,保守方向正确;
+- 本地 value 按首次出现顺序分配 ID(`ValueToId`)——结构相同 ⇒ ID 序相同;
+- **Module 名不参与哈希**(`update(M)` 只遍历 globals/functions)——
+  `spec_<cacheKey>` 天然无害,无需规范化;
+- 常量(含替换进的 ConstantInt)在 DetailedHash 下进指令操作数哈希——
+  **特化常量差异在此被捕获**。
+
+**必须补的盲点**:`update(const GlobalVariable &GV)` 对模块内定义的全局只哈希
+类型 ID,不含 **initializer**;指令引用 GV 也只按名字。风险场景:O2-ish
+`runOptimizationPipeline` 中 GlobalOpt 可能把静态变量提升为常量全局、把特化
+常量编进 initializer——两个版本指令完全相同、仅 initializer 不同,会漏检
+(与机器码方案下 AArch64 literal pool 是同类问题,提前到 IR 层)。
+
+补法:自写 ~30 行 initializer 哈希 walker(类型 + Constant opcode + 递归操作数,
+GV 引用按名字),对每个非声明 GV 折进指纹。不用 `M.print`→SHA-1 兜底
+(全模块打印代价高;walker 足够)。
+
+**二级哈希**:叠加一个独立 FNV-1a 于指令流,`DedupEntry` 存双哈希,命中需两个
+都相等,压缩碰撞概率到可忽略。
+
+**覆盖面与构造保证(检视修订)**:`StructuralHash` 不哈希的维度比想象的多--
+除 initializer 外,还包括**函数签名(参数/返回类型,只哈希 arg_size 与
+isVarArg)、函数属性(byval/sret/align 等)、指令 flags(nsw/nuw/volatile/
+atomic/fastmath)、全部 metadata**(`update(const Function&)` 与
+`hashInstruction` 的实现)。这些维度不逐一补哈希,而是由 **v1 合并范围限定在
+同 funcIdx 内**一次性覆盖:同 funcIdx ⇒ 同一 bitcode ⇒ 签名/属性/metadata
+构造上全同;flags 由同一确定性 pipeline 产出,亦构造上全同。限定不成立的
+反例(跨函数碰撞,已核实可构造):
+
+```llvm
+define void @f(i32 %a) { ret void }   ; %a 未使用
+define void @g(i8  %a) { ret void }   ; arg_size 同为 1,体同构
+                                      ; -> StructuralHash 相同,签名却不同
+```
+
+跨 funcIdx 合并若未来开启,必须先补齐签名 + 属性 + flags 哈希(见 §12)。
+
+**实现期断言**(写进实现清单):
+
+- [ ] gtest 断言同一输入两次编译指纹相同(确定性回归);
+- [ ] gtest 断言不同 cellIdx 且内容不同的两次编译指纹不同;
+- [ ] 构造 GlobalOpt 提升用例,断言 initializer walker 使指纹分化;
+- [ ] gtest 断言同 funcIdx 不同签名的两个函数(手构 bitcode)不会被合并
+      (key 含 funcIdx 后构造上不可能,断言防回归)。
+
+### 5.5 去重索引
+
+```cpp
+struct DedupEntry {
+  uint32_t funcIndex;   // v1 限定同 funcIdx 合并(见 §5.4 覆盖面说明)
+  stable_hash fp;      // StructuralHash(Detailed)
+  uint64_t fp2;        // FNV 二级哈希
+  uint64_t irUnits;    // 函数数 + 指令计数粗计数(快速比对)
+  void *fnPtr;         // 已发布版本的入口
+};                     // 40B/条(512 项 = 20KB)
+```
+
+**存放位置**:owner 编译核私有内存,挂 `EJitOrcEngine::Impl`(pimpl)上,
+与 `specDylibs` 同级同生命周期。不放跨核共享段(查询/插入只在 owner 编译线程
+发生,放共享段要动 abiVersion 而收益为零;命中结果对 peer 的可见性走既有
+cache slot 的 fnPtr);不存 IR 副本,只存哈希--这是用双哈希 + irUnits
+代替"留全文精确比较"的原因:
+
+```
+┌─ 跨核共享段(EJitSharedTaskPoolState)────┐  ┌─ owner worker 核私有 ───────────┐
+│  cache buckets/slots (identity -> fnPtr)   │  │  EJitOrcEngine::Impl           │
+│  queue / 在飞 dedup / counters             │  │    specDylibs (map)            │
+│  ← 指纹不放这里:ABI 零改动                │  │    dedupIndex ← 指纹在这里     │
+│                                            │  │    (40B × 512 = 20KB 定长)    │
+└────────────────────────────────────────────┘  └────────────────────────────────┘
+```
+
+读写时机都在 `specializeAndResolve` 内、编译线程上完成:pipeline 后算指纹
+-> `find(funcIdx, fp)` -> 命中返回旧 fnPtr;未命中走完 codegen/lookup 后
+`insert`。无锁(F1 串行),无跨核发布。
+
+- **owner 私有、定长、开地址**:默认 512 项,满则对新条目静默降级
+  (记一次日志)。定长换嵌入式内存可预测;挂引擎私有状态(与 `specDylibs`
+  同生命周期);
+- **key = (funcIndex, fp, fp2, irUnits)**:v1 不做跨函数合并。理由见 §5.4--
+    `StructuralHash` 不哈希签名/属性/flags/metadata,跨函数碰撞会产生
+    wrong-code(调用约定/属性不匹配);同 funcIdx 下这些维度由同 bitcode
+    构造上保证相同。跨函数合并移至 §12,前置条件是补齐这些维度的哈希;
+- **清理时机**:owner 代数更替(generation bump)时清空(唯一现实触发点;
+  `ejit_clear_cache` 现为 no-op--legacy LRU 已退役,EJit.cpp `clearCache`)。
+  严格说 v1 代码永不回收、旧 fnPtr 永远可调用(F5),不清也健全;清空是保守
+  策略,换取"索引生命周期与 ORC 引擎一致"的心智模型;
+- **releaser 硬门(检视修订)**:`runCompile`/sync 路径在 VersionMismatch 与
+  publish 失败时会对 `compileFn_` 返回的 fn 调 `releaseFn_`(EJitSharedTaskPool.cpp
+  `runCompile` 尾部、sync 分支)。dedup 命中时该 fn 是**其他身份正在派发的
+  共享指针**,一旦释放即多身份 UAF。因此 dedup 启用是**硬不变量:
+  dedupMode != OFF ⇒ releaser 必须为 null**--init 时 assert,或检测到
+  `setReleaser` 接线即自动降级 dedup OFF(与 `icacheReclamationSafe_` 门
+  同构;该门只管 icacheFill,管不到本路径,不能作为替代)。
+
+### 5.6 IRTransformLayer 直通
+
+引擎加 `P->preSpecialized` 标志:第 5 步 `addIRModule` 前置位,transform
+lambda 检查到即原样返回。编译全部串行在 owner 核(F1),普通 bool 无竞态,
+加 assert。dump/capture 逻辑随 pipeline 迁走后,transform 内不再有其他职责。
+
+### 5.7 发布路径零改动的逐点核对
+
+去重命中后,新身份 slot 发布**旧 fnPtr + 旧代码区间**,现有机制逐点透明:
+
+| 机制 | 键 | 共享同一 fnPtr 的影响 |
+|---|---|---|
+| cache slot / `cachePublish` | `(funcIndex, dims)` | 无:别名的只是 fnPtr 值,发布 API 不改一行 |
+| `codeRangeFn_` → `findRange` | FinalizedRanges(append-only,F5) | 旧指针照常解析出旧区间 |
+| inline-cache cell / per-core L0 | 身份 | 无(每身份一个 cell,值相同而已) |
+| peer 4K seal `executableCoreMask` | 每 slot 独立 | 同一页可能被 peer 经两个 slot 各 seal 一次;`enable_ex` 幂等(F6),冷路径小开销 |
+| 驱逐/重编译 | slot | 驱逐后再编译 → 指纹命中 → 又发布旧指针,天然幂等 |
+| `releaseFn_`(VersionMismatch/publish 失败路径) | - | **唯一例外**:会对 `compileFn_` 返回的共享指针调释放;由 §5.5 releaser 硬门排除(dedup ON ⇒ releaser 为 null) |
+| `dispatchEpoch` | 全局事件 | 发布行为与普通发布一致,无增量 |
+
+## 6. 失效方向分析(方案核心安全性)
+
+| 不确定因素 | 失效方向 |
+|---|---|
+| StructuralHash 未覆盖的边角(metadata/attr/打印不确定性) | 指纹不同 → 不合并(安全) |
+| initializer walker 遗漏新形式的 IR 差异 | 同上 |
+| 索引满 | 新条目不去重(安全) |
+| 哈希碰撞 | 双 64 位哈希 + irUnits 都相等,概率压到可忽略(512 条,生日碰撞 ~10⁻¹⁵ 量级) |
+| 竞态/TOCTOU | 见 §7 |
+
+唯一能朝"错误合并"方向失效的是哈希碰撞,已由双哈希压制。
+
+## 7. 并发与竞态
+
+- **编译串行**(F1):索引读写无锁;
+- **TOCTOU(编译期间数组内容被改)**:指纹是对 pipeline **实际产出**的 IR 算的。
+  撕裂读 ⇒ 指纹不再等于任何干净版本 ⇒ 走正常编译。与今天"撕裂编译照样发布"
+  同类,是已接受的风险,**没有引入新窗口**;
+- **activate/deactivate 竞态**:现有版本门(cp1/cp2、`cachePublish` 内重验)
+  对 dedup 命中路径同样生效——`compileFn_` 返回后校验的语义不变;
+- **peer 并发读 cache**:与普通发布完全相同(slot 状态机 + bucket 锁),
+  别名不改变发布协议。
+
+## 8. 开销
+
+| 路径 | 增量 |
+|---|---|
+| dedup 未命中(每次编译) | 一次 StructuralHash + walker,O(模块大小),远小于 pipeline 本身 |
+| dedup 命中 | 仍付 parse + pipeline;省 codegen + JITLink + seal + pool 分配。**收益是代码段体积与 icache,不是时延** |
+| 常驻内存 | 索引 20KB(512 × 40B,§5.5) |
+| 共享内存 ABI | 零 |
+
+收益上限 = 被合并版本数 × 单版本代码体积;命中率取决于负载中"等值内容多实例"
+与"常量不影响代码"的占比,**先 DryRun 实测再启用**(§9)。
+
+## 9. 配置与 DryRun
+
+`ejit_config_t` 末尾追加(additive,零默认 = 关):
+
+```c
+typedef enum {
+  EJIT_DEDUP_OFF = 0,     // 默认,行为与今天完全一致
+  EJIT_DEDUP_DRY_RUN = 1, // 算指纹、计数"本可合并",照常编译(测量用,零风险)
+  EJIT_DEDUP_ON = 2,      // 启用合并
+} ejit_dedup_mode_t;
+```
+
+- DryRun 是上板测量步骤:统计"本可合并次数 × 当次代码体积"即预估节省量,
+  且因不改变行为,可与 ON 版本做 A/B 回归。**计数口径**:只在最终发布成功
+  (过版本门)时计数--version-gate 失败被丢弃的编译不计,避免高估;
+- 统计口径注意:dedup 命中同样走 `Published` -> `asyncCompiles` +1,
+  现有计数看不出"省了一次编译";靠 dedup 专属 diag/计数区分;
+- 诊断:`EJIT_DIAG("dedup merge func=%u -> fn=%p (fp=%016llx)")` +
+  owner 侧计数;v1 不进 `ejit_taskpool_stats_t` C-ABI(加字段需过 abiVersion),
+  后续有需要再走 ABI 升级。
+
+## 10. 测试计划
+
+**gtest(`llvm/unittests/ExecutionEngine/EJIT/`)**
+
+1. 双等值 cell:编译 `f(cell0)`、`f(cell1)`(内容相同)→ 同一 fnPtr,
+   dedup 计数 +1,code pool `usedBytes` 只涨一份;
+2. **健全性回归**:§5.1 的 idx 分支函数,等值 cell → **必须不合并**
+   (fnPtr 不同);
+3. cell1 内容改写后重编译 → 不同 fnPtr(指纹随内容分化);
+4. initializer walker 单测:GlobalOpt 提升用例 → 指纹分化;
+5. 确定性回归:同输入两次编译指纹相同;
+6. 驱逐/重编译幂等:驱逐 slot → 重编译 → 指纹命中 → 同 fnPtr;
+7. `ejit_clear_cache` / generation bump → 索引清空(下一编译全新);
+8. DryRun:计数生效、fnPtr 仍各不相同、行为与 OFF 一致;
+9. releaser 硬门:dedup ON + `setReleaser` 接线 -> init 报错或 dedup 自动
+   降级 OFF(不会出现共享指针被释放的路径)。
+
+**集成(`ejit_test/`)**
+
+9. N 个同配置 cell 的 workload → `ejit_get_code_pool_stats` 的
+   usedBytes/finalizedRangeCount 增量 ≈ 一份;
+10. 共享 taskpool 构建:peer 核 resolve 合并 slot → 4K seal 成功(走既有
+    `icacheCrossCoreExecutable` 路径),执行结果与 OFF 构建逐位一致。
+
+**lit**:不涉及(纯运行时特性)。
+
+## 11. 实施步骤
+
+| 步骤 | 内容 | 规模 |
+|---|---|---|
+| 1 | EJitOrcEngine:拆 `loadBitcodeModule` → `specializeAndResolve`(搬运 parse 前置段与 pipeline/dump/capture;`preSpecialized` 直通标志) | ~200 行 |
+| 2 | 指纹:`StructuralHash(Detailed)` + initializer walker + FNV 二级 | ~80 行 |
+| 3 | DedupIndex(定长开地址、generation/clear_cache 清理钩子) | ~80 行 |
+| 4 | `compileCold` 接新 API;`ejit_config_t` dedupMode;diag/计数 | ~60 行 |
+| 5 | §10 测试 | ~300 行 |
+
+合计约 2–3 天(含测试)。
+
+## 12. 非目标 / 未来工作
+
+- **方案 A(机器码比对合并)**:B 启用后理论上无增量收益;仅当 DryRun/线上
+  数据怀疑存在 codegen 不确定性时再评估,届时需 pool bump 回滚 API + seal 前
+  决策 + debug 段剔除;
+- **per-DedupEntry 体积统计与命中率上报进 C-ABI**:待 DryRun 数据证明价值后
+  走 abiVersion 升级;
+- **代码回收(releaser + 引用计数)**:见 §13--共享指针回收的三层复杂度
+  拆解与回收路径排序;
+- **跨 funcIdx 合并**:v1 明确不做(§5.4 反例:未用参数类型不同即碰撞)。
+  开启前置条件:指纹补齐函数签名(参数/返回类型)、函数属性(byval/sret/
+  align)、指令 flags(nsw/volatile/atomic/fastmath)与 metadata 哈希,
+  并有跨函数合并的调用约定等价性论证;收益上限低(不同 entry 特化后 IR
+  全同的概率小),优先级最低。
+
+## 13. 未来工作:代码回收与共享指针的设计输入
+
+v1 不释放任何代码(生产 releaser 为 null、pool append-only、sealed 页不
+回收)。若未来引入回收,共享指针的复杂性是**三层叠加**,dedup 只新增第三层:
+
+| 层 | 障碍 | 与 dedup 的关系 |
+|---|---|---|
+| ① pool 页回收 | bump 分配 + "sealed 页不回收"是 v1 硬约束;`deallocate()` 只跑 dealloc action,字节不还给池;回收 sealed 页需 unseal(RX->RW)+ 复用,是 W^X/TLB 议题 | 无关,今天就不存在回收 |
+| ② 无痕派发 | icache 命中路径 plain `ldr + br`,不持 read token(EJIT_ICACHE_MULTIVERSION §6 明言:接 releaser 即 UAF);慢路径才有 token 可做静默检测 | 无关,先于 dedup 存在 |
+| ③ 别名引用计数 | slot 驱逐 ≠ 可释放(其他 identity 仍指向同一 fnPtr);计数须覆盖 slot + icache cell + L0,还要等 ② 的在飞窗口排空 | **dedup 新增** |
+
+共享指针的完整扇出(释放安全 = 下列持有者全部断开):
+
+```
+                           ┌─ dedup index 条目本身(owner 私有)
+                           ├─ 共享 cache slot × N(每 identity 一个,可跨 bucket)
+一个 canonical fnPtr ─别名→ ├─ icache cell × N(共享表,按 identity;drain 才清零)
+                           ├─ per-core L0 memo × N(按 identity,epoch 失效)
+                           └─ 某核在飞调用(寄存器中的 fnPtr,无 token 窗口)
+```
+
+易漏点:`cachePublish` 驱逐旧 slot / 同 identity 重编译覆盖时,同样会对旧
+fnPtr 调 `releaseFn_`(不止版本竞态路径)。dedup ON 时这些全是共享指针,
+由 §5.5 硬门一并挡掉。
+
+若真要做回收,按代价排序的三条路径:
+
+1. **代际批量重置(首选)**:只在 owner 代数更替 / 显式 reset 等静默点整代
+   丢弃(清全部 slot + drain 全部 cell + 池换代)。无引用计数、无单条目
+   释放,与"generation bump 清 dedup 索引"同构;
+2. **合并条目永生,只回收独占条目**:refcount>1 永不释放,refcount==1 走
+   正常回收。规则简单;合并条目每份内容本就只有一份代码,不回收也不会
+   重新膨胀;
+3. **完整引用计数 + 静默期**:计数覆盖 slot/cell/L0 + 在飞调用排空(需要给
+   icache 命中路径补 quiescence 机制,等于要改 ②)。最完整也最贵,仅当
+   单代内 churn 严重才值得。
+
+## 14. 实现状态(v1,分支 ejit_spec_dedup)
+
+| 组件 | 位置 | 状态 |
+|---|---|---|
+| 指纹 + 定长开地址索引 | `EJitDedupIndex.{h,cpp}`(新) | 完成:fp1=StructuralHash(Detailed),fp2=FNV(定义全局 identity+initializer+计数),irUnits;key=(funcIndex,fp1,fp2,irUnits),容量 512 |
+| 引擎一次性编译入口 | `EJitOrcEngine::specializeAndResolve` + `ParsedSpecModule` 拆分(parse/emit 共享 legacy 路径)+ transform 层 `preSpecialized` 直通标志 | 完成 |
+| 驱动接线 | `EJitCompileDriver::compileCold` 改调新 API;`effectiveDedupMode()` releaser 硬门(检出即降级 Off + 清索引) | 完成 |
+| 配置 | `ejit_config_t.dedupMode`(additive,0/1/2)+ `Config::dedupMode` + `parseConfig` clamp | 完成 |
+| 池侧 | `EJitTaskPoolCache/EJitTaskPool::hasReleaser()`、`EJitSharedTaskPool::hasReleaser()`(读共享 icacheReleasersWired 计数,peer-aware) | 完成 |
+| 诊断 | merge/would-merge/insert-full 三类 EJIT_DIAG;引擎侧计数(dedupIndex().stats()) | 完成(v1 不进 C-ABI,见 §9) |
+| 测试 | `EJitDedupTest.cpp`:指纹确定性/常量分化/initializer 盲点、索引 CRUD、等值 cell 合并+可执行性、idx 分支不合并、内容变化分化、DryRun 口径、同 identity 重编译再合并、Off 空索引、releaser 门两级 | 完成(12 用例全绿) |
+
+**与设计的偏差/实现决定**
+
+1. DryRun 命中后照常编译,插入时同指纹**刷新**已有条目(非新增),故 entries 计数按"不同指纹数"理解;
+2. dedup 命中时该 cacheKey 不建 JITDylib,与 §5.3 一致;同 identity 重编译会先移除 stale JD 再命中索引,幂等返回旧指针;
+3. `ParsedSpecModule` 成员声明序(Ctx 先、M 后)是正确性要求:反向销毁时 Module 析构要触碰存活的 context;
+4. 既有缺口顺带修复(host gtest 链接,与本方案无关但阻塞验证):LLVMEJIT 补链 X86AsmParser(InitializeAllAsmParsers 无条件引用);新增 `EJitTestHostStubs.cpp` 提供 host x86-64 glibc 没有的全局 `__stack_chk_guard`(SRE libc 有);EJitDump 引擎级测试的手工模块缺 `ejit_entry` 标签被管线 internalize 后 lookup 失败,补标签修复;
+5. 已知未做:§10-9 集成用例(ejit_test)、共享统计 C-ABI 字段、EJITTaskPoolTests 在 freestanding 配置下的链接(全局 `add_definitions(-DEJIT_FREESTANDING)` 既有问题,与本方案无关)。

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -94,6 +94,13 @@ public:
   void stopSharedTaskPool() { sharedPool_.ownerShutdown(); }
 #endif
 
+  /// The dedup mode actually in effect for the next compile: the configured
+  /// mode, force-lowered to Off whenever a physical-code releaser is wired on
+  /// any taskpool (a dedup hit hands the release paths a fnPtr shared with
+  /// other identities - EJIT_SPECIALIZATION_DEDUP.md §5.5 hard gate). Also
+  /// clears the engine's dedup index so no stale aliases survive the wiring.
+  DedupMode effectiveDedupMode();
+
   EJitRuntimeState &getRuntimeState() { return runtimeState_; }
   EJitModuleLoader &getLoader() { return loader_; }
   const Config &getConfig() { return config_; }

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDedupIndex.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDedupIndex.h
@@ -1,0 +1,128 @@
+//===-- EJitDedupIndex.h - Specialization dedup fingerprint index ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.
+//
+//===----------------------------------------------------------------------===//
+//
+//  Post-pipeline IR fingerprint + owner-private dedup index for EmbeddedJIT
+//  specialization merging (design: jit_design_doc/EJIT_SPECIALIZATION_DEDUP.md).
+//
+//  Two specialization compiles of the same funcIndex whose post-pipeline IR
+//  fingerprints match produce, under the engine's deterministic single-thread
+//  compilation, identical machine code. The second compile can therefore
+//  reuse the first's published fnPtr instead of consuming another code-pool
+//  allocation. The index maps (funcIndex, fingerprint) -> canonical fnPtr.
+//
+//  Fingerprint = three words:
+//    fp1     llvm::StructuralHash(M, DetailedHash=true): BB/instruction
+//            structure, opcodes, operand types, constants, GlobalValue
+//            references by NAME. Module name and metadata are NOT hashed.
+//    fp2     FNV-1a over every module-defined global's name/linkage/
+//            isConstant + INITIALIZER (StructuralHash's module-level
+//            GlobalVariable update hashes only the type ID - a GlobalOpt
+//            promotion baking a specialized constant into an initializer
+//            would otherwise be invisible).
+//    irUnits (numDefinedFuncs << 32) | numInstructions - cheap reject.
+//
+//  Correctness envelope (why same-funcIndex only): StructuralHash does not
+//  hash function signatures, attributes, instruction flags (nsw/volatile/
+//  atomic/fastmath) or metadata. Two DIFFERENT functions can collide
+//  (e.g. `f(i32 %unused){ret void}` vs `g(i8 %unused){ret void}`). The key
+//  therefore includes funcIndex: same funcIndex means same bitcode, so all
+//  unhashed dimensions are identical by construction.
+//
+//  Failure direction: any nondeterminism or blind spot produces a DIFFERENT
+//  fingerprint -> no merge (safe). Only a simultaneous fp1+fp2+irUnits
+//  collision could wrongly merge; at the default capacity the birthday
+//  probability is ~1e-15.
+//
+//  Memory: the index is a fixed-capacity open-addressed table owned by the
+//  compile owner (EJitOrcEngine::Impl), owner-thread-only (all compilation
+//  is serialized on the owner core), never shared cross-core. Full -> dedup
+//  silently degrades for new entries (one diag).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITDEDUPINDEX_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITDEDUPINDEX_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace llvm {
+class Module;
+
+namespace ejit {
+
+/// Fingerprint of a post-specialization-pipeline Module.
+struct DedupFingerprint {
+  /// llvm::StructuralHash(M, /*DetailedHash=*/true).
+  uint64_t fp1 = 0;
+  /// FNV-1a over defined-global identity + initializers (see header comment).
+  uint64_t fp2 = 0;
+  /// (numDefinedFuncs << 32) | numInstructions.
+  uint64_t irUnits = 0;
+
+  bool operator==(const DedupFingerprint &O) const {
+    return fp1 == O.fp1 && fp2 == O.fp2 && irUnits == O.irUnits;
+  }
+  bool operator!=(const DedupFingerprint &O) const { return !(*this == O); }
+};
+
+/// Compute the fingerprint of \p M. O(#globals + #instructions); must be
+/// called on the OWNER compile thread only (it is pure, but like the rest of
+/// the compile path it assumes serialized access to the module).
+DedupFingerprint computeModuleFingerprint(const Module &M);
+
+/// Fixed-capacity open-addressed (funcIndex, fingerprint) -> fnPtr index.
+/// Owner-private; no locking (single compile thread). Zero-capacity failure
+/// is a clean degrade, never an error.
+class EJitDedupIndex {
+public:
+  static constexpr size_t kCapacity = 512;
+
+  struct Stats {
+    uint64_t inserts = 0;     ///< entries inserted (fresh compiles)
+    uint64_t merges = 0;      ///< ON-mode hits served with a reused fnPtr
+    uint64_t wouldMerge = 0;  ///< DryRun-mode hits counted (still compiled)
+    uint32_t entries = 0;     ///< live entries
+    bool full = false;        ///< capacity reached (dedup degraded)
+  };
+
+  /// Exact-match lookup. Returns the canonical fnPtr or nullptr.
+  void *find(uint32_t funcIndex, const DedupFingerprint &FP);
+
+  /// DryRun bookkeeping: record a would-be merge without affecting entries.
+  void noteWouldMerge() { Stats_.wouldMerge++; }
+
+  /// ON-mode bookkeeping: a hit was served with a reused fnPtr.
+  void noteMerge() { Stats_.merges++; }
+
+  /// Insert/refresh an entry. Returns false when the table is full (the
+  /// caller logs once and keeps compiling without dedup for new entries).
+  bool insert(uint32_t funcIndex, const DedupFingerprint &FP, void *fnPtr);
+
+  /// Drop every entry (owner re-election hands the engine - and thus the
+  /// index - to a fresh instance anyway; this is the explicit reset).
+  void clear();
+
+  const Stats &stats() const { return Stats_; }
+  size_t size() const { return Stats_.entries; }
+
+private:
+  struct Slot {
+    uint32_t funcIndex = 0;
+    bool used = false;
+    DedupFingerprint FP;
+    void *fnPtr = nullptr;
+  };
+  Slot Slots_[kCapacity];
+  Stats Stats_;
+};
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITDEDUPINDEX_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
@@ -24,6 +24,13 @@ namespace ejit {
 enum class CompileMode { Off, Sync, Async };
 enum class OptimizationLevel { L1 = 1, L2 = 2, L3 = 3 };
 
+/// Specialization-dedup mode (EJIT_SPECIALIZATION_DEDUP.md). Off = today's
+/// behavior exactly (no fingerprint cost). DryRun = fingerprint + count
+/// would-be merges, still compile (measurement, behavior-identical). On =
+/// reuse the canonical fnPtr for an equal-fingerprint compile instead of
+/// consuming another code-pool allocation.
+enum class DedupMode : uint8_t { Off = 0, DryRun = 1, On = 2 };
+
 struct Config {
   CompileMode compileMode = CompileMode::Async;
   OptimizationLevel optLevel = OptimizationLevel::L2;
@@ -40,6 +47,11 @@ struct Config {
   /// If non-empty, dump JIT-optimized LLVM IR (.ll) to this directory.
   /// One file per specialization, named <funcName>_<cacheKey>.ll.
   std::string dumpJITDir;
+  /// Specialization dedup (EJIT_SPECIALIZATION_DEDUP.md). The compile driver
+  /// force-lowers this to Off whenever a releaser is wired on a taskpool:
+  /// a dedup hit returns a fnPtr shared with other identities, which the
+  /// version-mismatch/eviction release paths must never free.
+  DedupMode dedupMode = DedupMode::Off;
 };
 
 } // namespace ejit

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -10,6 +10,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITORCENGINE_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDedupIndex.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/Support/Error.h"
@@ -92,9 +93,33 @@ public:
   /// Load a bitcode module into a per-specialization JITDylib identified
   /// by cacheKey. Each specialization gets its own JITDylib so symbols
   /// from the same TU bitcode can be defined multiple times without conflict.
+  /// The specialization pipeline runs lazily in the IR transform layer at
+  /// lookup time (legacy path; kept for direct/test callers).
   Error loadBitcodeModule(StringRef bitcodeData,
                           uint64_t cacheKey,
                           const std::string &origFnName);
+
+  /// Result of the one-shot compile entry point below.
+  struct SpecializeResult {
+    /// The compiled entry pointer - or, on a dedup hit, the canonical pointer
+    /// of an earlier equal-fingerprint compile (no new code was emitted and
+    /// no code-pool bytes were consumed).
+    void *fnPtr = nullptr;
+    /// True when fnPtr was reused from the dedup index.
+    bool deduped = false;
+  };
+
+  /// One-shot specialization compile (EJIT_SPECIALIZATION_DEDUP.md §5.3):
+  /// parse -> run the specialization pipeline EAGERLY (pre-materialization)
+  /// -> fingerprint the specialized IR -> dedup check -> on miss emit into a
+  /// per-cacheKey JITDylib and look the entry up. On a dedup hit in On mode
+  /// no JITDylib is created and no machine code is generated. Must be called
+  /// on the owner compile thread with setActiveContext() set (compilation is
+  /// serialized there; asserted via the pass-through flag).
+  Expected<SpecializeResult>
+  specializeAndResolve(StringRef bitcodeData, uint64_t cacheKey,
+                       uint32_t funcIndex, const std::string &origFnName,
+                       DedupMode dedupMode);
 
   /// Look up a compiled function symbol in the specialization JITDylib
   /// identified by cacheKey.
@@ -123,7 +148,32 @@ public:
   bool findCodeRange(const void *FnPtr, EJitCompiledCodeInfo &Out) const;
 #endif
 
+  /// Owner-private dedup index state (test/diagnostic read access).
+  const EJitDedupIndex &dedupIndex() const;
+
+  /// Drop every dedup index entry (used when a releaser is wired while dedup
+  /// is configured on, so aliases to potentially-freed code disappear).
+  void clearDedupIndex();
+
 private:
+  /// Parsed specialization bitcode: module + its owning context (both move
+  /// together into the ThreadSafeModule at emit time).
+  struct ParsedSpecModule;
+  /// Parse the bitcode and apply the pre-pipeline fixups (module name,
+  /// dso_local on AArch64 ELF declarations, external-linkage promotion of a
+  /// static entry). Steps 1-3 shared by loadBitcodeModule and
+  /// specializeAndResolve.
+  Expected<ParsedSpecModule> parseSpecModule(StringRef bitcodeData,
+                                             uint64_t cacheKey,
+                                             const std::string &origFnName);
+  /// Collect external symbols, create/populate the per-cacheKey JITDylib and
+  /// add the module. Steps 4-10 shared by both paths.
+  Error emitSpecModule(ParsedSpecModule PM, uint64_t cacheKey);
+  /// Run the specialization pipeline + IR/ASM dumps + diagnostic capture on
+  /// \p M. Shared by the eager path (specializeAndResolve, before codegen)
+  /// and the legacy lazy path (IR transform layer during materialization).
+  void specializeModuleEagerly(Module &M, const SpecializationContext &ctx);
+
   struct Impl;
   std::unique_ptr<Impl> P;
 };

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -109,6 +109,13 @@ typedef struct {
   bool forceStaticRegistry;
   /// If non-NULL, dump JIT-optimized LLVM IR (.ll) to this directory.
   const char *dumpJITDir;
+  /// Specialization dedup (EJIT_SPECIALIZATION_DEDUP.md): 0 = off (default,
+  /// zero-init keeps today's behavior), 1 = dry-run (fingerprint + count
+  /// would-be merges, still compile - measurement only), 2 = on (reuse the
+  /// canonical fnPtr for an equal-fingerprint compile; no second code copy).
+  /// Additive tail field: recompile callers with the updated header; a
+  /// zero-initialized struct selects "off".
+  int dedupMode;
 } ejit_config_t;
 
 typedef struct {

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -455,6 +455,15 @@ public:
     compileFn_ = fn;
     compileCtx_ = ctx;
   }
+
+  /// True when ANY facade (this core or a peer) has a physical-code releaser
+  /// wired: the shared icacheReleasersWired count is non-zero. Consumers that
+  /// alias fnPtrs across identities (specialization dedup) must disable
+  /// themselves while this is true - the release paths would otherwise free a
+  /// pointer other identities still dispatch through.
+  bool hasReleaser() const {
+    return state_ && state_->icacheReleasersWired.loadAcquire() != 0;
+  }
   void setReleaser(ReleaseCallback fn, void *ctx) {
     const bool had = (releaseFn_ != nullptr);
     releaseFn_ = fn;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -190,6 +190,11 @@ public:
     releaseCtx_ = ctx;
   }
 
+  /// True when a physical-code releaser is wired: published fnPtrs may be
+  /// freed. Consumers that alias fnPtrs across identities (specialization
+  /// dedup) must disable themselves while this is true.
+  bool hasReleaser() const { return releaseFn_ != nullptr; }
+
   EJitCacheLookupResult lookup(uint32_t funcIndex, const EJitDimPair *dims,
                                uint32_t numDims);
 
@@ -312,6 +317,9 @@ public:
   void setReleaser(EJitTaskPoolCache::ReleaseCallback fn, void *ctx) {
     cache_.setReleaser(fn, ctx);
   }
+
+  /// True when a physical-code releaser is wired on this taskpool's cache.
+  bool hasReleaser() const { return cache_.hasReleaser(); }
 
   EJitSwitchController &switchController() { return switch_; }
   EJitTaskPoolCache &cache() { return cache_; }

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -49,8 +49,10 @@ endif()
 set(EJIT_TARGET_COMPONENTS "")
 foreach(_t ${LLVM_TARGETS_TO_BUILD})
   list(APPEND EJIT_TARGET_COMPONENTS ${_t}CodeGen ${_t}Desc ${_t}Info)
-  if(_t STREQUAL "AArch64")
-    list(APPEND EJIT_TARGET_COMPONENTS AArch64AsmParser)
+  # InitializeAllAsmParsers() (EJit.cpp host init) references every built
+  # target's AsmParser unconditionally, so every LLVMEJIT consumer needs it.
+  if(_t STREQUAL "AArch64" OR _t STREQUAL "X86")
+    list(APPEND EJIT_TARGET_COMPONENTS ${_t}AsmParser)
   endif()
 endforeach()
 
@@ -58,6 +60,7 @@ set(EJIT_SOURCES
   EJit.cpp
   EJitRuntime.cpp
   EJitRegistryTable.c
+  EJitDedupIndex.cpp
   EJitOrcEngine.cpp
   EJitLinkDiagPlugin.cpp
   EJitLinkOptimizationPlugin.cpp

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -348,6 +348,38 @@ void EJitCompileDriver::registerSymbol(const std::string &name, void *addr) {
     jitEngine_->addUserSymbol(name, addr);
 }
 
+DedupMode EJitCompileDriver::effectiveDedupMode() {
+  if (config_.dedupMode == DedupMode::Off)
+    return DedupMode::Off;
+
+  // Hard gate (EJIT_SPECIALIZATION_DEDUP.md 5.5): a wired releaser frees code
+  // through the version-mismatch / eviction release paths, and a dedup hit
+  // returns a fnPtr shared with other identities. Degrade to Off and drop the
+  // existing aliases so no release path can free shared code.
+  bool ReleaserWired = false;
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  ReleaserWired = ReleaserWired || sharedPool_.hasReleaser();
+#endif
+#ifdef EJIT_SRE_TASKPOOL
+  ReleaserWired = ReleaserWired || (taskPool_ && taskPool_->hasReleaser());
+#endif
+  if (!ReleaserWired)
+    return config_.dedupMode;
+
+  // One-shot warn: this runs per compile, and while a releaser stays wired
+  // every compile takes this branch.
+  static bool Warned = false;
+  if (!Warned) {
+    Warned = true;
+    EJIT_DIAG("dedup DISABLED: a releaser is wired on a taskpool "
+              "(configured mode=%u)",
+              static_cast<unsigned>(config_.dedupMode));
+  }
+  if (jitEngine_)
+    jitEngine_->clearDedupIndex();
+  return DedupMode::Off;
+}
+
 void *EJitCompileDriver::compileCold(uint64_t cacheKey, bool storeLru) {
   // ── Cold path: decode cacheKey, verify, compile ────────────────────────
   uint32_t funcIdx = static_cast<uint32_t>(cacheKey >> 32);
@@ -439,43 +471,33 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, bool storeLru) {
     return nullptr;
   }
 
+  // One-shot compile: parse -> EAGER specialization pipeline -> dedup
+  // fingerprint check (reuse an equal-fingerprint fnPtr when enabled and one
+  // exists) -> emit + resolve. See EJIT_SPECIALIZATION_DEDUP.md 5.3.
   jitEngine_->setActiveContext(&ctx);
-
-  if (auto Err = jitEngine_->loadBitcodeModule(bitcode, cacheKey, funcName)) {
-    jitEngine_->setActiveContext(nullptr);
-    EJIT_DIAG("compile FAIL key=0x%016lx func=%s: load bitcode module failed",
-              cacheKey, funcName.c_str());
-#ifndef EJIT_FREESTANDING
-    if (logger_)
-      logger_->log(EJIT_ERR_COMPILE_FAILED, "Failed to load bitcode module",
-                   funcName, std::to_string(cacheKey));
-#else
-    consumeError(std::move(Err));
-#endif
-    return nullptr;
-  }
-
-  auto addrOrErr = jitEngine_->lookup(cacheKey, funcName);
+  auto ResOrErr = jitEngine_->specializeAndResolve(bitcode, cacheKey, funcIdx,
+                                                   funcName,
+                                                   effectiveDedupMode());
   jitEngine_->setActiveContext(nullptr);
 
-  if (!addrOrErr) {
-    EJIT_DIAG("compile FAIL key=0x%016lx func=%s: lookup after compile failed",
+  if (!ResOrErr) {
+    Error E = ResOrErr.takeError();
+    EJIT_DIAG("compile FAIL key=0x%016lx func=%s: specialize/resolve failed",
               cacheKey, funcName.c_str());
 #ifndef EJIT_FREESTANDING
     if (logger_)
       logger_->log(EJIT_ERR_COMPILE_FAILED,
-                   "Failed to look up compiled function", funcName,
+                   "Failed to compile specialization", funcName,
                    std::to_string(cacheKey));
-#else
-    consumeError(addrOrErr.takeError());
 #endif
+    consumeError(std::move(E));
     return nullptr;
   }
 
-  void *funcPtr = *addrOrErr;
+  void *funcPtr = ResOrErr->fnPtr;
 
-  EJIT_DIAG("compile OK key=0x%016lx func=%s → pfn=%p", cacheKey,
-            funcName.c_str(), funcPtr);
+  EJIT_DIAG("compile OK key=0x%016lx func=%s -> pfn=%p deduped=%u", cacheKey,
+            funcName.c_str(), funcPtr, ResOrErr->deduped ? 1u : 0u);
   return funcPtr;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitDedupIndex.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitDedupIndex.cpp
@@ -1,0 +1,179 @@
+//===-- EJitDedupIndex.cpp - Specialization dedup fingerprint index -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitDedupIndex.h"
+
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/StructuralHash.h"
+
+using namespace llvm;
+
+namespace llvm {
+namespace ejit {
+
+namespace {
+
+/// FNV-1a 64. Deliberately independent of StructuralHash's mixing so that a
+/// defect in one hash does not correlate with the other.
+struct FNV64 {
+  uint64_t H = 1469598103934665603ULL; // FNV offset basis
+  void byte(uint8_t B) { H = (H ^ B) * 1099511628211ULL; }
+  void u64(uint64_t V) {
+    for (unsigned I = 0; I < 8; ++I)
+      byte(static_cast<uint8_t>((V >> (8 * I)) & 0xFF));
+  }
+  void i64(int64_t V) { u64(static_cast<uint64_t>(V)); }
+  void str(StringRef S) {
+    u64(S.size()); // length first so concatenations cannot alias
+    for (char C : S)
+      byte(static_cast<uint8_t>(C));
+  }
+  uint64_t finish() const { return H; }
+};
+
+/// Hash one Constant, recursively. GlobalValue references hash by NAME
+/// (stable across two parses of the same bitcode, unlike pointer identity).
+void hashConstant(FNV64 &H, const Constant *C) {
+  if (!C) {
+    H.u64(0);
+    return;
+  }
+  H.u64(C->getValueID());
+  H.u64(static_cast<uint64_t>(C->getType()->getTypeID()));
+
+  if (const auto *GV = dyn_cast<GlobalValue>(C)) {
+    // Not the pointer: two parses of the same bitcode create distinct
+    // GlobalValue objects. Name + linkage capture identity for merge purposes.
+    H.str(GV->getName());
+    H.u64(static_cast<uint64_t>(GV->getLinkage()));
+    return;
+  }
+
+  if (const auto *CI = dyn_cast<ConstantInt>(C)) {
+    const APInt &V = CI->getValue();
+    H.u64(V.getNumWords());
+    for (unsigned I = 0; I < V.getNumWords(); ++I)
+      H.u64(V.getRawData()[I]);
+    return;
+  }
+  if (const auto *CF = dyn_cast<ConstantFP>(C)) {
+    const APInt &Bits = CF->getValueAPF().bitcastToAPInt();
+    H.u64(Bits.getNumWords());
+    for (unsigned I = 0; I < Bits.getNumWords(); ++I)
+      H.u64(Bits.getRawData()[I]);
+    return;
+  }
+  if (const auto *Seq = dyn_cast<ConstantDataSequential>(C)) {
+    H.u64(Seq->getNumElements());
+    for (unsigned I = 0; I < Seq->getNumElements(); ++I)
+      hashConstant(H, Seq->getElementAsConstant(I));
+    return;
+  }
+
+  // ConstantAggregate / ConstantExpr / BlockAddress / DSOLocalEquivalent:
+  // recurse over operands (covers GlobalOpt-promoted initializer trees).
+  H.u64(C->getNumOperands());
+  for (const Use &Op : C->operands())
+    hashConstant(H, dyn_cast<Constant>(Op));
+}
+
+} // namespace
+
+DedupFingerprint computeModuleFingerprint(const Module &M) {
+  DedupFingerprint Out;
+  Out.fp1 = StructuralHash(M, /*DetailedHash=*/true);
+
+  FNV64 H;
+  uint32_t NumFuncs = 0;
+  uint32_t NumInsts = 0;
+
+  // Defined globals: identity + initializer. This closes the StructuralHash
+  // blind spot where a GlobalOpt promotion bakes a specialized constant into
+  // a promoted initializer while leaving every instruction identical.
+  for (const GlobalVariable &GV : M.globals()) {
+    if (GV.isDeclaration())
+      continue;
+    H.str(GV.getName());
+    H.u64(static_cast<uint64_t>(GV.getLinkage()));
+    H.u64(GV.isConstant() ? 1 : 0);
+    hashConstant(H, GV.getInitializer());
+  }
+
+  for (const Function &F : M) {
+    if (F.isDeclaration())
+      continue;
+    ++NumFuncs;
+    for (const BasicBlock &BB : F)
+      NumInsts += static_cast<uint32_t>(BB.size());
+  }
+
+  // Fold the counts into fp2 as well so irUnits cannot diverge from the
+  // hashed content unnoticed.
+  H.u64(NumFuncs);
+  H.u64(NumInsts);
+  Out.fp2 = H.finish();
+  Out.irUnits = (static_cast<uint64_t>(NumFuncs) << 32) | NumInsts;
+  return Out;
+}
+
+void *EJitDedupIndex::find(uint32_t funcIndex, const DedupFingerprint &FP) {
+  size_t Start = (FP.fp1 ^ (static_cast<uint64_t>(funcIndex) * 0x9e3779b97f4a7c15ULL)) %
+                 kCapacity;
+  for (size_t Probe = 0; Probe < kCapacity; ++Probe) {
+    const Slot &S = Slots_[(Start + Probe) % kCapacity];
+    if (!S.used)
+      return nullptr; // linear probe: an empty slot ends the run
+    if (S.funcIndex == funcIndex && S.FP == FP)
+      return S.fnPtr;
+  }
+  return nullptr;
+}
+
+bool EJitDedupIndex::insert(uint32_t funcIndex, const DedupFingerprint &FP,
+                            void *fnPtr) {
+  size_t Start = (FP.fp1 ^ (static_cast<uint64_t>(funcIndex) * 0x9e3779b97f4a7c15ULL)) %
+                 kCapacity;
+  for (size_t Probe = 0; Probe < kCapacity; ++Probe) {
+    Slot &S = Slots_[(Start + Probe) % kCapacity];
+    if (!S.used) {
+      S.used = true;
+      S.funcIndex = funcIndex;
+      S.FP = FP;
+      S.fnPtr = fnPtr;
+      ++Stats_.entries;
+      ++Stats_.inserts;
+      return true;
+    }
+    if (S.funcIndex == funcIndex && S.FP == FP) {
+      S.fnPtr = fnPtr; // same fingerprint recompiled: refresh the pointer
+      ++Stats_.inserts;
+      return true;
+    }
+  }
+  Stats_.full = true;
+  return false;
+}
+
+void EJitDedupIndex::clear() {
+  for (Slot &S : Slots_) {
+    S.used = false;
+    S.fnPtr = nullptr;
+    S.FP = DedupFingerprint();
+  }
+  Stats_ = Stats{};
+}
+
+} // namespace ejit
+} // namespace llvm

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -113,6 +113,14 @@ struct EJitOrcEngine::Impl {
   /// emitted assembly matches the real JIT output). Null if creation failed.
   std::unique_ptr<TargetMachine> dumpFunctionTM;
   std::unique_ptr<TargetMachine> dumpModuleTM;
+  /// Specialization dedup index (owner-private; EJIT_SPECIALIZATION_DEDUP.md
+  /// §5.5). All compilation is serialized on the owner thread, so no lock.
+  EJitDedupIndex dedupIndex;
+  /// True across the emit+lookup window of specializeAndResolve(): the
+  /// module it adds is already specialized, so the IR transform layer must
+  /// pass it through unchanged. Compile serialization makes a plain bool
+  /// safe; set/clear are asserted non-nested.
+  bool preSpecialized = false;
 };
 
 namespace llvm {
@@ -742,115 +750,21 @@ EJitOrcEngine::Create(const Config &config,
           const orc::MaterializationResponsibility &R)
           -> Expected<orc::ThreadSafeModule> {
         TSM.withModuleDo([engine](Module &M) {
+          // specializeAndResolve() runs the pipeline EAGERLY (pre-codegen, so
+          // the specialized IR can be fingerprinted for dedup) and brackets
+          // its emit+lookup window with P->preSpecialized; a module arriving
+          // here inside that window is already specialized and must pass
+          // through unchanged. The legacy lazy path (loadBitcodeModule
+          // callers) still specializes here. Compilation is serialized on the
+          // owner thread, so the plain bool cannot be observed half-set.
+          if (engine->P->preSpecialized)
+            return;
           LLVM_DEBUG(dbgs() << "ejit-orc-engine: JIT transform on "
                             << M.getName() << "\n");
           const SpecializationContext *ctx = engine->P->activeCtx;
           if (!ctx)
             return;
-
-          // Clear stale analysis results from previous compilations
-          // (each compilation uses a fresh Module with new IR unit pointers).
-          engine->P->optimizer->clearAnalyses();
-
-          // Dump pre-optimization IR (before the JIT pipeline runs).
-          if (!engine->P->dumpJITDir.empty()) {
-            std::string prePath = engine->P->dumpJITDir + "/" +
-                                  ctx->fnName + "_" +
-                                  std::to_string(ctx->cacheKey) + "_pre.ll";
-            std::error_code EC;
-            llvm::raw_fd_ostream preOS(prePath, EC);
-            if (!EC)
-              M.print(preOS, nullptr);
-          }
-
-          engine->P->optimizer->runPipeline(M, *ctx);
-
-          // Dump post-optimization IR.
-          if (!engine->P->dumpJITDir.empty()) {
-            std::string path = engine->P->dumpJITDir + "/" +
-                               ctx->fnName + "_" +
-                               std::to_string(ctx->cacheKey) + "_opt.ll";
-            std::error_code EC;
-            llvm::raw_fd_ostream OS(path, EC);
-            if (!EC)
-              M.print(OS, nullptr);
-          }
-
-          // Name-filtered IR+ASM capture for later selective printing. Filter
-          // set via ejit_dump_func(); captured entries printed on demand via
-          // ejit_print_dumped(). Bare-metal-safe (strings only, no
-          // raw_fd_ostream). Captures the post-optimization IR and the emitted
-          // assembly (from the same TargetMachine the JIT compiles with).
-          // Capture is exact-name only. The local gDumpStore keeps one dynamic
-          // IR/ASM payload per captured function name (overwritten on
-          // re-compile); the shared dump table keeps cross-core visible dynamic
-          // payloads for recent captures.
-          {
-            std::string DumpFilter;
-            bool hasFilter = getActiveDumpFilter(DumpFilter);
-            bool match =
-                hasFilter && (DumpFilter == "*" || ctx->fnName == DumpFilter);
-            EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
-                            "key_lo=0x%08x match=%d &filter=%p",
-                            hasFilter ? DumpFilter.c_str() : "(off)",
-                            ctx->fnName.c_str(), (uint32_t)(ctx->cacheKey >> 32),
-                            (uint32_t)(ctx->cacheKey & 0xffffffffu), match ? 1 : 0,
-                            (void *)&gDumpFuncFilter);
-            if (match) {
-              // IR capture always runs first so it succeeds even if the ASM
-              // diagnostic path is disabled or fails. Capture only the entry
-              // definition: M also contains its full direct-call closure.
-              std::string FunctionIR;
-              if (!detail::renderDumpFunctionIR(M, ctx->fnName, FunctionIR))
-                EJIT_DIAG("dump capture: function not found fn=%s",
-                          ctx->fnName.c_str());
-              std::string ModuleIR;
-              detail::renderDumpModuleIR(M, ModuleIR);
-
-              std::string FunctionAsm;
-              std::string ModuleAsm;
-              // Textual ASM emit goes through addPassesToEmitFile ->
-              // addAsmPrinter -> createMCStreamer(AssemblyFile). Under
-              // EJIT_TRIM_LLVM_BACKEND that path is compile-time removed and
-              // createMCStreamer returns "textual assembly output unavailable";
-              // addAsmPrinter reports it via MCContext::reportError ->
-              // llvm::errs() (raw_fd_ostream fd 2), whose constructor is
-              // unmapped on bare-metal/SRE and crashes. So under trim we skip
-              // ASM (IR is still captured — M.print to a string stream is
-              // SRE-safe). To get ASM on target, build with EJIT_DUMP_ASM=ON
-              // (re-enables the textual asm backend under trim). The ASM emit's
-              // InstPrinter needs snprintf/vsnprintf: link a libc that provides
-              // them, OR ejit_test/stubs/ejit_sre_format_stubs.cpp if the SRE
-              // libc lacks them (not both — strong-symbol conflict). The success
-              // path of the emit does not call errs(), so once the path is
-              // compiled in it is SRE-safe.
-#if !defined(EJIT_TRIM_LLVM_BACKEND) || defined(EJIT_DUMP_ASM)
-              if (engine->P->dumpFunctionTM && engine->P->dumpModuleTM) {
-                EJIT_DIAG_DEBUG("dump asm begin fn=%s", ctx->fnName.c_str());
-                bool FunctionOK = renderDumpAssembly(
-                    *engine->P->dumpFunctionTM,
-                    cloneDumpFunctionModule(M, ctx->fnName), FunctionAsm);
-                bool ModuleOK = renderDumpAssembly(
-                    *engine->P->dumpModuleTM, CloneModule(M), ModuleAsm);
-                if (!FunctionOK || !ModuleOK) {
-                  EJIT_DIAG_DEBUG("dump asm addPassesToEmitFile failed fn=%s",
-                                  ctx->fnName.c_str());
-                }
-                EJIT_DIAG_DEBUG(
-                    "dump asm sizes function=%u module=%u fn=%s",
-                    (unsigned)FunctionAsm.size(), (unsigned)ModuleAsm.size(),
-                    ctx->fnName.c_str());
-              }
-#else
-              EJIT_DIAG_DEBUG("dump asm skipped (EJIT_TRIM_LLVM_BACKEND, "
-                              "EJIT_DUMP_ASM off) fn=%s; IR captured",
-                              ctx->fnName.c_str());
-#endif
-              captureDump(ctx->fnName, ctx->cacheKey,
-                          std::move(FunctionIR), std::move(FunctionAsm),
-                          std::move(ModuleIR), std::move(ModuleAsm));
-            }
-          }
+          engine->specializeModuleEagerly(M, *ctx);
         });
         return std::move(TSM);
       });
@@ -859,17 +773,32 @@ EJitOrcEngine::Create(const Config &config,
   return engine;
 }
 
-Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
-                                       uint64_t cacheKey,
-                                       const std::string &origFnName) {
-  EJIT_DIAG_VERBOSE("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
-                    origFnName.c_str(), bitcodeData.size());
+//===----------------------------------------------------------------------===//
+// One-shot specialization compile with dedup (EJIT_SPECIALIZATION_DEDUP.md).
+//
+// Phase 1 parse+fixup and phase 3 emit are shared with the legacy
+// loadBitcodeModule path; phase 2 (the specialization pipeline) runs EAGERLY
+// here instead of inside the IR transform layer so the specialized IR can be
+// fingerprinted BEFORE any machine code is emitted.
+//===----------------------------------------------------------------------===//
+struct EJitOrcEngine::ParsedSpecModule {
+  // Declaration order is load-bearing: members destroy in reverse order, so
+  // the Module must be declared LAST - it dereferences the context in its
+  // destructor (LLVMContext::removeModule) and must die while Ctx is alive
+  // (the dedup-hit early return destroys an owning ParsedSpecModule).
+  std::unique_ptr<LLVMContext> Ctx;
+  std::unique_ptr<Module> M;
+};
+
+Expected<EJitOrcEngine::ParsedSpecModule>
+EJitOrcEngine::parseSpecModule(StringRef bitcodeData, uint64_t cacheKey,
+                               const std::string &origFnName) {
   auto Ctx = std::make_unique<LLVMContext>();
   auto Buf = MemoryBuffer::getMemBuffer(
       bitcodeData, ("spec_" + std::to_string(cacheKey) + ".bc"));
   auto ModuleOrErr = parseBitcodeFile(Buf->getMemBufferRef(), *Ctx);
   if (!ModuleOrErr) {
-    EJIT_DIAG("loadBitcode FAIL key=0x%016lx: parse bitcode error", cacheKey);
+    EJIT_DIAG("parseSpec FAIL key=0x%016lx: parse bitcode error", cacheKey);
     return ModuleOrErr.takeError();
   }
 
@@ -904,10 +833,18 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     if (!EntryF->isDeclaration() && EntryF->hasLocalLinkage())
       EntryF->setLinkage(GlobalValue::ExternalLinkage);
 
+  ParsedSpecModule PM;
+  PM.M = std::move(*ModuleOrErr);
+  PM.Ctx = std::move(Ctx);
+  return PM;
+}
+
+Error EJitOrcEngine::emitSpecModule(ParsedSpecModule PM, uint64_t cacheKey) {
+  Module *M = PM.M.get();
   // Collect global variable addresses from the registry for symbols
   // that appear as external declarations in the bitcode module.
   orc::SymbolMap globalSymbols;
-  for (GlobalVariable &GV : (*ModuleOrErr)->globals()) {
+  for (GlobalVariable &GV : M->globals()) {
     if (!GV.isDeclaration() || GV.getName().empty())
       continue;
     void *addr = nullptr;
@@ -951,9 +888,9 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   static constexpr size_t kMaxUnresolvedNames = 32;
   SmallPtrSet<const Function *, 16> ReferencedExternalFuncs;
   SmallPtrSet<const GlobalVariable *, 16> ReferencedExternalGlobals;
-  collectReferencedExternalDecls(**ModuleOrErr, ReferencedExternalFuncs,
+  collectReferencedExternalDecls(*M, ReferencedExternalFuncs,
                                  ReferencedExternalGlobals);
-  for (Function &F : (*ModuleOrErr)->functions()) {
+  for (Function &F : M->functions()) {
     if (!F.isDeclaration() || F.getName().empty())
       continue;
     std::string name = F.getName().str();
@@ -972,7 +909,7 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
         orc::ExecutorSymbolDef(orc::ExecutorAddr::fromPtr(it->second),
                                JITSymbolFlags::Exported);
   }
-  for (GlobalVariable &GV : (*ModuleOrErr)->globals()) {
+  for (GlobalVariable &GV : M->globals()) {
     if (!GV.isDeclaration() || GV.getName().empty())
       continue;
     std::string name = GV.getName().str();
@@ -1027,7 +964,7 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
   }
 
   if (auto Err = P->J->addIRModule(*JDOrErr,
-      orc::ThreadSafeModule(std::move(*ModuleOrErr), std::move(Ctx)))) {
+      orc::ThreadSafeModule(std::move(PM.M), std::move(PM.Ctx)))) {
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: add IR module error", cacheKey);
     return Err;
   }
@@ -1037,6 +974,202 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
                     origFnName.c_str());
   return Error::success();
 }
+
+Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
+                                       uint64_t cacheKey,
+                                       const std::string &origFnName) {
+  EJIT_DIAG_VERBOSE("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
+                    origFnName.c_str(), bitcodeData.size());
+  auto PMOrErr = parseSpecModule(bitcodeData, cacheKey, origFnName);
+  if (!PMOrErr)
+    return PMOrErr.takeError();
+  return emitSpecModule(std::move(*PMOrErr), cacheKey);
+}
+
+void EJitOrcEngine::specializeModuleEagerly(Module &M,
+                                            const SpecializationContext &ctx) {
+  LLVM_DEBUG(dbgs() << "ejit-orc-engine: specialize (eager) on "
+                    << M.getName() << "\n");
+  // Clear stale analysis results from previous compilations
+  // (each compilation uses a fresh Module with new IR unit pointers).
+  P->optimizer->clearAnalyses();
+
+  // Dump pre-optimization IR (before the JIT pipeline runs).
+  if (!P->dumpJITDir.empty()) {
+    std::string prePath = P->dumpJITDir + "/" +
+                          ctx.fnName + "_" +
+                          std::to_string(ctx.cacheKey) + "_pre.ll";
+    std::error_code EC;
+    llvm::raw_fd_ostream preOS(prePath, EC);
+    if (!EC)
+      M.print(preOS, nullptr);
+  }
+
+  P->optimizer->runPipeline(M, ctx);
+
+  // Dump post-optimization IR.
+  if (!P->dumpJITDir.empty()) {
+    std::string path = P->dumpJITDir + "/" +
+                       ctx.fnName + "_" +
+                       std::to_string(ctx.cacheKey) + "_opt.ll";
+    std::error_code EC;
+    llvm::raw_fd_ostream OS(path, EC);
+    if (!EC)
+      M.print(OS, nullptr);
+  }
+
+  // Name-filtered IR+ASM capture for later selective printing. Filter
+  // set via ejit_dump_func(); captured entries printed on demand via
+  // ejit_print_dumped(). Bare-metal-safe (strings only, no
+  // raw_fd_ostream). Captures the post-optimization IR and the emitted
+  // assembly (from the same TargetMachine the JIT compiles with).
+  // Capture is exact-name only. The local gDumpStore keeps one dynamic
+  // IR/ASM payload per captured function name (overwritten on
+  // re-compile); the shared dump table keeps cross-core visible dynamic
+  // payloads for recent captures.
+  {
+    std::string DumpFilter;
+    bool hasFilter = getActiveDumpFilter(DumpFilter);
+    bool match =
+        hasFilter && (DumpFilter == "*" || ctx.fnName == DumpFilter);
+    EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
+                    "key_lo=0x%08x match=%d &filter=%p",
+                    hasFilter ? DumpFilter.c_str() : "(off)",
+                    ctx.fnName.c_str(), (uint32_t)(ctx.cacheKey >> 32),
+                    (uint32_t)(ctx.cacheKey & 0xffffffffu), match ? 1 : 0,
+                    (void *)&gDumpFuncFilter);
+    if (match) {
+      // IR capture always runs first so it succeeds even if the ASM
+      // diagnostic path is disabled or fails. Capture only the entry
+      // definition: M also contains its full direct-call closure.
+      std::string FunctionIR;
+      if (!detail::renderDumpFunctionIR(M, ctx.fnName, FunctionIR))
+        EJIT_DIAG("dump capture: function not found fn=%s",
+                  ctx.fnName.c_str());
+      std::string ModuleIR;
+      detail::renderDumpModuleIR(M, ModuleIR);
+
+      std::string FunctionAsm;
+      std::string ModuleAsm;
+      // Textual ASM emit goes through addPassesToEmitFile ->
+      // addAsmPrinter -> createMCStreamer(AssemblyFile). Under
+      // EJIT_TRIM_LLVM_BACKEND that path is compile-time removed and
+      // createMCStreamer returns "textual assembly output unavailable";
+      // addAsmPrinter reports it via MCContext::reportError ->
+      // llvm::errs() (raw_fd_ostream fd 2), whose constructor is
+      // unmapped on bare-metal/SRE and crashes. So under trim we skip
+      // ASM (IR is still captured — M.print to a string stream is
+      // SRE-safe). To get ASM on target, build with EJIT_DUMP_ASM=ON
+      // (re-enables the textual asm backend under trim). The ASM emit's
+      // InstPrinter needs snprintf/vsnprintf: link a libc that provides
+      // them, OR ejit_test/stubs/ejit_sre_format_stubs.cpp if the SRE
+      // libc lacks them (not both — strong-symbol conflict). The success
+      // path of the emit does not call errs(), so once the path is
+      // compiled in it is SRE-safe.
+#if !defined(EJIT_TRIM_LLVM_BACKEND) || defined(EJIT_DUMP_ASM)
+      if (P->dumpFunctionTM && P->dumpModuleTM) {
+        EJIT_DIAG_DEBUG("dump asm begin fn=%s", ctx.fnName.c_str());
+        bool FunctionOK = renderDumpAssembly(
+            *P->dumpFunctionTM,
+            cloneDumpFunctionModule(M, ctx.fnName), FunctionAsm);
+        bool ModuleOK = renderDumpAssembly(
+            *P->dumpModuleTM, CloneModule(M), ModuleAsm);
+        if (!FunctionOK || !ModuleOK) {
+          EJIT_DIAG_DEBUG("dump asm addPassesToEmitFile failed fn=%s",
+                          ctx.fnName.c_str());
+        }
+        EJIT_DIAG_DEBUG(
+            "dump asm sizes function=%u module=%u fn=%s",
+            (unsigned)FunctionAsm.size(), (unsigned)ModuleAsm.size(),
+            ctx.fnName.c_str());
+      }
+#else
+      EJIT_DIAG_DEBUG("dump asm skipped (EJIT_TRIM_LLVM_BACKEND, "
+                      "EJIT_DUMP_ASM off) fn=%s; IR captured",
+                      ctx.fnName.c_str());
+#endif
+      captureDump(ctx.fnName, ctx.cacheKey,
+                  std::move(FunctionIR), std::move(FunctionAsm),
+                  std::move(ModuleIR), std::move(ModuleAsm));
+    }
+  }
+}
+
+Expected<EJitOrcEngine::SpecializeResult>
+EJitOrcEngine::specializeAndResolve(StringRef bitcodeData, uint64_t cacheKey,
+                                    uint32_t funcIndex,
+                                    const std::string &origFnName,
+                                    DedupMode dedupMode) {
+  EJIT_DIAG_VERBOSE("specialize key=0x%016lx func=%s size=%zu dedup=%u",
+                    cacheKey, origFnName.c_str(), bitcodeData.size(),
+                    static_cast<unsigned>(dedupMode));
+
+  // Phase 1: parse + pre-pipeline fixups.
+  auto PMOrErr = parseSpecModule(bitcodeData, cacheKey, origFnName);
+  if (!PMOrErr)
+    return PMOrErr.takeError();
+  ParsedSpecModule PM = std::move(*PMOrErr);
+
+  // Phase 2: eager specialization + fingerprint + dedup check. Must run
+  // before codegen: an On-mode hit returns here having consumed no JITDylib,
+  // no code-pool bytes and no link time. Without an active context nothing
+  // was specialized, so the fingerprint is meaningless - skip dedup.
+  const SpecializationContext *ctx = P->activeCtx;
+  DedupFingerprint FP;
+  bool HaveFP = false;
+  if (ctx) {
+    specializeModuleEagerly(*PM.M, *ctx);
+    if (dedupMode != DedupMode::Off) {
+      FP = computeModuleFingerprint(*PM.M);
+      HaveFP = true;
+      if (void *Canonical = P->dedupIndex.find(funcIndex, FP)) {
+        if (dedupMode == DedupMode::On) {
+          P->dedupIndex.noteMerge();
+          EJIT_DIAG("dedup MERGE func=%u key=0x%016lx -> fn=%p fp1=0x%016llx",
+                    funcIndex, cacheKey, Canonical,
+                    (unsigned long long)FP.fp1);
+          return SpecializeResult{Canonical, true};
+        }
+        P->dedupIndex.noteWouldMerge();
+        EJIT_DIAG("dedup WOULD-MERGE (dry-run) func=%u key=0x%016lx "
+                  "fp1=0x%016llx",
+                  funcIndex, cacheKey, (unsigned long long)FP.fp1);
+      }
+    }
+  }
+
+  // Phase 3: emit + resolve (today's path). The pass-through flag keeps the
+  // IR transform layer from re-specializing the finished module; it brackets
+  // emit+lookup because materialization runs inside lookup. Compilation is
+  // serialized on the owner thread (asserted), so a plain bool is safe.
+  assert(!P->preSpecialized && "nested specializeAndResolve");
+  P->preSpecialized = true;
+  Error EmitErr = emitSpecModule(std::move(PM), cacheKey);
+  if (EmitErr) {
+    P->preSpecialized = false;
+    return std::move(EmitErr);
+  }
+  auto FnOrErr = lookup(cacheKey, origFnName);
+  P->preSpecialized = false;
+  if (!FnOrErr)
+    return FnOrErr.takeError();
+
+  // Phase 4: publish the fingerprint for later equal-input compiles. A full
+  // index is a clean degrade (logged once per failed insert).
+  if (HaveFP && !P->dedupIndex.insert(funcIndex, FP, *FnOrErr))
+    EJIT_DIAG("dedup INDEX FULL func=%u: merging degraded for new entries",
+              funcIndex);
+
+  EJIT_DIAG_VERBOSE("specialize OK key=0x%016lx func=%s ptr=%p deduped=0",
+                    cacheKey, origFnName.c_str(), *FnOrErr);
+  return SpecializeResult{*FnOrErr, false};
+}
+
+const EJitDedupIndex &EJitOrcEngine::dedupIndex() const {
+  return P->dedupIndex;
+}
+
+void EJitOrcEngine::clearDedupIndex() { P->dedupIndex.clear(); }
 
 Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
                                        const std::string &name) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -250,6 +250,10 @@ static void parseConfig(const ejit_config_t *src, Config &dst) {
   dst.forceStaticRegistry = src->forceStaticRegistry;
   if (src->dumpJITDir && src->dumpJITDir[0])
     dst.dumpJITDir = src->dumpJITDir;
+  // Dedup mode: clamp anything unexpected to Off (zero-init = Off).
+  dst.dedupMode = (src->dedupMode == 1 || src->dedupMode == 2)
+                      ? static_cast<DedupMode>(src->dedupMode)
+                      : DedupMode::Off;
 #ifdef EJIT_FREESTANDING
   dst.enableLogger = false;
 #endif

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -13,8 +13,12 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(EJITTests
   EJitRuntimeTest.cpp
+  EJitDedupTest.cpp
   EJitFieldOffsetTest.cpp
   EJitLinkOptimizationPluginTest.cpp
+  # __stack_chk_guard/__stack_chk_fail definitions for host linking (see the
+  # file header); production binaries never compile this TU in.
+  EJitTestHostStubs.cpp
 
   PARTIAL_SOURCES_INTENDED
   )

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitDedupTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitDedupTest.cpp
@@ -1,0 +1,464 @@
+//===-- EJitDedupTest.cpp - Specialization dedup unit tests ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.
+//
+//===----------------------------------------------------------------------===//
+//
+//  Tests for the post-pipeline IR fingerprint + dedup index
+//  (EJIT_SPECIALIZATION_DEDUP.md):
+//
+//    * fingerprint determinism / divergence (constants, the initializer
+//      blind spot StructuralHash leaves)
+//    * engine-level merge: equal-content cells reuse one fnPtr (and the
+//      merged pointer really executes the specialized body)
+//    * soundness: an idx-dependent branch must NOT merge even when the two
+//      cells' contents are equal (the design's key counterexample)
+//    * content change -> fingerprint change -> no merge
+//    * DryRun counts would-be merges without changing behavior
+//    * recompiling an identity re-merges against its own earlier entry
+//    * releaser hard gate: hasReleaser() accessors + effectiveDedupMode()
+//      force-lowering
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/AsmParser/Parser.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCompileDriver.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDedupIndex.h"
+#include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
+#include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
+#include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+#ifdef EJIT_SRE_TASKPOOL
+#include "llvm/ExecutionEngine/EJIT/EJitTaskPool.h"
+#endif
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::ejit;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Module builders
+//===----------------------------------------------------------------------===//
+
+/// The merge workload: `i32 @entry(i32 %cellIdx) { ret i32 g_arr[%cellIdx] }`
+/// where g_arr is a period array of the "cell" lifecycle and the load is
+/// may_const. After specialization with cellIdx = C the body folds to
+/// `ret i32 <g_arr[C]>`: two cells with equal contents produce identical IR.
+static void buildCellLoadModule(LLVMContext &Ctx, Module &M) {
+  M.setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+  IRBuilder<> B(Ctx);
+  auto *I32 = B.getInt32Ty();
+
+  auto *ArrTy = ArrayType::get(I32, 4);
+  auto *GVar = new GlobalVariable(
+      M, ArrTy, /*isConstant*/ false, GlobalValue::InternalLinkage,
+      ConstantAggregateZero::get(ArrTy), "g_arr");
+  Metadata *ArrMDOps[] = {
+      MDString::get(Ctx, TAG_EJIT_PERIOD_ARR),
+      MDString::get(Ctx, "cell"),
+      ConstantAsMetadata::get(ConstantInt::get(I32, 4)),
+  };
+  GVar->setMetadata(MD_EJIT_METADATA, MDNode::get(Ctx, {MDNode::get(Ctx, ArrMDOps)}));
+
+  FunctionType *FT = FunctionType::get(I32, {I32}, false);
+  auto *F = Function::Create(FT, GlobalValue::ExternalLinkage, "dedup_entry", &M);
+  F->arg_begin()->setName("cell_idx");
+
+  Metadata *IndMDOps[] = {
+      MDString::get(Ctx, TAG_EJIT_PERIOD_ARR_IND),
+      MDString::get(Ctx, "cell"),
+      ConstantAsMetadata::get(ConstantInt::get(I32, 0)),
+  };
+  // The entry tag matters: the JIT pipeline internalizes every non-entry
+  // definition (IPSCCP propagation prep), and ORC's IR layer never registers
+  // local-linkage symbols - without it lookup fails with "Symbols not found".
+  Metadata *EntryMDOps[] = {MDString::get(Ctx, TAG_EJIT_ENTRY)};
+  F->setMetadata(MD_EJIT_METADATA,
+                 MDNode::get(Ctx, {MDNode::get(Ctx, IndMDOps),
+                                   MDNode::get(Ctx, EntryMDOps)}));
+
+  B.SetInsertPoint(BasicBlock::Create(Ctx, "entry", F));
+  Value *IdxList[] = {B.getInt32(0), F->arg_begin()};
+  auto *GEP = B.CreateInBoundsGEP(ArrTy, GVar, IdxList, "cell.gep");
+  auto *Load = B.CreateLoad(I32, GEP, "cell.load");
+  Load->setMetadata("ejit.may_const", MDNode::get(Ctx, MDString::get(Ctx, "ejit")));
+  B.CreateRet(Load);
+}
+
+/// The soundness counterexample: `i32 @entry(i32 %cellIdx)` branching on the
+/// index itself. Equal cell contents are irrelevant - the folded branch
+/// differs per cellIdx, so the fingerprints must differ.
+static void buildIdxBranchModule(LLVMContext &Ctx, Module &M) {
+  M.setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+  IRBuilder<> B(Ctx);
+  auto *I32 = B.getInt32Ty();
+
+  FunctionType *FT = FunctionType::get(I32, {I32}, false);
+  auto *F = Function::Create(FT, GlobalValue::ExternalLinkage, "dedup_entry", &M);
+
+  Metadata *IndMDOps[] = {
+      MDString::get(Ctx, TAG_EJIT_PERIOD_ARR_IND),
+      MDString::get(Ctx, "cell"),
+      ConstantAsMetadata::get(ConstantInt::get(I32, 0)),
+  };
+  // The entry tag matters: the JIT pipeline internalizes every non-entry
+  // definition (IPSCCP propagation prep), and ORC's IR layer never registers
+  // local-linkage symbols - without it lookup fails with "Symbols not found".
+  Metadata *EntryMDOps[] = {MDString::get(Ctx, TAG_EJIT_ENTRY)};
+  F->setMetadata(MD_EJIT_METADATA,
+                 MDNode::get(Ctx, {MDNode::get(Ctx, IndMDOps),
+                                   MDNode::get(Ctx, EntryMDOps)}));
+
+  BasicBlock *Entry = BasicBlock::Create(Ctx, "entry", F);
+  BasicBlock *Zero = BasicBlock::Create(Ctx, "is_zero", F);
+  BasicBlock *Other = BasicBlock::Create(Ctx, "is_other", F);
+  B.SetInsertPoint(Entry);
+  B.CreateCondBr(B.CreateICmpEQ(F->arg_begin(), B.getInt32(0)), Zero, Other);
+  B.SetInsertPoint(Zero);
+  B.CreateRet(B.getInt32(111));
+  B.SetInsertPoint(Other);
+  B.CreateRet(B.getInt32(222));
+}
+
+/// Fingerprint-level builder: one function plus one module-internal constant
+/// global whose initializer is a parameter (the StructuralHash blind spot:
+/// module-level global update hashes only the type, never the initializer).
+static std::unique_ptr<Module> buildConstGlobalModule(LLVMContext &Ctx,
+                                                      uint32_t InitVal) {
+  auto M = std::make_unique<Module>("fp_const_global", Ctx);
+  M->setTargetTriple(Triple("x86_64-unknown-linux-gnu"));
+  IRBuilder<> B(Ctx);
+  auto *I32 = B.getInt32Ty();
+
+  auto *CG = new GlobalVariable(*M, I32, /*isConstant*/ true,
+                                GlobalValue::InternalLinkage,
+                                ConstantInt::get(I32, InitVal), "cg");
+  (void)CG;
+
+  FunctionType *FT = FunctionType::get(I32, {I32}, false);
+  auto *F = Function::Create(FT, GlobalValue::ExternalLinkage, "f", M.get());
+  B.SetInsertPoint(BasicBlock::Create(Ctx, "entry", F));
+  B.CreateRet(B.CreateAdd(F->arg_begin(), B.getInt32(1)));
+  return M;
+}
+
+static std::string toBitcode(const Module &M) {
+  std::string BC;
+  raw_string_ostream OS(BC);
+  WriteBitcodeToFile(M, OS);
+  OS.flush();
+  return BC;
+}
+
+//===----------------------------------------------------------------------===//
+// Fingerprint unit tests (no engine)
+//===----------------------------------------------------------------------===//
+
+TEST(EJitDedupFingerprint, IdenticalBuildsAreEqual) {
+  LLVMContext C1, C2;
+  auto FP1 = computeModuleFingerprint(*buildConstGlobalModule(C1, 42));
+  auto FP2 = computeModuleFingerprint(*buildConstGlobalModule(C2, 42));
+  EXPECT_EQ(FP1, FP2);
+}
+
+TEST(EJitDedupFingerprint, InstructionConstantDiverges) {
+  // Two builds differing only in an instruction-level constant.
+  LLVMContext C1, C2;
+  auto M1 = buildConstGlobalModule(C1, 42);
+  auto M2 = buildConstGlobalModule(C2, 42);
+  // Rewrite the add's constant in M2: +1 -> +2.
+  for (Function &F : *M2)
+    for (BasicBlock &BB : F)
+      for (Instruction &I : BB)
+        if (auto *BO = dyn_cast<BinaryOperator>(&I))
+          BO->setOperand(1, ConstantInt::get(Type::getInt32Ty(C2), 2));
+  auto FP1 = computeModuleFingerprint(*M1);
+  auto FP2 = computeModuleFingerprint(*M2);
+  EXPECT_NE(FP1, FP2);
+}
+
+TEST(EJitDedupFingerprint, InitializerBlindSpotIsCovered) {
+  // Identical instructions, module-defined global initializer differs.
+  // StructuralHash's module-level global update would NOT see this; the
+  // fingerprint's FNV pass over initializers must.
+  LLVMContext C1, C2;
+  auto FP1 = computeModuleFingerprint(*buildConstGlobalModule(C1, 5));
+  auto FP2 = computeModuleFingerprint(*buildConstGlobalModule(C2, 7));
+  EXPECT_NE(FP1, FP2);
+}
+
+TEST(EJitDedupIndex, InsertFindFullClear) {
+  EJitDedupIndex Index;
+  DedupFingerprint FP;
+  FP.fp1 = 0x1234;
+  FP.fp2 = 0x5678;
+  FP.irUnits = 42;
+  int Code = 1;
+  ASSERT_TRUE(Index.insert(7, FP, &Code));
+  EXPECT_EQ(Index.find(7, FP), &Code);
+  // Same fingerprint, different funcIndex: no cross-function merge (v1).
+  EXPECT_EQ(Index.find(8, FP), nullptr);
+  EXPECT_EQ(Index.stats().entries, 1u);
+
+  DedupFingerprint Other = FP;
+  Other.fp2 = 0xaaaa;
+  EXPECT_EQ(Index.find(7, Other), nullptr);
+
+  Index.clear();
+  EXPECT_EQ(Index.size(), 0u);
+  EXPECT_EQ(Index.find(7, FP), nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Engine-level dedup tests
+//===----------------------------------------------------------------------===//
+
+class EJitDedupEngineTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    llvm::InitializeNativeTarget();
+    llvm::InitializeNativeTargetAsmPrinter();
+  }
+
+  struct EngineFixture {
+    EJitRuntimeState State;
+    std::unique_ptr<EJitOrcEngine> Engine;
+  };
+
+  // Registry arrays live in the fixture; the mock cells must outlive it.
+  struct Cells {
+    int32_t Data[4] = {7, 7, 9, 11};
+  };
+
+  // EJitRuntimeState holds a mutex (non-movable), so the fixture is heap-held.
+  std::unique_ptr<EngineFixture> makeEngine(Cells &cells, Config Cfg = Config()) {
+    auto Fx = std::make_unique<EngineFixture>();
+    Fx->State.getRegistry().registerArray("cell", "g_arr", cells.Data, 4);
+    auto Eng = EJitOrcEngine::Create(Cfg, Fx->State.getRegistry(), Fx->State);
+    EXPECT_TRUE(static_cast<bool>(Eng));
+    Fx->Engine = std::move(*Eng);
+    return Fx;
+  }
+
+  // cacheKey layout matches production: (funcIndex << 32) | packed dims.
+  static uint64_t key(uint32_t funcIdx, uint8_t cell) {
+    return (uint64_t(funcIdx) << 32) | cell;
+  }
+
+  EJitOrcEngine::SpecializeResult
+  compileCell(EJitOrcEngine &Eng, uint64_t CacheKey, uint32_t funcIdx,
+              uint8_t Cell, StringRef Bitcode, DedupMode Mode) {
+    SpecializationContext Ctx;
+    Ctx.fnName = "dedup_entry";
+    Ctx.cacheKey = CacheKey;
+    Ctx.dimensions.push_back({"cell", Cell});
+    Eng.setActiveContext(&Ctx);
+    auto R = Eng.specializeAndResolve(Bitcode, CacheKey, funcIdx,
+                                      "dedup_entry", Mode);
+    Eng.setActiveContext(nullptr);
+    if (!R) {
+      ADD_FAILURE() << "specializeAndResolve failed: "
+                    << toString(R.takeError());
+      return {nullptr, false};
+    }
+    return *R;
+  }
+};
+
+TEST_F(EJitDedupEngineTest, EqualContentCellsMerge) {
+  Cells cells; // cell 0 and cell 1 hold the same value 7
+  auto Fx = makeEngine(cells);
+  std::string BC;
+  {
+    LLVMContext Ctx;
+    Module M("dedup_cellload", Ctx);
+    buildCellLoadModule(Ctx, M);
+    BC = toBitcode(M);
+  }
+
+  auto R0 = compileCell(*Fx->Engine, key(1, 0), 1, 0, BC, DedupMode::On);
+  ASSERT_NE(R0.fnPtr, nullptr);
+  EXPECT_FALSE(R0.deduped);
+
+  auto R1 = compileCell(*Fx->Engine, key(1, 1), 1, 1, BC, DedupMode::On);
+  ASSERT_NE(R1.fnPtr, nullptr);
+  EXPECT_TRUE(R1.deduped);
+  EXPECT_EQ(R1.fnPtr, R0.fnPtr);
+
+  EXPECT_EQ(Fx->Engine->dedupIndex().stats().merges, 1u);
+  EXPECT_EQ(Fx->Engine->dedupIndex().stats().entries, 1u);
+
+  // The merged pointer really runs the specialized body: both cells folded
+  // to `ret i32 7`.
+  auto *Fn = reinterpret_cast<int32_t (*)(int32_t)>(R1.fnPtr);
+  EXPECT_EQ(Fn(123), 7);
+  EXPECT_EQ(reinterpret_cast<int32_t (*)(int32_t)>(R0.fnPtr)(456), 7);
+}
+
+TEST_F(EJitDedupEngineTest, IdxBranchDoesNotMerge) {
+  // Design doc 5.4 counterexample: the function branches on the cell index
+  // itself. Cell contents are irrelevant; the folded control flow differs.
+  Cells cells;
+  auto Fx = makeEngine(cells);
+  std::string BC;
+  {
+    LLVMContext Ctx;
+    Module M("dedup_idxbranch", Ctx);
+    buildIdxBranchModule(Ctx, M);
+    BC = toBitcode(M);
+  }
+
+  auto R0 = compileCell(*Fx->Engine, key(2, 0), 2, 0, BC, DedupMode::On);
+  auto R1 = compileCell(*Fx->Engine, key(2, 1), 2, 1, BC, DedupMode::On);
+  ASSERT_NE(R0.fnPtr, nullptr);
+  ASSERT_NE(R1.fnPtr, nullptr);
+  EXPECT_FALSE(R1.deduped);
+  EXPECT_NE(R1.fnPtr, R0.fnPtr);
+  EXPECT_EQ(Fx->Engine->dedupIndex().stats().merges, 0u);
+
+  // Cell 0 folds to 111, cell 1 to 222 - merging these would be wrong-code.
+  EXPECT_EQ(reinterpret_cast<int32_t (*)(int32_t)>(R0.fnPtr)(0), 111);
+  EXPECT_EQ(reinterpret_cast<int32_t (*)(int32_t)>(R1.fnPtr)(0), 222);
+}
+
+TEST_F(EJitDedupEngineTest, ContentChangeDiverges) {
+  Cells cells;
+  auto Fx = makeEngine(cells);
+  std::string BC;
+  {
+    LLVMContext Ctx;
+    Module M("dedup_cellload2", Ctx);
+    buildCellLoadModule(Ctx, M);
+    BC = toBitcode(M);
+  }
+
+  auto R0 = compileCell(*Fx->Engine, key(3, 0), 3, 0, BC, DedupMode::On);
+  ASSERT_NE(R0.fnPtr, nullptr);
+
+  // Same cells, then cell 1's content changes: the specialization for cell 1
+  // must NOT merge with the cell 0 entry anymore.
+  cells.Data[1] = 8;
+  auto R1 = compileCell(*Fx->Engine, key(3, 1), 3, 1, BC, DedupMode::On);
+  ASSERT_NE(R1.fnPtr, nullptr);
+  EXPECT_FALSE(R1.deduped);
+  EXPECT_NE(R1.fnPtr, R0.fnPtr);
+  EXPECT_EQ(reinterpret_cast<int32_t (*)(int32_t)>(R1.fnPtr)(0), 8);
+}
+
+TEST_F(EJitDedupEngineTest, DryRunCountsButDoesNotMerge) {
+  Cells cells;
+  auto Fx = makeEngine(cells);
+  std::string BC;
+  {
+    LLVMContext Ctx;
+    Module M("dedup_cellload3", Ctx);
+    buildCellLoadModule(Ctx, M);
+    BC = toBitcode(M);
+  }
+
+  auto R0 = compileCell(*Fx->Engine, key(4, 0), 4, 0, BC, DedupMode::DryRun);
+  auto R1 = compileCell(*Fx->Engine, key(4, 1), 4, 1, BC, DedupMode::DryRun);
+  ASSERT_NE(R0.fnPtr, nullptr);
+  ASSERT_NE(R1.fnPtr, nullptr);
+  EXPECT_FALSE(R0.deduped);
+  EXPECT_FALSE(R1.deduped);
+  EXPECT_NE(R1.fnPtr, R0.fnPtr);
+
+  const auto &St = Fx->Engine->dedupIndex().stats();
+  EXPECT_EQ(St.wouldMerge, 1u);
+  EXPECT_EQ(St.merges, 0u);
+  // One entry, not two: the second (identical) fingerprint refreshes the
+  // first entry rather than adding a duplicate.
+  EXPECT_EQ(St.entries, 1u);
+}
+
+TEST_F(EJitDedupEngineTest, RecompileOfSameIdentityReMerges) {
+  // Eviction re-drives compilation of an identity whose canonical code is
+  // already indexed: the recompile re-merges (idempotently) instead of
+  // burning another code copy.
+  Cells cells;
+  auto Fx = makeEngine(cells);
+  std::string BC;
+  {
+    LLVMContext Ctx;
+    Module M("dedup_cellload4", Ctx);
+    buildCellLoadModule(Ctx, M);
+    BC = toBitcode(M);
+  }
+
+  auto R0 = compileCell(*Fx->Engine, key(5, 0), 5, 0, BC, DedupMode::On);
+  ASSERT_NE(R0.fnPtr, nullptr);
+  auto R0b = compileCell(*Fx->Engine, key(5, 0), 5, 0, BC, DedupMode::On);
+  EXPECT_TRUE(R0b.deduped);
+  EXPECT_EQ(R0b.fnPtr, R0.fnPtr);
+}
+
+TEST_F(EJitDedupEngineTest, OffModeKeepsIndexEmpty) {
+  Cells cells;
+  auto Fx = makeEngine(cells);
+  std::string BC;
+  {
+    LLVMContext Ctx;
+    Module M("dedup_cellload5", Ctx);
+    buildCellLoadModule(Ctx, M);
+    BC = toBitcode(M);
+  }
+
+  auto R0 = compileCell(*Fx->Engine, key(6, 0), 6, 0, BC, DedupMode::Off);
+  auto R1 = compileCell(*Fx->Engine, key(6, 1), 6, 1, BC, DedupMode::Off);
+  ASSERT_NE(R0.fnPtr, nullptr);
+  ASSERT_NE(R1.fnPtr, nullptr);
+  EXPECT_NE(R1.fnPtr, R0.fnPtr);
+  EXPECT_EQ(Fx->Engine->dedupIndex().size(), 0u);
+}
+
+//===----------------------------------------------------------------------===//
+// Releaser hard gate (EJIT_SPECIALIZATION_DEDUP.md 5.5)
+//===----------------------------------------------------------------------===//
+
+#ifdef EJIT_SRE_TASKPOOL
+
+static void mockRelease(void *, void *) {}
+
+TEST(EJitDedupReleaserGate, TaskPoolHasReleaserTracksWiring) {
+  EJitSwitchController Dummy;
+  EJitTaskPoolCache Cache(Dummy);
+  EXPECT_FALSE(Cache.hasReleaser());
+  Cache.setReleaser(&mockRelease, nullptr);
+  EXPECT_TRUE(Cache.hasReleaser());
+  Cache.setReleaser(nullptr, nullptr);
+  EXPECT_FALSE(Cache.hasReleaser());
+}
+
+TEST(EJitDedupReleaserGate, EffectiveDedupModeLoweredWhenReleaserWired) {
+  EJitRuntimeState State;
+  EJitModuleLoader Loader;
+  Config Cfg;
+  Cfg.dedupMode = DedupMode::On;
+  EJitCompileDriver Driver(Cfg, State, Loader);
+  EXPECT_EQ(Driver.effectiveDedupMode(), DedupMode::On);
+
+  Driver.taskPool()->setReleaser(&mockRelease, nullptr);
+  EXPECT_EQ(Driver.effectiveDedupMode(), DedupMode::Off);
+  // Unwiring re-arms dedup.
+  Driver.taskPool()->setReleaser(nullptr, nullptr);
+  EXPECT_EQ(Driver.effectiveDedupMode(), DedupMode::On);
+}
+
+#endif // EJIT_SRE_TASKPOOL
+
+} // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -86,6 +86,12 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
     auto *FT = FunctionType::get(I32, {I32}, false);
     for (StringRef Name : {"dump_a", "dump_b", "dump_c"}) {
       auto *F = Function::Create(FT, Function::ExternalLinkage, Name, &M);
+      // The entry tag is required: the JIT pipeline internalizes every
+      // non-entry definition and ORC never registers local-linkage symbols,
+      // so an untagged function fails lookup ("Symbols not found").
+      Metadata *EntryMDOps[] = {MDString::get(Ctx, TAG_EJIT_ENTRY)};
+      F->setMetadata(MD_EJIT_METADATA,
+                     MDNode::get(Ctx, {MDNode::get(Ctx, EntryMDOps)}));
       IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
       B.CreateRet(B.CreateAdd(F->getArg(0), B.getInt32(Name.back())));
     }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTestHostStubs.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTestHostStubs.cpp
@@ -1,0 +1,32 @@
+//===-- EJitTestHostStubs.cpp - host-link stubs for the EJIT gtests --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception.
+//
+//===----------------------------------------------------------------------===//
+//
+//  EJitLibcallStubs registers __stack_chk_guard/__stack_chk_fail as
+//  JIT-visible symbols by referencing the HOST binary's definitions. The SRE
+//  target's libc provides them; host x86-64 glibc does NOT export a global
+//  __stack_chk_guard (its own stack protector uses the FS:0x28 TLS slot), so
+//  a host gtest binary linking LLVMEJIT needs these stubs. Test-link only:
+//  production binaries must never pull this TU in.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+
+extern "C" {
+
+// Nonzero, fixed: JIT-compiled code with -fstack-protector only ever
+// compares against it; host code on x86-64 uses the FS slot instead and
+// never reads this symbol.
+uintptr_t __stack_chk_guard = 0x5eedba5e5eedba5eULL;
+
+void __stack_chk_fail(void) {
+  // No test path should reach a stack smash; trap loudly if one does.
+  __builtin_trap();
+}
+
+} // extern "C"


### PR DESCRIPTION
Multi-version specialization bloats the JIT code segment when different cell identities hold equal contents (or the constants do not affect codegen): every identity burns its own code-pool allocation forever.

Add post-pipeline IR fingerprint dedup (design: jit_design_doc/ EJIT_SPECIALIZATION_DEDUP.md):

- EJitDedupIndex: StructuralHash(Detailed) + FNV over defined-global initializers (StructuralHash's blind spot) + irUnits, keyed by (funcIndex, fingerprint); fixed 512-entry open-addressed owner-private table. Failure direction is always "no merge".
- EJitOrcEngine::specializeAndResolve: one-shot compile entry that runs the specialization pipeline EAGERLY (pre-codegen) so the specialized IR can be fingerprinted; an equal-fingerprint hit returns the canonical fnPtr with no JITDylib, no codegen and no pool bytes. loadBitcodeModule becomes a wrapper over the same parse/emit helpers; the IR transform layer passes through modules the eager path already specialized (preSpecialized flag, owner-compile-thread serialized).
- EJitCompileDriver: compileCold goes through the new entry; dedup is force-lowered to Off whenever a releaser is wired on a taskpool (a hit returns a fnPtr shared with other identities - never hand that to a release path) and the index is dropped.
- config: ejit_config_t.dedupMode (0 off / 1 dry-run / 2 on, additive tail field).
- tests: EJitDedupTest - fingerprint determinism/divergence incl. the initializer blind spot, index CRUD, equal-content cells merge (and the merged pointer executes the specialized body), the idx-branch counterexample must NOT merge, content change diverges, dry-run accounting, same-identity recompile re-merges, releaser gate.

Host gtest link gaps fixed alongside (pre-existing, blocked validation): LLVMEJIT now links the built target's AsmParser (InitializeAllAsmParsers references it unconditionally), EJitTestHostStubs provides the global __stack_chk_guard that host x86-64 glibc does not export, and the EJitDump engine test's hand-built modules gain the ejit_entry tag the internalization step requires for ORC lookup.