### PR TITLE
[EJIT] Add branchless sentinel icache wrapper for NumDims <= 2

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -94,6 +94,8 @@ _set_min_libs() {
     ${_l}/libLLVMCore.a ${_l}/libLLVMSupport.a ${_l}/libLLVMDemangle.a
     ${_l}/libLLVMBinaryFormat.a ${_l}/libLLVMBitReader.a ${_l}/libLLVMBitstreamReader.a
     ${_l}/libLLVMAnalysis.a ${_l}/libLLVMScalarOpts.a ${_l}/libLLVMInstCombine.a
+    ${_l}/libLLVMPasses.a ${_l}/libLLVMAggressiveInstCombine.a
+    ${_l}/libLLVMCoroutines.a
     ${_l}/libLLVMipo.a ${_l}/libLLVMTransformUtils.a ${_l}/libLLVMVectorize.a
     ${_l}/libLLVMCodeGen.a
     ${_l}/libLLVMCodeGenTypes.a ${_l}/libLLVMTarget.a ${_l}/libLLVMTargetParser.a
@@ -113,7 +115,8 @@ _set_min_libs() {
   case "$1" in
     x86)
       MIN_LIBS="${MIN_LIBS_COMMON}
-        ${_l}/libLLVMX86CodeGen.a ${_l}/libLLVMX86Desc.a ${_l}/libLLVMX86Info.a"
+        ${_l}/libLLVMX86CodeGen.a ${_l}/libLLVMX86Desc.a ${_l}/libLLVMX86Info.a
+        ${_l}/libLLVMX86AsmParser.a"
       ;;
     aarch64)
       MIN_LIBS="${MIN_LIBS_COMMON}
@@ -160,7 +163,11 @@ else
   _set_min_libs "${ARCH}"
   OTHER_LIBS=$(echo "${MIN_LIBS}" | sed '/^$/d' | tr '\n' ' ')
 fi
-LINK_LIBS="-lz -lpthread -ldl"
+# EJitLibcallStubs references the stack-protector ABI symbol __stack_chk_guard
+# by address; host glibc on x86_64 (TLS canary) no longer exports it as data.
+# Define it at 0 for the static link - the test binaries themselves compile
+# without stack protector, so nothing ever loads the value.
+LINK_LIBS="-lz -lpthread -ldl -Wl,--defsym,__stack_chk_guard=0"
 STRIP_FLAG="-Wl,--strip-all"
 if ${NO_STRIP}; then STRIP_FLAG=""; fi
 
@@ -201,6 +208,7 @@ ALL_TESTS=(
   ejit_pgo_test
   ejit_pgo_sre_multicore_test
   ejit_vp_multicore_test
+  ejit_sentinel_smoke_test
 )
 
 # Per-test compile flags (e.g. for disabling global constructors)
@@ -210,6 +218,9 @@ COMPILE_FLAGS[ejit_manual_register_test]="-mllvm -enable-ejit-global-ctors=false
 # registry tables walked via linker-script-provided __start_/__stop_ symbols.
 COMPILE_FLAGS[ejit_baremetal_link_test]="-mllvm -enable-ejit-global-ctors=false"
 COMPILE_FLAGS[ejit_fixed_dim_test]=""
+# Sentinel-wrapper smoke: icache ON so the wrapper takes the branchless
+# (NumDims <= 2, cell table defined pre-filled with &MissFn) form.
+COMPILE_FLAGS[ejit_sentinel_smoke_test]="-mllvm -ejit-inline-cache"
 
 # Override the primary source file for a test (default: <name>.c). Lets a test
 # reuse existing sources under a different build/link recipe without copying.
@@ -233,6 +244,7 @@ LINKER_SCRIPT[ejit_manual_register_test]="ejit_baremetal.ld"
 declare -A EXTRA_SRCS
 EXTRA_SRCS[ejit_multi_tu_test]="ejit_multi_tu_test_b.c"
 EXTRA_SRCS[ejit_baremetal_link_test]="ejit_multi_tu_test_b.c"
+EXTRA_SRCS[ejit_sentinel_smoke_test]="ejit_sentinel_smoke_test_1d.c ejit_sentinel_smoke_test_3d.c"
 
 declare -A TEST_ARGS
 TEST_ARGS[ejit_complex_test]="0 1 2 3"

--- a/ejit_test/ejit_sentinel_smoke_test.c
+++ b/ejit_test/ejit_sentinel_smoke_test.c
@@ -1,0 +1,217 @@
+//===-- ejit_sentinel_smoke_test.c ----------------------------------------===//
+//
+// EJIT sentinel-wrapper host smoke (x86, async shared pool, icache ON).
+//
+// Built with -mllvm -ejit-inline-cache. For NumDims <= 2 the AOT emits the
+// BRANCHLESS wrapper: the cell table is DEFINED pre-filled with &MissFn and
+// the hot path is one load + musttail BLR with no null guard. This test
+// walks that wrapper through its whole lifecycle and checks the observable
+// contract end to end:
+//
+//   1. Warm: the first call finds the cell still holding &MissFn -> the BLR
+//      lands in MissFn -> taskpool resolve (async compile enqueued, AOT
+//      fallback answers). ejit_drain_taskpool() lets the worker publish; the
+//      NEXT resolve is a taskpool cache hit which icacheFill's the cell.
+//   2. Frozen: mutating the may_const source WITHOUT invalidating keeps the
+//      old (compile-time) answer -- the BLR served the cached
+//      specialization; an AOT fallback execution would answer the new value.
+//   3. Re-resolve: a period toggle drains the cells -- to the &MissFn
+//      sentinel for the branchless tables, 0 for the guarded one -- bumps
+//      the instance version, and retires the taskpool entry, so the next
+//      call misses, resolves fresh, and re-freezes the NEW values.
+//
+// The lifecycle runs on a 1-dim entry ([16] table, sentinel form) and a
+// 3-dim entry ([16]^3 table, GUARDED form: the wrapper keeps its null
+// guard and drain writes 0 -- the only shape the sentinel does not cover).
+//
+// The 0-dim entry runs a REDUCED lifecycle: its specialization key has no
+// dims, so no lifecycle event can retire its taskpool entry -- once
+// compiled it is frozen by design (a static may_const source has no time
+// window in which it may change; give the entry a dim if it must
+// re-specialize). ejit_clear_cache() still drains the scalar cell back to
+// &MissFn, so the observable contract there is: the next call re-enters
+// MissFn (branchless round-trip through the sentinel) and the taskpool
+// cache-hit re-serves the SAME frozen body.
+//
+// TU layout: each entry lives in its OWN translation unit with the period
+// arrays it specializes on. A TU's registered bitcode is the JIT's
+// specialization unit: compiling an entry JITs that whole blob under the
+// entry's OWN dim context, so a sibling entry with a different dim
+// signature would keep an unfoldable period-indexed load in the blob and
+// the module could not link (on a host whose JIT slab sits >2GB from the
+// AOT data, any leftover AOT-global reference is unrepresentable in a
+// rip-relative Delta32). One entry shape per TU is also the embedded
+// deployment shape. The 0-dim source is a plain (non-period) struct, not a
+// bare scalar: ejit_may_const applies to struct FIELDS only - Sema drops
+// it on a VarDecl - and ejit_period(static) registers the struct so the
+// JIT can resolve its address when freezing the field.
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "ejit_test_helpers.h"
+
+extern void ejit_clear_cache(void);
+
+// Entry functions from the sibling TUs (plain externs; the wrappers, their
+// dim attributes, and their icache cells live with the defining TUs).
+extern uint32_t sentinel_1d(uint8_t i0);
+extern uint32_t guarded_3d(uint8_t i1, uint8_t i2, uint8_t i3);
+// may_const setters exported by the sibling TUs (the period arrays are
+// private to their TUs; the harness mutates them through these).
+extern void sentinel_smoke_set_p0(uint8_t i, uint32_t kind);
+extern void sentinel_smoke_set_3d(uint8_t i, uint32_t kind);
+
+//===-- Data ---------------------------------------------------------------===//
+
+struct ScalarCfg {
+  ejit_may_const uint32_t kind; // 1 -> "on" branch, 0 -> "off"
+};
+ejit_period(static) struct ScalarCfg g_scalar = {1};
+
+//===-- Entry (0-dim) -------------------------------------------------------===//
+// noinline keeps the wrapper dispatch out of the callers.
+
+// 0-dim: scalar sentinel cell. on -> 10, off -> 20.
+ejit_entry __attribute__((noinline)) uint32_t sentinel_0d(void) {
+  return (g_scalar.kind == 1u) ? 10u : 20u;
+}
+
+//===-- Harness ------------------------------------------------------------===//
+
+static int g_fail = 0;
+#define T(cond, fmt, ...)                                                      \
+  do {                                                                         \
+    if (cond)                                                                  \
+      printf("  OK   " fmt "\n", ##__VA_ARGS__);                               \
+    else {                                                                     \
+      printf("  FAIL " fmt "\n", ##__VA_ARGS__);                               \
+      g_fail++;                                                                \
+    }                                                                          \
+  } while (0)
+
+static uint8_t cellIdx = 1;
+
+static void set_scalar(uint32_t kind) { g_scalar.kind = kind; }
+static void set_p0(uint32_t kind) { sentinel_smoke_set_p0(cellIdx, kind); }
+static void set_all3(uint32_t kind) { sentinel_smoke_set_3d(cellIdx, kind); }
+
+// One lifecycle, parametrized by the call, its two answers (source "on" /
+// "off"), the invalidation to run between them, and the source setter.
+#define LIFECYCLE(label, call_expr, v_on, v_off, invalidate_expr, set_kind)    \
+  do {                                                                         \
+    printf("--- %s: warm (cell=&MissFn -> BLR -> MissFn -> resolve) ---\n",    \
+           label);                                                             \
+    uint32_t _a = (call_expr); /* PENDING -> AOT fallback */                   \
+    T(_a == (v_on), "%s warm = %u (expected %u)", label, _a, v_on);            \
+    ejit_drain_taskpool();                                                     \
+    uint32_t _b = (call_expr); /* taskpool hit -> icacheFill */                \
+    T(_b == (v_on), "%s fill = %u (expected %u)", label, _b, v_on);            \
+                                                                               \
+    printf("--- %s: hot hit serves the frozen specialization ---\n", label);   \
+    set_kind(0u); /* no invalidation: the cell keeps the old code */           \
+    uint32_t _c = (call_expr); /* icache hit: BLR the cached body */           \
+    T(_c == (v_on), "%s frozen = %u (expected %u; AOT fallback would answer "  \
+                  "%u)", label, _c, v_on, v_off);                              \
+                                                                               \
+    printf("--- %s: invalidation drains -> miss -> re-resolve ---\n", label);  \
+    set_kind(1u); /* restore, then flip the values the NEXT compile freezes */ \
+    invalidate_expr; /* drains every cell to its empty value */                \
+    set_kind(0u);                                                              \
+    uint32_t _d = (call_expr); /* empty cell -> MissFn -> fresh resolve */     \
+    T(_d == (v_off), "%s post-drain resolve = %u (expected %u)", label, _d,    \
+      v_off);                                                                  \
+    ejit_drain_taskpool();                                                     \
+    uint32_t _e = (call_expr); /* new specialization cached + filled */        \
+    T(_e == (v_off), "%s refilled = %u (expected %u)", label, _e, v_off);      \
+                                                                               \
+    set_kind(1u); /* restore for the next lifecycle */                         \
+  } while (0)
+
+int main(int argc, char **argv) {
+  if (argc >= 2)
+    cellIdx = (uint8_t)atoi(argv[1]);
+  if (cellIdx >= 4) {
+    printf("cellIdx must be < 4\n");
+    return 2;
+  }
+
+  printf("=== EJIT Sentinel Wrapper Smoke (cellIdx=%u) ===\n\n", cellIdx);
+
+  sentinel_smoke_set_p0(cellIdx, 1);
+  sentinel_smoke_set_3d(cellIdx, 1);
+
+  ejit_config_t cfg;
+  ejit_default_config(&cfg);
+  if (ejit_init(&cfg) != EJIT_OK) {
+    printf("FAIL: ejit_init\n");
+    return 2;
+  }
+
+  // The dimensioned entries resolve only while their period instance is
+  // active. The 0-dim entry has no period and needs no activation.
+  T(ejit_activate("p0", cellIdx) == EJIT_OK, "activate p0[%u]", cellIdx);
+  T(ejit_activate("p1", cellIdx) == EJIT_OK, "activate p1[%u]", cellIdx);
+  T(ejit_activate("p2", cellIdx) == EJIT_OK, "activate p2[%u]", cellIdx);
+  T(ejit_activate("p3", cellIdx) == EJIT_OK, "activate p3[%u]", cellIdx);
+  ejit_drain_taskpool();
+
+  // 0-dim: scalar cell, reduced lifecycle. icacheFill declines 0-dim cells
+  // on platforms that prepare execute permission per core (one cell shared
+  // by every core), so every call resolves through MissFn; the cell's
+  // &MissFn initializer is still what makes that safe. ejit_clear_cache
+  // drains the cell back to &MissFn but cannot retire the dimension-less
+  // taskpool entry, so the post-drain resolve re-serves the frozen body.
+  printf("--- sentinel_0d: warm (cell=&MissFn -> BLR -> MissFn -> resolve) ---\n");
+  {
+    uint32_t a = sentinel_0d(); /* cell=&MissFn -> MissFn -> fallback */
+    T(a == 10u, "sentinel_0d warm = %u (expected 10)", a);
+    ejit_drain_taskpool();
+    uint32_t b = sentinel_0d(); /* taskpool hit (fill declined) */
+    T(b == 10u, "sentinel_0d fill = %u (expected 10)", b);
+
+    printf("--- sentinel_0d: hot hit serves the frozen specialization ---\n");
+    set_scalar(0u);
+    uint32_t c = sentinel_0d();
+    T(c == 10u,
+      "sentinel_0d frozen = %u (expected 10; AOT fallback would answer 20)",
+      c);
+    set_scalar(1u); /* restore */
+
+    printf("--- sentinel_0d: clear_cache drains the cell; the dimension-less "
+           "entry re-serves the frozen body ---\n");
+    ejit_clear_cache(); /* scalar cell -> &MissFn */
+    set_scalar(0u);
+    uint32_t d = sentinel_0d(); /* &MissFn -> MissFn -> taskpool hit */
+    T(d == 10u,
+      "sentinel_0d post-drain resolve = %u (expected 10: no dimension to "
+      "version, so the frozen body re-serves; fresh re-compile would answer "
+      "20)",
+      d);
+    ejit_drain_taskpool();
+    uint32_t e = sentinel_0d();
+    T(e == 10u, "sentinel_0d refilled = %u (expected 10)", e);
+    set_scalar(1u); /* restore */
+  }
+
+  // 1-dim: p0 toggle drains (the [16] table's cell goes back to &MissFn).
+  LIFECYCLE("sentinel_1d", sentinel_1d(cellIdx), 100u + cellIdx,
+            200u + cellIdx,
+            (ejit_deactivate("p0", cellIdx), ejit_activate("p0", cellIdx)),
+            set_p0);
+
+  // 3-dim: guarded form - same observable lifecycle, drain writes 0 and the
+  // wrapper null-guards it.
+  LIFECYCLE("guarded_3d", guarded_3d(cellIdx, cellIdx, cellIdx), 7u, 0u,
+            (ejit_deactivate("p1", cellIdx), ejit_activate("p1", cellIdx)),
+            set_all3);
+
+  ejit_shutdown();
+  printf("\n%s (%d failures)\n", g_fail ? "SMOKE FAILED" : "SMOKE PASSED",
+         g_fail);
+  return g_fail ? 1 : 0;
+}

--- a/ejit_test/ejit_sentinel_smoke_test_1d.c
+++ b/ejit_test/ejit_sentinel_smoke_test_1d.c
@@ -1,0 +1,25 @@
+//===-- ejit_sentinel_smoke_test_1d.c -------------------------------------===//
+//
+// 1-dim entry of the sentinel-wrapper smoke: a [16] icache cell table in
+// sentinel form (defined pre-filled with &MissFn, branchless probe). Owns
+// its period array - see the TU-layout note in ejit_sentinel_smoke_test.c.
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+
+#include "ejit_test_helpers.h"
+
+struct Cfg {
+  ejit_may_const uint32_t kind; // 1 -> "on" branch, 0 -> "off"
+};
+
+ejit_period_arr(p0) struct Cfg g_p0[4];
+
+void sentinel_smoke_set_p0(uint8_t i, uint32_t kind) { g_p0[i].kind = kind; }
+
+// 1-dim: [16] sentinel table. on -> 100+i, off -> 200+i.
+ejit_entry __attribute__((noinline)) uint32_t
+sentinel_1d(ejit_period_arr_ind(p0) uint8_t i0) {
+  return (g_p0[i0].kind == 1u) ? 100u + i0 : 200u + i0;
+}

--- a/ejit_test/ejit_sentinel_smoke_test_3d.c
+++ b/ejit_test/ejit_sentinel_smoke_test_3d.c
@@ -1,0 +1,37 @@
+//===-- ejit_sentinel_smoke_test_3d.c -------------------------------------===//
+//
+// 3-dim entry of the sentinel-wrapper smoke: a [16]^3 icache cell table in
+// GUARDED form (NumDims > 2 keeps the zero-init table and the null guard;
+// drain writes 0). Owns its period arrays - see the TU-layout note in
+// ejit_sentinel_smoke_test.c.
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+
+#include "ejit_test_helpers.h"
+
+struct Cfg3 {
+  ejit_may_const uint32_t kind;
+};
+
+ejit_period_arr(p1) struct Cfg3 g_q1[4];
+ejit_period_arr(p2) struct Cfg3 g_q2[4];
+ejit_period_arr(p3) struct Cfg3 g_q3[4];
+
+void sentinel_smoke_set_3d(uint8_t i, uint32_t kind) {
+  g_q1[i].kind = kind;
+  g_q2[i].kind = kind;
+  g_q3[i].kind = kind;
+}
+
+// 3-dim: all-on -> 7, all-off -> 0.
+ejit_entry __attribute__((noinline)) uint32_t
+guarded_3d(ejit_period_arr_ind(p1) uint8_t i1,
+           ejit_period_arr_ind(p2) uint8_t i2,
+           ejit_period_arr_ind(p3) uint8_t i3) {
+  uint32_t r = (g_q1[i1].kind == 1u) ? 1u : 0u;
+  r |= (g_q2[i2].kind == 1u) ? 2u : 0u;
+  r |= (g_q3[i3].kind == 1u) ? 4u : 0u;
+  return r;
+}

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -94,8 +94,12 @@ constexpr const char *FN_REGISTER_FUNCINDEX = "ejit_register_funcindex";
 // @__ejit_icache_fn_<name> global (a frozen, sticky specialization pointer) is
 // registered by name so the runtime can backfill it on a successful resolve
 // (icacheFill). The wrapper reads it directly with an inline atomic load - no
-// ejit_icache_try call - so the hit path is one load + null-check + indirect
-// call. Signature: void ejit_register_icache_slot(const char *name, void *slot).
+// ejit_icache_try call - so the hit path is one load + indirect call (plus a
+// null-check only on guarded 3D/4D shapes; <=2D tables are defined pre-filled
+// with &MissFn and BLR it branchlessly). Signature: void
+// ejit_register_icache_slot(const char *name, void *slot, uint32_t numDims,
+// void *missFn), where missFn is the slot's sentinel for branchless tables
+// (drain/fill-retract write it back instead of 0) and null for guarded ones.
 constexpr const char *FN_REGISTER_ICACHE_SLOT = "ejit_register_icache_slot";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h
@@ -38,7 +38,8 @@ typedef struct {
   ejit_reg_type_t type;
   const char
       *name1; // funcName / periodName / varName / symbolName / lifecycleName
-  const char *name2; // varName (period/static), NULL otherwise
+  const char *name2; // varName (period/static), MissFn sentinel
+                     //   (EJIT_REG_ICACHE_SLOT, branchless tables), else NULL
   const void *ptr;   // bitcode data / baseAddr / symbol addr / &i32 slot /
                      //   &ptr icache slot base (EJIT_REG_ICACHE_SLOT)
   uint64_t size;     // bitcode size / array size / numDims (EJIT_REG_ICACHE_SLOT)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -173,18 +173,21 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut);
 
 // Register the wrapper's per-function inline-cache cell table
 // (@__ejit_icache_fn_<name> global address) by name, with its dimensionality
-// (number of ejit_dim params). The runtime writes the specialization pointer
+// (number of ejit_dim params) and, for sentinel-form slots, the MissFn pointer
+// the table is pre-filled with. The runtime writes the specialization pointer
 // through the [D]^numDims cell at [i0][i1]... on a successful resolve
-// (icacheFill) and zeroes every cell on a period toggle (icacheDrainAll); the
-// wrapper reads the cell directly on the hit path (GEP + one load + null-check
-// + indirect call, no ejit_icache_try call). Keys the slot by the SAME registry
-// funcIndex assigned by ejit_register_funcindex. Called by AOT auto-registration
-// on EVERY core: the table is one shared object, so each core records the same
-// base and a drain on any of them clears the cells all of them read. A null
-// slot, capacity exhaustion, or a numDims above the cap is recorded; the base
-// stays null and the probe misses.
+// (icacheFill) and writes every cell back to its empty value on a period
+// toggle (icacheDrainAll) -- the &MissFn sentinel when \p missFn is non-null
+// (the branchless probe BLRs the cell, so the empty value must be callable),
+// 0 otherwise. Keys the slot by the SAME registry funcIndex assigned by
+// ejit_register_funcindex. Called by AOT auto-registration on EVERY core: the
+// table is one shared object, so each core records the same base and a drain
+// on any of them clears the cells all of them read. A null slot, capacity
+// exhaustion, or a numDims above the cap is recorded; the base stays null and
+// the probe misses. \p missFn has no default: this header is shared with pure
+// C translation units (default arguments are C++-only).
 void ejit_register_icache_slot(const char *funcName, void *slot,
-                               uint32_t numDims);
+                               uint32_t numDims, void *missFn);
 
 // Lifecycle. Activation is keyed by lifecycle/period name + instance index
 // only; there is no array-pointer dimension in the active state (a period name

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -112,11 +112,13 @@ enum class EJitWorkerStep : uint32_t {
 //    what it was when the table was private: no gate, no contention, one load.
 //
 //  * DRAINABLE ACROSS CORES, which a private table is not. activate/deactivate
-//    zeroes every registered cell in place (icacheDrainAll), reaching a peer's
-//    partition directly. A permanently-hot core -- one that never misses and
-//    never calls the runtime again -- stops running the stale specialization on
-//    its next call, with no invalidation epoch on the probe, no per-core drain
-//    rendezvous, and no sync entry point for the application to call.
+//    rewrites every registered cell to its empty value in place (icacheDrainAll
+//    -- the &MissFn sentinel for sentinel-form tables, 0 for guarded ones),
+//    reaching a peer's partition directly. A permanently-hot core -- one that
+//    never misses and never calls the runtime again -- stops running the stale
+//    specialization on its next call, with no invalidation epoch on the probe,
+//    no per-core drain rendezvous, and no sync entry point for the application
+//    to call.
 //
 // PREREQUISITE, and it is a CORRECTNESS one: the partitioning must be real --
 // each core drives its OWN ejit_period_lc instance indices, so no two cores
@@ -215,12 +217,17 @@ void ejitIcacheClearAll();
 
 // Register a per-function icache slot: \p base is the address of the wrapper's
 // @__ejit_icache_fn_<name> global (a uintptr_t cell, or a [D]^numDims array of
-// them for a multi-version entry), and \p numDims is its dimensionality. The
-// runtime writes the specialization pointer through the cell at [i0][i1]...
-// (linearized from dims) on a successful resolve (icacheFill), and zeroes the
-// whole array on a period toggle (icacheDrainAll); the wrapper reads the cell
-// directly. Called from ejit_register_icache_slot (name->funcIndex resolution)
-// at ejit_auto_register / .ejit_period time.
+// them for a multi-version entry), \p numDims is its dimensionality, and \p
+// missFn is the slot's SENTINEL value when the wrapper's probe is branchless
+// (the table is defined pre-filled with &MissFn): non-null tells
+// icacheDrainAll and icacheFill's retract to write \p missFn back instead of
+// 0, so the cell never holds a non-callable value. Null keeps the historical
+// zero semantics for guarded (3D/4D, timing) slots. The runtime writes the
+// specialization pointer through the cell at [i0][i1]... (linearized from
+// dims) on a successful resolve (icacheFill), and empties the whole array on
+// a period toggle (icacheDrainAll); the wrapper reads the cell directly.
+// Called from ejit_register_icache_slot (name->funcIndex resolution) at
+// ejit_auto_register / .ejit_period time.
 //
 // Every core registers the SAME base: with EJIT_ICACHE_SECTION set the array is
 // one shared object, which is what lets a drain on any core clear the cells
@@ -237,7 +244,8 @@ void ejitIcacheClearAll();
 enum class EJitIcacheRegResult { Ok, CapacityMiss, Invalid };
 
 EJitIcacheRegResult ejitIcacheRegisterSlot(uint32_t funcIndex, void *base,
-                                           uint32_t numDims);
+                                           uint32_t numDims,
+                                           const void *missFn = nullptr);
 
 /// Diagnostic: dump every registered icache slot to the diagnostic log.
 /// Shows funcIndex, base pointer, numDims, the per-slot cell capacity
@@ -917,8 +925,10 @@ public:
   // NOTE: the production hit path does NOT use icacheTry. With -ejit-inline-cache
   // the ejit_entry wrapper reads its per-function @__ejit_icache_fn_<name> slot
   // directly - a GEP into the [D]^numDims array by the ejit_dim arg values, one
-  // load + null-check + indirect call, NO ejit_icache_try call, NO
-  // per-call guards. icacheTry is retained for unit tests / diagnostics: on a
+  // load + indirect call, NO ejit_icache_try call, NO
+  // per-call guards; for NumDims <= 2 (no timing) the table is sentinel-formed,
+  // so even the null-check is gone - a miss BLRs into MissFn itself. icacheTry
+  // is retained for unit tests / diagnostics: on a
   // hit it sets *outFn to the cached specialization for the given dims (call
   // with NO releaseRead) and returns true; on a miss returns false. It keeps
   // the reclamation-safety, pool-Ready, range, and cross-core code-sharing gates
@@ -1001,7 +1011,20 @@ public:
   void icacheFill(uint32_t funcIndex, void *fnPtr, const EJitDimPair *dims,
                   uint32_t numDims, uint64_t token);
 
-  /// Zero every cell of every registered icache slot, bracketed by
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+  /// Test-only hook fired inside icacheFill() AFTER the cell store and BEFORE
+  /// the post-store re-validation, so a single-threaded test can interleave a
+  /// drain exactly where a preempting peer core would - the only way to reach
+  /// the retract deterministically (the pre-store checks decline a token that
+  /// is already stale when icacheFill is entered).
+  using IcacheFillMidpointHook = void (*)(void *ctx);
+  void setIcacheFillMidpointForTest(IcacheFillMidpointHook fn, void *ctx) {
+    icacheFillMidpointHook_ = fn;
+    icacheFillMidpointCtx_ = ctx;
+  }
+#endif
+
+  /// Empty every cell of every registered icache slot, bracketed by
   /// icacheDrainsInFlight and closed by an icacheDrainSeq bump, so any resolve
   /// this overlaps drops its fill. This is THE cross-core
   /// invalidation: the cells are shared, so clearing them here clears them for
@@ -1014,8 +1037,9 @@ public:
   ///
   /// Safe against a concurrent probe on any core: it reads the old pointer (and
   /// calls it once more; the code is never freed under the gate this cache
-  /// requires) or 0 (and misses).
-  /// Zero every registered cell. \p reason names the event that triggered it
+  /// requires) or the empty value (and misses -- for sentinel-form tables the
+  /// empty value IS MissFn, so the miss executes the slow path directly).
+  /// \p reason names the event that triggered it
   /// and appears in the EJIT_DIAG line, which is what makes a drain visible on
   /// an SRE board -- the probe never enters the runtime on a hit, so a sudden
   /// burst of misses is otherwise unexplained.
@@ -1282,6 +1306,10 @@ private:
   EJitCompileMode configuredMode_ = EJitCompileMode::Async;
   bool codeSharingEnabled_ = false;
   bool isOwner_ = false;
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+  IcacheFillMidpointHook icacheFillMidpointHook_ = nullptr;
+  void *icacheFillMidpointCtx_ = nullptr;
+#endif
   // Inline-cache safety gate: true while the cache is safe to use (no releaser
   // wired - the production default). v2 does no HP-scan retire, so a wired
   // releaser (code may be freed) + the cache = UAF; the gate then auto-disables

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -81,11 +81,18 @@ endif()
 # Build target component list from LLVM_TARGETS_TO_BUILD.
 # Each target needs CodeGen, Desc, and Info for native target initialization.
 # AsmPrinter init lives in CodeGen, so no separate AsmPrinter component needed.
+# AsmParser is needed for AArch64 (EJit.cpp's trimmed AArch64 path calls it)
+# and for X86 (the untrimmed fallback calls InitializeAllAsmParsers(), which
+# references every built target's AsmParser - without the component, any host
+# binary linking LLVMEJIT on an X86 build fails to link).
 set(EJIT_TARGET_COMPONENTS "")
 foreach(_t ${LLVM_TARGETS_TO_BUILD})
   list(APPEND EJIT_TARGET_COMPONENTS ${_t}CodeGen ${_t}Desc ${_t}Info)
   if(_t STREQUAL "AArch64")
     list(APPEND EJIT_TARGET_COMPONENTS AArch64AsmParser)
+  endif()
+  if(_t STREQUAL "X86")
+    list(APPEND EJIT_TARGET_COMPONENTS X86AsmParser)
   endif()
 endforeach()
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -207,12 +207,14 @@ EJit::EJit(const Config &config) : config_(config) {
           // Wire the wrapper's per-function @__ejit_icache_fn_<name> slot into
           // the runtime's slot registry (gIcacheSlots), keyed by the SAME
           // registry funcIndex assigned above. e->size carries numDims (the
-          // [D]^numDims shape) so icacheFill can linearize. The wrapper reads
-          // the cell directly on the icache hit path (no ejit_icache_try call);
-          // icacheFill writes the frozen specialization pointer through it on
-          // resolve. A null fixup pointer or an exhausted funcIndex capacity is
-          // a hard init failure (the base stays null -> probe misses -> taskpool
-          // fallback, correct but without the icache fast path).
+          // [D]^numDims shape) so icacheFill can linearize; e->name2 carries
+          // the sentinel MissFn pointer for branchless-probe slots (null for
+          // guarded ones). The wrapper reads the cell directly on the icache
+          // hit path (no ejit_icache_try call); icacheFill writes the frozen
+          // specialization pointer through it on resolve. A null fixup pointer
+          // or an exhausted funcIndex capacity is a hard init failure (the
+          // base stays null -> probe misses -> taskpool fallback, correct but
+          // without the icache fast path).
           if (!e->name1 || !e->ptr) {
             recordInitError(EJIT_ERR_INVALID_PARAM,
                             "icache slot registration has a null fixup pointer",
@@ -228,7 +230,7 @@ EJit::EJit(const Config &config) : config_(config) {
             break;
           }
           switch (ejitIcacheRegisterSlot(idx, const_cast<void *>(e->ptr),
-                                         numDims)) {
+                                         numDims, e->name2)) {
           case EJitIcacheRegResult::Ok:
             break;
           case EJitIcacheRegResult::CapacityMiss:

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -566,12 +566,16 @@ void ejit_register_funcindex(const char *funcName, uint32_t *slotOut) {
 }
 
 void ejit_register_icache_slot(const char *funcName, void *slot,
-                               uint32_t numDims) {
+                               uint32_t numDims, void *missFn) {
   // Wire the wrapper's per-function @__ejit_icache_fn_<name> cell table into
   // the runtime slot registry, keyed by the SAME registry funcIndex
   // ejit_register_funcindex assigns by name. numDims is the [D]^numDims shape
-  // so icacheFill can linearize and icacheDrainAll knows how far to walk. The
-  // wrapper reads a cell directly on the icache hit path. Idempotent by name
+  // so icacheFill can linearize and icacheDrainAll knows how far to walk.
+  // missFn is non-null exactly for sentinel-form slots (their table is defined
+  // pre-filled with &MissFn and the branchless probe BLRs the cell): the
+  // runtime writes it back on drain / fill-retract so the cell never holds a
+  // non-callable value. The wrapper reads a cell directly on the icache hit
+  // path. Idempotent by name
   // (resolveAssign is), and every core registering the same shared table
   // records the same base. A null slot, an unresolvable name, or a numDims
   // above the cap is recorded; the base stays null and the wrapper's probe
@@ -581,7 +585,8 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
               (const void *)funcName, slot);
     return;
   }
-  EJIT_DIAG_VERBOSE("register_icache_slot name=%s numDims=%u", funcName, numDims);
+  EJIT_DIAG_VERBOSE("register_icache_slot name=%s numDims=%u missFn=%p",
+                    funcName, numDims, missFn);
 #ifdef EJIT_SRE_TASKPOOL
   if (gEJIT && gEJIT->registrationFrozen()) {
     EJitRegistrationStore::instance().recordError(
@@ -601,7 +606,7 @@ void ejit_register_icache_slot(const char *funcName, void *slot,
               funcName);
     return;
   }
-  switch (ejitIcacheRegisterSlot(idx, slot, numDims)) {
+  switch (ejitIcacheRegisterSlot(idx, slot, numDims, missFn)) {
   case EJitIcacheRegResult::Ok:
     EJIT_DIAG_VERBOSE("register_icache_slot OK name=%s idx=%u numDims=%u",
                       funcName, idx, numDims);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -195,8 +195,9 @@ constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 // ejit_dim arg values + one load + null-check + indirect call) with NO
 // ejit_icache_try call and NO per-call guards. icacheFill writes the
 // specialization pointer through the cell at [i0][i1]... (linearized from dims)
-// on a successful resolve; icacheDrainAll zeroes them on a period toggle;
-// icacheTry (test/diagnostic only) reads them.
+// on a successful resolve; icacheDrainAll writes every cell back to its empty
+// value on a period toggle (the &MissFn sentinel for sentinel-form tables, 0
+// for guarded ones); icacheTry (test/diagnostic only) reads them.
 //
 // The REGISTRY is core-private (default BSS); the CELLS it points at are not.
 // With EJIT_ICACHE_SECTION set @__ejit_icache_fn_<name> is one shared object,
@@ -212,6 +213,12 @@ constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 struct EJitIcacheSlotReg {
   uintptr_t *base;
   uint32_t numDims;
+  // Non-null for SENTINEL-form slots: the wrapper's cell table is defined
+  // pre-filled with this MissFn pointer and the probe BLRs the cell without a
+  // null guard, so every value ever stored into a cell must be callable.
+  // icacheDrainAll and icacheFill's retract write this back instead of 0.
+  // Null for guarded slots (3D/4D, timing): their empty value stays 0.
+  const void *missFn;
 };
 EJitIcacheSlotReg gIcacheSlots[EJIT_ICACHE_FUNC_SLOTS];
 
@@ -265,9 +272,8 @@ static uintptr_t icacheLinearize(const EJitDimPair *dims, uint32_t numDims) {
 
 } // namespace
 
-EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex,
-                                                       void *base,
-                                                       uint32_t numDims) {
+EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(
+    uint32_t funcIndex, void *base, uint32_t numDims, const void *missFn) {
   if (!base)
     return EJitIcacheRegResult::Invalid;
   // numDims sizes the array the drain walks, so an out-of-cap value writes far
@@ -281,6 +287,27 @@ EJitIcacheRegResult llvm::ejit::ejitIcacheRegisterSlot(uint32_t funcIndex,
     return EJitIcacheRegResult::CapacityMiss;
   gIcacheSlots[funcIndex].base = reinterpret_cast<uintptr_t *>(base);
   gIcacheSlots[funcIndex].numDims = numDims;
+  gIcacheSlots[funcIndex].missFn = missFn;
+  // Sentinel deployment check: a branchless probe BLRs whatever its cell
+  // holds, so a table whose definition-time &MissFn initializer never made it
+  // into the placed image -- a linker script that maps the shared section
+  // NOLOAD/zero instead of carrying its initialized data -- crashes on the
+  // function's first call, and nothing downstream can catch that. Compare
+  // cell[0] (the scalar, or [0]...[0] of the splat) against the registered
+  // sentinel and say it loudly here, where the mis-deployment is still
+  // attributable. Bounded output: once per function per core.
+  if (missFn && icacheCell(reinterpret_cast<uintptr_t *>(base), 0)
+                       .loadRelaxed() !=
+                   reinterpret_cast<uintptr_t>(missFn)) {
+    EJIT_DIAG("icache slot %u: sentinel-form cell[0]=%p != &MissFn=%p -- the "
+              "image did not place the table's initializer (shared section "
+              "mapped NOLOAD/zero?); the branchless wrapper will crash on "
+              "the first call to this function",
+              funcIndex,
+              (void *)icacheCell(reinterpret_cast<uintptr_t *>(base), 0)
+                  .loadRelaxed(),
+              missFn);
+  }
   return EJitIcacheRegResult::Ok;
 }
 
@@ -295,6 +322,7 @@ void llvm::ejit::ejitIcacheClearAll() {
   for (uint32_t f = 0; f < EJIT_ICACHE_FUNC_SLOTS; ++f) {
     gIcacheSlots[f].base = nullptr;
     gIcacheSlots[f].numDims = 0;
+    gIcacheSlots[f].missFn = nullptr;
   }
 }
 
@@ -310,9 +338,11 @@ void llvm::ejit::ejitDumpIcacheSlots(const EJitModuleLoader *loader) {
     registered++;
     // For multi-dim arrays, cell[0] is the [0]...[0] element; for 0-dim,
     // it is the scalar cell. Either way it tells us whether the first
-    // identity has been resolved yet.
+    // identity has been resolved yet. A sentinel-form table's empty value is
+    // &MissFn, so "filled" must exclude it explicitly.
+    const uintptr_t empty = reinterpret_cast<uintptr_t>(reg.missFn);
     const uintptr_t c0 = icacheCell(reg.base, 0).loadRelaxed();
-    if (c0)
+    if (c0 != 0 && c0 != empty)
       filled++;
     // The slot index IS the funcIndex (a static_assert above guarantees
     // EJIT_ICACHE_FUNC_SLOTS >= EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX), so a
@@ -325,10 +355,11 @@ void llvm::ejit::ejitDumpIcacheSlots(const EJitModuleLoader *loader) {
       name = s.empty() ? "<unknown>" : s.c_str();
     }
     (void)name; // consumed by EJIT_DIAG_RAW only; silence DIAG-off builds
+    const char *state =
+        c0 == 0 ? "(empty)" : c0 == empty ? "(sentinel)" : "(filled)";
     EJIT_DIAG_RAW("  [%2u] %.24s base=%p numDims=%u cells=%u cell[0]=%p %s",
                   f, name, (void *)reg.base, reg.numDims,
-                  (unsigned)icacheCellCount(reg.numDims), (void *)c0,
-                  c0 ? "(filled)" : "(empty)");
+                  (unsigned)icacheCellCount(reg.numDims), (void *)c0, state);
     ejitDiagPrintThrottle();
   }
   EJIT_DIAG_RAW("=== icache slots: %u registered, %u with cell[0] filled ===",
@@ -381,16 +412,20 @@ void EJitSharedTaskPool::icacheDrainAll(const char *reason) {
       continue;
     if (reg.numDims > EJIT_ICACHE_MAX_DIMS)
       continue; // defence in depth: never walk past a mis-sized array
+    // Sentinel-form slots drain to &MissFn (their branchless probe BLRs the
+    // cell unconditionally, so 0 would be a crash, not a miss); guarded slots
+    // keep the historical 0.
+    const uintptr_t empty = reinterpret_cast<uintptr_t>(reg.missFn);
     const uintptr_t cells = icacheCellCount(reg.numDims);
 #ifdef EJIT_DIAG_ENABLE
     ++walkedSlots;
 #endif
     for (uintptr_t c = 0; c < cells; ++c) {
 #ifdef EJIT_DIAG_ENABLE
-      if (icacheCell(reg.base, c).loadRelaxed() != 0)
+      if (icacheCell(reg.base, c).loadRelaxed() != empty)
         ++clearedCells;
 #endif
-      icacheCell(reg.base, c).storeRelaxed(0);
+      icacheCell(reg.base, c).storeRelaxed(empty);
     }
   }
   // Only after a real walk: a skip cleared nothing, and clearing the flag it
@@ -547,10 +582,11 @@ bool EJitSharedTaskPool::icacheTry(uint32_t funcIndex, const EJitDimPair *dims,
   // Read this identity's cell. Relaxed is enough, and is what the AOT probe
   // emits: the cell holds a self-contained pointer, the caller's indirect call
   // depends on the value loaded (data dependency), and the only cross-core
-  // write is a drain storing 0 -- which yields a miss, never a bad pointer.
+  // write is a drain storing the slot's empty value -- which yields a miss
+  // (the sentinel IS MissFn), never a bad pointer.
   uintptr_t idx = icacheLinearize(dims, numDims);
   uintptr_t p = icacheCell(reg.base, idx).loadRelaxed();
-  if (p == 0)
+  if (p == 0 || p == reinterpret_cast<uintptr_t>(reg.missFn))
     return false;
   *outFn = reinterpret_cast<void *>(p);
   return true;
@@ -769,22 +805,32 @@ void EJitSharedTaskPool::icacheFill(uint32_t funcIndex, void *fnPtr,
   const uintptr_t idx = icacheLinearize(dims, numDims);
   EJitAtomicUPtr &cell = icacheCell(reg.base, idx);
   cell.storeRelaxed(reinterpret_cast<uintptr_t>(fnPtr));
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+  // Test seam: the window between the store and the re-validation below is
+  // exactly where a preempting peer core's drain lands in production. A hook
+  // lets a single-threaded test fire a drain there deterministically and reach
+  // the retract, which the pre-store checks otherwise decline.
+  if (icacheFillMidpointHook_)
+    icacheFillMidpointHook_(icacheFillMidpointCtx_);
+#endif
 
   // Re-validate AFTER the store and retract on conflict. The checks above only
-  // PRECEDE the store: a drain can begin after they pass, zero this cell, and
+  // PRECEDE the store: a drain can begin after they pass, empty this cell, and
   // finish before the store lands, stranding a pre-toggle specialization that
   // nothing clears again -- and a preempted filler makes that gap unbounded.
   // If a drain overlapped, it has either bumped the sequence or is still in
-  // flight, and both are visible here. Writing 0 discards only this core's own
-  // fill (disjointness), and a null cell is always safe.
+  // flight, and both are visible here. Writing the slot's empty value (the
+  // &MissFn sentinel for sentinel-form tables, 0 for guarded ones) discards
+  // only this core's own fill (disjointness), and an empty cell is always
+  // safe: the sentinel is callable, and 0 is guarded.
   if (state_->icacheDrainsInFlight.loadAcquire() != 0 ||
       static_cast<uint32_t>(token) != state_->icacheDrainSeq.loadAcquire()) {
-    cell.storeRelaxed(0);
+    cell.storeRelaxed(reinterpret_cast<uintptr_t>(reg.missFn));
     if (!gIcacheFillRejectLogged[kFillRejectRetracted]) {
       gIcacheFillRejectLogged[kFillRejectRetracted] = true;
       EJIT_DIAG("icacheFill RETRACT func=%u: a drain began after the fill was "
-                "cleared to proceed; cell reset to 0",
-                funcIndex);
+                "cleared to proceed; cell reset to its empty value (%p)",
+                funcIndex, reg.missFn);
     }
     return;
   }

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -307,7 +307,10 @@ static GlobalVariable *getOrCreateFuncIndexGlobal(Module &M,
 
 // A per-function inline-cache global plus its dimensionality (number of
 // ejit_dim params). The runtime needs NumDims to linearize the [D]^NumDims
-// array on fill, and the hit-path emitter needs it to build the GEP.
+// array on fill, and the hit-path emitter needs it to build the GEP. The
+// slot's sentinel (when the table is defined pre-filled with &MissFn) is
+// derived from the table's initializer at registration-emission time, so no
+// bookkeeping is kept here.
 struct IcacheSlotInfo {
   GlobalVariable *GV = nullptr;
   unsigned NumDims = 0;
@@ -351,6 +354,24 @@ static GlobalVariable *getOrCreateIcacheFnGlobal(Module &M,
   if (!EJitIcacheSection.empty())
     GV->setSection(EJitIcacheSection);
   return GV;
+}
+
+// Sentinel initializer for an icache cell table: the [D]^NumDims shape (or the
+// scalar ptr for NumDims == 0) with every element set to &MissFn. This
+// definition-time value is what makes the branchless probe safe: before the
+// first fill, after a drain, or before registration has run, the load yields
+// MissFn and the tail call lands in the slow path instead of a null pointer.
+static Constant *buildIcacheSentinelInit(Type *SlotTy, Function *MissFn,
+                                          unsigned NumDims) {
+  Constant *MissFnC = MissFn;
+  if (NumDims == 0)
+    return MissFnC;
+  auto *ArrTy = cast<ArrayType>(SlotTy);
+  Constant *Inner =
+      buildIcacheSentinelInit(ArrTy->getElementType(), MissFn, NumDims - 1);
+  SmallVector<Constant *, EJIT_ICACHE_DIM_SIZE> Elems(
+      ArrTy->getNumElements(), Inner);
+  return ConstantArray::get(ArrTy, Elems);
 }
 
 // Emit registration that fills each per-function dense-funcIndex global with
@@ -447,11 +468,30 @@ emitIcacheSlotRegistration(Module &M,
   auto *I32Ty = Type::getInt32Ty(Ctx);
   auto *I64Ty = Type::getInt64Ty(Ctx);
 
-  // void ejit_register_icache_slot(const char *name, void *slot, uint32_t numDims)
+  // void ejit_register_icache_slot(const char *name, void *slot, uint32_t numDims,
+  //                                void *missFn)
   // numDims tells the runtime the [D]^numDims shape so icacheFill can linearize.
+  // missFn is non-null exactly for sentinel-form slots: the runtime writes it
+  // back into the cells on drain / fill-retract so the branchless probe never
+  // BLRs 0. Null for guarded (3D/4D, timing) slots, whose drain value stays 0.
   M.getOrInsertFunction(
       FN_REGISTER_ICACHE_SLOT,
-      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy, I32Ty}, false));
+      FunctionType::get(Type::getVoidTy(Ctx), {PtrTy, PtrTy, I32Ty, PtrTy},
+                        false));
+
+  // Derive each slot's sentinel from its table's DEFINITION rather than from
+  // wrap-loop bookkeeping: a function skipped by the idempotency guard still
+  // carries its sentinel initializer from an earlier pass run, and registering
+  // it as guarded would let a later drain write 0 into a branchless table.
+  // A 0D table initializes to the MissFn pointer itself; a [D]^NumDims table
+  // splats it into every element, so element [0][0]...[0] carries it either
+  // way. Zero-init tables (3D/4D, timing) yield null.
+  auto missFnOf = [](const IcacheSlotInfo &Info) -> Constant * {
+    Constant *Elem = Info.GV->getInitializer();
+    while (Elem && Elem->getType()->isArrayTy())
+      Elem = Elem->getAggregateElement(0u);
+    return (Elem && !Elem->isNullValue()) ? Elem : nullptr;
+  };
 
   Function *AutoReg = M.getFunction(FN_AUTO_REGISTER);
   bool CreatedAutoReg = false;
@@ -468,8 +508,12 @@ emitIcacheSlotRegistration(Module &M,
   for (auto &KV : Fns) {
     IRBuilder<> Builder(Ret);
     Value *Name = Builder.CreateGlobalString(KV.first);
+    Constant *MissFnArg = missFnOf(KV.second);
+    if (!MissFnArg)
+      MissFnArg = ConstantPointerNull::get(PtrTy);
     Builder.CreateCall(FnReg, {Name, Builder.CreateBitCast(KV.second.GV, PtrTy),
-                               ConstantInt::get(I32Ty, KV.second.NumDims)});
+                               ConstantInt::get(I32Ty, KV.second.NumDims),
+                               MissFnArg});
   }
 
   if (EnableEJitGlobalCtors && CreatedAutoReg)
@@ -477,7 +521,8 @@ emitIcacheSlotRegistration(Module &M,
 
   // Static registry entries for bare-metal / testing fallback (same linker-
   // concatenated .ejit_period model as funcindex above). The `size` (i64) field
-  // carries NumDims; the ejit_init walker forwards it to ejitIcacheRegisterSlot.
+  // carries NumDims and the spare name2 ptr carries the sentinel MissFn; the
+  // ejit_init walker forwards both to ejitIcacheRegisterSlot.
   StructType *EntryTy = StructType::get(
       Ctx, {I32Ty, PtrTy, PtrTy, PtrTy, I64Ty}, /*isPacked=*/false);
   auto makeStrGV = [&](const std::string &S) -> Constant * {
@@ -489,9 +534,14 @@ emitIcacheSlotRegistration(Module &M,
   };
   SmallVector<Constant *, 16> Entries;
   for (auto &KV : Fns) {
+    // name2 (unused by icache entries until now) carries the sentinel MissFn
+    // pointer; null for guarded slots.
+    Constant *MissFnConst = missFnOf(KV.second);
+    if (!MissFnConst)
+      MissFnConst = ConstantPointerNull::get(PtrTy);
     Entries.push_back(ConstantStruct::get(
         EntryTy, {ConstantInt::get(I32Ty, EJIT_REG_ICACHE_SLOT),
-                  makeStrGV(KV.first), ConstantPointerNull::get(PtrTy),
+                  makeStrGV(KV.first), MissFnConst,
                   ConstantExpr::getBitCast(KV.second.GV, PtrTy),
                   ConstantInt::get(I64Ty, KV.second.NumDims)}));
   }
@@ -641,7 +691,9 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       Info.NumDims = NumDims;
       IcacheFnGlobals.emplace(F->getName().str(), Info);
     }
-    emitIcacheSlotRegistration(M, IcacheFnGlobals);
+    // The slot registration is emitted AFTER the wrap loop below: it now
+    // carries &MissFn for sentinel-form slots, and MissFn is created inside
+    // that loop.
   }
 
   LLVM_DEBUG(dbgs() << "ejit-wrapper-gen: " << EntryFuncs.size()
@@ -1086,11 +1138,13 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       if (!HasMustTailAotExit)
         instrumentAotBody(MissFallback, MissWrapperBegin);
 
-      // Wrapper (F): frame-less probe + tail calls.
+      // Wrapper (F): frame-less probe + tail calls. Sentinel-form tables
+      // (NumDims <= 2, timing off) are defined pre-filled with &MissFn, so
+      // their wrapper is ONE block - probe + musttail BLR, no guard; the
+      // dispatch/miss blocks below exist only for the guarded shapes.
       auto *JitEntry = BasicBlock::Create(Ctx, "jit_entry", F);
-      auto *JitIcacheDispatch =
-          BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
-      auto *JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
+      BasicBlock *JitIcacheDispatch = nullptr;
+      BasicBlock *JitMiss = nullptr;
       IRBuilder<> B(JitEntry);
       Value *WrapperBegin = nullptr;
       if (EJitFunctionBodyTiming)
@@ -1105,6 +1159,19 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       }
       GlobalVariable *IcacheSlot = IcacheIt->second.GV;
       unsigned NumDims = IcacheIt->second.NumDims;
+      // The sentinel initializer is a [D]^NumDims splat of &MissFn: at D=16
+      // that is 1/16/256 relocations for 0/1/2 dims, but 4096 and 65536 for
+      // 3 and 4 - so 3D/4D keep the zero-init table and the null guard.
+      // Function-body timing is also excluded: it threads an extra wrapper-
+      // begin argument into MissFn (changing its signature away from F's) and
+      // emits trace calls around the specialization call, neither of which
+      // survives a single-block musttail BLR.
+      const bool Sentinelize = !EJitWrapperTiming && !EJitFunctionBodyTiming &&
+                               NumDims <= 2;
+      if (!Sentinelize) {
+        JitIcacheDispatch = BasicBlock::Create(Ctx, "jit_icache_dispatch", F);
+        JitMiss = BasicBlock::Create(Ctx, "jit_miss", F);
+      }
       Value *SlotPtr = IcacheSlot;
       if (NumDims > 0) {
         SmallVector<Value *, 5> Indices;
@@ -1125,88 +1192,112 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       LoadInst *ICSlotLoad = B.CreateLoad(PtrTy, SlotPtr, "ejit_ic_fn");
       ICSlotLoad->setAlignment(Align(8));
       // Monotonic, nothing stronger: the cell is shared, so a peer's drain can
-      // store 0 concurrently and the atomic makes that a defined race (old
-      // pointer or 0) instead of UB. The value is self-contained and the call
-      // below carries a data dependency on it, so acquire would buy nothing and
-      // cost an LDAR per hit. Lowers to the same LDR on AArch64.
+      // store the drain value (the &MissFn sentinel for sentinel-form tables,
+      // 0 for guarded ones) concurrently and the atomic makes that a defined
+      // race (old pointer or drain value) instead of UB. The value is
+      // self-contained and the call below carries a data dependency on it, so
+      // acquire would buy nothing and cost an LDAR per hit. Lowers to the same
+      // LDR on AArch64.
       ICSlotLoad->setAtomic(AtomicOrdering::Monotonic);
       Value *TAfterIcache = nullptr;
       if (EJitWrapperTiming)
         TAfterIcache = B.CreateCall(TraceNow, {}, "ejit_t_after_icache");
-      Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
-      IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
-                               {IHit, ConstantInt::getTrue(Ctx)});
-      B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
-
-      // Hit: tail-call the cached specialization directly (no release_read).
-      // With -ejit-wrapper-timing the wrapper is NOT frame-less (JitEntry emits
-      // bl @ejit_taskpool_trace_now), so the hit path cannot be a musttail tail
-      // call: emitHitTiming() inserts calls BETWEEN the call and the ret, which
-      // would violate the musttail rule ("musttail call must precede a ret")
-      // and yield broken IR -> codegen silently drops the function -> boot
-      // translation fault. Use a plain (framed) call + trace + ret instead; the
-      // frame-less musttail fast path is reserved for the no-timing case.
-      B.SetInsertPoint(JitIcacheDispatch);
-      SmallVector<Value *, 8> ICArgs;
-      for (auto &A : F->args())
-        ICArgs.push_back(&A);
-      Value *BodyBegin = nullptr;
-      if (EJitFunctionBodyTiming)
-        BodyBegin = B.CreateCall(TraceNow, {}, "ejit_jit_body_begin");
-      auto emitHitTiming = [&]() {
-        Value *BodyEnd = nullptr;
-        if (EJitFunctionBodyTiming)
-          BodyEnd = B.CreateCall(TraceNow, {}, "ejit_jit_body_end");
-        Value *WrapperEnd = nullptr;
-        if (EJitFunctionBodyTiming)
-          WrapperEnd = B.CreateCall(TraceNow, {}, "ejit_wrapper_end");
-        if (EJitWrapperTiming) {
-          Value *TAfterFn =
-              BodyEnd ? BodyEnd : B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
-          B.CreateCall(TraceWrapper,
-                       {FuncIdxForTiming,
-                        ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
-                        ICSlotLoad, ConstantInt::get(I32Ty, 0), TBeforeIcache,
-                        TAfterIcache, TAfterFn, TAfterFn});
-        }
-        if (EJitFunctionBodyTiming) {
-          emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, WrapperBegin,
-                                 BodyBegin, BodyEnd, WrapperEnd);
-        }
-      };
-      if (F->getReturnType()->isVoidTy()) {
+      if (Sentinelize) {
+        // Definition-time sentinel: every cell of the table is DEFINED as
+        // &MissFn, so the loaded value is always a callable pointer - the
+        // specialization on a hit, MissFn itself before the first fill, after
+        // a drain, or before registration has run (whose funcidx guard then
+        // falls to the AOT body, exactly like the guarded form). The wrapper
+        // is the probe plus one musttail BLR - no guard, no branch. The
+        // registration derives the sentinel from this initializer, so no
+        // per-slot bookkeeping is needed here.
+        IcacheSlot->setInitializer(buildIcacheSentinelInit(
+            IcacheSlot->getValueType(), MissFn, NumDims));
+        SmallVector<Value *, 8> ICArgs;
+        for (auto &A : F->args())
+          ICArgs.push_back(&A);
         CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming && !EJitFunctionBodyTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        emitHitTiming();
-        B.CreateRetVoid();
+        CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+        if (F->getReturnType()->isVoidTy())
+          B.CreateRetVoid();
+        else
+          B.CreateRet(CI);
       } else {
-        CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
-        if (!EJitWrapperTiming && !EJitFunctionBodyTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        emitHitTiming();
-        B.CreateRet(CI);
+        Value *IHit = B.CreateIsNotNull(ICSlotLoad, "ejit_icache_hit");
+        IHit = B.CreateIntrinsic(Intrinsic::expect, {IHit->getType()},
+                                 {IHit, ConstantInt::getTrue(Ctx)});
+        B.CreateCondBr(IHit, JitIcacheDispatch, JitMiss);
+
+        // Hit: tail-call the cached specialization directly (no release_read).
+        // With -ejit-wrapper-timing the wrapper is NOT frame-less (JitEntry emits
+        // bl @ejit_taskpool_trace_now), so the hit path cannot be a musttail tail
+        // call: emitHitTiming() inserts calls BETWEEN the call and the ret, which
+        // would violate the musttail rule ("musttail call must precede a ret")
+        // and yield broken IR -> codegen silently drops the function -> boot
+        // translation fault. Use a plain (framed) call + trace + ret instead; the
+        // frame-less musttail fast path is reserved for the no-timing case.
+        B.SetInsertPoint(JitIcacheDispatch);
+        SmallVector<Value *, 8> ICArgs;
+        for (auto &A : F->args())
+          ICArgs.push_back(&A);
+        Value *BodyBegin = nullptr;
+        if (EJitFunctionBodyTiming)
+          BodyBegin = B.CreateCall(TraceNow, {}, "ejit_jit_body_begin");
+        auto emitHitTiming = [&]() {
+          Value *BodyEnd = nullptr;
+          if (EJitFunctionBodyTiming)
+            BodyEnd = B.CreateCall(TraceNow, {}, "ejit_jit_body_end");
+          Value *WrapperEnd = nullptr;
+          if (EJitFunctionBodyTiming)
+            WrapperEnd = B.CreateCall(TraceNow, {}, "ejit_wrapper_end");
+          if (EJitWrapperTiming) {
+            Value *TAfterFn =
+                BodyEnd ? BodyEnd : B.CreateCall(TraceNow, {}, "ejit_t_after_fn");
+            B.CreateCall(TraceWrapper,
+                         {FuncIdxForTiming,
+                          ConstantInt::get(I32Ty, kEJitIcacheHitTimingStatus),
+                          ICSlotLoad, ConstantInt::get(I32Ty, 0), TBeforeIcache,
+                          TAfterIcache, TAfterFn, TAfterFn});
+          }
+          if (EJitFunctionBodyTiming) {
+            emitFunctionBodyRecord(B, kEJitFunctionBodyPathJIT, WrapperBegin,
+                                   BodyBegin, BodyEnd, WrapperEnd);
+          }
+        };
+        if (F->getReturnType()->isVoidTy()) {
+          CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
+          if (!EJitWrapperTiming && !EJitFunctionBodyTiming)
+            CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+          emitHitTiming();
+          B.CreateRetVoid();
+        } else {
+          CallInst *CI = B.CreateCall(F->getFunctionType(), ICSlotLoad, ICArgs);
+          if (!EJitWrapperTiming && !EJitFunctionBodyTiming)
+            CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+          emitHitTiming();
+          B.CreateRet(CI);
+        }
+
+        // Miss: tail-call MissFn (which does compile_or_get + dispatch/fallback).
+        B.SetInsertPoint(JitMiss);
+        SmallVector<Value *, 8> MissArgs;
+        for (auto &A : F->args())
+          MissArgs.push_back(&A);
+        if (ThreadWrapperBegin)
+          MissArgs.push_back(WrapperBegin);
+        if (F->getReturnType()->isVoidTy()) {
+          CallInst *CI =
+              B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+          if (!EJitFunctionBodyTiming)
+            CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+          B.CreateRetVoid();
+        } else {
+          CallInst *CI =
+              B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
+          if (!EJitFunctionBodyTiming)
+            CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
+          B.CreateRet(CI);
       }
-
-      // Miss: tail-call MissFn (which does compile_or_get + dispatch/fallback).
-      B.SetInsertPoint(JitMiss);
-      SmallVector<Value *, 8> MissArgs;
-      for (auto &A : F->args())
-        MissArgs.push_back(&A);
-      if (ThreadWrapperBegin)
-        MissArgs.push_back(WrapperBegin);
-      if (F->getReturnType()->isVoidTy()) {
-        CallInst *CI =
-            B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
-        if (!EJitFunctionBodyTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        B.CreateRetVoid();
-      } else {
-        CallInst *CI =
-            B.CreateCall(MissFn->getFunctionType(), MissFn, MissArgs);
-        if (!EJitFunctionBodyTiming)
-          CI->setTailCallKind(CallInst::TailCallKind::TCK_MustTail);
-        B.CreateRet(CI);
       }
 
       // Cluster all frame-less dispatchers into a dedicated section so they
@@ -1237,6 +1328,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
     Changed = true;
   }
+
+  // Icache-slot registration, emitted after wrapping so sentinel-form slots
+  // can carry their MissFn pointer (no-ops when the map is empty).
+  emitIcacheSlotRegistration(M, IcacheFnGlobals);
 
   return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
@@ -26,6 +26,12 @@
 ; above the threshold: preopt inlines it away, the extraction skips it, and
 ; the AOT side still registers it (harmless dead entry, by design).
 ;
+; NOTE: the EXT/HI assertions assume preOptimizeBitcode actually RUNS: it is
+; #ifdef NDEBUG-guarded (cyclic link dependency in debug/shared builds), so
+; a debug opt is a no-op there - no inlining, no tail markers - and this
+; test fails. Run the EJIT lit suite with a release/NDEBUG opt (see
+; CLAUDE.md's note on debug builds skipping optimizations).
+;
 ; NOTE: the pass mutates only its extraction clone; the -S output (MOD) is
 ; the ORIGINAL module plus the embedded bitcode, the ejit_auto_register
 ; calls, and the .ejit_bitcode registry section.

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing-musttail.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-function-body-timing-musttail.ll
@@ -7,11 +7,14 @@
 ; the caller and callee parameter counts differ. Keep MissFn ABI-identical,
 ; preserve every original musttail, and time only JIT execution for this entry.
 ;
+; OFF (no timing flags): NumDims=1 and no timing -> the SENTINEL form. The
+; table is defined pre-filled with &MissFn and the wrapper is ONE block
+; (load + musttail BLR, no guard/miss blocks); musttail survives on the hit
+; path exactly as it did in the guarded form.
+; OFF: @__ejit_icache_fn_musttail_entry = internal global [16 x ptr] [ptr @musttail_entry_miss, {{.*}}]
 ; OFF-LABEL: define i32 @musttail_entry(
-; OFF-LABEL: jit_icache_dispatch:
+; OFF-NOT: br
 ; OFF: musttail call i32 %ejit_ic_fn
-; OFF-LABEL: jit_miss:
-; OFF: musttail call i32 @musttail_entry_miss(i32 %cell)
 ; OFF-LABEL: define internal i32 @musttail_entry_miss(i32 %0)
 ; OFF: musttail call i32 @helper(i32 %0)
 ;

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-sentinel.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache-sentinel.ll
@@ -1,0 +1,62 @@
+; Sentinel-form selection: NumDims <= 2 (and no -ejit-wrapper-timing) gets the
+; branchless wrapper whose cell table is DEFINED pre-filled with &MissFn;
+; 3D/4D keep the historical guarded shape - a [D]^N splat initializer costs
+; 4096/65536 relocations per table at D=16, so their tables stay zero-init and
+; the null guard stays load-bearing. The registration's 4th argument tells the
+; runtime which empty value to write back on drain / fill-retract: &MissFn for
+; sentinel slots, null (0) for guarded ones.
+
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s | FileCheck %s
+
+; --- Cell tables + static .ejit_period registry entries (globals section):
+;     the 0D table is defined pre-filled with its MissFn sentinel and its
+;     registry entry carries the same pointer in name2 (3rd field); the 3D
+;     table stays zero-init and its entry passes null. ---
+; CHECK-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr @zero_dim_entry_miss, align 8
+; CHECK-DAG: @__ejit_icache_fn_three_dim_entry = internal global [16 x [16 x [16 x ptr]]] zeroinitializer, align 8
+; CHECK-DAG: { i32 {{[0-9]+}}, ptr {{[^{]*}}, ptr @zero_dim_entry_miss, ptr @__ejit_icache_fn_zero_dim_entry, i64 0 }
+; CHECK-DAG: { i32 {{[0-9]+}}, ptr {{[^{]*}}, ptr null, ptr @__ejit_icache_fn_three_dim_entry, i64 3 }
+
+; --- 0D wrapper: sentinel form - the whole wrapper is load + musttail, no
+;     guard branch anywhere. ---
+; CHECK-LABEL: define i32 @zero_dim_entry(
+; CHECK-NOT: br
+; CHECK: load atomic ptr, ptr @__ejit_icache_fn_zero_dim_entry monotonic, align 8
+; CHECK-NOT: br
+; CHECK: musttail call {{.*}} %ejit_ic_fn
+; CHECK: ret
+
+; --- 3D wrapper: guarded form retained - expect + condBr, dispatch and miss
+;     blocks. ---
+; CHECK-LABEL: define i32 @three_dim_entry(
+; CHECK: load atomic ptr, ptr {{.*}} monotonic, align 8
+; CHECK: call {{.*}} @llvm.expect
+; CHECK: br i1 {{.*}}, label %jit_icache_dispatch, label %jit_miss
+; CHECK-LABEL: jit_miss:
+; CHECK: musttail call {{.*}} @three_dim_entry_miss
+
+; --- Registration calls (auto_register body): the 0D slot carries its MissFn
+;     sentinel as the 4th argument, the 3D slot passes null. ---
+; CHECK-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0, ptr @zero_dim_entry_miss)
+; CHECK-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_three_dim_entry, i32 3, ptr null)
+
+define i32 @zero_dim_entry(i32 %x) !ejit.metadata !0 {
+entry:
+  ret i32 %x
+}
+
+define i32 @three_dim_entry(i32 %a, i32 %b, i32 %c) !ejit.metadata !1 {
+entry:
+  %v = load i32, ptr @data
+  ret i32 %v
+}
+
+@data = global i32 0, !ejit.metadata !10
+@data2 = global i32 0, !ejit.metadata !11
+@data3 = global i32 0, !ejit.metadata !12
+
+!0 = distinct !{!{!"ejit_entry"}}
+!1 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"p1", i32 0}, !{!"ejit_period_arr_ind", !"p2", i32 1}, !{!"ejit_period_arr_ind", !"p3", i32 2}}
+!10 = distinct !{!{!"ejit_period_arr", !"p1", i32 16}}
+!11 = distinct !{!{!"ejit_period_arr", !"p2", i32 16}}
+!12 = distinct !{!{!"ejit_period_arr", !"p3", i32 16}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-icache.ll
@@ -1,15 +1,18 @@
 ; -ejit-inline-cache (ON): emits an inline probe DIRECTLY in the ejit_entry
 ; wrapper - a GEP into the per-function @__ejit_icache_fn_<name> [D]^numDims
 ; cell table (D = EJIT_ICACHE_DIM_SIZE, power-of-2) by the ejit_dim argument
-; values, then ONE monotonic load + null-check; the hit path
-; (jit_icache_dispatch) calls the cached specialization directly with NO
-; ejit_icache_try call and NO ejit_taskpool_release_read. The load is atomic
-; because the table is shared across cores (a peer's period toggle zeroes cells
-; in place); monotonic is the weakest order that makes that a defined race, and
-; lowers to the same LDR a plain load would. There is NO freshness check on the
-; hit path - draining the shared cells IS the invalidation. numDims=0 is a
-; scalar cell (no GEP). Default (OFF): the original 4-block wrapper, no icache.
-; Idempotent: running the pass twice does not duplicate the probe.
+; values, then ONE monotonic load + musttail indirect call. For NumDims <= 2
+; (no timing) the table is DEFINED pre-filled with &<name>_miss: the loaded
+; value is always a callable pointer (the specialization on a hit, MissFn
+; itself before the first fill / after a drain), so the wrapper has NO guard
+; branch at all - a miss simply executes MissFn, whose funcidx guard falls to
+; the AOT body while registration has not run. The load is atomic because the
+; table is shared across cores (a peer's period toggle rewrites cells in
+; place); monotonic is the weakest order that makes that a defined race, and
+; lowers to the same LDR a plain load would. There is NO freshness check on
+; the hit path - draining the shared cells IS the invalidation. numDims=0 is
+; a scalar cell (no GEP). Default (OFF): the original 4-block wrapper, no
+; icache. Idempotent: running the pass twice does not duplicate the probe.
 
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s | FileCheck %s --check-prefix=ICACHE
 ; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s --check-prefix=NOICACHE
@@ -28,38 +31,45 @@
 ;     other core probes. Nothing else about the wrapper changes. ---
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section=.mc_shared -S %s | FileCheck %s --check-prefix=SECTION
 
-; --- icache globals: [D]^numDims, D=8 (EJIT_ICACHE_DIM_SIZE). 0D is scalar. ---
-; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, align 8
-; ICACHE-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, align 8
-; ICACHE-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, align 8
+; --- icache globals: [D]^numDims, D=16 (EJIT_ICACHE_DIM_SIZE). 0D is scalar.
+;     Every cell is DEFINED as &<name>_miss - the sentinel that makes the
+;     branchless probe safe. ---
+; ICACHE-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr @zero_dim_entry_miss, align 8
+; ICACHE-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] [ptr @one_dim_entry_miss, {{.*}}], align 8
+; ICACHE-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] {{.*}}@two_dim_entry_miss{{.*}}, align 8
 
-; --- 0D entry: scalar slot, direct plain load (NO GEP).  Without extra flags
-;     the dispatcher stays in default .text (no section attribute). ---
+; --- 0D entry: scalar slot, direct plain load (NO GEP), NO guard branch -
+;     the whole wrapper is load + musttail. Without extra flags the dispatcher
+;     stays in default .text (no section attribute). ---
 ; ICACHE-LABEL: define i32 @zero_dim_entry(
 ; ICACHE-NOT: section
 ; ICACHE-NOT: ejit_icache_try
 ; ICACHE-NOT: getelementptr
+; ICACHE-NOT: br
 ; ICACHE: load atomic ptr, ptr @__ejit_icache_fn_zero_dim_entry monotonic, align 8
-; ICACHE-LABEL: jit_icache_dispatch:
-; ICACHE-NOT: call void @ejit_taskpool_release_read
-; ICACHE: call {{.*}} %ejit_ic_fn
+; ICACHE-NOT: br
+; ICACHE: musttail call {{.*}} %ejit_ic_fn
 ; ICACHE: ret
 
-; --- 1D entry: [16 x ptr] slot, GEP by the single dim arg + plain load. ---
+; --- 1D entry: [16 x ptr] slot, GEP by the single dim arg + plain load,
+;     still branchless. ---
 ; ICACHE-LABEL: define i32 @one_dim_entry(
 ; ICACHE-NOT: section
 ; ICACHE-NOT: ejit_icache_try
+; ICACHE-NOT: br
 ; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
 ; ICACHE: load atomic ptr, ptr {{.*}} monotonic, align 8
-; ICACHE-LABEL: jit_icache_dispatch:
 ; ICACHE-NOT: call void @ejit_taskpool_release_read
-; ICACHE: call {{.*}} %ejit_ic_fn
+; ICACHE-NOT: br
+; ICACHE: musttail call {{.*}} %ejit_ic_fn
 ; ICACHE: ret
 
-; --- 2D entry: [16 x [16 x ptr]] slot, 2-subscript GEP. ---
+; --- 2D entry: [16 x [16 x ptr]] slot, 2-subscript GEP, branchless. ---
 ; ICACHE-LABEL: define i32 @two_dim_entry(
 ; ICACHE-NOT: section
 ; ICACHE: getelementptr {{.*}} ptr @__ejit_icache_fn_two_dim_entry, i32 0, i32 {{.*}}, i32 {{.*}}
+; ICACHE: load atomic ptr, ptr {{.*}} monotonic, align 8
+; ICACHE: musttail call {{.*}} %ejit_ic_fn
 
 ; --- OPT (dispatcher-cluster + missfn-cold ON): section and cold present ---
 ; OPT-LABEL: define i32 @zero_dim_entry(
@@ -76,24 +86,25 @@
 ; OPT-SAME: #[[MISS_ATTRS]]
 ; OPT-DAG: attributes #[[MISS_ATTRS]] = { cold noinline }
 
-; --- registration carries numDims (3rd arg): 0 / 1 / 2 (DAG: order-independent). ---
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0)
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1)
-; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 2)
+; --- registration carries numDims (3rd arg) and the sentinel MissFn (4th arg,
+;     which the runtime writes back on drain / fill-retract). DAG: order-
+;     independent. ---
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_zero_dim_entry, i32 0, ptr @zero_dim_entry_miss)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1, ptr @one_dim_entry_miss)
+; ICACHE-DAG: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_two_dim_entry, i32 2, ptr @two_dim_entry_miss)
 
 ; --- -ejit-icache-section (default .mc_shared, pinned here so the test does not
 ;     depend on the CMake value): every cell table lands in the inter-core
-;     shared section and the probe is unchanged (one monotonic load + null
-;     check, no freshness compare). The other RUN lines pin it EMPTY to check
-;     the plain-.bss shape. ---
-; SECTION-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr null, section ".mc_shared", align 8
-; SECTION-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] zeroinitializer, section ".mc_shared", align 8
-; SECTION-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] zeroinitializer, section ".mc_shared", align 8
+;     shared section - now carrying its &MissFn sentinel initializer, which is
+;     what the image loader must place before any core runs - and the probe is
+;     unchanged (one monotonic load + musttail, no freshness compare). The
+;     other RUN lines pin it EMPTY to check the plain-.bss shape. ---
+; SECTION-DAG: @__ejit_icache_fn_zero_dim_entry = internal global ptr @zero_dim_entry_miss, section ".mc_shared", align 8
+; SECTION-DAG: @__ejit_icache_fn_one_dim_entry = internal global [16 x ptr] [ptr @one_dim_entry_miss, {{.*}}], section ".mc_shared", align 8
+; SECTION-DAG: @__ejit_icache_fn_two_dim_entry = internal global [16 x [16 x ptr]] {{.*}}@two_dim_entry_miss{{.*}}, section ".mc_shared", align 8
 ; SECTION-LABEL: define i32 @one_dim_entry(
 ; SECTION: load atomic ptr, ptr {{.*}} monotonic, align 8
-; SECTION-LABEL: jit_icache_dispatch:
-; SECTION-NOT: load
-; SECTION: call {{.*}} %ejit_ic_fn
+; SECTION: musttail call {{.*}} %ejit_ic_fn
 
 ; --- Default (flag OFF): no icache anywhere; original compile_or_get path. ---
 ; NOICACHE-LABEL: define i32 @one_dim_entry(
@@ -101,9 +112,11 @@
 ; NOICACHE-NOT: ejit_register_icache_slot
 ; NOICACHE: call i32 @ejit_taskpool_compile_or_get_1d(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, ptr {{.*}}, ptr {{.*}})
 
-; --- Idempotent: two passes emit each probe exactly once. ---
+; --- Idempotent: two passes emit each probe exactly once, and the sentinel
+;     registration (with its MissFn argument) is not duplicated either. ---
 ; IDEM-LABEL: define i32 @one_dim_entry(
 ; IDEM-COUNT-1: getelementptr {{.*}} @__ejit_icache_fn_one_dim_entry, i32 0, i32 {{.*}}
+; IDEM-COUNT-1: call void @ejit_register_icache_slot({{.*}} @__ejit_icache_fn_one_dim_entry, i32 1, ptr @one_dim_entry_miss)
 
 ; --- timing hit path: plain call (NOT musttail) + trace + ret. The miss path
 ;     stays musttail (no trailing calls), so we only forbid musttail within the

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -769,6 +769,11 @@ extern void ejit_register_period_array(const char *, const char *, void *,
 extern void ejit_register_bitcode(const char *, const uint8_t *, uint64_t);
 extern void ejit_register_static_var(const char *, void *);
 extern void ejit_register_lifecycle(const char *, uint32_t *);
+// Icache slot registration: name-keyed (resolved against the SAME registry
+// funcIndex ejit_register_funcindex assigns), 4th arg is the sentinel MissFn
+// for branchless-probe slots (null keeps the guarded form's 0 semantics).
+extern void ejit_register_funcindex(const char *, uint32_t *);
+extern void ejit_register_icache_slot(const char *, void *, uint32_t, void *);
 extern void ejit_set_log_level(int level);
 extern int ejit_get_log_level(void);
 extern void ejit_print_registry(void);
@@ -1046,6 +1051,69 @@ TEST(EJitCApiTaskpool, PreInitLifecycleActivateAndArraySync) {
   EXPECT_FALSE(ejit_is_active("wrong", 0));
   ejit_shutdown();
 }
+
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+// The C ABI's ejit_register_icache_slot gained a 4th argument: the sentinel
+// MissFn the branchless wrapper's cell table is DEFINED pre-filled with. The
+// registration must carry it into the slot registry, so a drain triggered
+// through the public activate path empties a sentinel-form cell to &MissFn --
+// never 0, which the branchless probe would BLR -- while a slot registered
+// with a null missFn (guarded form: 3D/4D, timing) keeps the historical 0.
+TEST(EJitCApiTaskpool, IcacheSlotRegistrationCarriesTheSentinel) {
+  resetTaskpoolRegState();
+  // A lifecycle + period array, so the public activate below has a registered
+  // period to toggle (its drain is the observable under test).
+  uint32_t lifeSlot = 0xFFFFFFFFu;
+  ejit_register_lifecycle("cell", &lifeSlot);
+  static int cellArr[16];
+  ejit_register_period_array("cell", "cellArr", cellArr, 16);
+
+  // Stand-ins for the AOT globals: two [D] cell tables, and (for the sentinel
+  // slot) the MissFn the table is defined pre-filled with. The runtime only
+  // stores and compares these addresses; nothing ever calls through them.
+  constexpr uint32_t D = 16;
+  static uintptr_t sentinelCells[D];
+  static uintptr_t guardedCells[D];
+  static uintptr_t missFnStandIn = 0;
+  sentinelCells[3] = reinterpret_cast<uintptr_t>(&missFnStandIn);
+
+  // C ABI registration: funcindex first (name -> registry funcIndex), then
+  // the slot with its dimensionality and sentinel.
+  uint32_t sentinelIdx = 0xFFFFFFFFu;
+  uint32_t guardedIdx = 0xFFFFFFFFu;
+  ejit_register_funcindex("sentinel_c_fn", &sentinelIdx);
+  ejit_register_funcindex("guarded_c_fn", &guardedIdx);
+  ASSERT_NE(sentinelIdx, 0xFFFFFFFFu);
+  ASSERT_NE(guardedIdx, 0xFFFFFFFFu);
+  ejit_register_icache_slot("sentinel_c_fn", &sentinelCells[0], 1,
+                            &missFnStandIn);
+  ejit_register_icache_slot("guarded_c_fn", &guardedCells[0], 1, nullptr);
+
+  EJit ejit(Config{});
+  ASSERT_FALSE(ejit.initFailed());
+  EJitSharedTaskPool *sp = ejit.sharedTaskPool();
+  ASSERT_NE(sp, nullptr);
+
+  // Model a resolve that filled each slot's identity (this also arms the
+  // table, so the toggle's drain actually walks it).
+  EJitDimPair id[1] = {{0, 3}};
+  sp->icacheFill(sentinelIdx, reinterpret_cast<void *>(0x2000), id, 1,
+                 sp->icacheBeginResolve());
+  sp->icacheFill(guardedIdx, reinterpret_cast<void *>(0x3000), id, 1,
+                 sp->icacheBeginResolve());
+  ASSERT_EQ(sentinelCells[3], 0x2000u);
+  ASSERT_EQ(guardedCells[3], 0x3000u);
+
+  // The public activate path drains: sentinel slot -> &MissFn, guarded slot
+  // -> 0. This is the C-ABI end of the contract the SharedTaskPool tests pin
+  // at the internal-API level.
+  EXPECT_TRUE(ejit.activate("cell", 3));
+  EXPECT_EQ(sentinelCells[3], reinterpret_cast<uintptr_t>(&missFnStandIn))
+      << "a sentinel slot registered through the C ABI must drain to &MissFn";
+  EXPECT_EQ(guardedCells[3], 0u)
+      << "a guarded (null-missFn) slot must keep the historical 0";
+}
+#endif // EJIT_SRE_SHARED_TASKPOOL
 
 // Finding (一): name-level activate/deactivate through the PUBLIC EJit API
 // syncs the time-window state AND the taskpool SwitchController; the version

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -310,9 +310,12 @@ protected:
   }
 
   // Register a test-local stand-in for the wrapper's @__ejit_icache_fn_<name>
-  // cell table.
-  void registerSlot(uint32_t funcIndex, void *base, uint32_t numDims) {
-    ASSERT_EQ(ejitIcacheRegisterSlot(funcIndex, base, numDims),
+  // cell table. \p missFn non-null models a SENTINEL-form slot (NumDims <= 2,
+  // timing off): the table is defined pre-filled with &MissFn and the runtime
+  // must write that value back on drain / retract.
+  void registerSlot(uint32_t funcIndex, void *base, uint32_t numDims,
+                    const void *missFn = nullptr) {
+    ASSERT_EQ(ejitIcacheRegisterSlot(funcIndex, base, numDims, missFn),
               EJitIcacheRegResult::Ok);
   }
 
@@ -4217,6 +4220,224 @@ TEST_F(SharedTaskPoolTest, InlineCacheMultiVersion) {
   for (uint32_t i = 0; i < D; ++i)
     for (uint32_t j = 0; j < D; ++j)
       ASSERT_EQ(slots[i][j], 0u) << "cell [" << i << "][" << j << "] survived";
+}
+
+//===----------------------------------------------------------------------===//
+// Sentinel-form slots: the branchless wrapper.
+//
+// For NumDims <= 2 (no -ejit-wrapper-timing) the AOT DEFINES the cell table
+// pre-filled with &MissFn and the wrapper is load + musttail BLR with no null
+// guard, so a cell holding 0 is a crash, not a miss. The runtime's side of
+// that contract: whatever path empties a cell writes the slot's registered
+// missFn back, and icacheTry reports the sentinel as a miss. Guarded slots
+// (3D/4D, timing - registered with a null missFn) keep the historical 0.
+//===----------------------------------------------------------------------===//
+
+namespace {
+// A stand-in for the AOT-generated <name>_miss: the runtime only stores and
+// compares the address, so any stable non-null function address models it.
+// C++ has no implicit function-pointer -> void* conversion (and the cast is
+// not a constant expression), so both forms come from these helpers.
+void testMissFn() {}
+const void *testSentinelPtr() {
+  return reinterpret_cast<const void *>(&testMissFn);
+}
+uintptr_t testSentinel() {
+  return reinterpret_cast<uintptr_t>(&testMissFn);
+}
+} // namespace
+
+// The full sentinel lifecycle: definition-time sentinel -> miss; fill -> hit;
+// period toggle -> SENTINEL back (never 0); refill -> hit again.
+TEST_F(SharedTaskPoolTest, InlineCacheSentinelDrainsToMissFn) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  // The cell as the image loader places it: DEFINED as &MissFn. 0D here; the
+  // multi-dim walk is pinned below.
+  uintptr_t slot = testSentinel();
+  registerSlot(kFunc, &slot, 0, testSentinelPtr());
+  void *fn = codeFor(kFunc);
+  void *out = nullptr;
+
+  // The sentinel IS a miss: icacheTry reports it with *outFn cleared.
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, nullptr);
+
+  // A resolve fills over the sentinel and serves.
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+
+  // A period toggle empties the cell back to the SENTINEL. This is the
+  // load-bearing assertion of the branchless wrapper: the probe BLRs the cell
+  // unconditionally, so 0 here would be a jump to null.
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_EQ(slot, testSentinel()) << "drain must empty a sentinel slot to &MissFn";
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+
+  // Not poisoned: a fresh resolve refills and serves again.
+  pool.icacheFill(kFunc, fn, nullptr, 0, pool.icacheBeginResolve());
+  EXPECT_TRUE(pool.icacheTry(kFunc, nullptr, 0, &out));
+  EXPECT_EQ(out, fn);
+}
+
+// A stale-token fill DECLINES before storing, so it must leave the sentinel
+// the drain just wrote in place -- it must not zero the cell either.
+TEST_F(SharedTaskPoolTest, InlineCacheSentinelDeclinesLeaveTheDrainValue) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = testSentinel();
+  registerSlot(kFunc, &slot, 0, testSentinelPtr());
+
+  // Arm the table with a live fill, so the toggle's drain below actually
+  // walks (an unarmed drain skips the walk -- there is nothing to empty).
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_NE(slot, testSentinel());
+
+  const uint64_t staleTok = pool.icacheBeginResolve();
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true)); // drain -> sentinel
+  EXPECT_EQ(slot, testSentinel());
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, staleTok); // declines
+  EXPECT_EQ(slot, testSentinel())
+      << "a declined fill must leave the drain's sentinel untouched";
+  void *out = nullptr;
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+}
+
+// The retract: a drain that begins after the fill's pre-store checks pass but
+// before its re-validation. Reached deterministically through the test-only
+// midpoint hook (the production interleave is a preempting peer core). The
+// retracted cell must hold the SENTINEL, not 0 -- same contract as the drain.
+TEST_F(SharedTaskPoolTest, InlineCacheSentinelFillRetractWritesMissFn) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = testSentinel();
+  registerSlot(kFunc, &slot, 0, testSentinelPtr());
+
+  // Fire a period toggle from inside the fill, between the store and the
+  // re-validation -- exactly where a preempting peer's drain lands.
+  pool.setIcacheFillMidpointForTest(
+      [](void *ctx) {
+        static_cast<EJitSharedTaskPool *>(ctx)->setInstanceEnabled(0, 5, true);
+      },
+      &pool);
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0,
+                  pool.icacheBeginResolve());
+  pool.setIcacheFillMidpointForTest(nullptr, nullptr);
+
+  EXPECT_EQ(slot, testSentinel())
+      << "a retracted fill must reset the cell to &MissFn, not 0";
+  void *out = nullptr;
+  EXPECT_FALSE(pool.icacheTry(kFunc, nullptr, 0, &out));
+}
+
+// The same retract with a GUARDED slot (null missFn): the empty value stays 0.
+// One seam, both forms - the retract picks its value from the registration.
+TEST_F(SharedTaskPoolTest, InlineCacheGuardedFillRetractStillWritesZero) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0); // guarded form: no missFn
+
+  pool.setIcacheFillMidpointForTest(
+      [](void *ctx) {
+        static_cast<EJitSharedTaskPool *>(ctx)->setInstanceEnabled(0, 5, true);
+      },
+      &pool);
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0,
+                  pool.icacheBeginResolve());
+  pool.setIcacheFillMidpointForTest(nullptr, nullptr);
+
+  EXPECT_EQ(slot, 0u) << "a guarded slot's retract keeps the historical 0";
+}
+
+// A multi-dim (2D) sentinel table: the drain walks every cell writing the
+// sentinel, wherever the filled identities sit.
+TEST_F(SharedTaskPoolTest, InlineCacheSentinelDrainsEveryCellOfAMultiDimTable) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  constexpr uint32_t D = EJIT_ICACHE_DIM_SIZE;
+  // The [D][D] table as defined: every cell &MissFn.
+  uintptr_t slots[D][D];
+  for (uint32_t i = 0; i < D; ++i)
+    for (uint32_t j = 0; j < D; ++j)
+      slots[i][j] = testSentinel();
+  registerSlot(kFunc, &slots[0][0], 2, testSentinelPtr());
+
+  EJitDimPair id01[2] = {{0, 0}, {0, 1}};
+  EJitDimPair id10[2] = {{0, 1}, {0, 0}};
+  void *out = nullptr;
+
+  EXPECT_FALSE(pool.icacheTry(kFunc, id01, 2, &out));
+  pool.icacheFill(kFunc, codeFor(kFunc), id01, 2, pool.icacheBeginResolve());
+  pool.icacheFill(kFunc, codeFor(kFunc + 1), id10, 2,
+                  pool.icacheBeginResolve());
+  EXPECT_EQ(slots[0][1], reinterpret_cast<uintptr_t>(codeFor(kFunc)));
+  EXPECT_EQ(slots[1][0], reinterpret_cast<uintptr_t>(codeFor(kFunc + 1)));
+
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  for (uint32_t i = 0; i < D; ++i)
+    for (uint32_t j = 0; j < D; ++j)
+      ASSERT_EQ(slots[i][j], testSentinel())
+          << "cell [" << i << "][" << j << "] must drain to &MissFn";
+  EXPECT_FALSE(pool.icacheTry(kFunc, id01, 2, &out));
+  EXPECT_FALSE(pool.icacheTry(kFunc, id10, 2, &out));
+}
+
+// One drain, two forms: a sentinel slot and a guarded slot registered side by
+// side empty to their own values. The registration is the ONLY thing that
+// decides the empty value - a guarded slot next to a sentinel one must not
+// inherit the sentinel.
+TEST_F(SharedTaskPoolTest, InlineCacheGuardedSlotStillDrainsToZero) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kSentinelFunc = 3;
+  constexpr uint32_t kGuardedFunc = 4;
+  uintptr_t sentinelSlot = testSentinel();
+  uintptr_t guardedSlot = 0;
+  registerSlot(kSentinelFunc, &sentinelSlot, 0, testSentinelPtr());
+  registerSlot(kGuardedFunc, &guardedSlot, 0); // guarded: null missFn
+
+  pool.icacheFill(kSentinelFunc, codeFor(kSentinelFunc), nullptr, 0,
+                  pool.icacheBeginResolve());
+  pool.icacheFill(kGuardedFunc, codeFor(kGuardedFunc), nullptr, 0,
+                  pool.icacheBeginResolve());
+  ASSERT_EQ(sentinelSlot, reinterpret_cast<uintptr_t>(codeFor(kSentinelFunc)));
+  ASSERT_EQ(guardedSlot, reinterpret_cast<uintptr_t>(codeFor(kGuardedFunc)));
+
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_EQ(sentinelSlot, testSentinel());
+  EXPECT_EQ(guardedSlot, 0u);
+  void *out = nullptr;
+  EXPECT_FALSE(pool.icacheTry(kSentinelFunc, nullptr, 0, &out));
+  EXPECT_FALSE(pool.icacheTry(kGuardedFunc, nullptr, 0, &out));
+}
+
+// ejitIcacheClearAll() retires the registration wholesale: re-registering the
+// same funcIndex as a guarded slot must not inherit the stale missFn (a drain
+// would then write &MissFn into a wrapper that null-checks 0 - harmless to
+// execution, but the sentinel-vs-0 contract would be lying).
+TEST_F(SharedTaskPoolTest, InlineCacheClearAllDropsTheSentinelRegistration) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  constexpr uint32_t kFunc = 3;
+  uintptr_t slot = 0;
+  registerSlot(kFunc, &slot, 0, testSentinelPtr());
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_NE(slot, 0u);
+
+  ejitIcacheClearAll();
+  slot = 0;
+  registerSlot(kFunc, &slot, 0); // re-register guarded
+  pool.icacheFill(kFunc, codeFor(kFunc), nullptr, 0, pool.icacheBeginResolve());
+  ASSERT_NE(slot, 0u);
+  ASSERT_TRUE(pool.setInstanceEnabled(0, 5, true));
+  EXPECT_EQ(slot, 0u) << "clearAll must drop the missFn, not leak it";
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

For inline-cache slots with NumDims <= 2 (and no `-ejit-wrapper-timing`), the cell table is now **defined pre-filled with &MissFn**, so the wrapper collapses to a single block: `[GEP] + atomic monotonic load + musttail BLR`, with no null guard. A miss simply lands in MissFn (funcidx guard -> compile_or_get -> AOT fallback), which also makes pre-init calls behave exactly like the guarded form. 3D/4D keep the guarded shape: a D=16 splat initializer would cost 4096/65536 relocations per table.

**Core invariant**: any path that writes a sentinel-form cell may only store `{specialization pointer, &MissFn}`, never 0 — `icacheDrainAll` and `icacheFill`'s retract now write the slot's registered sentinel.

## ABI

- `ejit_register_icache_slot` gains a 4th `missFn` argument (C ABI, no default — the header is shared with pure C)
- The `.ejit_period` static entry reuses its spare `name2` field to carry the sentinel
- The pass derives the sentinel from the table's initializer (not wrap-loop bookkeeping), so an idempotency-skipped function still registers correctly, and logs loudly if `cell[0] != &MissFn` at registration (mis-deployed shared section)

## Also

- Registration emission moves after the wrap loop (MissFn is created inside it)
- `-ejit-function-body-timing` excludes the sentinel form (guarded shape kept there)
- X86AsmParser component for host links
- Integration smoke test (multi-TU, 0D/1D sentinel + 3D guarded lifecycles)
- 7 new sentinel gtests + sentinel-form lit coverage; lit expectations for the body-timing musttail test updated to the new no-timing form

## Testing

- `llvm-lit llvm/test/Transforms/EmbeddedJIT` (release opt): 46 passed / 4 expected-fail / 0 failed
- EJIT gtests: all 7 sentinel tests pass (remaining failures are pre-existing on the base and reproduce identically without this change)
- `ejit_test` sentinel smoke test: OK
