### PR TITLE
[EJIT][PGO] Rank may-const benefits by runtime impact

### DIFF
--- a/jit_design_doc/EJIT_BRANCH_PROFILE_AUDIT.md
+++ b/jit_design_doc/EJIT_BRANCH_PROFILE_AUDIT.md
@@ -44,7 +44,9 @@ unique-cache-key aggregate for that entry:
 ```text
 [EJIT] mayconst-audit entry=FuncA key=0x1234 tier=2 versions=30 \
   mayconst=42/3/0 removed=42 direct=39 pipeline=3 runtime_hits=99872 \
-  hit_sites=17 avg_removed=40 weighted_permille=952 min=36 max=42
+  hit_sites=17 removed_runtime_hits=95000 removed_hit_sites=16 \
+  sampled_entries=67 sample_cycles=1900000 avg_removed=40 \
+  weighted_permille=952 min=36 max=42
 ```
 
 `mayconst=input/specialized/final` counts only may-const loads. Negative removal is
@@ -91,23 +93,40 @@ ejit_print_mayconst_ranking();
 
 The call is read-only and does not start profiling or compilation. In a shared
 taskpool build, a non-owner core posts a diagnostic request and waits while the
-owner worker prints its local optimizer data. It prints one row per entry,
-ordered by the average number of runtime-active may-const sites across that
-entry's unique JIT cache keys:
+owner worker prints its local optimizer data. Each Tier-1 may-const load carries
+a stable audit site ID. A site contributes to `removed_runtime_hits` only when
+all copies of that ID are absent after final optimization; unknown provenance is
+matched conservatively by field/source identity, and a site with no recoverable
+identity is kept. Rows are ordered by removed dynamic load executions per
+million platform timestamp units:
 
 ```text
-[EJIT] mayconst-ranking entries=2 sort=avg_active_sites_desc
-[EJIT] rank=1 entry=FuncA versions=30 avg_active_sites=17.000 \
-  hit_sites=510 runtime_hits=99872 avg_removed=40 total_removed=1200 \
+[EJIT] mayconst-ranking entries=2 sort=benefit_per_mcycle_desc
+[EJIT] rank=1 entry=FuncA versions=30 benefit_per_mcycle=71225.850 \
+  removed_per_entry=20882.518 removed_runtime_hits=8582715 \
+  sampled_entries=411 sample_cycles=120500000 avg_active_sites=17.000 \
+  hit_sites=510 runtime_hits=10000000 avg_removed=40 total_removed=1200 \
   min=36 max=42
 ```
 
-`avg_active_sites` is `hit_sites / versions` and is the primary ranking key;
+`sample_cycles` uses `SRE_CycleCountGet64()` ticks on SRE and steady-clock
+nanoseconds on hosts. All ratios use wide integer intermediates, round to the
+nearest fixed-point value, and saturate to `uint64_t`; diagnostics use no
+floating point. The primary score is
+`removed_runtime_hits * 1,000,000 / sample_cycles`. The equivalent decomposition
+is `(removed_runtime_hits / sampled_entries) *
+(sampled_entries / sample_cycles)`: work removed per entry multiplied by entry
+frequency. Recording the actual entries and elapsed ticks makes samples
+comparable even though the asynchronous Tier-2 snapshot normally occurs after
+the nominal 64-hit trigger rather than at exactly 64 completed calls.
+
+`avg_active_sites` is `hit_sites / versions` and remains an explanatory metric;
 three decimal places are printed using integer fixed-point arithmetic.
 `runtime_hits` is the sum of dynamic T0 executions of recognized may-const
 load sites; `hit_sites` is the sum of sites that executed at least once in each
-sampled version. Entries tied on `avg_active_sites` are ordered by
-`runtime_hits`, then `avg_removed`, then name. An entry appears only after at
+sampled version. Entries tied on `benefit_per_mcycle` are ordered by
+`removed_per_entry`, `avg_active_sites`, `runtime_hits`, `avg_removed`, then
+name. An entry appears only after at
 least one specialization has completed its audit window and final compilation.
 The aggregation state stays local to the compile-owner worker; only a
 request/completion sequence and a boolean result cross shared memory.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
@@ -34,6 +34,9 @@ struct EJitMayConstLoadSite {
   std::string functionName;
   std::string globalName;
   std::string sourceFile;
+  /// Stable module-order identity attached to the load as IR metadata before
+  /// optimization. Zero means that provenance could not be recovered.
+  uint64_t siteId = 0;
   uint64_t fieldOffset = 0;
   uint64_t runtimeHits = 0;
   uint32_t sourceLine = 0;
@@ -48,6 +51,10 @@ struct EJitMayConstBenefitSample {
   uint64_t finalMayConstLoads = 0;
   uint64_t runtimeHits = 0;
   uint64_t hitSites = 0;
+  uint64_t removedRuntimeHits = 0;
+  uint64_t removedHitSites = 0;
+  uint64_t sampledEntries = 0;
+  uint64_t sampleCycles = 0;
 };
 
 struct EJitMayConstBenefitSummary {
@@ -64,9 +71,18 @@ struct EJitMayConstBenefitSummary {
   int64_t maximumRemoved = 0;
   uint64_t runtimeHits = 0;
   uint64_t hitSites = 0;
+  uint64_t removedRuntimeHits = 0;
+  uint64_t removedHitSites = 0;
+  uint64_t sampledEntries = 0;
+  uint64_t sampleCycles = 0;
   /// Average dynamically-reached may_const sites per unique JIT version,
   /// scaled by 1000 so freestanding diagnostics need no floating point.
   uint64_t averageActiveSitesPermille = 0;
+  /// Removed dynamic load executions per sampled root entry, scaled by 1000.
+  uint64_t removedHitsPerEntryPermille = 0;
+  /// Removed dynamic load executions per million platform timestamp units,
+  /// scaled by 1000 for three decimal places.
+  uint64_t benefitPerMillionCyclesMilli = 0;
 };
 
 /// Summarize the branch weights attached by PGOInstrumentationUse. This is a

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -193,9 +193,14 @@ private:
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
   struct Tier1MayConstState {
     uintptr_t counterBase = 0;
+    uint64_t sampleStart = 0;
     std::vector<EJitMayConstLoadSite> sites;
   };
   std::unordered_map<uint64_t, Tier1MayConstState> tier1MayConst_;
+  /// The owner worker compiles and publishes serially, so the publish callback
+  /// can use this key to timestamp the Tier-1 sample window exactly at publish.
+  uint64_t pendingTier1MayConstKey_ = 0;
+  bool hasPendingTier1MayConstKey_ = false;
 #endif
 #ifdef EJIT_SRE_PGO_VALUE_PROFILE
   /// Value-profile capture per cacheKey (EJIT_VALUE_PROFILE.md §5.1): the

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -95,8 +95,8 @@ public:
     scalarSiteCountsByFunc_[funcName] = count;
   }
 
-  /// Print a descending per-entry ranking of average runtime-active may_const
-  /// sites per unique JIT version.
+  /// Print a descending per-entry ranking of dynamically removed may_const
+  /// loads per million sample ticks, with per-entry and active-site context.
   /// Returns false when no completed specialization sample is available.
   bool printMayConstRanking() const;
 
@@ -145,7 +145,8 @@ private:
   void recordMayConstBenefit(const SpecializationContext &ctx,
                              ArrayRef<EJitMayConstLoadSite> inputSites,
                              uint64_t specializedMayConstLoads,
-                             uint64_t finalMayConstLoads);
+                             ArrayRef<EJitMayConstLoadSite> finalSites,
+                             uint64_t sampledEntries);
 #endif
 
   /// Pick the cached function-simplification FPM for an EJIT optimization tier.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -103,6 +103,9 @@ struct SpecializationContext {
   /// Runtime hit snapshot from the temporary Instrumented tier. Populated by
   /// the compile driver before the final compile starts.
   std::vector<EJitMayConstLoadSite> mayConstLoadSites;
+  /// Platform timestamp distance from Tier-1 counter capture to the Tier-2
+  /// snapshot. SRE uses cycle counter ticks; hosts use steady-clock ns.
+  uint64_t mayConstSampleCycles = 0;
   /// True when profile data is collected for diagnostics only. The optimizer
   /// restores weights for reporting but must publish ordinary Baseline code.
   bool profileAuditOnly = false;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
@@ -59,6 +59,8 @@ public:
   static void removeMayConstLoadInstrumentation(Module &M);
 
   static constexpr const char *MayConstCounterName = "__ejit_mayconst_hits";
+  static constexpr const char *MayConstAuditSiteMD =
+      "ejit.mayconst.audit.site";
 #endif
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
@@ -1,6 +1,7 @@
 //===-- EJitBranchProfile.cpp - Online-PGO branch audit -------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitBranchProfile.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instruction.h"
@@ -8,6 +9,7 @@
 #include "llvm/IR/ProfDataUtils.h"
 
 #include <algorithm>
+#include <limits>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -22,6 +24,24 @@ uint64_t floorPercent(uint64_t Total, uint32_t Percent) {
   return (Total / 100) * Percent + ((Total % 100) * Percent) / 100;
 }
 
+uint64_t saturatingAdd(uint64_t L, uint64_t R) {
+  const uint64_t Max = std::numeric_limits<uint64_t>::max();
+  return R > Max - L ? Max : L + R;
+}
+
+uint64_t scaledRatio(uint64_t Numerator, uint64_t Denominator,
+                     uint64_t Scale) {
+  if (Denominator == 0)
+    return 0;
+  APInt Wide(129, Numerator);
+  Wide *= APInt(129, Scale);
+  Wide += APInt(129, Denominator / 2);
+  Wide = Wide.udiv(APInt(129, Denominator));
+  if (Wide.getActiveBits() > 64)
+    return std::numeric_limits<uint64_t>::max();
+  return Wide.getZExtValue();
+}
+
 } // namespace
 
 EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
@@ -33,11 +53,22 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
 
   bool First = true;
   for (const EJitMayConstBenefitSample &Sample : Samples) {
-    Summary.inputMayConstLoads += Sample.inputMayConstLoads;
-    Summary.specializedMayConstLoads += Sample.specializedMayConstLoads;
-    Summary.finalMayConstLoads += Sample.finalMayConstLoads;
-    Summary.runtimeHits += Sample.runtimeHits;
-    Summary.hitSites += Sample.hitSites;
+    Summary.inputMayConstLoads =
+        saturatingAdd(Summary.inputMayConstLoads, Sample.inputMayConstLoads);
+    Summary.specializedMayConstLoads = saturatingAdd(
+        Summary.specializedMayConstLoads, Sample.specializedMayConstLoads);
+    Summary.finalMayConstLoads =
+        saturatingAdd(Summary.finalMayConstLoads, Sample.finalMayConstLoads);
+    Summary.runtimeHits = saturatingAdd(Summary.runtimeHits, Sample.runtimeHits);
+    Summary.hitSites = saturatingAdd(Summary.hitSites, Sample.hitSites);
+    Summary.removedRuntimeHits =
+        saturatingAdd(Summary.removedRuntimeHits, Sample.removedRuntimeHits);
+    Summary.removedHitSites =
+        saturatingAdd(Summary.removedHitSites, Sample.removedHitSites);
+    Summary.sampledEntries =
+        saturatingAdd(Summary.sampledEntries, Sample.sampledEntries);
+    Summary.sampleCycles =
+        saturatingAdd(Summary.sampleCycles, Sample.sampleCycles);
     const int64_t Removed = static_cast<int64_t>(Sample.inputMayConstLoads) -
                             static_cast<int64_t>(Sample.finalMayConstLoads);
     if (First) {
@@ -61,8 +92,11 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
   Summary.averageRemoved =
       Summary.totalRemoved / static_cast<int64_t>(Summary.versions);
   Summary.averageActiveSitesPermille =
-      (Summary.hitSites / Summary.versions) * 1000 +
-      ((Summary.hitSites % Summary.versions) * 1000) / Summary.versions;
+      scaledRatio(Summary.hitSites, Summary.versions, 1000);
+  Summary.removedHitsPerEntryPermille =
+      scaledRatio(Summary.removedRuntimeHits, Summary.sampledEntries, 1000);
+  Summary.benefitPerMillionCyclesMilli = scaledRatio(
+      Summary.removedRuntimeHits, Summary.sampleCycles, 1000000000);
   if (Summary.inputMayConstLoads != 0)
     Summary.weightedRemovedPermille =
         Summary.totalRemoved * 1000 /

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -483,6 +483,10 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
       auto mayConstIt = tier1MayConst_.find(cacheKey);
       if (mayConstIt != tier1MayConst_.end()) {
         ctx.mayConstLoadSites = mayConstIt->second.sites;
+        const uint64_t SampleEnd = ejit_taskpool_trace_now();
+        if (mayConstIt->second.sampleStart != 0)
+          ctx.mayConstSampleCycles =
+              SampleEnd - mayConstIt->second.sampleStart;
         const auto *Counters = reinterpret_cast<const EJitAtomicU64 *>(
             mayConstIt->second.counterBase);
         if (Counters) {
@@ -664,6 +668,7 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
     Tier1MayConstState &MayConst = tier1MayConst_[cacheKey];
     MayConst.counterBase = 0;
+    MayConst.sampleStart = 0;
     MayConst.sites.assign(jitEngine_->getLastMayConstLoadSites().begin(),
                           jitEngine_->getLastMayConstLoadSites().end());
     if (!MayConst.sites.empty()) {
@@ -674,6 +679,8 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
     }
     EJIT_DIAG("mayconst T0 published key=0x%016lx func=%s sites=%zu", cacheKey,
               funcName.c_str(), MayConst.sites.size());
+    pendingTier1MayConstKey_ = cacheKey;
+    hasPendingTier1MayConstKey_ = true;
 #endif
 
 #ifdef EJIT_SRE_PGO_VALUE_PROFILE
@@ -825,6 +832,18 @@ void *EJitCompileDriver::compileNow(const EJitCompileRequest &req) {
 
 void EJitCompileDriver::notifyTaskpoolPublished(const EJitCompileRequest &req,
                                                 bool published) {
+#if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
+  const uint32_t AuditTier = decodeReqTier(req.funcIndex);
+  if (AuditTier == kEJitTierInstrumented) {
+    if (published && hasPendingTier1MayConstKey_) {
+      auto It = tier1MayConst_.find(pendingTier1MayConstKey_);
+      if (It != tier1MayConst_.end())
+        It->second.sampleStart = ejit_taskpool_trace_now();
+    }
+    pendingTier1MayConstKey_ = 0;
+    hasPendingTier1MayConstKey_ = false;
+  }
+#endif
 #ifdef EJIT_SRE_PGO_VALUE_PROFILE
   const uint32_t tier = decodeReqTier(req.funcIndex);
   const bool consumesRound = (tier == kEJitTierPgoUse && published) ||

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -3,6 +3,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitOptimizer.h"
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
 #include "llvm/ExecutionEngine/EJIT/EJitBranchProfile.h"
+#include "llvm/ADT/DenseSet.h"
 #endif
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
@@ -39,6 +40,7 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/LoopSimplify.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
+#include <limits>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -51,6 +53,21 @@ collectMayConstSites(Module &M, PeriodArrayRegistry &Registry) {
   EJitStructFieldPass Pass(Registry);
   Pass.initFromModule(M);
   return Pass.collectMayConstLoadSites(M);
+}
+
+static uint64_t saturatingAuditAdd(uint64_t L, uint64_t R) {
+  const uint64_t Max = std::numeric_limits<uint64_t>::max();
+  return R > Max - L ? Max : L + R;
+}
+
+static bool mayConstSitesCorrespond(const EJitMayConstLoadSite &L,
+                                    const EJitMayConstLoadSite &R) {
+  if (L.hasFieldOffset && R.hasFieldOffset && !L.globalName.empty() &&
+      L.globalName == R.globalName && L.fieldOffset == R.fieldOffset)
+    return true;
+  return L.sourceLine != 0 && R.sourceLine != 0 && !L.sourceFile.empty() &&
+         L.sourceFile == R.sourceFile && L.sourceLine == R.sourceLine &&
+         L.sourceColumn == R.sourceColumn;
 }
 #endif
 
@@ -129,6 +146,7 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
 
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
   std::vector<EJitMayConstLoadSite> AuditInputSites;
+  uint64_t AuditSampledEntries = 0;
   if (ctx.tier == CompileTier::Instrumented ||
       ctx.tier == CompileTier::PGOUse) {
     EJitStructFieldPass AuditPass(registry_);
@@ -284,8 +302,10 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
         Biased += Summary.biasedSites95;
         Balanced += Summary.balancedSites60;
         ZeroEdges += Summary.zeroCountEdges;
-        if (Summary.isRoot)
+        if (Summary.isRoot) {
           RootEntries = Summary.entryCount;
+          AuditSampledEntries = Summary.entryCount;
+        }
         EJIT_DIAG_DEBUG(
             "branch-audit-fn entry=%s fn=%s root=%u entries=%llu insts=%llu "
             "branches=%u profiled=%u biased95=%u balanced60=%u zero_edges=%u",
@@ -317,8 +337,9 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
       clearAnalyses();
       runOptimizationPipeline(M, ctx.optLevel, CompileTier::Baseline);
 #if defined(EJIT_DIAG_ENABLE)
+      auto FinalSites = collectMayConstSites(M, registry_);
       recordMayConstBenefit(ctx, AuditInputSites, AuditSpecializedMayConstLoads,
-                            collectMayConstSites(M, registry_).size());
+                            FinalSites, AuditSampledEntries);
 #endif
       EJIT_DIAG_VERBOSE("pipeline done (audit-only Baseline) func=%s "
                         "key=0x%016lx",
@@ -375,8 +396,9 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
 #endif
     runOptimizationPipeline(M, ctx.optLevel, ctx.tier);
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
+    auto FinalSites = collectMayConstSites(M, registry_);
     recordMayConstBenefit(ctx, AuditInputSites, AuditSpecializedMayConstLoads,
-                          collectMayConstSites(M, registry_).size());
+                          FinalSites, AuditSampledEntries);
 #endif
     EJIT_DIAG_VERBOSE("pipeline done (Tier-2) func=%s key=0x%016lx",
                       ctx.fnName.c_str(), ctx.cacheKey);
@@ -386,8 +408,9 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
   // Baseline (PGO off): the existing full specialization pipeline.
   runOptimizationPipeline(M, ctx.optLevel, ctx.tier);
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
+  auto FinalSites = collectMayConstSites(M, registry_);
   recordMayConstBenefit(ctx, AuditInputSites, AuditSpecializedMayConstLoads,
-                        collectMayConstSites(M, registry_).size());
+                        FinalSites, AuditSampledEntries);
 #endif
   EJIT_DIAG_VERBOSE("pipeline done func=%s key=0x%016lx", ctx.fnName.c_str(),
                     ctx.cacheKey);
@@ -396,13 +419,42 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
 void EJitOptimizer::recordMayConstBenefit(
     const SpecializationContext &ctx, ArrayRef<EJitMayConstLoadSite> InputSites,
-    uint64_t SpecializedMayConstLoads, uint64_t FinalMayConstLoads) {
+    uint64_t SpecializedMayConstLoads,
+    ArrayRef<EJitMayConstLoadSite> FinalSites, uint64_t SampledEntries) {
   const uint64_t InputMayConstLoads = InputSites.size();
+  const uint64_t FinalMayConstLoads = FinalSites.size();
   uint64_t RuntimeHits = 0;
   uint64_t HitSites = 0;
+  uint64_t RemovedRuntimeHits = 0;
+  uint64_t RemovedHitSites = 0;
+  DenseSet<uint64_t> SurvivingSiteIDs;
+  SmallVector<bool, 16> UnknownFinalMatched(FinalSites.size(), false);
+  for (const EJitMayConstLoadSite &Site : FinalSites)
+    if (Site.siteId != 0)
+      SurvivingSiteIDs.insert(Site.siteId);
   for (const EJitMayConstLoadSite &Site : InputSites) {
-    RuntimeHits += Site.runtimeHits;
+    RuntimeHits = saturatingAuditAdd(RuntimeHits, Site.runtimeHits);
     HitSites += Site.runtimeHits != 0;
+    // A surviving clone keeps the original ID, so count a site as removed only
+    // when every clone disappeared. If a transform rebuilt a load without
+    // copying metadata, consume one matching field/source identity before
+    // claiming removal. Completely unknown provenance is kept conservatively.
+    bool Survives = Site.siteId == 0 || SurvivingSiteIDs.contains(Site.siteId);
+    if (!Survives) {
+      for (size_t I = 0; I < FinalSites.size(); ++I) {
+        if (FinalSites[I].siteId != 0 || UnknownFinalMatched[I] ||
+            !mayConstSitesCorrespond(Site, FinalSites[I]))
+          continue;
+        UnknownFinalMatched[I] = true;
+        Survives = true;
+        break;
+      }
+    }
+    if (!Survives) {
+      RemovedRuntimeHits =
+          saturatingAuditAdd(RemovedRuntimeHits, Site.runtimeHits);
+      RemovedHitSites += Site.runtimeHits != 0;
+    }
   }
 
   EJitMayConstBenefitSample Sample;
@@ -412,6 +464,10 @@ void EJitOptimizer::recordMayConstBenefit(
   Sample.finalMayConstLoads = FinalMayConstLoads;
   Sample.runtimeHits = RuntimeHits;
   Sample.hitSites = HitSites;
+  Sample.removedRuntimeHits = RemovedRuntimeHits;
+  Sample.removedHitSites = RemovedHitSites;
+  Sample.sampledEntries = SampledEntries;
+  Sample.sampleCycles = ctx.mayConstSampleCycles;
 
   uint32_t Expected = 0;
   while (!mayConstBenefitLock_.compareExchange(Expected, 1))
@@ -433,7 +489,9 @@ void EJitOptimizer::recordMayConstBenefit(
                            static_cast<int64_t>(FinalMayConstLoads);
   EJIT_DIAG("mayconst-audit entry=%s key=0x%016llx tier=%u versions=%llu "
             "mayconst=%llu/%llu/%llu removed=%lld direct=%lld pipeline=%lld "
-            "runtime_hits=%llu hit_sites=%llu avg_removed=%lld "
+            "runtime_hits=%llu hit_sites=%llu removed_runtime_hits=%llu "
+            "removed_hit_sites=%llu sampled_entries=%llu sample_cycles=%llu "
+            "avg_removed=%lld "
             "weighted_permille=%lld min=%lld max=%lld",
             ctx.fnName.c_str(), static_cast<unsigned long long>(ctx.cacheKey),
             static_cast<unsigned>(ctx.tier),
@@ -445,6 +503,10 @@ void EJitOptimizer::recordMayConstBenefit(
             static_cast<long long>(Pipeline),
             static_cast<unsigned long long>(RuntimeHits),
             static_cast<unsigned long long>(HitSites),
+            static_cast<unsigned long long>(RemovedRuntimeHits),
+            static_cast<unsigned long long>(RemovedHitSites),
+            static_cast<unsigned long long>(SampledEntries),
+            static_cast<unsigned long long>(ctx.mayConstSampleCycles),
             static_cast<long long>(Aggregate.averageRemoved),
             static_cast<long long>(Aggregate.weightedRemovedPermille),
             static_cast<long long>(Aggregate.minimumRemoved),
@@ -500,6 +562,14 @@ bool EJitOptimizer::printMayConstRanking() const {
     return false;
   }
   llvm::sort(Rows, [](const RankingRow &L, const RankingRow &R) {
+    if (L.summary.benefitPerMillionCyclesMilli !=
+        R.summary.benefitPerMillionCyclesMilli)
+      return L.summary.benefitPerMillionCyclesMilli >
+             R.summary.benefitPerMillionCyclesMilli;
+    if (L.summary.removedHitsPerEntryPermille !=
+        R.summary.removedHitsPerEntryPermille)
+      return L.summary.removedHitsPerEntryPermille >
+             R.summary.removedHitsPerEntryPermille;
     if (L.summary.averageActiveSitesPermille !=
         R.summary.averageActiveSitesPermille)
       return L.summary.averageActiveSitesPermille >
@@ -511,18 +581,30 @@ bool EJitOptimizer::printMayConstRanking() const {
     return L.entry < R.entry;
   });
 
-  EJIT_DIAG_RAW("mayconst-ranking entries=%u sort=avg_active_sites_desc",
+  EJIT_DIAG_RAW("mayconst-ranking entries=%u sort=benefit_per_mcycle_desc",
                 static_cast<unsigned>(Rows.size()));
   for (size_t I = 0; I < Rows.size(); ++I) {
     const RankingRow &Row = Rows[I];
     const uint64_t AvgActiveSites =
         Row.summary.averageActiveSitesPermille;
+    const uint64_t RemovedPerEntry =
+        Row.summary.removedHitsPerEntryPermille;
+    const uint64_t Benefit = Row.summary.benefitPerMillionCyclesMilli;
     EJIT_DIAG_RAW(
-        "rank=%u entry=%s versions=%llu avg_active_sites=%llu.%03llu "
+        "rank=%u entry=%s versions=%llu benefit_per_mcycle=%llu.%03llu "
+        "removed_per_entry=%llu.%03llu removed_runtime_hits=%llu "
+        "sampled_entries=%llu sample_cycles=%llu avg_active_sites=%llu.%03llu "
         "hit_sites=%llu runtime_hits=%llu avg_removed=%lld "
         "total_removed=%lld min=%lld max=%lld",
         static_cast<unsigned>(I + 1), Row.entry.c_str(),
         static_cast<unsigned long long>(Row.summary.versions),
+        static_cast<unsigned long long>(Benefit / 1000),
+        static_cast<unsigned long long>(Benefit % 1000),
+        static_cast<unsigned long long>(RemovedPerEntry / 1000),
+        static_cast<unsigned long long>(RemovedPerEntry % 1000),
+        static_cast<unsigned long long>(Row.summary.removedRuntimeHits),
+        static_cast<unsigned long long>(Row.summary.sampledEntries),
+        static_cast<unsigned long long>(Row.summary.sampleCycles),
         static_cast<unsigned long long>(AvgActiveSites / 1000),
         static_cast<unsigned long long>(AvgActiveSites % 1000),
         static_cast<unsigned long long>(Row.summary.hitSites),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -188,6 +188,11 @@ EJitStructFieldPass::collectMayConstLoadSites(const Module &M) const {
 
         EJitMayConstLoadSite Site;
         Site.functionName = F.getName().str();
+        if (MDNode *SiteMD = LI->getMetadata(MayConstAuditSiteMD))
+          if (SiteMD->getNumOperands() == 1)
+            if (auto *SiteID =
+                    mdconst::dyn_extract<ConstantInt>(SiteMD->getOperand(0)))
+              Site.siteId = SiteID->getZExtValue();
         const GlobalVariable *RootGV = nullptr;
         if (auto Offset =
                 ejitMayConstFieldOffset(LI->getPointerOperand(), DL, RootGV)) {
@@ -232,6 +237,13 @@ EJitStructFieldPass::instrumentMayConstLoadSites(Module &M) {
         auto *LI = dyn_cast<LoadInst>(&I);
         if (!LI || !isMayConstLoad(LI, mayConstFieldMap_, DL))
           continue;
+
+        const uint64_t SiteID = SiteIndex + 1;
+        LI->setMetadata(
+            MayConstAuditSiteMD,
+            MDNode::get(Ctx, ConstantAsMetadata::get(
+                                 ConstantInt::get(I64, SiteID))));
+        Sites[SiteIndex].siteId = SiteID;
 
         IRBuilder<> Builder(LI);
         Value *Counter = Builder.CreateInBoundsGEP(

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 
 #include <algorithm>
+#include <limits>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -84,9 +85,9 @@ TEST(EJitBranchProfile, ClassifiesBranchShapeWithoutChangingIR) {
 
 TEST(EJitBranchProfile, AggregatesMayConstSpecializations) {
   const EJitMayConstBenefitSample Samples[] = {
-      {1, 100, 70, 40, 1000, 10},
-      {2, 120, 90, 50, 2000, 20},
-      {3, 80, 75, 85, 3000, 31}};
+      {1, 100, 70, 40, 1000, 10, 800, 8, 64, 1000000},
+      {2, 120, 90, 50, 2000, 20, 1500, 15, 80, 2000000},
+      {3, 80, 75, 85, 3000, 31, 0, 0, 100, 1000000}};
   EJitMayConstBenefitSummary Summary = summarizeMayConstBenefits(Samples);
   EXPECT_EQ(Summary.versions, 3u);
   EXPECT_EQ(Summary.inputMayConstLoads, 300u);
@@ -102,6 +103,32 @@ TEST(EJitBranchProfile, AggregatesMayConstSpecializations) {
   EXPECT_EQ(Summary.runtimeHits, 6000u);
   EXPECT_EQ(Summary.hitSites, 61u);
   EXPECT_EQ(Summary.averageActiveSitesPermille, 20333u);
+  EXPECT_EQ(Summary.removedRuntimeHits, 2300u);
+  EXPECT_EQ(Summary.removedHitSites, 23u);
+  EXPECT_EQ(Summary.sampledEntries, 244u);
+  EXPECT_EQ(Summary.sampleCycles, 4000000u);
+  EXPECT_EQ(Summary.removedHitsPerEntryPermille, 9426u);
+  EXPECT_EQ(Summary.benefitPerMillionCyclesMilli, 575000u);
+}
+
+TEST(EJitBranchProfile, BenefitScalingSaturatesWithoutOverflow) {
+  EJitMayConstBenefitSample Sample;
+  Sample.removedRuntimeHits = std::numeric_limits<uint64_t>::max();
+  Sample.sampledEntries = 1;
+  Sample.sampleCycles = 1;
+  EJitMayConstBenefitSummary Summary = summarizeMayConstBenefits({Sample});
+  EXPECT_EQ(Summary.removedHitsPerEntryPermille,
+            std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(Summary.benefitPerMillionCyclesMilli,
+            std::numeric_limits<uint64_t>::max());
+}
+
+TEST(EJitBranchProfile, BenefitScalingRoundsToNearestFixedPoint) {
+  EJitMayConstBenefitSample Sample;
+  Sample.removedRuntimeHits = 2;
+  Sample.sampledEntries = 3;
+  EJitMayConstBenefitSummary Summary = summarizeMayConstBenefits({Sample});
+  EXPECT_EQ(Summary.removedHitsPerEntryPermille, 667u);
 }
 
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -1534,6 +1534,7 @@ TEST(EJitStructFieldPass, InstrumentsRuntimeMayConstHitsBeforeReplacement) {
 
   auto Sites = Pass.instrumentMayConstLoadSites(M);
   ASSERT_EQ(Sites.size(), 1u);
+  EXPECT_EQ(Sites[0].siteId, 1u);
   auto *Counters = M.getGlobalVariable(
       EJitStructFieldPass::MayConstCounterName);
   ASSERT_NE(Counters, nullptr);
@@ -1553,6 +1554,9 @@ TEST(EJitStructFieldPass, InstrumentsRuntimeMayConstHitsBeforeReplacement) {
   EJitStructFieldPass::removeMayConstLoadInstrumentation(M);
   EXPECT_EQ(M.getGlobalVariable(EJitStructFieldPass::MayConstCounterName),
             nullptr);
+  auto SurvivingSites = Pass.collectMayConstLoadSites(M);
+  ASSERT_EQ(SurvivingSites.size(), 1u);
+  EXPECT_EQ(SurvivingSites[0].siteId, 1u);
   AtomicAdds = 0;
   for (Instruction &I : instructions(*F))
     AtomicAdds += isa<AtomicRMWInst>(I);


### PR DESCRIPTION
## Summary
- rank may-const specialization candidates by removed runtime load executions per million sample cycles
- correlate Tier-1 runtime counters with surviving final-IR sites using stable metadata IDs and conservative provenance fallback
- report removed hits per sampled entry, sample duration, and supporting active-site metrics
- use wide integer fixed-point arithmetic with rounding and saturation

## Validation
- syntax-compiled the changed EJIT implementation and tests with branch audit, diagnostics, shared taskpool, and value profiling enabled
- checked audit-disabled and value-profile-disabled configurations
- git diff --check

Full linked unit tests were not available in this checkout because it has no matching build directory.