### PR TITLE
[EJIT] Propagate bound pointer snapshots through direct helpers

### DIFF
--- a/jit_design_doc/EJIT_BOUND_PTR.md
+++ b/jit_design_doc/EJIT_BOUND_PTR.md
@@ -28,10 +28,19 @@ Only loads of `ejit_may_const` fields are replaced from the snapshot. Other
 fields, such as `runtime_bias` above, remain ordinary loads through the pointer
 passed to each invocation of the JIT function.
 
+The annotation belongs only on the `ejit_entry` parameter. When that pointer is
+passed through non-inlined direct helpers, EJIT tracks the corresponding formal
+argument through the call chain and specializes marked field loads in those
+helpers from the same owned snapshot. Helpers do not need `ejit_entry` or a
+repeated `EJIT_BOUND_PTR` annotation.
+
 ## Contract and limits
 
 - The function must have exactly one matching `EJIT_DIM(period)` parameter.
 - The first implementation supports one `EJIT_BOUND_PTR` parameter per entry.
+- Helper propagation accepts pointer casts and constant-offset GEPs. It stops
+  conservatively at indirect calls, address-taken helpers, or a helper argument
+  that receives different pointer sources at different call sites.
 - The copy is shallow. Pointer fields inside the object are not followed.
 - An `ejit_may_const` field must remain stable while its period instance is
   active. Change it only as part of the normal deactivate/update/reactivate

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
@@ -14,6 +14,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT
 #include "llvm/ExecutionEngine/EJIT/EJitBranchProfile.h"
 #include <vector>
@@ -40,9 +41,11 @@ class EJitStructFieldPass : public PassInfoMixin<EJitStructFieldPass> {
 public:
   EJitStructFieldPass(PeriodArrayRegistry &reg,
                       const uint8_t *boundData = nullptr,
-                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0)
+                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0,
+                      StringRef boundRootFunction = {})
       : registry_(reg), boundData_(boundData), boundSize_(boundSize),
-        boundArgIndex_(boundArgIndex) {}
+        boundArgIndex_(boundArgIndex),
+        boundRootFunction_(boundRootFunction.str()) {}
 
   /// Pre-build GV metadata maps from the Module (call once before run()).
   void initFromModule(Module &M);
@@ -72,6 +75,14 @@ private:
   const uint8_t *boundData_ = nullptr;
   uint32_t boundSize_ = 0;
   uint32_t boundArgIndex_ = 0;
+  std::string boundRootFunction_;
+
+  // A specialization owns one pointee snapshot. Track which formal arguments
+  // are proven to receive that snapshot, and their byte offset into it, across
+  // direct calls from the entry. Ambiguous or indirect flows are omitted.
+  DenseMap<const Argument *, uint64_t> boundArguments_;
+  SmallVector<std::pair<uint64_t, uint64_t>, 4> boundMayConstFields_;
+  void initBoundArgumentPropagation(Module &M);
 
   // Cached metadata maps — built once per module, reused across functions.
   GVPeriodMap gvPeriodMap_;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -684,7 +684,8 @@ void EJitOptimizer::runStructFieldPass(Module &M,
                                        const SpecializationContext &ctx) {
   EJitStructFieldPass structField(
       registry_, ctx.boundData.empty() ? nullptr : ctx.boundData.data(),
-      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex);
+      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex,
+      ctx.fnName);
   structField.initFromModule(M);
   for (Function &F : M.functions())
     if (!F.isDeclaration())

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -18,8 +18,10 @@
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
+#include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <limits>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -76,6 +78,7 @@ void EJitStructFieldPass::initFromModule(Module &M) {
       mayConstFieldMap_[&GV] = std::move(offsets);
   }
 
+  initBoundArgumentPropagation(M);
   mapsBuilt_ = true;
 #ifdef EJIT_DIAG_ENABLE
   EJIT_DIAG_DEBUG("struct-field initFromModule module=%s globals=%zu "
@@ -125,55 +128,27 @@ static bool functionBindsArgument(const Function &F, unsigned ArgIndex) {
   return false;
 }
 
-static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
-                                                        const Value *PtrOp,
-                                                        const Argument *Root);
-
-static bool isBoundMayConstLoad(LoadInst *LI, const Function &F,
-                                unsigned ArgIndex, const DataLayout &DL) {
-  if (LI->isVolatile() || LI->isAtomic() || ArgIndex >= F.arg_size())
-    return false;
-  const Argument *Root = findRootArgument(LI->getPointerOperand());
-  if (!Root || Root->getArgNo() != ArgIndex)
-    return false;
-  if (LI->hasMetadata(MD_EJIT_MAY_CONST))
-    return true;
-
-  auto Offset = accumulateArgumentOffset(DL, LI->getPointerOperand(), Root);
-  TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
-  if (!Offset || AccessSize.isScalable())
-    return false;
-
+static MDNode *getBoundArgumentMetadata(const Function &F,
+                                        unsigned ArgIndex) {
   MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
   if (!MD)
-    return false;
+    return nullptr;
   for (const MDOperand &Op : MD->operands()) {
     auto *Sub = dyn_cast<MDNode>(Op.get());
     if (!Sub || Sub->getNumOperands() < 4)
       continue;
     auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
     auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
-    if (!Tag || Tag->getString() != TAG_EJIT_BOUND_PTR || !Idx ||
-        Idx->getZExtValue() != ArgIndex)
-      continue;
-    for (unsigned I = 4; I < Sub->getNumOperands(); ++I) {
-      auto *Field = dyn_cast<MDNode>(Sub->getOperand(I));
-      if (!Field || Field->getNumOperands() != 2)
-        continue;
-      auto *FieldOffset =
-          mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
-      auto *FieldSize = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
-      if (FieldOffset && FieldSize) {
-        uint64_t Begin = FieldOffset->getZExtValue();
-        uint64_t Size = FieldSize->getZExtValue();
-        if (*Offset >= Begin && *Offset - Begin <= Size &&
-            AccessSize.getFixedValue() <= Size - (*Offset - Begin))
-          return true;
-      }
-    }
+    if (Tag && Tag->getString() == TAG_EJIT_BOUND_PTR && Idx &&
+        Idx->getZExtValue() == ArgIndex)
+      return Sub;
   }
-  return false;
+  return nullptr;
 }
+
+static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
+                                                        const Value *PtrOp,
+                                                        const Argument *Root);
 
 /// If all GEP indices are ConstantInt, compute the cumulative byte offset.
 /// Returns std::nullopt if any index is not constant.
@@ -233,6 +208,173 @@ static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
     PtrOp = GEP->getPointerOperand();
   }
   return std::nullopt;
+}
+
+static std::optional<uint64_t> getBoundSnapshotOffset(
+    const Value *V, const DenseMap<const Argument *, uint64_t> &BoundArguments,
+    const DataLayout &DL) {
+  const Argument *Root = findRootArgument(V);
+  if (!Root)
+    return std::nullopt;
+  auto It = BoundArguments.find(Root);
+  if (It == BoundArguments.end())
+    return std::nullopt;
+  auto Relative = accumulateArgumentOffset(DL, V, Root);
+  if (!Relative ||
+      It->second > std::numeric_limits<uint64_t>::max() - *Relative)
+    return std::nullopt;
+  return It->second + *Relative;
+}
+
+static Function *getDirectCallee(CallBase &CB) {
+  return dyn_cast<Function>(CB.getCalledOperand()->stripPointerCasts());
+}
+
+void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
+  boundArguments_.clear();
+  boundMayConstFields_.clear();
+  if (!boundData_ || !boundSize_)
+    return;
+
+  Function *Root = nullptr;
+  if (!boundRootFunction_.empty()) {
+    Root = M.getFunction(boundRootFunction_);
+  } else {
+    // Direct pass users may omit the root name. Infer it only when the module
+    // contains a unique matching bound parameter.
+    for (Function &F : M) {
+      if (!functionBindsArgument(F, boundArgIndex_))
+        continue;
+      if (Root) {
+        Root = nullptr;
+        break;
+      }
+      Root = &F;
+    }
+  }
+  if (!Root || Root->isDeclaration() || boundArgIndex_ >= Root->arg_size() ||
+      !functionBindsArgument(*Root, boundArgIndex_))
+    return;
+
+  Argument *RootArgument = Root->getArg(boundArgIndex_);
+  if (!RootArgument->getType()->isPointerTy())
+    return;
+  boundArguments_[RootArgument] = 0;
+
+  if (MDNode *BoundMD = getBoundArgumentMetadata(*Root, boundArgIndex_)) {
+    for (unsigned I = 4; I < BoundMD->getNumOperands(); ++I) {
+      auto *Field = dyn_cast<MDNode>(BoundMD->getOperand(I));
+      if (!Field || Field->getNumOperands() != 2)
+        continue;
+      auto *Offset = mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
+      auto *Size = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
+      if (Offset && Size)
+        boundMayConstFields_.push_back(
+            {Offset->getZExtValue(), Size->getZExtValue()});
+    }
+  }
+
+  const DataLayout &DL = M.getDataLayout();
+  SmallVector<CallBase *, 32> DirectCalls;
+  DenseMap<const Function *, SmallVector<CallBase *, 4>> CallsByCallee;
+  for (Function &Caller : M) {
+    if (Caller.isDeclaration())
+      continue;
+    for (BasicBlock &BB : Caller) {
+      for (Instruction &I : BB) {
+        auto *CB = dyn_cast<CallBase>(&I);
+        if (!CB)
+          continue;
+        Function *Callee = getDirectCallee(*CB);
+        if (!Callee || Callee->isDeclaration())
+          continue;
+        DirectCalls.push_back(CB);
+        CallsByCallee[Callee].push_back(CB);
+      }
+    }
+  }
+
+  bool Changed;
+  do {
+    Changed = false;
+    for (CallBase *CB : DirectCalls) {
+      Function *Callee = getDirectCallee(*CB);
+      unsigned Count =
+          std::min<unsigned>(CB->arg_size(), Callee->arg_size());
+      for (unsigned ArgIndex = 0; ArgIndex < Count; ++ArgIndex) {
+        Argument *Formal = Callee->getArg(ArgIndex);
+        if (!Formal->getType()->isPointerTy())
+          continue;
+        auto Offset = getBoundSnapshotOffset(CB->getArgOperand(ArgIndex),
+                                             boundArguments_, DL);
+        if (!Offset || *Offset >= boundSize_)
+          continue;
+        Changed |= boundArguments_.try_emplace(Formal, *Offset).second;
+      }
+    }
+  } while (Changed);
+
+  // A callee is safe only if every call represented in this specialization
+  // module passes the same snapshot-derived pointer to that formal argument.
+  // Prune to a fixed point so ambiguity in an upper helper also removes all
+  // mappings derived through it further down the chain.
+  do {
+    Changed = false;
+    SmallVector<const Argument *, 8> Invalid;
+    for (const auto &[Formal, ExpectedOffset] : boundArguments_) {
+      if (Formal == RootArgument)
+        continue;
+      const Function *Callee = Formal->getParent();
+      if (Callee->hasAddressTaken()) {
+        Invalid.push_back(Formal);
+        continue;
+      }
+      bool SawCall = false;
+      bool AllMatch = true;
+      auto CallsIt = CallsByCallee.find(Callee);
+      if (CallsIt != CallsByCallee.end()) {
+        for (CallBase *CB : CallsIt->second) {
+          SawCall = true;
+          unsigned ArgIndex = Formal->getArgNo();
+          if (ArgIndex >= CB->arg_size()) {
+            AllMatch = false;
+            continue;
+          }
+          auto ActualOffset = getBoundSnapshotOffset(
+              CB->getArgOperand(ArgIndex), boundArguments_, DL);
+          if (!ActualOffset || *ActualOffset != ExpectedOffset)
+            AllMatch = false;
+        }
+      }
+      if (!SawCall || !AllMatch)
+        Invalid.push_back(Formal);
+    }
+    for (const Argument *Formal : Invalid)
+      Changed |= boundArguments_.erase(Formal);
+  } while (Changed);
+}
+
+static bool isBoundMayConstLoad(
+    LoadInst *LI, const DenseMap<const Argument *, uint64_t> &BoundArguments,
+    ArrayRef<std::pair<uint64_t, uint64_t>> MayConstFields,
+    const DataLayout &DL) {
+  if (LI->isVolatile() || LI->isAtomic())
+    return false;
+  auto Offset =
+      getBoundSnapshotOffset(LI->getPointerOperand(), BoundArguments, DL);
+  if (!Offset)
+    return false;
+  if (LI->hasMetadata(MD_EJIT_MAY_CONST))
+    return true;
+
+  TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
+  if (AccessSize.isScalable())
+    return false;
+  for (const auto &[Begin, Size] : MayConstFields)
+    if (*Offset >= Begin && *Offset - Begin <= Size &&
+        AccessSize.getFixedValue() <= Size - (*Offset - Begin))
+      return true;
+  return false;
 }
 
 /// Check whether a load is (or can be treated as) a may_const access.
@@ -504,17 +646,14 @@ static Constant *tryReplacePeriodAbsoluteAddress(
   return nullptr;
 }
 
-static Constant *tryReplaceBoundPointer(LoadInst *LI, const Function &F,
-                                        const uint8_t *Data, uint32_t Size,
-                                        uint32_t ArgIndex,
-                                        const DataLayout &DL) {
-  if (!Data || !Size || ArgIndex >= F.arg_size() ||
-      !functionBindsArgument(F, ArgIndex))
+static Constant *tryReplaceBoundPointer(
+    LoadInst *LI, const uint8_t *Data, uint32_t Size,
+    const DenseMap<const Argument *, uint64_t> &BoundArguments,
+    const DataLayout &DL) {
+  if (!Data || !Size)
     return nullptr;
-  const Argument *Root = findRootArgument(LI->getPointerOperand());
-  if (!Root || Root->getArgNo() != ArgIndex)
-    return nullptr;
-  auto Offset = accumulateArgumentOffset(DL, LI->getPointerOperand(), Root);
+  auto Offset =
+      getBoundSnapshotOffset(LI->getPointerOperand(), BoundArguments, DL);
   TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
   if (!Offset || AccessSize.isScalable() || *Offset > Size ||
       AccessSize.getFixedValue() > Size - *Offset)
@@ -733,7 +872,8 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
         continue;
       }
 
-      bool BoundMayConst = isBoundMayConstLoad(LI, F, boundArgIndex_, DL);
+      bool BoundMayConst = isBoundMayConstLoad(
+          LI, boundArguments_, boundMayConstFields_, DL);
       if (!BoundMayConst && !isMayConstLoad(LI, mayConstFieldMap_, DL))
         continue;
 #ifdef EJIT_DIAG_ENABLE
@@ -750,8 +890,8 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
       // from the owned snapshot; the pointer argument and all dynamic fields
       // remain live inputs to the specialization.
       if (!C)
-        C = tryReplaceBoundPointer(LI, F, boundData_, boundSize_,
-                                   boundArgIndex_, DL);
+        C = tryReplaceBoundPointer(LI, boundData_, boundSize_, boundArguments_,
+                                   DL);
 
       // Pattern 1: direct GlobalVariable load (scalar static variable).
       if (!C) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
+#include <algorithm>
 #ifndef EJIT_FREESTANDING
 #include <thread>
 #endif
@@ -1712,6 +1713,108 @@ TEST(EJitStructFieldPass, BoundPointerUsesOwnedSnapshot) {
   }
   EXPECT_EQ(Loads, 1u) << "dynamic field must remain a runtime load";
   EXPECT_TRUE(SawSnapshotConstant);
+}
+
+TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32, i32 }
+    define i32 @bound_chain(i32 %cell, ptr %cfg) !ejit.metadata !0 {
+    entry:
+      %result = call i32 @bound_helper1(i64 123, ptr %cfg)
+      ret i32 %result
+    }
+    define internal i32 @bound_helper1(i64 %unused, ptr %cfg) noinline {
+    entry:
+      %mode.ptr = getelementptr %Cfg, ptr %cfg, i32 0, i32 1
+      %result = call i32 @bound_helper2(ptr %mode.ptr)
+      ret i32 %result
+    }
+    define internal i32 @bound_helper2(ptr %mode.ptr) noinline {
+    entry:
+      %mode = load i32, ptr %mode.ptr, !ejit.may_const !4
+      ret i32 %mode
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, !5}
+    !4 = !{!"ejit"}
+    !5 = !{i64 4, i64 4}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  struct Config {
+    uint32_t dynamic;
+    uint32_t mode;
+  } Snapshot{99, 17};
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&Snapshot),
+                           sizeof(Snapshot), 1, "bound_chain");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  for (Function &F : *M)
+    if (!F.isDeclaration())
+      Pass.run(F, FAM);
+
+  Function *Leaf = M->getFunction("bound_helper2");
+  ASSERT_NE(Leaf, nullptr);
+  EXPECT_EQ(std::count_if(inst_begin(Leaf), inst_end(Leaf),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            0);
+  auto *Ret = dyn_cast<ReturnInst>(Leaf->getEntryBlock().getTerminator());
+  ASSERT_NE(Ret, nullptr);
+  auto *Value = dyn_cast<ConstantInt>(Ret->getReturnValue());
+  ASSERT_NE(Value, nullptr);
+  EXPECT_EQ(Value->getZExtValue(), 17u);
+}
+
+TEST(EJitStructFieldPass, AmbiguousHelperPointerIsNotSpecialized) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32 }
+    define i32 @bound_ambiguous(i32 %cell, ptr %cfg, ptr %other)
+        !ejit.metadata !0 {
+    entry:
+      %a = call i32 @shared_helper(ptr %cfg)
+      %b = call i32 @shared_helper(ptr %other)
+      %sum = add i32 %a, %b
+      ret i32 %sum
+    }
+    define internal i32 @shared_helper(ptr %cfg) noinline {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !4
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
+    !4 = !{!"ejit"}
+    !5 = !{i64 0, i64 4}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t Snapshot = 23;
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&Snapshot),
+                           sizeof(Snapshot), 1, "bound_ambiguous");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Pass.run(*M->getFunction("shared_helper"), FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(M->getFunction("shared_helper")),
+                          inst_end(M->getFunction("shared_helper")),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

- keep `EJIT_BOUND_PTR(period)` only on the `ejit_entry` parameter
- propagate the owned snapshot association through non-inlined direct helper calls
- track the corresponding formal argument and constant byte offset at each call edge
- stop conservatively for indirect/address-taken callees or inconsistent pointer sources
- preserve the original field whitelist from the entry metadata, so only `ejit_may_const` fields are folded

## Example

```c
ejit_entry void FuncA(
    ejit_period_arr_ind(cell) int cell,
    EJIT_BOUND_PTR(cell) const CellConfig *cfg) {
  FuncB(cfg);
}

static void FuncB(const CellConfig *cfg) {
  FuncC(&cfg->stable);
}
```

`FuncB` and `FuncC` do not need `ejit_entry` or repeated bound-pointer annotations. Constant-offset subobject pointers are tracked from the same owned snapshot.

## Safety

A helper argument is specialized only when every direct call represented in the specialization module derives that argument from the same snapshot offset. Mixed pointer sources invalidate the mapping, and invalidation propagates to deeper helpers.

## Validation

- `EJitStructFieldPass.cpp` compiles successfully with the configured LLVM build
- `EJitOptimizer.cpp` compiles successfully against the complete mainline PGO declaration
- added a three-level `noinline` test with a constant-offset subobject pointer
- added an ambiguity test where one helper receives both the bound pointer and an unrelated pointer; its runtime load must remain
- `git diff --check` passes

The full local `EJITTests` target could not be rebuilt because this offline worktree contains a synthetic overlap-only copy of the latest PGO/shared-state base. The remote branch is parented directly on the complete merged mainline commit.