### PR TITLE
[EJIT] Restore bound-pointer helper propagation

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9516,14 +9516,18 @@ def EjitBoundPtrDocs : Documentation {
   let Content = [{
 EmbeddedJIT: binds a pointer parameter's pointee to a specialization dimension.
 
-On a JIT cache miss, the runtime snapshots the complete pointee before the
-call returns. Loads of ``ejit_may_const`` fields through the parameter may then
-be specialized from that snapshot. The function must also have exactly one
+On a JIT cache miss, the worker reads the pointee through a borrowed raw pointer
+while compiling. The caller must keep the object alive, mapped at the same
+virtual address, and unchanged until compilation finishes. Loads of
+``ejit_may_const`` fields through the parameter may then be specialized from
+that object. The function must also have exactly one
 ``ejit_period_arr_ind`` parameter with the same period name.
 
 Only a pointer to a complete object type is accepted. The first implementation
-supports one bound pointer per function and performs a shallow object copy;
-pointers contained inside the object are not followed.
+supports up to eight bound pointers per function. Pointers contained inside an
+object are not followed. The pointer and object contents are transport data,
+not part of the cache identity; changing them requires deactivating the
+dimension, modifying the object, and reactivating the dimension.
 
 .. code-block:: c
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13504,8 +13504,8 @@ def err_ejit_bound_ptr_invalid_type : Error<
 def err_ejit_bound_ptr_missing_dim : Error<
   "ejit_bound_ptr(%0) requires exactly one matching "
   "ejit_period_arr_ind(%0) parameter">;
-def err_ejit_bound_ptr_too_many : Error<
-  "function %0 has %1 ejit_bound_ptr parameters; at most one is supported">;
+def err_ejit_bound_ptr_too_many : Error<"function %0 has %1 ejit_bound_ptr "
+                                        "parameters; at most 8 are supported">;
 def err_ejit_entry_recursive : Error<
   "ejit_entry function %0 cannot be recursive">;
 def err_ejit_period_lc_no_index : Error<

--- a/clang/lib/CodeGen/CGEJIT.cpp
+++ b/clang/lib/CodeGen/CGEJIT.cpp
@@ -83,8 +83,8 @@ void clang::CodeGen::emitEjitFunctionMetadata(CodeGenModule &CGM,
   }
 
   // ejit_bound_ptr (on pointer parameters). The pointee size is part of the
-  // metadata so the AOT wrapper can snapshot it before an async request
-  // outlives the call and its pointer.
+  // metadata so the wrapper can build a fixed borrowed descriptor at the
+  // compile slow path. The runtime never takes ownership of the pointee.
   for (unsigned I = 0; I < FD->getNumParams(); ++I) {
     const ParmVarDecl *PD = FD->getParamDecl(I);
     if (const auto *BoundAttr = PD->getAttr<EjitBoundPtrAttr>()) {

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 
+using llvm::ejit::MAX_BOUND_PTR_PARAMS;
 using llvm::ejit::MAX_PERIOD_ARR_IND_PARAMS;
 using llvm::ejit::MAX_PERIOD_ARR_SIZE;
 
@@ -331,22 +332,28 @@ void checkEjitBoundPtrIndex(Sema &S, const FunctionDecl *FD) {
       LastBound = A;
     }
 
-  if (BoundCount > 1 && LastBound) {
+  if (BoundCount > MAX_BOUND_PTR_PARAMS && LastBound) {
     S.Diag(LastBound->getLocation(), diag::err_ejit_bound_ptr_too_many)
         << FD << BoundCount;
     return;
   }
 
-  if (!LastBound)
+  if (!BoundCount)
     return;
-  unsigned MatchingDims = 0;
-  for (const ParmVarDecl *P : FD->parameters())
-    if (const auto *D = P->getAttr<EjitPeriodArrIndAttr>())
-      if (D->getPeriodName() == LastBound->getPeriodName())
-        ++MatchingDims;
-  if (MatchingDims != 1)
-    S.Diag(LastBound->getLocation(), diag::err_ejit_bound_ptr_missing_dim)
-        << LastBound->getPeriodName();
+
+  for (const ParmVarDecl *P : FD->parameters()) {
+    const auto *Bound = P->getAttr<EjitBoundPtrAttr>();
+    if (!Bound)
+      continue;
+    unsigned MatchingDims = 0;
+    for (const ParmVarDecl *DimP : FD->parameters())
+      if (const auto *D = DimP->getAttr<EjitPeriodArrIndAttr>())
+        if (D->getPeriodName() == Bound->getPeriodName())
+          ++MatchingDims;
+    if (MatchingDims != 1)
+      S.Diag(Bound->getLocation(), diag::err_ejit_bound_ptr_missing_dim)
+          << Bound->getPeriodName();
+  }
 }
 
 /// checkEjitEntryLcConflict - ejit_entry and ejit_period_lc are mutually

--- a/clang/test/CodeGen/ejit_metadata.c
+++ b/clang/test/CodeGen/ejit_metadata.c
@@ -35,6 +35,16 @@ int bound_entry(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx,
   return cfg->cellType + cfg->xx;
 }
 
+// CHECK: define {{.*}}i32 @multi_bound_entry({{.*}} !ejit.metadata ![[MULTI_BOUND_META:[0-9]+]]
+__attribute__((ejit_entry))
+int multi_bound_entry(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx,
+                      __attribute__((ejit_bound_ptr("cell")))
+                      const struct CellConfig *cfgA,
+                      __attribute__((ejit_bound_ptr("cell")))
+                      const struct CellConfig *cfgB) {
+  return cfgA->cellType + cfgB->cellType + cellIdx;
+}
+
 // CHECK-DAG: ![[MAYCONST_FIELD:[0-9]+]] = !{!"ejit_may_const_field", i32 0}
 // CHECK-DAG: ![[PERIOD_META]] = distinct !{![[PERIOD:[0-9]+]], ![[MAYCONST_FIELD]]}
 // CHECK-DAG: ![[PERIOD]] = !{!"ejit_period", !"static"}
@@ -49,3 +59,6 @@ int bound_entry(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx,
 // CHECK-DAG: ![[BOUND_META]] = distinct !{![[ENTRY]], ![[IND]], ![[BOUND:[0-9]+]]}
 // CHECK-DAG: ![[BOUND]] = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, ![[BOUND_FIELD:[0-9]+]]}
 // CHECK-DAG: ![[BOUND_FIELD]] = !{i64 0, i64 4}
+// CHECK-DAG: ![[MULTI_BOUND_META]] = distinct !{![[ENTRY]], ![[IND]], ![[BOUND_A:[0-9]+]], ![[BOUND_B:[0-9]+]]}
+// CHECK-DAG: ![[BOUND_A]] = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, ![[BOUND_FIELD]]}
+// CHECK-DAG: ![[BOUND_B]] = !{!"ejit_bound_ptr", !"cell", i32 2, i64 8, ![[BOUND_FIELD]]}

--- a/clang/test/Sema/ejit_bound_ptr.c
+++ b/clang/test/Sema/ejit_bound_ptr.c
@@ -26,4 +26,27 @@ __attribute__((ejit_entry))
 void two_bound(__attribute__((ejit_period_arr_ind("cell"))) int cell,
                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *a,
                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *b);
-// expected-error@-1 {{function 'two_bound' has 2 ejit_bound_ptr parameters; at most one is supported}}
+
+__attribute__((ejit_entry))
+void eight_bound(__attribute__((ejit_period_arr_ind("cell"))) int cell,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *a,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *b,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *c,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *d,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *e,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *f,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *g,
+                 __attribute__((ejit_bound_ptr("cell"))) struct Cfg *h);
+
+__attribute__((ejit_entry))
+void nine_bound(__attribute__((ejit_period_arr_ind("cell"))) int cell,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *a,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *b,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *c,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *d,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *e,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *f,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *g,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *h,
+                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *i);
+// expected-error@-1 {{function 'nine_bound' has 9 ejit_bound_ptr parameters; at most 8 are supported}}

--- a/ejit_test/README.md
+++ b/ejit_test/README.md
@@ -49,11 +49,11 @@ Integration tests for the EmbeddedJIT JIT compilation system.
 ### Board-only Multicore Demo
 
 `ejit_bound_ptr_sre_multicore_test.c` provides the SRE `test_ejit_period`
-entry for validating dimension-bound pointer snapshots across cores:
+entry for validating dimension-bound raw pointers across cores:
 
 1. Core 8 runs `test_ejit_period` to start the shared worker and arm capture.
 2. Core 18 runs `test_ejit_period` to enqueue independent cell 1 (`scale=5`)
-   and cell 2 (`scale=9`) stack snapshots, then verifies both JIT versions.
+   and cell 2 (`scale=9`) shared objects, then verifies both JIT versions.
 3. Core 8 runs `test_ejit_bound_ptr_print` to print the optimized function.
 
 The expected AOT/JIT pairs are `153/253` for cell 1 and `194/294` for cell 2.

--- a/ejit_test/ejit_bound_ptr_sre_multicore_test.c
+++ b/ejit_test/ejit_bound_ptr_sre_multicore_test.c
@@ -1,12 +1,11 @@
-//===-- ejit_bound_ptr_sre_multicore_test.c - cross-core snapshot demo ----===//
+//===-- ejit_bound_ptr_sre_multicore_test.c - cross-core raw pointer demo --===//
 //
 // Board flow after a reset:
 //   1. Core 8:  test_ejit_period
 //      Initializes EJIT, owns the shared compile worker, and arms the dump.
 //   2. Core 18: test_ejit_period
-//      Enqueues compilation from a stack-local bound object, destroys that
-//      object, waits for publication, then verifies a JIT cache hit using a
-//      second object whose dynamic field has a different value.
+//      Enqueues compilation from shared per-cell objects, waits for
+//      publication, then verifies JIT cache hits using those same objects.
 //   3. Core 8:  test_ejit_bound_ptr_print
 //      Prints the worker-local optimized IR/ASM.
 //
@@ -141,19 +140,11 @@ bound_cell_config_mc(ejit_period_arr_ind(cell) uint8_t cellIndex,
   return input + cellRelated->runtimeBias;
 }
 
-__attribute__((noinline)) static uint32_t
-enqueue_from_stack(uint8_t cell, uint32_t scale, uint32_t runtimeBias) {
-  struct CellRelated local = {7u, scale, runtimeBias};
-  return bound_cell_config_mc(cell, BOUND_PTR_TRP, &local, 10u);
-}
+EJIT_SHARED_SECTION_ATTR struct CellRelated g_bound_configs[8] = {
+    {7u, 5u, 100u}, {7u, 9u, 100u}};
 
-// Encourage reuse of the caller stack after enqueue_from_stack has returned.
-// Correctness must not depend on whether this happens to overlap its old slot.
-__attribute__((noinline)) static void clobber_producer_stack(void) {
-  volatile uint8_t bytes[512];
-  for (uint32_t i = 0; i < sizeof(bytes); ++i)
-    bytes[i] = (uint8_t)(0xa5u ^ i);
-  __asm__ volatile("" : : "r"(&bytes[0]) : "memory");
+static uint32_t enqueue_from_shared(uint8_t cell) {
+  return bound_cell_config_mc(cell, BOUND_PTR_TRP, &g_bound_configs[cell], 10u);
 }
 
 static int wait_for_compiles(uint64_t baseline, uint64_t expected) {
@@ -202,10 +193,10 @@ static int run_producer(void) {
   // In-flight dedup is keyed by funcIndex, not by the complete dimension
   // identity. Submit the two cell versions serially; otherwise cell 2 sees
   // AlreadyPending while cell 1 is compiling and is never enqueued.
-  // Each first call returns AOT, and its stack object is dead before the worker
-  // completes, preserving the lifetime stress this demo is meant to cover.
-  uint32_t aotA = enqueue_from_stack(BOUND_PTR_CELL_A, 5u, 100u);
-  clobber_producer_stack();
+  // Each first call returns AOT while the shared object remains alive through
+  // worker compilation. The raw pointer is transport-only and is never freed
+  // by the queue or worker.
+  uint32_t aotA = enqueue_from_shared(BOUND_PTR_CELL_A);
   if (ejit_publish_pending_code() != EJIT_OK) {
     SRE_printf("[BOUND-PTR-MC][core=%u] FAIL cell1 batch publish\n",
                BOUND_PTR_PRODUCER_CORE);
@@ -218,8 +209,7 @@ static int run_producer(void) {
     return -6;
   }
 
-  uint32_t aotB = enqueue_from_stack(BOUND_PTR_CELL_B, 9u, 100u);
-  clobber_producer_stack();
+  uint32_t aotB = enqueue_from_shared(BOUND_PTR_CELL_B);
   if (ejit_publish_pending_code() != EJIT_OK) {
     SRE_printf("[BOUND-PTR-MC][core=%u] FAIL cell2 batch publish\n",
                BOUND_PTR_PRODUCER_CORE);
@@ -245,13 +235,12 @@ static int run_producer(void) {
   ejit_taskpool_stats_t compiled = {0};
   (void)ejit_taskpool_get_stats(&compiled);
 
-  // Each cell keeps its own stable scale, while runtimeBias deliberately
-  // changes. Reusing cell 1's scale=5 specialization for cell 2 would return
-  // 254 instead of 294 and fail this check.
-  uint32_t jitA = enqueue_from_stack(BOUND_PTR_CELL_A, 5u, 200u);
-  uint32_t jitB = enqueue_from_stack(BOUND_PTR_CELL_B, 9u, 200u);
-  const uint32_t expectedJitA = 253u;
-  const uint32_t expectedJitB = 294u;
+  // Each cell keeps its own stable scale and object address. Reusing cell 1's
+  // scale=5 specialization for cell 2 would return 153 instead of 194.
+  uint32_t jitA = enqueue_from_shared(BOUND_PTR_CELL_A);
+  uint32_t jitB = enqueue_from_shared(BOUND_PTR_CELL_B);
+  const uint32_t expectedJitA = expectedAotA;
+  const uint32_t expectedJitB = expectedAotB;
   ejit_taskpool_stats_t after = {0};
   (void)ejit_taskpool_get_stats(&after);
   if (jitA != expectedJitA || jitB != expectedJitB) {

--- a/ejit_test/ejit_bound_ptr_sre_multicore_test.c
+++ b/ejit_test/ejit_bound_ptr_sre_multicore_test.c
@@ -85,6 +85,7 @@ extern ejit_status_t ejit_init(const ejit_config_t *config);
 extern ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx);
 extern void ejit_clear_cache(void);
 extern unsigned ejit_taskpool_pending_count(void);
+extern ejit_status_t ejit_publish_pending_code(void);
 extern ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out);
 extern void ejit_taskpool_print_stats(void);
 extern void ejit_taskpool_print_compiled(void);
@@ -155,7 +156,7 @@ __attribute__((noinline)) static void clobber_producer_stack(void) {
   __asm__ volatile("" : : "r"(&bytes[0]) : "memory");
 }
 
-static int wait_for_two_compiles(uint64_t baseline) {
+static int wait_for_compiles(uint64_t baseline, uint64_t expected) {
   for (uint32_t round = 0; round < BOUND_PTR_WAIT_ROUNDS; ++round) {
     ejit_taskpool_stats_t stats = {0};
     (void)ejit_taskpool_get_stats(&stats);
@@ -165,12 +166,13 @@ static int wait_for_two_compiles(uint64_t baseline) {
                  (unsigned long long)stats.publishFailed);
       return 0;
     }
-    if (stats.asyncCompiles >= baseline + 2u &&
+    if (stats.asyncCompiles >= baseline + expected &&
         ejit_taskpool_pending_count() == 0)
       return 1;
     if ((round % 500u) == 0)
-      SRE_printf("[BOUND-PTR-MC] waiting compiles=%llu/2 pending=%u\n",
+      SRE_printf("[BOUND-PTR-MC] waiting compiles=%llu/%llu pending=%u\n",
                  (unsigned long long)(stats.asyncCompiles - baseline),
+                 (unsigned long long)expected,
                  ejit_taskpool_pending_count());
     (void)SRE_TaskDelay(BOUND_PTR_WAIT_TICKS);
   }
@@ -180,15 +182,16 @@ static int wait_for_two_compiles(uint64_t baseline) {
 static int run_producer(void) {
   uint32_t stage = __atomic_load_n(&g_bound_ptr_demo_stage, __ATOMIC_ACQUIRE);
   if (stage != BOUND_PTR_DEMO_WORKER_READY) {
-    SRE_printf("[BOUND-PTR-MC][core=18] FAIL stage=%u; run core 8 first\n",
-               stage);
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL stage=%u; run core %u first\n",
+               BOUND_PTR_PRODUCER_CORE, stage, BOUND_PTR_WORKER_CORE);
     return -3;
   }
 
   if (ejit_activate("cell", BOUND_PTR_CELL_A) != EJIT_OK ||
       ejit_activate("cell", BOUND_PTR_CELL_B) != EJIT_OK ||
       ejit_activate("trp", BOUND_PTR_TRP) != EJIT_OK) {
-    SRE_printf("[BOUND-PTR-MC][core=18] FAIL activate\n");
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL activate\n",
+               BOUND_PTR_PRODUCER_CORE);
     return -4;
   }
 
@@ -196,26 +199,47 @@ static int run_producer(void) {
   ejit_taskpool_stats_t before = {0};
   (void)ejit_taskpool_get_stats(&before);
 
-  // The first call returns AOT while the worker is pending. The local object
-  // is dead before this producer starts waiting. Stack clobbering strengthens
-  // the lifetime stress, while the taskpool unit test supplies the
-  // deterministic enqueue-before-poll ownership proof.
+  // In-flight dedup is keyed by funcIndex, not by the complete dimension
+  // identity. Submit the two cell versions serially; otherwise cell 2 sees
+  // AlreadyPending while cell 1 is compiling and is never enqueued.
+  // Each first call returns AOT, and its stack object is dead before the worker
+  // completes, preserving the lifetime stress this demo is meant to cover.
   uint32_t aotA = enqueue_from_stack(BOUND_PTR_CELL_A, 5u, 100u);
   clobber_producer_stack();
+  if (ejit_publish_pending_code() != EJIT_OK) {
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL cell1 batch publish\n",
+               BOUND_PTR_PRODUCER_CORE);
+    return -5;
+  }
+  if (!wait_for_compiles(before.asyncCompiles, 1u)) {
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL cell1 compile timeout\n",
+               BOUND_PTR_PRODUCER_CORE);
+    ejit_taskpool_print_stats();
+    return -6;
+  }
+
   uint32_t aotB = enqueue_from_stack(BOUND_PTR_CELL_B, 9u, 100u);
   clobber_producer_stack();
+  if (ejit_publish_pending_code() != EJIT_OK) {
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL cell2 batch publish\n",
+               BOUND_PTR_PRODUCER_CORE);
+    return -7;
+  }
   const uint32_t expectedAotA = 153u;
   const uint32_t expectedAotB = 194u;
   if (aotA != expectedAotA || aotB != expectedAotB) {
-    SRE_printf("[BOUND-PTR-MC][core=18] FAIL AOT cell1=%u/%u cell2=%u/%u\n",
-               aotA, expectedAotA, aotB, expectedAotB);
-    return -5;
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL AOT cell1=%u/%u "
+               "cell2=%u/%u\n",
+               BOUND_PTR_PRODUCER_CORE, aotA, expectedAotA, aotB,
+               expectedAotB);
+    return -8;
   }
 
-  if (!wait_for_two_compiles(before.asyncCompiles)) {
-    SRE_printf("[BOUND-PTR-MC][core=18] FAIL compile timeout\n");
+  if (!wait_for_compiles(before.asyncCompiles, 2u)) {
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL cell2 compile timeout\n",
+               BOUND_PTR_PRODUCER_CORE);
     ejit_taskpool_print_stats();
-    return -6;
+    return -9;
   }
 
   ejit_taskpool_stats_t compiled = {0};
@@ -231,27 +255,31 @@ static int run_producer(void) {
   ejit_taskpool_stats_t after = {0};
   (void)ejit_taskpool_get_stats(&after);
   if (jitA != expectedJitA || jitB != expectedJitB) {
-    SRE_printf("[BOUND-PTR-MC][core=18] FAIL JIT cell1=%u/%u cell2=%u/%u\n",
-               jitA, expectedJitA, jitB, expectedJitB);
-    return -7;
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL JIT cell1=%u/%u "
+               "cell2=%u/%u\n",
+               BOUND_PTR_PRODUCER_CORE, jitA, expectedJitA, jitB,
+               expectedJitB);
+    return -10;
   }
   if (after.cacheHits < compiled.cacheHits + 2u) {
-    SRE_printf("[BOUND-PTR-MC][core=18] FAIL no cache hit before=%llu "
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL no cache hit before=%llu "
                "after=%llu; check shared code-pointer support\n",
+               BOUND_PTR_PRODUCER_CORE,
                (unsigned long long)compiled.cacheHits,
                (unsigned long long)after.cacheHits);
-    return -8;
+    return -11;
   }
 
   __atomic_store_n(&g_bound_ptr_demo_sink,
                    ((uint64_t)jitA << 32) | (uint64_t)jitB, __ATOMIC_RELEASE);
   __atomic_store_n(&g_bound_ptr_demo_stage, BOUND_PTR_DEMO_COMPILED,
                    __ATOMIC_RELEASE);
-  SRE_printf("[BOUND-PTR-MC][core=18] PASS cell1 AOT/JIT=%u/%u cell2 "
+  SRE_printf("[BOUND-PTR-MC][core=%u] PASS cell1 AOT/JIT=%u/%u cell2 "
              "AOT/JIT=%u/%u compiles=2 hits=%llu; run "
-             "test_ejit_bound_ptr_print on core 8\n",
-             aotA, jitA, aotB, jitB,
-             (unsigned long long)(after.cacheHits - compiled.cacheHits));
+             "test_ejit_bound_ptr_print on core %u\n",
+             BOUND_PTR_PRODUCER_CORE, aotA, jitA, aotB, jitB,
+             (unsigned long long)(after.cacheHits - compiled.cacheHits),
+             BOUND_PTR_WORKER_CORE);
   return 0;
 }
 
@@ -262,14 +290,15 @@ static int run_worker(void) {
     ejit_dump_func("bound_cell_config_mc");
     __atomic_store_n(&g_bound_ptr_demo_stage, BOUND_PTR_DEMO_WORKER_READY,
                      __ATOMIC_RELEASE);
-    SRE_printf("[BOUND-PTR-MC][core=8] worker ready; run test_ejit_period on "
-               "core 18\n");
+    SRE_printf("[BOUND-PTR-MC][core=%u] worker ready; run test_ejit_period "
+               "on core %u\n",
+               BOUND_PTR_WORKER_CORE, BOUND_PTR_PRODUCER_CORE);
     return 0;
   }
 
-  SRE_printf("[BOUND-PTR-MC][core=8] worker already initialized stage=%u; "
+  SRE_printf("[BOUND-PTR-MC][core=%u] worker already initialized stage=%u; "
              "use test_ejit_bound_ptr_print for output\n",
-             stage);
+             BOUND_PTR_WORKER_CORE, stage);
   return 0;
 }
 
@@ -282,20 +311,21 @@ int test_ejit_bound_ptr_print(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   const uint32_t core = (uint32_t)g_ucLocalCoreID;
   if (core != BOUND_PTR_WORKER_CORE) {
     SRE_printf("[BOUND-PTR-MC][core=%u] FAIL: dump is worker-local; run "
-               "test_ejit_bound_ptr_print on core 8\n",
-               core);
+               "test_ejit_bound_ptr_print on core %u\n",
+               core, BOUND_PTR_WORKER_CORE);
     return -9;
   }
 
   uint32_t stage = __atomic_load_n(&g_bound_ptr_demo_stage, __ATOMIC_ACQUIRE);
   if (stage < BOUND_PTR_DEMO_COMPILED) {
-    SRE_printf("[BOUND-PTR-MC][core=8] FAIL stage=%u; run test_ejit_period "
-               "on core 18 first\n",
-               stage);
+    SRE_printf("[BOUND-PTR-MC][core=%u] FAIL stage=%u; run test_ejit_period "
+               "on core %u first\n",
+               BOUND_PTR_WORKER_CORE, stage, BOUND_PTR_PRODUCER_CORE);
     return -10;
   }
   if (stage == BOUND_PTR_DEMO_PRINTED) {
-    SRE_printf("[BOUND-PTR-MC][core=8] dump already printed\n");
+    SRE_printf("[BOUND-PTR-MC][core=%u] dump already printed\n",
+               BOUND_PTR_WORKER_CORE);
     return 0;
   }
 
@@ -304,10 +334,12 @@ int test_ejit_bound_ptr_print(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   ejit_taskpool_print_compiled();
   SRE_printf("\n[BOUND-PTR-MC] === OPTIMIZED FUNCTION ===\n");
   ejit_print_dumped("bound_cell_config_mc");
-  SRE_printf("[BOUND-PTR-MC][core=8] expect: algorithm/scale loads and "
+  SRE_printf("[BOUND-PTR-MC][core=%u] expect: algorithm/scale loads and "
              "branch removed; runtimeBias load retained. The function dump "
-             "is the latest capture (cell=2, scale=9).\n");
-  SRE_printf("[BOUND-PTR-MC][core=8] PASS sink=0x%llx\n",
+             "is the latest capture (cell=2, scale=9).\n",
+             BOUND_PTR_WORKER_CORE);
+  SRE_printf("[BOUND-PTR-MC][core=%u] PASS sink=0x%llx\n",
+             BOUND_PTR_WORKER_CORE,
              (unsigned long long)__atomic_load_n(&g_bound_ptr_demo_sink,
                                                  __ATOMIC_ACQUIRE));
   __atomic_store_n(&g_bound_ptr_demo_stage, BOUND_PTR_DEMO_PRINTED,
@@ -339,8 +371,8 @@ int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   if (rc != EJIT_OK)
     return -1;
   if (worker != BOUND_PTR_WORKER_CORE) {
-    SRE_printf("[BOUND-PTR-MC] FAIL worker=%u; reset and run core 8 first\n",
-               worker);
+    SRE_printf("[BOUND-PTR-MC] FAIL worker=%u; reset and run core %u first\n",
+               worker, BOUND_PTR_WORKER_CORE);
     return -2;
   }
 
@@ -349,6 +381,7 @@ int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   if (core == BOUND_PTR_PRODUCER_CORE)
     return run_producer();
 
-  SRE_printf("[BOUND-PTR-MC][core=%u] skip: use core 8 or core 18\n", core);
+  SRE_printf("[BOUND-PTR-MC][core=%u] skip: use core %u or core %u\n", core,
+             BOUND_PTR_WORKER_CORE, BOUND_PTR_PRODUCER_CORE);
   return 0;
 }

--- a/ejit_test/ejit_bound_ptr_sre_multistruct_test.c
+++ b/ejit_test/ejit_bound_ptr_sre_multistruct_test.c
@@ -1,0 +1,422 @@
+//===-- ejit_bound_ptr_sre_multistruct_test.c - borrowed pointer demo -----===//
+//
+// Board flow after reset:
+//   1. Core 6:  run test_ejit_period.  It initializes the fixed worker,
+//      enables capture, and waits for the producer.
+//   2. Core 16: run test_ejit_period.  It attaches to core 6, activates two
+//      cell versions, and compiles the entry through two shared structures.
+//   3. Core 6:  run test_ejit_bound_ptr_multistruct_print to inspect the
+//      compiled list, entry view, and complete module view.
+//
+// The negative checks use only invalid descriptors.  They do not create a
+// dangling pointer, concurrent write, or other intentional lifetime hazard.
+// Do not call ejit_shutdown(): the owner worker must survive shell invocations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
+#include <stddef.h>
+#include <stdint.h>
+
+extern void SRE_printf(const char *format, ...);
+extern uint32_t SRE_TaskDelay(uint32_t tick);
+extern void call_init_array_functions(void);
+extern uint8_t g_ucLocalCoreID;
+
+#ifndef EJIT_SHARED_SECTION_ATTR
+#define EJIT_SHARED_SECTION_ATTR __attribute__((section(".mc_shared")))
+#endif
+
+#define EJIT_BOUND_MULTI_WORKER_CORE 6u
+#define EJIT_BOUND_MULTI_PRODUCER_CORE 16u
+#define EJIT_BOUND_MULTI_CELL_A 1u
+#define EJIT_BOUND_MULTI_CELL_B 2u
+#define EJIT_BOUND_MULTI_TRP 2u
+#define EJIT_BOUND_MULTI_WAIT_ROUNDS 6000u
+#define EJIT_BOUND_MULTI_WAIT_TICKS 10u
+#define EJIT_BOUND_MULTI_PAYLOAD_WORDS 512u
+
+// These are deliberately larger than 1 KiB. They model shared application
+// state while keeping the request transport fixed at one descriptor each.
+typedef struct {
+  ejit_may_const uint32_t algorithm;
+  ejit_may_const uint32_t scale;
+  uint32_t runtimeBias;
+  uint32_t payload[EJIT_BOUND_MULTI_PAYLOAD_WORDS];
+} EJitBoundMultiCellConfig;
+
+typedef struct {
+  ejit_may_const uint32_t multiplier;
+  ejit_may_const uint32_t offset;
+  uint32_t runtimeTag;
+  uint32_t payload[EJIT_BOUND_MULTI_PAYLOAD_WORDS];
+} EJitBoundMultiTrpConfig;
+
+typedef char EJitBoundMultiCellMustBeLarge[
+    (sizeof(EJitBoundMultiCellConfig) > 1024u) ? 1 : -1];
+typedef char EJitBoundMultiTrpMustBeLarge[
+    (sizeof(EJitBoundMultiTrpConfig) > 1024u) ? 1 : -1];
+typedef char EJitBoundMultiDescriptorMustBeFixed[
+    (sizeof(ejit_bound_ptr_t) <= 32u) ? 1 : -1];
+
+enum BoundMultiStage {
+  BOUND_MULTI_RESET = 0,
+  BOUND_MULTI_WORKER_READY = 1,
+  BOUND_MULTI_COMPILED = 2,
+  BOUND_MULTI_PRINTED = 3,
+};
+
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(cell)
+uint32_t g_bound_multi_cells[8];
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(trp)
+uint32_t g_bound_multi_trps[8];
+EJIT_SHARED_SECTION_ATTR EJitBoundMultiCellConfig
+    g_bound_multi_cell_configs[8] = {
+        [EJIT_BOUND_MULTI_CELL_A] = {7u, 5u, 100u, {0xC011A001u}},
+        [EJIT_BOUND_MULTI_CELL_B] = {7u, 9u, 200u, {0xC011B002u}},
+    };
+EJIT_SHARED_SECTION_ATTR EJitBoundMultiTrpConfig
+    g_bound_multi_trp_configs[8] = {
+        [EJIT_BOUND_MULTI_TRP] = {3u, 11u, 0x7A2u, {0x7A2F0002u}},
+    };
+EJIT_SHARED_SECTION_ATTR volatile uint32_t g_bound_multi_stage;
+EJIT_SHARED_SECTION_ATTR volatile uint64_t g_bound_multi_sink;
+
+// The helper is independently addressable, so propagation is valid only
+// because it has EJIT_ENTRY and both matching dimensions.  It intentionally
+// repeats neither EJIT_BOUND_PTR annotation.
+EJIT_ENTRY uint32_t bound_multi_helper(
+    EJIT_DIM(cell) uint8_t cellIndex, EJIT_DIM(trp) uint8_t trpIndex,
+    const EJitBoundMultiCellConfig *cellConfig,
+    const EJitBoundMultiTrpConfig *trpConfig, uint32_t input) {
+  uint32_t value = input;
+  if (cellConfig->algorithm == 7u)
+    value *= cellConfig->scale;
+  return value + cellConfig->runtimeBias + trpConfig->multiplier +
+         trpConfig->offset + trpConfig->runtimeTag + cellIndex + trpIndex;
+}
+
+EJIT_ENTRY uint32_t bound_multi_root(
+    EJIT_DIM(cell) uint8_t cellIndex, EJIT_DIM(trp) uint8_t trpIndex,
+    EJIT_BOUND_PTR(cell) const EJitBoundMultiCellConfig *cellConfig,
+    EJIT_BOUND_PTR(trp) const EJitBoundMultiTrpConfig *trpConfig,
+    uint32_t input) {
+  return bound_multi_helper(cellIndex, trpIndex, cellConfig, trpConfig, input);
+}
+
+static uint32_t expected_value(uint32_t cell) {
+  const EJitBoundMultiCellConfig *cellConfig =
+      &g_bound_multi_cell_configs[cell];
+  const EJitBoundMultiTrpConfig *trpConfig =
+      &g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP];
+  uint32_t value = 10u;
+  if (cellConfig->algorithm == 7u)
+    value *= cellConfig->scale;
+  return value + cellConfig->runtimeBias + trpConfig->multiplier +
+         trpConfig->offset + trpConfig->runtimeTag + cell +
+         EJIT_BOUND_MULTI_TRP;
+}
+
+static uint32_t call_bound_root(uint32_t cell) {
+  return bound_multi_root(
+      (uint8_t)cell, (uint8_t)EJIT_BOUND_MULTI_TRP,
+      &g_bound_multi_cell_configs[cell],
+      &g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP], 10u);
+}
+
+static int wait_for_compiles(uint64_t baseline, uint32_t expected,
+                             const char *label) {
+  for (uint32_t round = 0; round < EJIT_BOUND_MULTI_WAIT_ROUNDS; ++round) {
+    ejit_taskpool_stats_t stats = {0};
+    (void)ejit_taskpool_get_stats(&stats);
+    if (stats.compileFailed || stats.publishFailed) {
+      SRE_printf("[BOUND-MULTI] FAIL %s compile=%llu publish=%llu\n", label,
+                 (unsigned long long)stats.compileFailed,
+                 (unsigned long long)stats.publishFailed);
+      return 0;
+    }
+    if (stats.asyncCompiles >= baseline + expected &&
+        stats.pendingEntries == 0 && stats.queueApproxSize == 0 &&
+        ejit_taskpool_pending_count() == 0)
+      return 1;
+    if ((round % 500u) == 0)
+      SRE_printf("[BOUND-MULTI] waiting %s compiles=%llu/%llu pending=%u\n",
+                 label, (unsigned long long)(stats.asyncCompiles - baseline),
+                 (unsigned long long)expected, stats.pendingEntries);
+    (void)SRE_TaskDelay(EJIT_BOUND_MULTI_WAIT_TICKS);
+  }
+  SRE_printf("[BOUND-MULTI] FAIL timeout waiting %s\n", label);
+  return 0;
+}
+
+static int check_transport_contract(void) {
+  const size_t cellSize = sizeof(EJitBoundMultiCellConfig);
+  const size_t trpSize = sizeof(EJitBoundMultiTrpConfig);
+  const size_t descriptorSize = sizeof(ejit_bound_ptr_t);
+  if (cellSize <= 1024u || trpSize <= 1024u || descriptorSize > 32u) {
+    SRE_printf("[BOUND-MULTI] FAIL transport sizes cell=%lu trp=%lu "
+               "descriptor=%lu\n",
+               (unsigned long)cellSize, (unsigned long)trpSize,
+               (unsigned long)descriptorSize);
+    return 0;
+  }
+  if (g_bound_multi_cell_configs[EJIT_BOUND_MULTI_CELL_A].payload[0] !=
+          0xC011A001u ||
+      g_bound_multi_cell_configs[EJIT_BOUND_MULTI_CELL_B].payload[0] !=
+          0xC011B002u ||
+      g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP].payload[0] !=
+          0x7A2F0002u) {
+    SRE_printf("[BOUND-MULTI] FAIL shared payload changed during compile\n");
+    return 0;
+  }
+  SRE_printf("[BOUND-MULTI] PASS borrowed transport cell=%luB trp=%luB "
+             "descriptor=%luB; payloads stayed shared\n",
+             (unsigned long)cellSize, (unsigned long)trpSize,
+             (unsigned long)descriptorSize);
+  return 1;
+}
+
+static int check_invalid_descriptors(void) {
+  ejit_bound_ptr_t tooMany[9];
+  for (uint32_t i = 0; i < 9u; ++i) {
+    tooMany[i].rawPtr = &g_bound_multi_cell_configs[EJIT_BOUND_MULTI_CELL_A];
+    tooMany[i].size = (uint32_t)sizeof(EJitBoundMultiCellConfig);
+    tooMany[i].argIndex = i;
+  }
+  ejit_status_t rc = ejit_taskpool_compile_or_get_bound_v(
+      0u, (const ejit_dim_pair_t *)0, 0u, tooMany, 9u, (void **)0,
+      (uint32_t *)0);
+  if (rc != EJIT_ERR_INVALID_PARAM) {
+    SRE_printf("[BOUND-MULTI] FAIL >8 descriptor check rc=%d\n", (int)rc);
+    return 0;
+  }
+
+  ejit_bound_ptr_t nullObject = {
+      (const void *)0, (uint32_t)sizeof(EJitBoundMultiCellConfig), 0u};
+  rc = ejit_taskpool_compile_or_get_bound_v(
+      0u, (const ejit_dim_pair_t *)0, 0u, &nullObject, 1u, (void **)0,
+      (uint32_t *)0);
+  if (rc != EJIT_ERR_INVALID_PARAM) {
+    SRE_printf("[BOUND-MULTI] FAIL null/lifetime check rc=%d\n", (int)rc);
+    return 0;
+  }
+
+  ejit_bound_ptr_t zeroSize = {
+      &g_bound_multi_cell_configs[EJIT_BOUND_MULTI_CELL_A], 0u, 0u};
+  rc = ejit_taskpool_compile_or_get_bound_v(
+      0u, (const ejit_dim_pair_t *)0, 0u, &zeroSize, 1u, (void **)0,
+      (uint32_t *)0);
+  if (rc != EJIT_ERR_INVALID_PARAM) {
+    SRE_printf("[BOUND-MULTI] FAIL zero-size check rc=%d\n", (int)rc);
+    return 0;
+  }
+
+  ejit_bound_ptr_t overflow = {
+      (const void *)(uintptr_t)UINTPTR_MAX, 8u, 0u};
+  rc = ejit_taskpool_compile_or_get_bound_v(
+      0u, (const ejit_dim_pair_t *)0, 0u, &overflow, 1u, (void **)0,
+      (uint32_t *)0);
+  if (rc != EJIT_ERR_INVALID_PARAM) {
+    SRE_printf("[BOUND-MULTI] FAIL overflow check rc=%d\n", (int)rc);
+    return 0;
+  }
+
+  ejit_bound_ptr_t duplicate[2] = {
+      {&g_bound_multi_cell_configs[EJIT_BOUND_MULTI_CELL_A],
+       (uint32_t)sizeof(EJitBoundMultiCellConfig), 0u},
+      {&g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP],
+       (uint32_t)sizeof(EJitBoundMultiTrpConfig), 0u},
+  };
+  rc = ejit_taskpool_compile_or_get_bound_v(
+      0u, (const ejit_dim_pair_t *)0, 0u, duplicate, 2u, (void **)0,
+      (uint32_t *)0);
+  if (rc != EJIT_ERR_INVALID_PARAM) {
+    SRE_printf("[BOUND-MULTI] FAIL duplicate argIndex check rc=%d\n", (int)rc);
+    return 0;
+  }
+
+  SRE_printf("[BOUND-MULTI] PASS invalid descriptor lists rejected before "
+             "worker dereference (>8, null, zero, overflow, duplicate); "
+             "no UAF constructed\n");
+  return 1;
+}
+
+static int run_producer(void) {
+  uint32_t stage = __atomic_load_n(&g_bound_multi_stage, __ATOMIC_ACQUIRE);
+  if (stage != BOUND_MULTI_WORKER_READY) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL stage=%u; run core %u first\n",
+               EJIT_BOUND_MULTI_PRODUCER_CORE, stage,
+               EJIT_BOUND_MULTI_WORKER_CORE);
+    return -3;
+  }
+
+  if (ejit_activate("cell", EJIT_BOUND_MULTI_CELL_A) != EJIT_OK ||
+      ejit_activate("cell", EJIT_BOUND_MULTI_CELL_B) != EJIT_OK ||
+      ejit_activate("trp", EJIT_BOUND_MULTI_TRP) != EJIT_OK) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL activate\n",
+               EJIT_BOUND_MULTI_PRODUCER_CORE);
+    return -4;
+  }
+
+  ejit_clear_cache();
+  if (!check_invalid_descriptors())
+    return -5;
+  if (!check_transport_contract())
+    return -6;
+
+  ejit_taskpool_stats_t before = {0};
+  (void)ejit_taskpool_get_stats(&before);
+
+  // Submit cell A and wait before cell B: current shared dedup is keyed by
+  // function identity, so serial submission makes both cell versions visible.
+  const uint32_t aotA = call_bound_root(EJIT_BOUND_MULTI_CELL_A);
+  if (aotA != expected_value(EJIT_BOUND_MULTI_CELL_A) ||
+      ejit_publish_pending_code() != EJIT_OK ||
+      !wait_for_compiles(before.asyncCompiles, 2u, "cell-A")) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL cell-A AOT/compile\n",
+               EJIT_BOUND_MULTI_PRODUCER_CORE);
+    ejit_taskpool_print_stats();
+    return -7;
+  }
+
+  const uint32_t aotB = call_bound_root(EJIT_BOUND_MULTI_CELL_B);
+  if (aotB != expected_value(EJIT_BOUND_MULTI_CELL_B) ||
+      ejit_publish_pending_code() != EJIT_OK ||
+      !wait_for_compiles(before.asyncCompiles, 4u, "cell-B")) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL cell-B AOT/compile\n",
+               EJIT_BOUND_MULTI_PRODUCER_CORE);
+    ejit_taskpool_print_stats();
+    return -8;
+  }
+
+  ejit_taskpool_stats_t compiled = {0};
+  (void)ejit_taskpool_get_stats(&compiled);
+  const uint32_t jitA = call_bound_root(EJIT_BOUND_MULTI_CELL_A);
+  const uint32_t jitB = call_bound_root(EJIT_BOUND_MULTI_CELL_B);
+  ejit_taskpool_stats_t after = {0};
+  (void)ejit_taskpool_get_stats(&after);
+  if (jitA != expected_value(EJIT_BOUND_MULTI_CELL_A) ||
+      jitB != expected_value(EJIT_BOUND_MULTI_CELL_B) ||
+      after.cacheHits < compiled.cacheHits + 2u) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL JIT cellA=%u cellB=%u "
+               "hits=%llu/%llu\n",
+               EJIT_BOUND_MULTI_PRODUCER_CORE, jitA, jitB,
+               (unsigned long long)(after.cacheHits - compiled.cacheHits),
+               (unsigned long long)2u);
+    return -9;
+  }
+
+  __atomic_store_n(&g_bound_multi_sink,
+                   ((uint64_t)jitA << 32) | (uint64_t)jitB, __ATOMIC_RELEASE);
+  __atomic_store_n(&g_bound_multi_stage, BOUND_MULTI_COMPILED,
+                   __ATOMIC_RELEASE);
+  SRE_printf("[BOUND-MULTI][core=%u] PASS cellA AOT/JIT=%u/%u cellB "
+             "AOT/JIT=%u/%u compiles=%llu hits=%llu; return to core %u "
+             "for dumps\n",
+             EJIT_BOUND_MULTI_PRODUCER_CORE, aotA, jitA, aotB, jitB,
+             (unsigned long long)(after.asyncCompiles - before.asyncCompiles),
+             (unsigned long long)(after.cacheHits - compiled.cacheHits),
+             EJIT_BOUND_MULTI_WORKER_CORE);
+  return 0;
+}
+
+static int run_worker(void) {
+  uint32_t stage = __atomic_load_n(&g_bound_multi_stage, __ATOMIC_ACQUIRE);
+  if (stage == BOUND_MULTI_RESET) {
+    __atomic_store_n(&g_bound_multi_sink, 0u, __ATOMIC_RELEASE);
+    ejit_dump_func("*");
+    __atomic_store_n(&g_bound_multi_stage, BOUND_MULTI_WORKER_READY,
+                     __ATOMIC_RELEASE);
+    SRE_printf("[BOUND-MULTI][core=%u] PASS worker ready; run "
+               "test_ejit_period on core %u\n",
+               EJIT_BOUND_MULTI_WORKER_CORE, EJIT_BOUND_MULTI_PRODUCER_CORE);
+    return 0;
+  }
+  SRE_printf("[BOUND-MULTI][core=%u] worker already ready stage=%u; wait "
+             "for core %u then run test_ejit_bound_ptr_multistruct_print\n",
+             EJIT_BOUND_MULTI_WORKER_CORE, stage,
+             EJIT_BOUND_MULTI_PRODUCER_CORE);
+  return 0;
+}
+
+int test_ejit_bound_ptr_multistruct_print(uint8_t a, uint8_t b, uint8_t c,
+                                          uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  if (core != EJIT_BOUND_MULTI_WORKER_CORE) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL dumps are worker-local; run on "
+               "core %u\n",
+               core, EJIT_BOUND_MULTI_WORKER_CORE);
+    return -10;
+  }
+  uint32_t stage = __atomic_load_n(&g_bound_multi_stage, __ATOMIC_ACQUIRE);
+  if (stage < BOUND_MULTI_COMPILED) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL stage=%u; run producer core %u "
+               "first\n",
+               core, stage, EJIT_BOUND_MULTI_PRODUCER_CORE);
+    return -11;
+  }
+  if (stage == BOUND_MULTI_PRINTED) {
+    SRE_printf("[BOUND-MULTI][core=%u] dumps already printed\n", core);
+    return 0;
+  }
+
+  SRE_printf("[BOUND-MULTI][core=%u] === COMPILED VERSIONS ===\n", core);
+  ejit_taskpool_print_compiled();
+  SRE_printf("[BOUND-MULTI][core=%u] === ROOT ENTRY VIEW ===\n", core);
+  ejit_print_dumped("bound_multi_root");
+  SRE_printf("[BOUND-MULTI][core=%u] === HELPER ENTRY VIEW ===\n", core);
+  ejit_print_dumped("bound_multi_helper");
+  SRE_printf("[BOUND-MULTI][core=%u] === ROOT MODULE VIEW ===\n", core);
+  ejit_print_dumped_module("bound_multi_root");
+  SRE_printf("[BOUND-MULTI][core=%u] PASS sink=0x%llx; expected root/helper "
+             "versions for cell A/B and no payload copy\n"
+             "[BOUND-MULTI] dump criterion: algorithm=7, scale=5/9, "
+             "multiplier=3, offset=11 must be folded in root/helper; "
+             "runtimeBias/runtimeTag remain runtime loads\n",
+             core,
+             (unsigned long long)__atomic_load_n(&g_bound_multi_sink,
+                                                 __ATOMIC_ACQUIRE));
+  __atomic_store_n(&g_bound_multi_stage, BOUND_MULTI_PRINTED,
+                   __ATOMIC_RELEASE);
+  return 0;
+}
+
+int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  SRE_printf("\n=== EJIT borrowed multi-structure demo (core=%u) ===\n", core);
+  call_init_array_functions();
+
+  ejit_config_t cfg = {0};
+  cfg.compileMode = EJIT_COMPILE_ASYNC;
+  cfg.optLevel = EJIT_OPT_L2;
+  cfg.enableLogger = true;
+  cfg.forceStaticRegistry = true;
+
+  ejit_status_t rc = ejit_init(&cfg);
+  uint32_t worker = ejit_taskpool_get_worker_core();
+  SRE_printf("[BOUND-MULTI][core=%u] init rc=%d worker=%u stage=%u\n", core,
+             (int)rc, worker,
+             __atomic_load_n(&g_bound_multi_stage, __ATOMIC_ACQUIRE));
+  if (rc != EJIT_OK)
+    return -1;
+  if (worker != EJIT_BOUND_MULTI_WORKER_CORE) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL worker=%u; expected core %u\n",
+               core, worker, EJIT_BOUND_MULTI_WORKER_CORE);
+    return -2;
+  }
+  if (core == EJIT_BOUND_MULTI_WORKER_CORE)
+    return run_worker();
+  if (core == EJIT_BOUND_MULTI_PRODUCER_CORE)
+    return run_producer();
+  SRE_printf("[BOUND-MULTI][core=%u] skip: use core %u or core %u\n", core,
+             EJIT_BOUND_MULTI_WORKER_CORE, EJIT_BOUND_MULTI_PRODUCER_CORE);
+  return 0;
+}

--- a/ejit_test/ejit_bound_ptr_sre_multistruct_test.c
+++ b/ejit_test/ejit_bound_ptr_sre_multistruct_test.c
@@ -4,7 +4,8 @@
 //   1. Core 6:  run test_ejit_period.  It initializes the fixed worker,
 //      enables capture, and waits for the producer.
 //   2. Core 16: run test_ejit_period.  It attaches to core 6, activates two
-//      cell versions, and compiles the entry through two shared structures.
+//      cell versions, then serially drives helper/root through AOT, 64 real
+//      Tier-1 dispatches, Tier-2 publication, and two Ready calls.
 //   3. Core 6:  run test_ejit_bound_ptr_multistruct_print to inspect the
 //      compiled list, entry view, and complete module view.
 //
@@ -14,9 +15,100 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
-#include <stddef.h>
-#include <stdint.h>
+// Kept self-contained for direct board integration: no project or libc
+// headers are required by this file.
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef __SIZE_TYPE__ size_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+typedef _Bool bool;
+
+#define true 1
+#define false 0
+#define UINTPTR_MAX (~(uintptr_t)0)
+
+#define EJIT_PERIOD_CONST __attribute__((ejit_period_const))
+#define EJIT_IN_PERIOD_ARRAY(x) __attribute__((ejit_in_period_array(#x)))
+#define EJIT_DIM(x) __attribute__((ejit_dim(#x)))
+#define EJIT_BOUND_PTR(x) __attribute__((ejit_bound_ptr(#x)))
+#define ejit_entry __attribute__((ejit_entry))
+#define EJIT_ENTRY ejit_entry
+
+#define ejit_may_const EJIT_PERIOD_CONST
+#define ejit_period_arr(x) EJIT_IN_PERIOD_ARRAY(x)
+
+typedef enum {
+  EJIT_OK = 0,
+  EJIT_ERR_INVALID_PARAM = -1,
+} ejit_status_t;
+
+typedef enum {
+  EJIT_COMPILE_SYNC = 0,
+  EJIT_COMPILE_ASYNC = 1,
+} ejit_compile_mode_t;
+
+typedef enum {
+  EJIT_OPT_L1 = 1,
+  EJIT_OPT_L2 = 2,
+  EJIT_OPT_L3 = 3,
+} ejit_opt_level_t;
+
+typedef struct {
+  ejit_compile_mode_t compileMode;
+  ejit_opt_level_t optLevel;
+  size_t maxCodeMemory;
+  size_t maxDataMemory;
+  size_t maxCacheEntries;
+  size_t maxCacheSize;
+  bool enableLogger;
+  bool forceStaticRegistry;
+  const char *dumpJITDir;
+} ejit_config_t;
+
+typedef struct {
+  uint32_t dimType;
+  uint32_t instanceId;
+} ejit_dim_pair_t;
+
+typedef struct {
+  const void *rawPtr;
+  uint32_t size;
+  uint32_t argIndex;
+} ejit_bound_ptr_t;
+
+typedef struct {
+  uint64_t cacheHits;
+  uint64_t asyncCompiles;
+  uint64_t asyncEnqueues;
+  uint64_t alreadyPending;
+  uint64_t queueFull;
+  uint64_t compileFailed;
+  uint64_t publishFailed;
+  uint64_t instanceDisabled;
+  uint64_t instanceDisabledPreActivate;
+  uint32_t readyEntries;
+  uint32_t pendingEntries;
+  uint32_t queueApproxSize;
+  uint32_t reserved;
+} ejit_taskpool_stats_t;
+
+extern ejit_status_t ejit_init_pgo(const ejit_config_t *config);
+extern ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx);
+extern bool ejit_is_active(const char *periodName, uint32_t cellIdx);
+extern void ejit_clear_cache(void);
+extern unsigned ejit_taskpool_pending_count(void);
+extern ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out);
+extern void ejit_taskpool_print_stats(void);
+extern void ejit_taskpool_print_compiled(void);
+extern uint32_t ejit_taskpool_get_worker_core(void);
+extern ejit_status_t ejit_taskpool_compile_or_get_bound_v(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const ejit_bound_ptr_t *bounds, uint32_t boundCount, void **outFn,
+    uint32_t *outBucket);
+extern void ejit_dump_func(const char *name);
+extern void ejit_print_dumped(const char *name);
+extern void ejit_print_dumped_module(const char *name);
 
 extern void SRE_printf(const char *format, ...);
 extern uint32_t SRE_TaskDelay(uint32_t tick);
@@ -35,6 +127,7 @@ extern uint8_t g_ucLocalCoreID;
 #define EJIT_BOUND_MULTI_WAIT_ROUNDS 6000u
 #define EJIT_BOUND_MULTI_WAIT_TICKS 10u
 #define EJIT_BOUND_MULTI_PAYLOAD_WORDS 512u
+#define EJIT_BOUND_MULTI_T1_SAMPLES 64u
 
 // These are deliberately larger than 1 KiB. They model shared application
 // state while keeping the request transport fixed at one descriptor each.
@@ -52,12 +145,13 @@ typedef struct {
   uint32_t payload[EJIT_BOUND_MULTI_PAYLOAD_WORDS];
 } EJitBoundMultiTrpConfig;
 
-typedef char EJitBoundMultiCellMustBeLarge[
-    (sizeof(EJitBoundMultiCellConfig) > 1024u) ? 1 : -1];
-typedef char EJitBoundMultiTrpMustBeLarge[
-    (sizeof(EJitBoundMultiTrpConfig) > 1024u) ? 1 : -1];
-typedef char EJitBoundMultiDescriptorMustBeFixed[
-    (sizeof(ejit_bound_ptr_t) <= 32u) ? 1 : -1];
+typedef char EJitBoundMultiCellMustBeLarge
+    [(sizeof(EJitBoundMultiCellConfig) > 1024u) ? 1 : -1];
+typedef char EJitBoundMultiTrpMustBeLarge
+    [(sizeof(EJitBoundMultiTrpConfig) > 1024u) ? 1 : -1];
+typedef char
+    EJitBoundMultiDescriptorMustBeFixed[(sizeof(ejit_bound_ptr_t) <= 32u) ? 1
+                                                                          : -1];
 
 enum BoundMultiStage {
   BOUND_MULTI_RESET = 0,
@@ -74,21 +168,21 @@ EJIT_SHARED_SECTION_ATTR EJitBoundMultiCellConfig
     g_bound_multi_cell_configs[8] = {
         [EJIT_BOUND_MULTI_CELL_A] = {7u, 5u, 100u, {0xC011A001u}},
         [EJIT_BOUND_MULTI_CELL_B] = {7u, 9u, 200u, {0xC011B002u}},
-    };
+};
 EJIT_SHARED_SECTION_ATTR EJitBoundMultiTrpConfig
     g_bound_multi_trp_configs[8] = {
         [EJIT_BOUND_MULTI_TRP] = {3u, 11u, 0x7A2u, {0x7A2F0002u}},
-    };
+};
 EJIT_SHARED_SECTION_ATTR volatile uint32_t g_bound_multi_stage;
 EJIT_SHARED_SECTION_ATTR volatile uint64_t g_bound_multi_sink;
 
-// The helper is independently addressable, so propagation is valid only
-// because it has EJIT_ENTRY and both matching dimensions.  It intentionally
-// repeats neither EJIT_BOUND_PTR annotation.
-EJIT_ENTRY uint32_t bound_multi_helper(
+// The helper owns an independent specialization identity and repeats the
+// matching dimension and bound-pointer contracts for both objects.
+ejit_entry uint32_t bound_multi_helper(
     EJIT_DIM(cell) uint8_t cellIndex, EJIT_DIM(trp) uint8_t trpIndex,
-    const EJitBoundMultiCellConfig *cellConfig,
-    const EJitBoundMultiTrpConfig *trpConfig, uint32_t input) {
+    EJIT_BOUND_PTR(cell) const EJitBoundMultiCellConfig *cellConfig,
+    EJIT_BOUND_PTR(trp) const EJitBoundMultiTrpConfig *trpConfig,
+    uint32_t input) {
   uint32_t value = input;
   if (cellConfig->algorithm == 7u)
     value *= cellConfig->scale;
@@ -96,7 +190,7 @@ EJIT_ENTRY uint32_t bound_multi_helper(
          trpConfig->offset + trpConfig->runtimeTag + cellIndex + trpIndex;
 }
 
-EJIT_ENTRY uint32_t bound_multi_root(
+ejit_entry uint32_t bound_multi_root(
     EJIT_DIM(cell) uint8_t cellIndex, EJIT_DIM(trp) uint8_t trpIndex,
     EJIT_BOUND_PTR(cell) const EJitBoundMultiCellConfig *cellConfig,
     EJIT_BOUND_PTR(trp) const EJitBoundMultiTrpConfig *trpConfig,
@@ -118,34 +212,161 @@ static uint32_t expected_value(uint32_t cell) {
 }
 
 static uint32_t call_bound_root(uint32_t cell) {
-  return bound_multi_root(
-      (uint8_t)cell, (uint8_t)EJIT_BOUND_MULTI_TRP,
-      &g_bound_multi_cell_configs[cell],
-      &g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP], 10u);
+  return bound_multi_root((uint8_t)cell, (uint8_t)EJIT_BOUND_MULTI_TRP,
+                          &g_bound_multi_cell_configs[cell],
+                          &g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP],
+                          10u);
 }
 
-static int wait_for_compiles(uint64_t baseline, uint32_t expected,
-                             const char *label) {
+enum BoundMultiTarget {
+  BOUND_MULTI_HELPER = 0,
+  BOUND_MULTI_ROOT = 1,
+};
+
+static const char *target_name(uint32_t target) {
+  return target == BOUND_MULTI_HELPER ? "helper" : "root";
+}
+
+static uint32_t call_bound_target(uint32_t target, uint32_t cell) {
+  if (target == BOUND_MULTI_HELPER)
+    return bound_multi_helper((uint8_t)cell, (uint8_t)EJIT_BOUND_MULTI_TRP,
+                              &g_bound_multi_cell_configs[cell],
+                              &g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP],
+                              10u);
+  return call_bound_root(cell);
+}
+
+static void print_profile_state(const char *phase, uint32_t target,
+                                uint32_t cell, uint32_t calls,
+                                uint64_t baseline,
+                                const ejit_taskpool_stats_t *stats) {
+  const uint64_t compiled =
+      stats->asyncCompiles >= baseline ? stats->asyncCompiles - baseline : 0u;
+  SRE_printf("[BOUND-MULTI] pgo=1 phase=%s target=%s cell=%u calls=%u "
+             "compiled=%llu/2 active(cell/trp)=%u/%u pending=%u/%u "
+             "queue=%u failed=%llu/%llu\n",
+             phase, target_name(target), cell, calls,
+             (unsigned long long)compiled,
+             (unsigned)ejit_is_active("cell", cell),
+             (unsigned)ejit_is_active("trp", EJIT_BOUND_MULTI_TRP),
+             ejit_taskpool_pending_count(), stats->pendingEntries,
+             stats->queueApproxSize, (unsigned long long)stats->compileFailed,
+             (unsigned long long)stats->publishFailed);
+}
+
+static int wait_for_t1(uint64_t baseline, uint32_t target, uint32_t cell) {
+  uint32_t emptyRounds = 0;
   for (uint32_t round = 0; round < EJIT_BOUND_MULTI_WAIT_ROUNDS; ++round) {
     ejit_taskpool_stats_t stats = {0};
-    (void)ejit_taskpool_get_stats(&stats);
+    if (ejit_taskpool_get_stats(&stats) != EJIT_OK)
+      return 0;
     if (stats.compileFailed || stats.publishFailed) {
-      SRE_printf("[BOUND-MULTI] FAIL %s compile=%llu publish=%llu\n", label,
-                 (unsigned long long)stats.compileFailed,
-                 (unsigned long long)stats.publishFailed);
+      print_profile_state("T1-failed", target, cell, 1u, baseline, &stats);
       return 0;
     }
-    if (stats.asyncCompiles >= baseline + expected &&
-        stats.pendingEntries == 0 && stats.queueApproxSize == 0 &&
+    if (stats.asyncCompiles >= baseline + 1u &&
         ejit_taskpool_pending_count() == 0)
       return 1;
+    if (stats.pendingEntries == 0 && stats.queueApproxSize == 0 &&
+        ejit_taskpool_pending_count() == 0 &&
+        stats.asyncCompiles < baseline + 1u) {
+      if (++emptyRounds >= 5u) {
+        print_profile_state("T1-missing", target, cell, 1u, baseline, &stats);
+        return 0;
+      }
+    } else {
+      emptyRounds = 0;
+    }
     if ((round % 500u) == 0)
-      SRE_printf("[BOUND-MULTI] waiting %s compiles=%llu/%llu pending=%u\n",
-                 label, (unsigned long long)(stats.asyncCompiles - baseline),
-                 (unsigned long long)expected, stats.pendingEntries);
+      print_profile_state("T1-wait", target, cell, 1u, baseline, &stats);
     (void)SRE_TaskDelay(EJIT_BOUND_MULTI_WAIT_TICKS);
   }
-  SRE_printf("[BOUND-MULTI] FAIL timeout waiting %s\n", label);
+  ejit_taskpool_stats_t stats = {0};
+  (void)ejit_taskpool_get_stats(&stats);
+  print_profile_state("T1-timeout", target, cell, 1u, baseline, &stats);
+  return 0;
+}
+
+static int drive_profile(uint32_t target, uint32_t cell, uint64_t *sink) {
+  ejit_taskpool_stats_t before = {0};
+  if (ejit_taskpool_get_stats(&before) != EJIT_OK)
+    return 0;
+  const uint64_t baseline = before.asyncCompiles;
+  const uint32_t expected = expected_value(cell);
+
+  uint32_t got = call_bound_target(target, cell);
+  if (got != expected || !wait_for_t1(baseline, target, cell)) {
+    SRE_printf("[BOUND-MULTI] FAIL target=%s cell=%u initial=%u expected=%u\n",
+               target_name(target), cell, got, expected);
+    return 0;
+  }
+  *sink ^= got;
+
+  for (uint32_t sample = 0; sample < EJIT_BOUND_MULTI_T1_SAMPLES; ++sample) {
+    got = call_bound_target(target, cell);
+    if (got != expected) {
+      SRE_printf("[BOUND-MULTI] FAIL target=%s cell=%u sample=%u/%u "
+                 "got=%u expected=%u\n",
+                 target_name(target), cell, sample + 1u,
+                 EJIT_BOUND_MULTI_T1_SAMPLES, got, expected);
+      return 0;
+    }
+    *sink ^= got;
+    if (sample == 0u || ((sample + 1u) % 16u) == 0u) {
+      ejit_taskpool_stats_t stats = {0};
+      (void)ejit_taskpool_get_stats(&stats);
+      print_profile_state("T1-sampling", target, cell, sample + 1u, baseline,
+                          &stats);
+    }
+    if (((sample + 1u) % 8u) == 0u)
+      (void)SRE_TaskDelay(1u);
+  }
+
+  for (uint32_t round = 0; round < EJIT_BOUND_MULTI_WAIT_ROUNDS; ++round) {
+    // Calls after the quota keep the wrapper progressing through AOT fallback,
+    // deferred Tier-2 enqueue, compile, publish, and finally Ready dispatch.
+    got = call_bound_target(target, cell);
+    if (got != expected)
+      return 0;
+    *sink ^= got;
+
+    ejit_taskpool_stats_t stats = {0};
+    if (ejit_taskpool_get_stats(&stats) != EJIT_OK)
+      return 0;
+    if (stats.compileFailed || stats.publishFailed) {
+      print_profile_state("T2-failed", target, cell,
+                          EJIT_BOUND_MULTI_T1_SAMPLES + round + 1u, baseline,
+                          &stats);
+      return 0;
+    }
+    if (stats.asyncCompiles >= baseline + 2u && stats.pendingEntries == 0 &&
+        stats.queueApproxSize == 0 && ejit_taskpool_pending_count() == 0) {
+      // Do not equate publication with execution: call the Ready version twice.
+      const uint32_t verify1 = call_bound_target(target, cell);
+      const uint32_t verify2 = call_bound_target(target, cell);
+      if (verify1 != expected || verify2 != expected)
+        return 0;
+      *sink ^= verify1;
+      *sink ^= verify2;
+      print_profile_state("T2-ready", target, cell,
+                          EJIT_BOUND_MULTI_T1_SAMPLES + round + 3u, baseline,
+                          &stats);
+      return 1;
+    }
+    if (round == 0u || ((round + 1u) % 500u) == 0u)
+      print_profile_state("T2-wait", target, cell,
+                          EJIT_BOUND_MULTI_T1_SAMPLES + round + 1u, baseline,
+                          &stats);
+    if (((round + 1u) % 8u) == 0u)
+      (void)SRE_TaskDelay(1u);
+  }
+
+  ejit_taskpool_stats_t stats = {0};
+  (void)ejit_taskpool_get_stats(&stats);
+  print_profile_state("T2-timeout", target, cell,
+                      EJIT_BOUND_MULTI_T1_SAMPLES +
+                          EJIT_BOUND_MULTI_WAIT_ROUNDS,
+                      baseline, &stats);
   return 0;
 }
 
@@ -193,9 +414,9 @@ static int check_invalid_descriptors(void) {
 
   ejit_bound_ptr_t nullObject = {
       (const void *)0, (uint32_t)sizeof(EJitBoundMultiCellConfig), 0u};
-  rc = ejit_taskpool_compile_or_get_bound_v(
-      0u, (const ejit_dim_pair_t *)0, 0u, &nullObject, 1u, (void **)0,
-      (uint32_t *)0);
+  rc = ejit_taskpool_compile_or_get_bound_v(0u, (const ejit_dim_pair_t *)0, 0u,
+                                            &nullObject, 1u, (void **)0,
+                                            (uint32_t *)0);
   if (rc != EJIT_ERR_INVALID_PARAM) {
     SRE_printf("[BOUND-MULTI] FAIL null/lifetime check rc=%d\n", (int)rc);
     return 0;
@@ -203,19 +424,18 @@ static int check_invalid_descriptors(void) {
 
   ejit_bound_ptr_t zeroSize = {
       &g_bound_multi_cell_configs[EJIT_BOUND_MULTI_CELL_A], 0u, 0u};
-  rc = ejit_taskpool_compile_or_get_bound_v(
-      0u, (const ejit_dim_pair_t *)0, 0u, &zeroSize, 1u, (void **)0,
-      (uint32_t *)0);
+  rc = ejit_taskpool_compile_or_get_bound_v(0u, (const ejit_dim_pair_t *)0, 0u,
+                                            &zeroSize, 1u, (void **)0,
+                                            (uint32_t *)0);
   if (rc != EJIT_ERR_INVALID_PARAM) {
     SRE_printf("[BOUND-MULTI] FAIL zero-size check rc=%d\n", (int)rc);
     return 0;
   }
 
-  ejit_bound_ptr_t overflow = {
-      (const void *)(uintptr_t)UINTPTR_MAX, 8u, 0u};
-  rc = ejit_taskpool_compile_or_get_bound_v(
-      0u, (const ejit_dim_pair_t *)0, 0u, &overflow, 1u, (void **)0,
-      (uint32_t *)0);
+  ejit_bound_ptr_t overflow = {(const void *)(uintptr_t)UINTPTR_MAX, 8u, 0u};
+  rc = ejit_taskpool_compile_or_get_bound_v(0u, (const ejit_dim_pair_t *)0, 0u,
+                                            &overflow, 1u, (void **)0,
+                                            (uint32_t *)0);
   if (rc != EJIT_ERR_INVALID_PARAM) {
     SRE_printf("[BOUND-MULTI] FAIL overflow check rc=%d\n", (int)rc);
     return 0;
@@ -227,9 +447,9 @@ static int check_invalid_descriptors(void) {
       {&g_bound_multi_trp_configs[EJIT_BOUND_MULTI_TRP],
        (uint32_t)sizeof(EJitBoundMultiTrpConfig), 0u},
   };
-  rc = ejit_taskpool_compile_or_get_bound_v(
-      0u, (const ejit_dim_pair_t *)0, 0u, duplicate, 2u, (void **)0,
-      (uint32_t *)0);
+  rc = ejit_taskpool_compile_or_get_bound_v(0u, (const ejit_dim_pair_t *)0, 0u,
+                                            duplicate, 2u, (void **)0,
+                                            (uint32_t *)0);
   if (rc != EJIT_ERR_INVALID_PARAM) {
     SRE_printf("[BOUND-MULTI] FAIL duplicate argIndex check rc=%d\n", (int)rc);
     return 0;
@@ -266,56 +486,45 @@ static int run_producer(void) {
 
   ejit_taskpool_stats_t before = {0};
   (void)ejit_taskpool_get_stats(&before);
-
-  // Submit cell A and wait before cell B: current shared dedup is keyed by
-  // function identity, so serial submission makes both cell versions visible.
-  const uint32_t aotA = call_bound_root(EJIT_BOUND_MULTI_CELL_A);
-  if (aotA != expected_value(EJIT_BOUND_MULTI_CELL_A) ||
-      ejit_publish_pending_code() != EJIT_OK ||
-      !wait_for_compiles(before.asyncCompiles, 2u, "cell-A")) {
-    SRE_printf("[BOUND-MULTI][core=%u] FAIL cell-A AOT/compile\n",
-               EJIT_BOUND_MULTI_PRODUCER_CORE);
-    ejit_taskpool_print_stats();
-    return -7;
+  uint64_t sink = 0;
+  const uint32_t cells[2] = {EJIT_BOUND_MULTI_CELL_A, EJIT_BOUND_MULTI_CELL_B};
+  for (uint32_t i = 0; i < 2u; ++i) {
+    const uint32_t cell = cells[i];
+    // Finish the helper identity first, then root. This prevents two functions
+    // or two cells of one function from occupying PGO admission slots while
+    // waiting on each other.
+    if (!drive_profile(BOUND_MULTI_HELPER, cell, &sink) ||
+        !drive_profile(BOUND_MULTI_ROOT, cell, &sink)) {
+      SRE_printf("[BOUND-MULTI][core=%u] FAIL profile target cell=%u\n",
+                 EJIT_BOUND_MULTI_PRODUCER_CORE, cell);
+      ejit_taskpool_print_stats();
+      return -7;
+    }
   }
 
-  const uint32_t aotB = call_bound_root(EJIT_BOUND_MULTI_CELL_B);
-  if (aotB != expected_value(EJIT_BOUND_MULTI_CELL_B) ||
-      ejit_publish_pending_code() != EJIT_OK ||
-      !wait_for_compiles(before.asyncCompiles, 4u, "cell-B")) {
-    SRE_printf("[BOUND-MULTI][core=%u] FAIL cell-B AOT/compile\n",
-               EJIT_BOUND_MULTI_PRODUCER_CORE);
-    ejit_taskpool_print_stats();
-    return -8;
-  }
-
-  ejit_taskpool_stats_t compiled = {0};
-  (void)ejit_taskpool_get_stats(&compiled);
-  const uint32_t jitA = call_bound_root(EJIT_BOUND_MULTI_CELL_A);
-  const uint32_t jitB = call_bound_root(EJIT_BOUND_MULTI_CELL_B);
   ejit_taskpool_stats_t after = {0};
   (void)ejit_taskpool_get_stats(&after);
-  if (jitA != expected_value(EJIT_BOUND_MULTI_CELL_A) ||
-      jitB != expected_value(EJIT_BOUND_MULTI_CELL_B) ||
-      after.cacheHits < compiled.cacheHits + 2u) {
-    SRE_printf("[BOUND-MULTI][core=%u] FAIL JIT cellA=%u cellB=%u "
-               "hits=%llu/%llu\n",
-               EJIT_BOUND_MULTI_PRODUCER_CORE, jitA, jitB,
-               (unsigned long long)(after.cacheHits - compiled.cacheHits),
-               (unsigned long long)2u);
+  if (after.asyncCompiles < before.asyncCompiles + 8u || after.compileFailed ||
+      after.publishFailed || ejit_taskpool_pending_count() != 0) {
+    SRE_printf("[BOUND-MULTI][core=%u] FAIL final compiles=%llu/8 "
+               "failed=%llu/%llu pending=%u\n",
+               EJIT_BOUND_MULTI_PRODUCER_CORE,
+               (unsigned long long)(after.asyncCompiles - before.asyncCompiles),
+               (unsigned long long)after.compileFailed,
+               (unsigned long long)after.publishFailed,
+               ejit_taskpool_pending_count());
     return -9;
   }
 
-  __atomic_store_n(&g_bound_multi_sink,
-                   ((uint64_t)jitA << 32) | (uint64_t)jitB, __ATOMIC_RELEASE);
+  __atomic_store_n(&g_bound_multi_sink, sink, __ATOMIC_RELEASE);
   __atomic_store_n(&g_bound_multi_stage, BOUND_MULTI_COMPILED,
                    __ATOMIC_RELEASE);
-  SRE_printf("[BOUND-MULTI][core=%u] PASS cellA AOT/JIT=%u/%u cellB "
-             "AOT/JIT=%u/%u compiles=%llu hits=%llu; return to core %u "
-             "for dumps\n",
-             EJIT_BOUND_MULTI_PRODUCER_CORE, aotA, jitA, aotB, jitB,
+  SRE_printf("[BOUND-MULTI][core=%u] PASS helper/root T2 Ready for cell=%u/%u "
+             "compiles=%llu hits=%llu; return to core %u for dumps\n",
+             EJIT_BOUND_MULTI_PRODUCER_CORE, EJIT_BOUND_MULTI_CELL_A,
+             EJIT_BOUND_MULTI_CELL_B,
              (unsigned long long)(after.asyncCompiles - before.asyncCompiles),
-             (unsigned long long)(after.cacheHits - compiled.cacheHits),
+             (unsigned long long)(after.cacheHits - before.cacheHits),
              EJIT_BOUND_MULTI_WORKER_CORE);
   return 0;
 }
@@ -380,8 +589,7 @@ int test_ejit_bound_ptr_multistruct_print(uint8_t a, uint8_t b, uint8_t c,
              core,
              (unsigned long long)__atomic_load_n(&g_bound_multi_sink,
                                                  __ATOMIC_ACQUIRE));
-  __atomic_store_n(&g_bound_multi_stage, BOUND_MULTI_PRINTED,
-                   __ATOMIC_RELEASE);
+  __atomic_store_n(&g_bound_multi_stage, BOUND_MULTI_PRINTED, __ATOMIC_RELEASE);
   return 0;
 }
 
@@ -400,7 +608,7 @@ int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
   cfg.enableLogger = true;
   cfg.forceStaticRegistry = true;
 
-  ejit_status_t rc = ejit_init(&cfg);
+  ejit_status_t rc = ejit_init_pgo(&cfg);
   uint32_t worker = ejit_taskpool_get_worker_core();
   SRE_printf("[BOUND-MULTI][core=%u] init rc=%d worker=%u stage=%u\n", core,
              (int)rc, worker,

--- a/ejit_test/ejit_bound_ptr_test.c
+++ b/ejit_test/ejit_bound_ptr_test.c
@@ -1,4 +1,4 @@
-//===-- ejit_bound_ptr_test.c - Dimension-bound pointee snapshot test -----===//
+//===-- ejit_bound_ptr_test.c - Dimension-bound raw pointer test -----------===//
 
 #include <stdint.h>
 #include <stdio.h>
@@ -26,32 +26,32 @@ ejit_entry uint32_t bound_cell_config(ejit_period_arr_ind(cell)
   return input + cellRelated->runtimeBias;
 }
 
-static uint32_t call_with_stack_instance(uint8_t cellIndex, uint8_t trpIndex,
-                                         uint32_t runtimeBias) {
-  CellRelated Local = {7, 5, runtimeBias};
-  return bound_cell_config(cellIndex, trpIndex, &Local, 10);
+static uint32_t call_with_instance(uint8_t cellIndex, uint8_t trpIndex,
+                                   const CellRelated *config) {
+  return bound_cell_config(cellIndex, trpIndex, config, 10);
 }
 
 int main(void) {
   const uint8_t Cell = 3;
   const uint8_t Trp = 2;
-  ejit_config_t Config;
-  ejit_default_config(&Config);
-  if (ejit_init(&Config) != EJIT_OK)
+  ejit_config_t RuntimeConfig;
+  ejit_default_config(&RuntimeConfig);
+  if (ejit_init(&RuntimeConfig) != EJIT_OK)
     return 1;
   if (ejit_activate("cell", Cell) != EJIT_OK ||
       ejit_activate("trp", Trp) != EJIT_OK)
     return 2;
 
+  // Keep the shared object alive until the asynchronous worker has finished.
+  // A stack-local object that dies after the entry call is not supported.
+  static const CellRelated CellConfig = {7, 5, 100};
   ejit_dump_func("bound_cell_config");
-  uint32_t Aot = call_with_stack_instance(Cell, Trp, 100);
+  uint32_t Aot = call_with_instance(Cell, Trp, &CellConfig);
   ejit_drain_taskpool();
 
-  // The first stack object is gone. The specialization must have consumed its
-  // owned snapshot, while this call's dynamic field must still be read here.
-  uint32_t Jit = call_with_stack_instance(Cell, Trp, 200);
+  uint32_t Jit = call_with_instance(Cell, Trp, &CellConfig);
   uint32_t ExpectedAot = 10 * 5 + 100 + Cell + Trp;
-  uint32_t ExpectedJit = 10 * 5 + 200 + Cell + Trp;
+  uint32_t ExpectedJit = ExpectedAot;
   printf("AOT=%u expected=%u JIT=%u expected=%u\n", Aot, ExpectedAot, Jit,
          ExpectedJit);
   ejit_print_dumped("bound_cell_config");

--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -376,6 +376,7 @@ def doit_gc_merge(args):
     optional_api = [
         "ejit_register_lifecycle", "ejit_register_funcindex",
         "ejit_taskpool_compile_or_get", "ejit_taskpool_compile_or_get_bound",
+        "ejit_taskpool_compile_or_get_bound_v",
         "ejit_taskpool_release_read",
         "ejit_taskpool_compile_or_get_0d", "ejit_taskpool_compile_or_get_1d",
         "ejit_taskpool_compile_or_get_2d", "ejit_taskpool_compile_or_get_3d",

--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -375,7 +375,8 @@ def doit_gc_merge(args):
     ]
     optional_api = [
         "ejit_register_lifecycle", "ejit_register_funcindex",
-        "ejit_taskpool_compile_or_get", "ejit_taskpool_release_read",
+        "ejit_taskpool_compile_or_get", "ejit_taskpool_compile_or_get_bound",
+        "ejit_taskpool_release_read",
         "ejit_taskpool_compile_or_get_0d", "ejit_taskpool_compile_or_get_1d",
         "ejit_taskpool_compile_or_get_2d", "ejit_taskpool_compile_or_get_3d",
         "ejit_taskpool_compile_or_get_4d",
@@ -384,7 +385,7 @@ def doit_gc_merge(args):
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
         "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped",
-        "ejit_dump_all", "ejit_print_mayconst_ranking",
+        "ejit_print_dumped_module", "ejit_dump_all", "ejit_print_mayconst_ranking",
         # Inline-cache: ejit_register_icache_slot is called from
         # ejit_auto_register (AOT) when -ejit-inline-cache is on, not from the
         # runtime, so gc-merge's --gc-sections would discard it without this GC

--- a/jit_design_doc/EJIT_BOUND_PTR.md
+++ b/jit_design_doc/EJIT_BOUND_PTR.md
@@ -28,10 +28,19 @@ Only loads of `ejit_may_const` fields are replaced from the snapshot. Other
 fields, such as `runtime_bias` above, remain ordinary loads through the pointer
 passed to each invocation of the JIT function.
 
+The annotation belongs only on the `ejit_entry` parameter. When that pointer is
+passed through non-inlined direct helpers, EJIT tracks the corresponding formal
+argument through the call chain and specializes marked field loads in those
+helpers from the same owned snapshot. Helpers do not need `ejit_entry` or a
+repeated `EJIT_BOUND_PTR` annotation.
+
 ## Contract and limits
 
 - The function must have exactly one matching `EJIT_DIM(period)` parameter.
 - The first implementation supports one `EJIT_BOUND_PTR` parameter per entry.
+- Helper propagation accepts pointer casts and constant-offset GEPs. It stops
+  conservatively at indirect calls, address-taken helpers, or a helper argument
+  that receives different pointer sources at different call sites.
 - The copy is shallow. Pointer fields inside the object are not followed.
 - An `ejit_may_const` field must remain stable while its period instance is
   active. Change it only as part of the normal deactivate/update/reactivate

--- a/jit_design_doc/EJIT_BOUND_PTR.md
+++ b/jit_design_doc/EJIT_BOUND_PTR.md
@@ -1,8 +1,9 @@
-# EJIT dimension-bound pointer snapshots
+# EJIT dimension-bound pointers
 
-`EJIT_BOUND_PTR(period)` associates one pointer parameter with an existing
-`EJIT_DIM(period)` parameter. It lets EJIT specialize fields whose values are
-stable for that period instance without requiring a global array name.
+`EJIT_BOUND_PTR(period)` associates a pointer parameter with an existing
+`EJIT_DIM(period)` parameter. It lets EJIT specialize `ejit_may_const` fields
+whose values are stable for a period instance without requiring a global array
+name.
 
 ```c
 typedef struct {
@@ -19,39 +20,75 @@ EJIT_ENTRY uint32_t process(
 }
 ```
 
-On a real JIT cache miss, the wrapper copies the complete `CellConfig` object
-into the compile request before returning. The asynchronous worker therefore
-never retains or dereferences the caller's pointer. Stack-local objects are
-safe to destroy immediately after the entry call.
+## Runtime model
 
-Only loads of `ejit_may_const` fields are replaced from the snapshot. Other
-fields, such as `runtime_bias` above, remain ordinary loads through the pointer
-passed to each invocation of the JIT function.
+The wrapper passes a fixed descriptor containing `{rawPtr, size, argIndex}`.
+The descriptor is copied into the request and queue, but the pointee bytes are
+never copied. The worker reads the object through `rawPtr` only during the
+actual compilation pass. The compile callback must finish all reads before it
+returns.
 
-The annotation belongs only on the `ejit_entry` parameter. When that pointer is
-passed through non-inlined direct helpers, EJIT tracks the corresponding formal
-argument through the call chain and specializes marked field loads in those
-helpers from the same owned snapshot. Helpers do not need `ejit_entry` or a
-repeated `EJIT_BOUND_PTR` annotation.
+The caller owns every object and must guarantee all of the following from
+enqueue until compilation finishes:
 
-## Contract and limits
+- the object remains alive and mapped;
+- producer and worker cores can use the same virtual address;
+- no thread writes the object while the worker reads it;
+- an active dimension specialization keeps the object's relevant contents
+  stable.
 
-- The function must have exactly one matching `EJIT_DIM(period)` parameter.
-- The first implementation supports one `EJIT_BOUND_PTR` parameter per entry.
-- Helper propagation accepts pointer casts and constant-offset GEPs. It stops
-  conservatively at indirect calls, address-taken helpers, or a helper argument
-  that receives different pointer sources at different call sites.
-- The copy is shallow. Pointer fields inside the object are not followed.
-- An `ejit_may_const` field must remain stable while its period instance is
-  active. Change it only as part of the normal deactivate/update/reactivate
-  lifecycle so the period version invalidates old specialized code.
-- The default snapshot cap is 256 bytes. Configure
-  `EJIT_BOUND_PTR_MAX_BYTES` to a positive multiple of 8 when a larger object
-  is required. An oversize request falls back to AOT without queuing work.
-- Volatile, atomic, bit-field, union, dynamically indexed, and unmarked field
-  loads are never folded from the snapshot.
+To update a bound object, deactivate the dimension, modify the object, and
+reactivate the dimension. Changing a pointer or its contents without that
+protocol is a contract violation. The pointer and pointee contents are
+transport data, not cache identity, so changing them does not create a new
+cache version by itself.
 
-The snapshot is carried inline in `EJitCompileRequest`. This increases shared
-queue storage by `EJIT_BOUND_PTR_MAX_BYTES * queue capacity`, but avoids heap
-allocation, ownership handoff, cleanup races, and dangling-pointer failure
-paths on the worker side.
+There is no bound-payload allocation, copy, destructor, or cross-core free.
+Queue retry, deduplication, batch layout, PGO Tier-1 and
+Tier-2, delayed publication, and shutdown retain only the fixed descriptors
+until the compile callback is done. Publication and cache state do not depend
+on dereferencing the pointer after compilation.
+
+## Multiple pointers
+
+An entry may have up to eight `EJIT_BOUND_PTR` parameters. Each one must point
+to a complete object type and name exactly one matching `EJIT_DIM` parameter.
+The `_bound_v` runtime API carries the fixed descriptor table. The original
+single-pointer `ejit_taskpool_compile_or_get_bound` API remains source and ABI
+compatible, but its pointer is borrowed under the same lifetime contract.
+
+The size in each descriptor is the readable byte range for that object. Null,
+zero-sized, overflowing, duplicate-argument, and more-than-eight descriptor
+lists are rejected and fall back cleanly to AOT. An object may be larger than
+1 KiB; request size is constant and does not grow with the object payload.
+
+Only marked `ejit_may_const` fields are read from the bound object. Other
+fields remain ordinary loads through the pointer passed to each invocation.
+No nested pointer is followed.
+
+## Helper propagation
+
+The annotation belongs on the root entry's pointer parameter. A direct helper
+may receive the same pointer without repeating `EJIT_BOUND_PTR`, but it must
+also be an `EJIT_ENTRY` and declare the matching `EJIT_DIM(period)` parameter.
+That gives the helper an independent wrapper/cache identity for the same cell.
+
+Every direct call edge is checked. The helper's period argument must come from
+the caller's same period formal, or from the same specialization constant after
+dimension replacement; pointer and integer casts are accepted where the
+existing IR pipeline proves them equivalent. Each pointer formal must also
+receive the same bound pointer source and offset. An unannotated helper,
+indirect or address-taken call, missing or ambiguous dimension, different
+constant, or inconsistent callsite is a conservative boundary: the bound
+pointer is not propagated across that edge.
+
+## Build and compatibility
+
+The shared request ABI is versioned for fixed raw-pointer descriptors. Rebuild
+and relink the EJIT runtime library and every business package that exchanges
+shared requests. Rebuild the EJIT-enabled Clang when using the multi-pointer
+attribute and wrapper generation; an unchanged Clang binary cannot emit the
+new wrapper path. No payload allocator or free hook is required.
+
+Volatile, atomic, bit-field, union, dynamically indexed, and unmarked field
+loads are never folded from a bound pointer.

--- a/jit_design_doc/EJIT_BOUND_PTR.md
+++ b/jit_design_doc/EJIT_BOUND_PTR.md
@@ -68,19 +68,21 @@ No nested pointer is followed.
 
 ## Helper propagation
 
-The annotation belongs on the root entry's pointer parameter. A direct helper
-may receive the same pointer without repeating `EJIT_BOUND_PTR`, but it must
-also be an `EJIT_ENTRY` and declare the matching `EJIT_DIM(period)` parameter.
-That gives the helper an independent wrapper/cache identity for the same cell.
+The root and every direct helper own their pointer contracts independently.
+A helper that receives propagated bound facts must repeat
+`EJIT_BOUND_PTR(period)` on that pointer formal, be an `EJIT_ENTRY`, and declare
+the matching `EJIT_DIM(period)` parameter. Its bound size and `ejit_may_const`
+field metadata must describe the same object range. Together these annotations
+give the helper an independent wrapper/cache identity for the same cell.
 
 Every direct call edge is checked. The helper's period argument must come from
 the caller's same period formal, or from the same specialization constant after
 dimension replacement; pointer and integer casts are accepted where the
 existing IR pipeline proves them equivalent. Each pointer formal must also
-receive the same bound pointer source and offset. An unannotated helper,
-indirect or address-taken call, missing or ambiguous dimension, different
-constant, or inconsistent callsite is a conservative boundary: the bound
-pointer is not propagated across that edge.
+receive the same bound pointer source and offset. A helper pointer formal
+without matching `EJIT_BOUND_PTR`, an indirect or address-taken call, missing
+or ambiguous dimension, different constant, or inconsistent callsite is a
+conservative boundary: the bound pointer is not propagated across that edge.
 
 ## Build and compatibility
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -840,8 +840,6 @@ set(EJIT_SRE_TASKPOOL_BUCKETS "32" CACHE STRING
 # Async work-queue capacity (rounded up to a power of two).
 set(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY "1024" CACHE STRING
   "EmbeddedJIT SRE taskpool async queue capacity (power of two)")
-set(EJIT_BOUND_PTR_MAX_BYTES "256" CACHE STRING
-  "Maximum shallow pointee snapshot carried by one EJIT compile request")
 # Flat dedup table capacity = max dense funcIndex (spec §3.5 inFlight_[]).
 set(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX "4096" CACHE STRING
   "EmbeddedJIT SRE taskpool flat dedup capacity (max dense funcIndex)")
@@ -849,7 +847,6 @@ set(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX "4096" CACHE STRING
 # value fails at `cmake` time with a clear message instead of mid-build.
 ejit_require_numeric(EJIT_SRE_TASKPOOL_BUCKETS)
 ejit_require_numeric(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY)
-ejit_require_numeric(EJIT_BOUND_PTR_MAX_BYTES)
 ejit_require_numeric(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX)
 if(EJIT_SRE_TASKPOOL_BUCKETS LESS 1 OR EJIT_SRE_TASKPOOL_BUCKETS GREATER 254)
   message(FATAL_ERROR
@@ -863,18 +860,6 @@ if(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY LESS 2 OR NOT _ejit_queue_pow2 EQUAL 0)
     "EJIT_SRE_TASKPOOL_QUEUE_CAPACITY (${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}) "
     "must be a power of two >= 2 (the ring queue indexes with a mask).")
 endif()
-if(EJIT_BOUND_PTR_MAX_BYTES LESS 1 OR EJIT_BOUND_PTR_MAX_BYTES GREATER 65536)
-  message(FATAL_ERROR
-    "EJIT_BOUND_PTR_MAX_BYTES must be in [1, 65536], got ${EJIT_BOUND_PTR_MAX_BYTES}")
-endif()
-math(EXPR _ejit_bound_ptr_rem "${EJIT_BOUND_PTR_MAX_BYTES} % 8")
-if(NOT _ejit_bound_ptr_rem EQUAL 0)
-  message(FATAL_ERROR
-    "EJIT_BOUND_PTR_MAX_BYTES must be a multiple of 8, got ${EJIT_BOUND_PTR_MAX_BYTES}")
-endif()
-unset(_ejit_bound_ptr_rem)
-add_definitions(-DEJIT_BOUND_PTR_MAX_BYTES=${EJIT_BOUND_PTR_MAX_BYTES})
-message(STATUS "EmbeddedJIT: bound-pointer snapshot cap=${EJIT_BOUND_PTR_MAX_BYTES} bytes")
 unset(_ejit_queue_pow2)
 if(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX LESS 1)
   message(FATAL_ERROR

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitBoundPtr.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitBoundPtr.h
@@ -1,0 +1,95 @@
+//===-- EJitBoundPtr.h - Non-owning bound pointer transport --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Bound pointers are borrowed references to shared application objects. This
+// header deliberately contains only fixed-layout, trivially-copyable types:
+// no payload ownership, allocation, or destruction crosses the taskpool.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITBOUNDPTR_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITBOUNDPTR_H
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace llvm {
+namespace ejit {
+
+/// Maximum number of bound pointer parameters carried by one request.
+constexpr uint32_t kEJitMaxBoundPointers = 8u;
+
+/// Fixed-layout transport descriptor. The pointer is borrowed and is valid
+/// only until the compile callback returns; it is never dereferenced by queue,
+/// deduplication, retry, or publication code.
+struct EJitBoundPtrDescriptor {
+  const void *rawPtr;
+  uint32_t size;
+  uint32_t argIndex;
+};
+
+/// Non-owning view used only while the worker is compiling the request.
+struct EJitBoundPointerView {
+  const uint8_t *rawPtr = nullptr;
+  uint32_t size = 0;
+  uint32_t argIndex = 0;
+  /// Specialization value of the bound period dimension, when known. This is
+  /// internal compile metadata, not part of the queue/C ABI descriptor.
+  uint32_t periodInstance = std::numeric_limits<uint32_t>::max();
+};
+
+static_assert(std::is_standard_layout<EJitBoundPtrDescriptor>::value,
+              "bound pointer descriptor must have a stable C ABI layout");
+static_assert(sizeof(EJitBoundPtrDescriptor) ==
+                  (sizeof(uintptr_t) == 8 ? 16u : 12u),
+              "bound pointer descriptor size must stay pointer-width fixed");
+static_assert(offsetof(EJitBoundPtrDescriptor, rawPtr) == 0,
+              "raw pointer must be the first descriptor field");
+static_assert(offsetof(EJitBoundPtrDescriptor, size) == sizeof(uintptr_t),
+              "bound size offset must follow the pointer");
+static_assert(offsetof(EJitBoundPtrDescriptor, argIndex) ==
+                  sizeof(uintptr_t) + sizeof(uint32_t),
+              "bound arg index offset must remain ABI stable");
+static_assert(std::is_trivially_copyable<EJitBoundPtrDescriptor>::value,
+              "bound pointer descriptor must be copied by value");
+static_assert(
+    std::is_trivially_default_constructible<EJitBoundPtrDescriptor>::value,
+    "bound pointer descriptor must have no initialization logic");
+static_assert(std::is_trivially_destructible<EJitBoundPtrDescriptor>::value,
+              "bound pointer descriptor must not own storage");
+
+/// Validate descriptors at the ABI/taskpool boundary. A zero-count list is
+/// the no-bound-pointer case. A present descriptor must identify a non-empty
+/// object and its byte range must not wrap the target pointer width.
+inline bool validateBoundPtrDescriptors(const EJitBoundPtrDescriptor *bounds,
+                                        uint32_t count) {
+  if (count == 0)
+    return true;
+  if (!bounds || count > kEJitMaxBoundPointers)
+    return false;
+
+  for (uint32_t i = 0; i < count; ++i) {
+    const EJitBoundPtrDescriptor &B = bounds[i];
+    if (!B.rawPtr || B.size == 0)
+      return false;
+    const uintptr_t Begin = reinterpret_cast<uintptr_t>(B.rawPtr);
+    if (Begin > std::numeric_limits<uintptr_t>::max() - B.size)
+      return false;
+    for (uint32_t j = 0; j < i; ++j)
+      if (bounds[j].argIndex == B.argIndex)
+        return false;
+  }
+  return true;
+}
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITBOUNDPTR_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -15,6 +15,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITCOMMON_H
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundPtr.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -105,6 +106,8 @@ constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_BOUND =
     "ejit_taskpool_compile_or_get_bound";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_BOUND_V =
+    "ejit_taskpool_compile_or_get_bound_v";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper
 // when -ejit-wrapper-fixed-dim-entry is enabled and the entry has <= 4 dims.
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_0D =
@@ -153,6 +156,7 @@ constexpr unsigned EJIT_CTOR_PRIORITY = 65535;
 // together with these values.
 constexpr unsigned MAX_PERIOD_ARR_IND_PARAMS = 4;
 constexpr unsigned MAX_PERIOD_ARR_SIZE = 100;
+constexpr unsigned MAX_BOUND_PTR_PARAMS = kEJitMaxBoundPointers;
 
 //===----------------------------------------------------------------------===//
 // Metadata utility functions (shared across AOT passes)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitModuleLoader.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitModuleLoader.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace llvm {
 namespace ejit {
@@ -50,6 +51,9 @@ public:
     unsigned dimCount = 0;
     std::string periodNames[4];
     uint32_t dimTypes[4] = {0, 0, 0, 0};
+    /// Argument indices declared by EJIT_BOUND_PTR on the registered root.
+    /// Direct descriptor APIs are checked against this list on the cold path.
+    std::vector<uint32_t> boundPointerArgIndices;
   };
   /// Parse bitcode once per funcIdx, cache the result.
   const FuncMeta &getOrCacheFuncMeta(uint32_t funcIdx);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -10,6 +10,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITORCENGINE_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundPtr.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/EJIT/EJitProfileMerge.h"
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -100,8 +100,9 @@ struct SpecializationContext {
     uint8_t cellIdx;
   };
   SmallVector<DimInfo, 4> dimensions;
-  uint32_t boundArgIndex = 0;
-  SmallVector<uint8_t, 256> boundData;
+  /// Borrowed bound-pointer views. This vector is used only during the
+  /// compile callback and never owns or frees the pointed-to objects.
+  SmallVector<EJitBoundPointerView, kEJitMaxBoundPointers> boundPointers;
   OptimizationLevel optLevel = OptimizationLevel::L2;
   /// PGO tier (Baseline when PGO is disabled or for the first compile).
   CompileTier tier = CompileTier::Baseline;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -224,18 +224,40 @@ typedef struct {
   uint32_t instanceId;
 } ejit_dim_pair_t;
 
+/// Borrowed bound object descriptor. The object must remain valid and mapped
+/// at the same virtual address from enqueue through the end of compilation.
+/// The runtime copies this descriptor only; it never copies, allocates, or
+/// frees the pointed-to bytes.
+typedef struct {
+  const void *rawPtr;
+  uint32_t size;
+  uint32_t argIndex;
+} ejit_bound_ptr_t;
+
 ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                                            const ejit_dim_pair_t *dims,
                                            uint32_t numDims, void **outFn,
                                            uint32_t *outBucket);
 
-// Slow-path variant used by wrappers with EJIT_BOUND_PTR. The runtime copies
-// snapshotData before returning; asynchronous compilation never retains the
-// caller's pointer. Oversize/null snapshots fail cleanly and execute AOT.
+// Slow-path compatibility variant used by wrappers with one EJIT_BOUND_PTR.
+// rawPtr is borrowed until the compile callback returns. It requires a
+// non-null, non-empty, non-overflowing object; invalid input returns
+// EJIT_ERR_INVALID_PARAM so the wrapper can take its AOT path.
 ejit_status_t ejit_taskpool_compile_or_get_bound(
     uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
-    const void *snapshotData, uint32_t snapshotSize, uint32_t boundArgIndex,
-    void **outFn, uint32_t *outBucket);
+    const void *rawPtr, uint32_t rawSize, uint32_t boundArgIndex, void **outFn,
+    uint32_t *outBucket);
+
+// Multi-pointer raw transport variant. The fixed descriptor list supports up
+// to eight bound parameters and has no relationship to cache identity. The
+// each argIndex must name a pointer formal declared with EJIT_BOUND_PTR in the
+// registered root; the cold compile path rejects other indices. The caller
+// owns every object and must apply the deactivate -> modify -> reactivate
+// protocol before changing an active specialization's object.
+ejit_status_t ejit_taskpool_compile_or_get_bound_v(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const ejit_bound_ptr_t *bounds, uint32_t boundCount, void **outFn,
+    uint32_t *outBucket);
 
 // Fixed-dimension fast paths (0-4 dims). Additive alternatives to
 // ejit_taskpool_compile_or_get that pass the dim identity as scalar arguments

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -98,14 +98,17 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// the shared blob also records completed-function and deferred-miss counts.
 /// v13: non-owner cores can post a may_const-ranking diagnostic request to the
 /// owner worker and wait for its completion without sharing optimizer objects.
-/// v14: EJitCompileRequest owns an inline bound-pointer snapshot.
+/// v14: EJitCompileRequest introduced the old inline bound-pointer payload.
 /// v15: each cache slot records whether its published JIT pointer was resolved
 /// by a later taskpool lookup, diagnosing compiled versions with no reuse.
 /// v16: code ranges identify near/far placement and the shared code-pool
 /// diagnostic mirror publishes aggregate plus placement-specific statistics.
 /// v17: cache slots can remain Pending while compact code waits for an explicit
 /// owner-worker batch publish request.
-constexpr uint32_t kEJitSharedAbiVersion = 17u;
+/// v18: the old inline payload is replaced by a fixed table of borrowed
+/// raw bound-pointer descriptors; no pointee bytes or ownership cross the
+/// shared queue.
+constexpr uint32_t kEJitSharedAbiVersion = 18u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -869,11 +869,25 @@ public:
   void ownerShutdown();
 
   //--- producer path ----------------------------------------------------------
+  /// Submit a request carrying borrowed raw bound-pointer descriptors. Only
+  /// the fixed descriptors are copied into the queue; pointee bytes are read
+  /// by the compile callback and are never owned by this pool.
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                   uint32_t numDims, void *fallback,
-                                  const void *boundData = nullptr,
-                                  uint32_t boundSize = 0,
-                                  uint32_t boundArgIndex = 0);
+                                  const EJitBoundPtrDescriptor *boundPointers,
+                                  uint32_t boundCount);
+
+  /// Source-compatible single-pointer entry point. A zero size means no bound
+  /// pointer; a nonzero size borrows the pointed-to object through compilation.
+  CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
+                                  uint32_t numDims, void *fallback,
+                                  const void *rawPtr = nullptr,
+                                  uint32_t rawSize = 0,
+                                  uint32_t boundArgIndex = 0) {
+    EJitBoundPtrDescriptor Bound{rawPtr, rawSize, boundArgIndex};
+    return compileOrGet(funcIndex, dims, numDims, fallback,
+                        rawSize ? &Bound : nullptr, rawSize ? 1u : 0u);
+  }
   /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
   /// terminal front half of compileOrGet(): the Ready check, the
   /// instance-enabled check, and the cache lookup, then classifies the outcome:
@@ -888,8 +902,10 @@ public:
   /// enabled, no shareable cached code) returns fastPathTerminal = false and
   /// the caller must fall through to compileOrGet(). compileOrGet() itself
   /// calls this so the ordering/counters/semantics stay identical.
-  CompileOrGetResult tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
-                                 uint32_t numDims);
+  CompileOrGetResult
+  tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+              const EJitBoundPtrDescriptor *boundPointers = nullptr,
+              uint32_t boundCount = 0);
   /// Fixed-dimension fast cache-hit entries (0-4 dims). Same terminal
   /// semantics as tryCacheHit() but the instance-enabled check is unrolled and
   /// the dim identity is built directly on the stack (no numDims loop / no
@@ -1163,6 +1179,9 @@ private:
     /// first-touch path (which self-revalidates), so the seqlock caller must
     /// not second-guess it with the bucket publishSeq check.
     bool coldPrepared = false;
+    /// The matching hit crossed the Tier-2 threshold. The caller decides
+    /// whether to enqueue immediately or attach bound descriptors first.
+    bool tier2Arm = false;
   };
 
   // shared cache helpers (POD table in the shared blob)
@@ -1225,7 +1244,15 @@ private:
   /// Submit Tier-2 from an identity/version-validated slot while its bucket
   /// read lock is held. This preserves the exact slot snapshot without
   /// enlarging the 16-byte CompileOrGetResult hot-path return value.
-  void enqueueTier2FromSlot(const EJitSharedCacheSlot &slot);
+  void
+  enqueueTier2FromSlot(const EJitSharedCacheSlot &slot,
+                       const EJitBoundPtrDescriptor *boundPointers = nullptr,
+                       uint32_t boundCount = 0);
+  void
+  enqueueTier2ForIdentity(uint32_t funcIndex, const EJitDimPair *dims,
+                          uint32_t numDims,
+                          const EJitBoundPtrDescriptor *boundPointers = nullptr,
+                          uint32_t boundCount = 0);
   /// Cold non-owner first-touch execute-permission preparation for a matched
   /// slot, with the bucket read lock HELD on entry (this function releases it).
   /// Snapshots the slot, drops the lock for the per-core platform seal, then
@@ -1239,7 +1266,8 @@ private:
   /// cache-hit counter is incremented exactly once and the semantics stay
   /// identical. Does NOT perform the Ready or instance-enabled checks (the
   /// callers do those first).
-  CompileOrGetResult classifyHit(const SharedLookup &Hit);
+  CompileOrGetResult classifyHit(const SharedLookup &Hit,
+                                 bool enqueueTier2 = true);
   EJitPublishStatus cachePublish(const EJitCompileRequest &req, void *fnPtr,
                                  const EJitCompiledCodeInfo *info,
                                  bool pgoClearExclusive = false);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
@@ -24,6 +24,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITSREQUEUE_H
 
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundPtr.h"
 #include <cstdint>
 
 //===----------------------------------------------------------------------===//
@@ -33,13 +34,6 @@
 #ifndef EJIT_SRE_TASKPOOL_QUEUE_CAPACITY
 #define EJIT_SRE_TASKPOOL_QUEUE_CAPACITY 1024u
 #endif
-#ifndef EJIT_BOUND_PTR_MAX_BYTES
-#define EJIT_BOUND_PTR_MAX_BYTES 256u
-#endif
-static_assert(EJIT_BOUND_PTR_MAX_BYTES > 0 &&
-                  (EJIT_BOUND_PTR_MAX_BYTES % 8u) == 0,
-              "EJIT_BOUND_PTR_MAX_BYTES must be a positive multiple of 8");
-
 namespace llvm {
 namespace ejit {
 
@@ -70,22 +64,18 @@ struct EJitCompileRequest {
   // cache. Unused (left 0) by the non-shared taskpool. Endianness: a plain
   // fixed-width scalar accessed by value, never byte-parsed.
   uint32_t generation;
-  // Optional shallow pointee snapshot for ejit_bound_ptr. It is stored inline
-  // so an async request owns every byte it needs after the caller returns.
-  // boundSize == 0 means no bound pointer. No raw caller pointer crosses the
-  // queue boundary.
-  uint32_t boundArgIndex;
-  uint32_t boundSize;
-  alignas(uintptr_t) uint8_t boundData[EJIT_BOUND_PTR_MAX_BYTES];
+  // Borrowed bound objects. The queue copies only these descriptors; it never
+  // owns, frees, or dereferences the pointed-to bytes. The compile callback
+  // must finish reading them before returning.
+  uint32_t boundCount;
+  EJitBoundPtrDescriptor boundPointers[kEJitMaxBoundPointers];
 };
 
-// Size is stable per pointer width: on a 64-bit target the trailing uint32_t
-// generation forces 4 bytes of tail padding (alignof == 8) -> 72; on a 32-bit
-// target everything is 4-aligned with no padding -> 64.
-static_assert(sizeof(EJitCompileRequest) ==
-                  (sizeof(uintptr_t) == 8 ? 80u + EJIT_BOUND_PTR_MAX_BYTES
-                                          : 72u + EJIT_BOUND_PTR_MAX_BYTES),
-              "EJitCompileRequest size must stay stable (incl. generation)");
+// Size is stable per pointer width and independent of pointee size: 200 bytes
+// on 64-bit targets and 164 bytes on 32-bit targets.
+static_assert(
+    sizeof(EJitCompileRequest) == (sizeof(uintptr_t) == 8 ? 200u : 164u),
+    "EJitCompileRequest size must stay fixed and payload-independent");
 static_assert(alignof(EJitCompileRequest) <= 8,
               "EJitCompileRequest alignment must stay <= 8 bytes");
 static_assert(sizeof(uintptr_t) == 4 || sizeof(uintptr_t) == 8,

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
@@ -9,12 +9,16 @@
 #ifndef LLVM_EXECUTIONENGINE_EJIT_EJITSTRUCTFIELDPASS_H
 #define LLVM_EXECUTIONENGINE_EJIT_EJITSTRUCTFIELDPASS_H
 
-#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
-#include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
-#include "llvm/IR/PassManager.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundPtr.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+#include "llvm/IR/PassManager.h"
+#include <limits>
+#include <optional>
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT
 #include "llvm/ExecutionEngine/EJIT/EJitBranchProfile.h"
 #include <vector>
@@ -35,17 +39,30 @@ using MayConstOffsetMap =
 
 /// PASS6: JIT-time specialization pass. Scans the module for load instructions
 /// with !ejit.may_const metadata, reads the actual runtime values from process
-/// memory via the PeriodArrayRegistry, and replaces the loads with LLVM
-/// constants.
+/// memory via the PeriodArrayRegistry or a borrowed bound-pointer view, and
+/// replaces the loads with LLVM constants.
 class EJitStructFieldPass : public PassInfoMixin<EJitStructFieldPass> {
 public:
   EJitStructFieldPass(PeriodArrayRegistry &reg,
-                      const uint8_t *boundData = nullptr,
-                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0,
+                      ArrayRef<EJitBoundPointerView> boundPointers,
                       StringRef boundRootFunction = {})
-      : registry_(reg), boundData_(boundData), boundSize_(boundSize),
-        boundArgIndex_(boundArgIndex),
+      : registry_(reg),
+        boundPointers_(boundPointers.begin(), boundPointers.end()),
         boundRootFunction_(boundRootFunction.str()) {}
+
+  /// Compatibility constructor for direct pass users. The data pointer is
+  /// borrowed for the duration of the pass and is never copied or freed.
+  EJitStructFieldPass(PeriodArrayRegistry &reg, const uint8_t *rawPtr = nullptr,
+                      uint32_t rawSize = 0, uint32_t boundArgIndex = 0,
+                      StringRef boundRootFunction = {},
+                      std::optional<uint8_t> boundPeriodInstance = std::nullopt)
+      : registry_(reg), boundRootFunction_(boundRootFunction.str()) {
+    if (rawPtr && rawSize)
+      boundPointers_.push_back({rawPtr, rawSize, boundArgIndex,
+                                boundPeriodInstance
+                                    ? *boundPeriodInstance
+                                    : std::numeric_limits<uint32_t>::max()});
+  }
 
   /// Pre-build GV metadata maps from the Module (call once before run()).
   void initFromModule(Module &M);
@@ -74,16 +91,15 @@ public:
 
 private:
   PeriodArrayRegistry &registry_;
-  const uint8_t *boundData_ = nullptr;
-  uint32_t boundSize_ = 0;
-  uint32_t boundArgIndex_ = 0;
+  SmallVector<EJitBoundPointerView, kEJitMaxBoundPointers> boundPointers_;
   std::string boundRootFunction_;
 
-  // A specialization owns one pointee snapshot. Track which formal arguments
-  // are proven to receive that snapshot, and their byte offset into it, across
-  // direct calls from the entry. Ambiguous or indirect flows are omitted.
-  DenseMap<const Argument *, uint64_t> boundArguments_;
-  SmallVector<std::pair<uint64_t, uint64_t>, 4> boundMayConstFields_;
+  struct BoundPointerState {
+    EJitBoundPointerView view;
+    DenseMap<const Argument *, uint64_t> boundArguments;
+    SmallVector<std::pair<uint64_t, uint64_t>, 4> mayConstFields;
+  };
+  SmallVector<BoundPointerState, kEJitMaxBoundPointers> boundStates_;
   void initBoundArgumentPropagation(Module &M);
 
   // Cached metadata maps — built once per module, reused across functions.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
@@ -14,6 +14,7 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT
 #include "llvm/ExecutionEngine/EJIT/EJitBranchProfile.h"
 #include <vector>
@@ -40,9 +41,11 @@ class EJitStructFieldPass : public PassInfoMixin<EJitStructFieldPass> {
 public:
   EJitStructFieldPass(PeriodArrayRegistry &reg,
                       const uint8_t *boundData = nullptr,
-                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0)
+                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0,
+                      StringRef boundRootFunction = {})
       : registry_(reg), boundData_(boundData), boundSize_(boundSize),
-        boundArgIndex_(boundArgIndex) {}
+        boundArgIndex_(boundArgIndex),
+        boundRootFunction_(boundRootFunction.str()) {}
 
   /// Pre-build GV metadata maps from the Module (call once before run()).
   void initFromModule(Module &M);
@@ -74,6 +77,14 @@ private:
   const uint8_t *boundData_ = nullptr;
   uint32_t boundSize_ = 0;
   uint32_t boundArgIndex_ = 0;
+  std::string boundRootFunction_;
+
+  // A specialization owns one pointee snapshot. Track which formal arguments
+  // are proven to receive that snapshot, and their byte offset into it, across
+  // direct calls from the entry. Ambiguous or indirect flows are omitted.
+  DenseMap<const Argument *, uint64_t> boundArguments_;
+  SmallVector<std::pair<uint64_t, uint64_t>, 4> boundMayConstFields_;
+  void initBoundArgumentPropagation(Module &M);
 
   // Cached metadata maps — built once per module, reused across functions.
   GVPeriodMap gvPeriodMap_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -366,11 +366,25 @@ public:
   EJitSwitchController &switchController() { return switch_; }
   EJitTaskPoolCache &cache() { return cache_; }
 
+  /// Submit a request carrying borrowed raw bound-pointer descriptors. Only
+  /// the fixed descriptors are copied into the queue; pointee bytes are read
+  /// by compileFn_ and are never owned by this pool.
   CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                   uint32_t numDims, void *fallback,
-                                  const void *boundData = nullptr,
-                                  uint32_t boundSize = 0,
-                                  uint32_t boundArgIndex = 0);
+                                  const EJitBoundPtrDescriptor *boundPointers,
+                                  uint32_t boundCount);
+
+  /// Source-compatible single-pointer entry point. A zero size means no bound
+  /// pointer; a nonzero size borrows the pointed-to object through compilation.
+  CompileOrGetResult compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
+                                  uint32_t numDims, void *fallback,
+                                  const void *rawPtr = nullptr,
+                                  uint32_t rawSize = 0,
+                                  uint32_t boundArgIndex = 0) {
+    EJitBoundPtrDescriptor Bound{rawPtr, rawSize, boundArgIndex};
+    return compileOrGet(funcIndex, dims, numDims, fallback,
+                        rawSize ? &Bound : nullptr, rawSize ? 1u : 0u);
+  }
 
   /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
   /// terminal front half of compileOrGet(): the instance-enabled check and the

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -514,15 +514,24 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
   ctx.optLevel = config_.optLevel;
   for (unsigned i = 0; i < dimCount; ++i)
     ctx.dimensions.push_back({periodNames[i], dims[i]});
-  if (request && request->boundSize) {
-    if (request->boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
-      EJIT_DIAG("compile FAIL key=0x%016lx func=%s: bound snapshot too large",
+  if (request && request->boundCount) {
+    if (!validateBoundPtrDescriptors(request->boundPointers,
+                                     request->boundCount)) {
+      EJIT_DIAG("compile FAIL key=0x%016lx func=%s: invalid bound pointer list",
                 cacheKey, funcName.c_str());
       return nullptr;
     }
-    ctx.boundArgIndex = request->boundArgIndex;
-    ctx.boundData.append(request->boundData,
-                         request->boundData + request->boundSize);
+    for (uint32_t I = 0; I < request->boundCount; ++I) {
+      const EJitBoundPtrDescriptor &B = request->boundPointers[I];
+      if (!llvm::is_contained(meta.boundPointerArgIndices, B.argIndex)) {
+        EJIT_DIAG("compile FAIL key=0x%016lx func=%s: bound argIndex=%u "
+                  "has no matching EJIT_BOUND_PTR pointer formal",
+                  cacheKey, funcName.c_str(), B.argIndex);
+        return nullptr;
+      }
+      ctx.boundPointers.push_back(
+          {static_cast<const uint8_t *>(B.rawPtr), B.size, B.argIndex});
+    }
   }
 
   // PGO tier (EJIT_ONLINE_PGO.md §4). Gated by Config::enablePgo: off => the

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -2,7 +2,6 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitCompileDriver.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
@@ -523,7 +522,17 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
     }
     for (uint32_t I = 0; I < request->boundCount; ++I) {
       const EJitBoundPtrDescriptor &B = request->boundPointers[I];
-      if (!llvm::is_contained(meta.boundPointerArgIndices, B.argIndex)) {
+      // Keep this lookup as an explicit loop. libc++ may lower generic
+      // uint32_t range searches to wmemchr, which is unavailable on the
+      // freestanding SRE target.
+      bool HasMatchingBoundFormal = false;
+      for (uint32_t ArgIndex : meta.boundPointerArgIndices) {
+        if (ArgIndex == B.argIndex) {
+          HasMatchingBoundFormal = true;
+          break;
+        }
+      }
+      if (!HasMatchingBoundFormal) {
         EJIT_DIAG("compile FAIL key=0x%016lx func=%s: bound argIndex=%u "
                   "has no matching EJIT_BOUND_PTR pointer formal",
                   cacheKey, funcName.c_str(), B.argIndex);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitModuleLoader.cpp
@@ -135,7 +135,23 @@ EJitModuleLoader::getOrCacheFuncMeta(uint32_t funcIdx) {
       if (!Sub || Sub->getNumOperands() < 3)
         continue;
       auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
-      if (!Tag || Tag->getString() != TAG_EJIT_PERIOD_ARR_IND)
+      if (!Tag)
+        continue;
+      if (Tag->getString() == TAG_EJIT_BOUND_PTR) {
+        auto *ArgIndexMD =
+            mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
+        if (!ArgIndexMD)
+          continue;
+        uint64_t ArgIndex = ArgIndexMD->getZExtValue();
+        if (ArgIndex < F.arg_size() &&
+            F.getArg(static_cast<unsigned>(ArgIndex))
+                ->getType()
+                ->isPointerTy())
+          meta.boundPointerArgIndices.push_back(
+              static_cast<uint32_t>(ArgIndex));
+        continue;
+      }
+      if (Tag->getString() != TAG_EJIT_PERIOD_ARR_IND)
         continue;
       auto *PN = dyn_cast<MDString>(Sub->getOperand(1));
       if (PN && meta.dimCount < 4) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -41,6 +41,7 @@
 #include "llvm/Transforms/Utils/LoopSimplify.h"
 #include "llvm/Transforms/Utils/Mem2Reg.h"
 #include <limits>
+#include <optional>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -764,10 +765,38 @@ void EJitOptimizer::runInterproceduralPropagation(Module &M) {
 
 void EJitOptimizer::runStructFieldPass(Module &M,
                                        const SpecializationContext &ctx) {
-  EJitStructFieldPass structField(
-      registry_, ctx.boundData.empty() ? nullptr : ctx.boundData.data(),
-      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex,
-      ctx.fnName);
+  SmallVector<EJitBoundPointerView, kEJitMaxBoundPointers> BoundPointers =
+      ctx.boundPointers;
+  if (!BoundPointers.empty()) {
+    Function *Root = M.getFunction(ctx.fnName);
+    if (Root) {
+      for (EJitBoundPointerView &View : BoundPointers) {
+        MDNode *MD = Root->getMetadata(MD_EJIT_METADATA);
+        StringRef BoundPeriodName;
+        if (MD)
+          for (const MDOperand &Op : MD->operands()) {
+            auto *Sub = dyn_cast<MDNode>(Op.get());
+            if (!Sub || Sub->getNumOperands() < 3)
+              continue;
+            auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
+            auto *Period = dyn_cast<MDString>(Sub->getOperand(1));
+            auto *Index = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
+            if (Tag && Period && Index &&
+                Tag->getString() == TAG_EJIT_BOUND_PTR &&
+                Index->getZExtValue() == View.argIndex) {
+              BoundPeriodName = Period->getString();
+              break;
+            }
+          }
+        for (const auto &Dim : ctx.dimensions)
+          if (Dim.periodName == BoundPeriodName) {
+            View.periodInstance = Dim.cellIdx;
+            break;
+          }
+      }
+    }
+  }
+  EJitStructFieldPass structField(registry_, BoundPointers, ctx.fnName);
   structField.initFromModule(M);
   for (Function &F : M.functions())
     if (!F.isDeclaration())

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -766,7 +766,8 @@ void EJitOptimizer::runStructFieldPass(Module &M,
                                        const SpecializationContext &ctx) {
   EJitStructFieldPass structField(
       registry_, ctx.boundData.empty() ? nullptr : ctx.boundData.data(),
-      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex);
+      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex,
+      ctx.fnName);
   structField.initFromModule(M);
   for (Function &F : M.functions())
     if (!F.isDeclaration())

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -901,11 +901,10 @@ inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
 }
 } // namespace
 
-static ejit_status_t
-taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
-                         uint32_t numDims, const void *snapshotData,
-                         uint32_t snapshotSize, uint32_t boundArgIndex,
-                         void **outFn, uint32_t *outBucket) {
+static ejit_status_t taskpoolCompileOrGetImpl(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const EJitBoundPtrDescriptor *boundPointers, uint32_t boundCount,
+    void **outFn, uint32_t *outBucket) {
   if (outFn)
     *outFn = nullptr;
   if (outBucket)
@@ -922,6 +921,12 @@ taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
   if (!tp) {
     EJIT_DIAG("taskpool_compile_or_get reject func=%u: no taskpool", funcIndex);
     return EJIT_ERR_NOT_ACTIVE;
+  }
+  if (!validateBoundPtrDescriptors(boundPointers, boundCount)) {
+    EJIT_DIAG("taskpool_compile_or_get reject func=%u: invalid bound pointer "
+              "list count=%u",
+              funcIndex, boundCount);
+    return EJIT_ERR_INVALID_PARAM;
   }
   const uint64_t icTok = ejitIcacheBeginResolve();
 
@@ -962,6 +967,11 @@ taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
   // disabled instance never returns stale code. A true miss falls through to
   // compileOrGet unchanged (enqueue/dedup/compile).
   void *l0Fn = nullptr;
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+  // L0 remains valid for bound calls: it contains only the identity -> code
+  // pointer mapping, while bound descriptors are needed only on a miss or a
+  // PGO Tier-2 arm. PGO enable/disable retires L0 via dispatchEpoch, so a
+  // successful L0 hit cannot bypass an active PGO counter.
   if (tp->l0Try(funcIndex, dimsCast, numDims, &l0Fn)) {
     if (outFn)
       *outFn = l0Fn;
@@ -969,7 +979,8 @@ taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
       *outBucket = kEJitNoBucket;
     return EJIT_OK;
   }
-  auto fast = tp->tryCacheHit(funcIndex, dimsCast, numDims);
+  auto fast =
+      tp->tryCacheHit(funcIndex, dimsCast, numDims, boundPointers, boundCount);
   if (fast.fastPathTerminal) {
     if (outFn)
       *outFn = fast.fnPtr;
@@ -983,10 +994,28 @@ taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
       tp->l0Fill(funcIndex, fast.fnPtr, dimsCast, numDims);
     return taskpoolStatus(fast.status);
   }
+#else
+  // The per-instance taskpool has no shared L0 layer. Its compileOrGet() owns
+  // the ordinary cache lookup and the bound descriptors are copied only when
+  // a miss is actually submitted.
+  if (boundCount == 0) {
+    auto fast = tp->tryCacheHit(funcIndex, dimsCast, numDims);
+    if (fast.fastPathTerminal) {
+      if (outFn)
+        *outFn = fast.fnPtr;
+      if (outBucket)
+        *outBucket = fast.bucketIndex;
+      EJIT_DIAG_VERBOSE("taskpool_compile_or_get func=%u fast status=%u fn=%p",
+                        funcIndex, static_cast<unsigned>(fast.status),
+                        fast.fnPtr);
+      ejitIcacheFillOnSuccess(funcIndex, fast.fnPtr, dimsCast, numDims, icTok);
+      return taskpoolStatus(fast.status);
+    }
+  }
+#endif
 
   auto r = tp->compileOrGet(funcIndex, dimsCast, numDims,
-                            /*fallback=*/nullptr, snapshotData, snapshotSize,
-                            boundArgIndex);
+                            /*fallback=*/nullptr, boundPointers, boundCount);
   if (outFn)
     *outFn = r.fnPtr;
   if (outBucket)
@@ -1003,17 +1032,51 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                                            const ejit_dim_pair_t *dims,
                                            uint32_t numDims, void **outFn,
                                            uint32_t *outBucket) {
-  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, nullptr, 0, 0,
-                                  outFn, outBucket);
+  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, nullptr, 0, outFn,
+                                  outBucket);
 }
 
 ejit_status_t ejit_taskpool_compile_or_get_bound(
     uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
-    const void *snapshotData, uint32_t snapshotSize, uint32_t boundArgIndex,
-    void **outFn, uint32_t *outBucket) {
-  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, snapshotData,
-                                  snapshotSize, boundArgIndex, outFn,
+    const void *rawPtr, uint32_t rawSize, uint32_t boundArgIndex, void **outFn,
+    uint32_t *outBucket) {
+  // This compatibility entry point promises a bound request. Treat an empty
+  // object as invalid instead of silently converting it into the generic,
+  // unbound API request (which could return an unbound JIT cache entry).
+  if (!rawPtr || rawSize == 0) {
+    if (outFn)
+      *outFn = nullptr;
+    if (outBucket)
+      *outBucket = 0;
+    EJIT_DIAG("taskpool_compile_or_get_bound reject func=%u: null/empty "
+              "bound object",
+              funcIndex);
+    return EJIT_ERR_INVALID_PARAM;
+  }
+  EJitBoundPtrDescriptor Bound{rawPtr, rawSize, boundArgIndex};
+  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, &Bound, 1u, outFn,
                                   outBucket);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_bound_v(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const ejit_bound_ptr_t *bounds, uint32_t boundCount, void **outFn,
+    uint32_t *outBucket) {
+  static_assert(sizeof(ejit_bound_ptr_t) == sizeof(EJitBoundPtrDescriptor),
+                "C and C++ bound descriptor layouts must match");
+  static_assert(offsetof(ejit_bound_ptr_t, rawPtr) ==
+                    offsetof(EJitBoundPtrDescriptor, rawPtr),
+                "C and C++ bound pointer offsets must match");
+  static_assert(offsetof(ejit_bound_ptr_t, size) ==
+                    offsetof(EJitBoundPtrDescriptor, size),
+                "C and C++ bound size offsets must match");
+  static_assert(offsetof(ejit_bound_ptr_t, argIndex) ==
+                    offsetof(EJitBoundPtrDescriptor, argIndex),
+                "C and C++ bound arg offsets must match");
+  return taskpoolCompileOrGetImpl(
+      funcIndex, dims, numDims,
+      reinterpret_cast<const EJitBoundPtrDescriptor *>(bounds), boundCount,
+      outFn, outBucket);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -70,6 +70,16 @@ namespace {
 // symbol, no arch-specific instruction in this layer).
 inline void cpuRelax() { __asm__ __volatile__("" ::: "memory"); }
 
+// Bound pointers are transport-only. Once the compile callback has returned,
+// no owner-private publication/retry state should retain or expose them.
+EJitCompileRequest requestForPublication(const EJitCompileRequest &Req) {
+  EJitCompileRequest Published = Req;
+  Published.boundCount = 0;
+  for (EJitBoundPtrDescriptor &Bound : Published.boundPointers)
+    Bound = {};
+  return Published;
+}
+
 // Fixed worker core (build policy, spec §11.4): CMake
 // EJIT_SRE_SHARED_TASKPOOL_WORKER_CORE pins the single shared worker to ONE
 // designated core. When set, ONLY that core may win the owner election - it
@@ -1424,7 +1434,8 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
           // lost to queue pressure. dedupMark makes the normal pending case a
           // cheap no-op. The slot and Tier-1 code remain intact because Tier-2
           // profile synthesis still reads their counter storage.
-          enqueueTier2FromSlot(Slot);
+          R.slot = &Slot;
+          R.tier2Arm = true;
 #ifndef EJIT_SRE_TASKPOOL_NO_RECLAIM
           bucketReadRelease(B);
 #endif
@@ -1461,7 +1472,11 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
       // >= (not ==): if the enqueue fails (queue full / already pending),
       // the next hit can still arm — a transient failure is not fatal (§7).
       if (threshold && sampleIndex >= threshold) {
-        enqueueTier2FromSlot(Slot);
+        // Preserve the fixed slot address even when this producer cannot read
+        // the cross-core code pointer. tryCacheHit() performs the deferred
+        // enqueue after lookup so a bound call can attach its descriptors.
+        R.slot = &Slot;
+        R.tier2Arm = true;
         if (slotTier == kEJitTierInstrumented && sampleIndex == threshold)
           EJIT_DIAG("PGO sampling complete func=%u: %llu/%u; routing AOT "
                     "until Tier-2 publish",
@@ -1535,38 +1550,52 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
     return R;
   }
 
-  // Cold: this core has never prepared this code. Tier-2 submission, when
-  // armed above, has already captured the exact slot.
-  return peerPrepareSlot(B, bucket, slotIndex);
+  // Cold: this core has never prepared this code. Preserve the Tier-2 signal
+  // across the out-of-line execute-permission preparation; the producer may
+  // need to attach bound descriptors before enqueueing the recompile.
+  SharedLookup Prepared = peerPrepareSlot(B, bucket, slotIndex);
+  Prepared.tier2Arm = R.tier2Arm;
+  return Prepared;
 }
 
-void EJitSharedTaskPool::enqueueTier2FromSlot(const EJitSharedCacheSlot &Slot) {
+void EJitSharedTaskPool::enqueueTier2ForIdentity(
+    uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+    const EJitBoundPtrDescriptor *boundPointers, uint32_t boundCount) {
   if (state_->mode.loadAcquire() !=
       static_cast<uint32_t>(EJitCompileMode::Async))
     return;
 
   EJitCompileRequest T2{};
-  T2.funcIndex = encodeReqTier(Slot.funcIndex, kEJitTierPgoUse);
-  T2.numDims = Slot.numDims;
-  T2.generation = Slot.generation;
-  for (uint32_t i = 0; i < Slot.numDims && i < 4; ++i) {
-    T2.dims[i] = Slot.dims[i];
-    T2.versions[i] = Slot.versions[i];
+  T2.funcIndex = encodeReqTier(funcIndex, kEJitTierPgoUse);
+  T2.numDims = numDims;
+  T2.generation = state_->generation.loadAcquire();
+  for (uint32_t i = 0; i < numDims && i < 4; ++i) {
+    T2.dims[i] = dims[i];
+    T2.versions[i] = instanceVersion(dims[i].dimType, dims[i].instanceId);
   }
+  T2.boundCount = boundCount;
+  for (uint32_t i = 0; i < boundCount; ++i)
+    T2.boundPointers[i] = boundPointers[i];
 
   if (dedupMark(T2.funcIndex, T2.generation) != EJitDedupResult::Claimed)
     return;
   if (queuePush(T2)) {
     EJIT_STAT_INC(state_->counters.asyncEnqueues);
     EJIT_DIAG_VERBOSE("shared taskpool PGO Tier-2 enqueued func=%u gen=%u",
-                      Slot.funcIndex, T2.generation);
+                      funcIndex, T2.generation);
     return;
   }
 
   dedupClear(T2.funcIndex, T2.generation);
   EJIT_STAT_INC(state_->counters.queueFull);
-  EJIT_DIAG("shared taskpool PGO Tier-2 drop func=%u: queue full",
-            Slot.funcIndex);
+  EJIT_DIAG("shared taskpool PGO Tier-2 drop func=%u: queue full", funcIndex);
+}
+
+void EJitSharedTaskPool::enqueueTier2FromSlot(
+    const EJitSharedCacheSlot &Slot,
+    const EJitBoundPtrDescriptor *boundPointers, uint32_t boundCount) {
+  enqueueTier2ForIdentity(Slot.funcIndex, Slot.dims, Slot.numDims,
+                          boundPointers, boundCount);
 }
 
 bool EJitSharedTaskPool::admitPgoFunction(uint32_t funcIndex,
@@ -2993,8 +3022,10 @@ void EJitSharedTaskPool::ownerShutdown() {
 // Producer path (§5.2).
 //===----------------------------------------------------------------------===//
 __attribute__((always_inline)) EJitSharedTaskPool::CompileOrGetResult
-EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
+EJitSharedTaskPool::classifyHit(const SharedLookup &Hit, bool enqueueTier2) {
   CompileOrGetResult R;
+  if (enqueueTier2 && Hit.tier2Arm && Hit.slot)
+    enqueueTier2FromSlot(*Hit.slot);
   if (Hit.hasReadToken && Hit.fnPtr) {
     if (Hit.slot)
       markPostPublishSeen(*Hit.slot);
@@ -3044,9 +3075,9 @@ EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   return R;
 }
 
-EJitSharedTaskPool::CompileOrGetResult
-EJitSharedTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
-                                uint32_t numDims) {
+EJitSharedTaskPool::CompileOrGetResult EJitSharedTaskPool::tryCacheHit(
+    uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+    const EJitBoundPtrDescriptor *boundPointers, uint32_t boundCount) {
   CompileOrGetResult R;
   // Parameter check already done by the C API layer.
 
@@ -3074,10 +3105,19 @@ EJitSharedTaskPool::tryCacheHit(uint32_t funcIndex, const EJitDimPair *dims,
   // Cache lookup (§5.2 step 1) — runs BEFORE the Off check, so an already
   // compiled entry is still served even when the pool is globally Off.
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
-  return classifyHit(cacheLookupSeq(funcIndex, dims, numDims));
+  SharedLookup Hit = cacheLookupSeq(funcIndex, dims, numDims);
 #else
-  return classifyHit(cacheLookup(funcIndex, dims, numDims));
+  SharedLookup Hit = cacheLookup(funcIndex, dims, numDims);
 #endif
+  if (Hit.tier2Arm && Hit.slot) {
+    if (boundCount)
+      enqueueTier2ForIdentity(funcIndex, dims, numDims, boundPointers,
+                              boundCount);
+    else
+      enqueueTier2FromSlot(*Hit.slot);
+    Hit.tier2Arm = false;
+  }
+  return classifyHit(Hit, /*enqueueTier2=*/false);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3205,15 +3245,23 @@ EJitSharedTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0,
 EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                  uint32_t numDims, void *fallback,
-                                 const void *boundData, uint32_t boundSize,
-                                 uint32_t boundArgIndex) {
+                                 const EJitBoundPtrDescriptor *boundPointers,
+                                 uint32_t boundCount) {
   EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p",
                     funcIndex, numDims, fallback);
   // Parameter check already done by the C API layer.
 
   // Fast cache-hit path (§5.2 steps 0-1). On any terminal outcome (hit,
   // disabled instance, not-Ready, or ready-but-not-shareable) return directly.
-  CompileOrGetResult R = tryCacheHit(funcIndex, dims, numDims);
+  CompileOrGetResult R;
+  if (!validateBoundPtrDescriptors(boundPointers, boundCount)) {
+    EJIT_DIAG("shared taskpool bound pointer reject func=%u count=%u",
+              funcIndex, boundCount);
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    R.fnPtr = fallback;
+    return R;
+  }
+  R = tryCacheHit(funcIndex, dims, numDims, boundPointers, boundCount);
   if (R.fastPathTerminal) {
     // Non-hit terminals surface the caller's fallback pointer (a hit already
     // carries the cached fnPtr + read token).
@@ -3230,13 +3278,6 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (cacheHasPending(funcIndex, dims, numDims)) {
     EJIT_STAT_INC(state_->counters.alreadyPending);
     R.status = EJitCompileOrGetStatus::AlreadyPending;
-    return R;
-  }
-  if ((boundSize != 0 && !boundData) || boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
-    EJIT_DIAG("shared taskpool bound snapshot reject func=%u size=%u max=%u",
-              funcIndex, boundSize,
-              static_cast<unsigned>(EJIT_BOUND_PTR_MAX_BYTES));
-    R.status = EJitCompileOrGetStatus::InvalidParam;
     return R;
   }
   // Off mode (§5.2 step 2).
@@ -3267,13 +3308,13 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       ReqLocal.versions[i] =
           instanceVersion(dims[i].dimType, dims[i].instanceId);
     }
-    ReqLocal.boundArgIndex = boundArgIndex;
-    ReqLocal.boundSize = boundSize;
-    if (boundSize)
-      std::memcpy(ReqLocal.boundData, boundData, boundSize);
+    ReqLocal.boundCount = boundCount;
+    for (uint32_t i = 0; i < boundCount; ++i)
+      ReqLocal.boundPointers[i] = boundPointers[i];
     if (!versionsCurrent(ReqLocal)) {
-      EJIT_DIAG("shared taskpool sync snapshot drop func=%u: version changed",
-                funcIndex);
+      EJIT_DIAG(
+          "shared taskpool sync bound request drop func=%u: version changed",
+          funcIndex);
       R.status = EJitCompileOrGetStatus::CompileFailed;
       return R;
     }
@@ -3395,17 +3436,17 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     Req.dims[i] = dims[i];
     Req.versions[i] = instanceVersion(dims[i].dimType, dims[i].instanceId);
   }
-  Req.boundArgIndex = boundArgIndex;
-  Req.boundSize = boundSize;
-  if (boundSize)
-    std::memcpy(Req.boundData, boundData, boundSize);
+  Req.boundCount = boundCount;
+  for (uint32_t i = 0; i < boundCount; ++i)
+    Req.boundPointers[i] = boundPointers[i];
   if (!versionsCurrent(Req) || state_->generation.loadAcquire() != gen) {
     dedupClear(funcIndex, gen);
     if (newlyAdmitted)
       finishPgoFunction(funcIndex, /*completed=*/false,
                         "lifecycle-changed-during-admission");
-    EJIT_DIAG("shared taskpool async snapshot drop func=%u: lifecycle changed",
-              funcIndex);
+    EJIT_DIAG(
+        "shared taskpool async bound request drop func=%u: lifecycle changed",
+        funcIndex);
     R.status = EJitCompileOrGetStatus::CompileFailed;
     return R;
   }
@@ -3799,6 +3840,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
               static_cast<unsigned>(ok), fn);
     return;
   }
+  const EJitCompileRequest PublishReq = requestForPublication(req);
   // Resolve the real executable range for the freshly compiled pointer (from
   // the owner's code-pool finalize metadata) so it can be published into the
   // cache slot for cross-core 4K sealing. Optional: if no provider is wired or
@@ -3813,7 +3855,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
       !versionsCurrent(req)) {
     dropBatchRequestMarker();
     if (publishFn_)
-      publishFn_(publishCtx_, req, false);
+      publishFn_(publishCtx_, PublishReq, false);
     dedupClear(req.funcIndex, req.generation);
     if (req.generation == state_->generation.loadAcquire() &&
         (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse))
@@ -3833,7 +3875,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
       // must not replace the live Tier-1 slot until the worker observes the
       // compile queue empty and seals the batch. Keep only owner-private state
       // and retain the in-flight claim.
-      pendingPublishes_.push_back({req, fn});
+      pendingPublishes_.push_back({PublishReq, fn});
       autoTier2PublishPending_ = true;
       EJIT_DIAG_DEBUG("PGO Tier-2 linked pending queue-drain publish func=%u "
                       "fn=%p pending=%zu",
@@ -3845,7 +3887,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
       // a pool-routing/configuration failure instead of delaying profiling or
       // replacing the AOT path with an NX pointer.
       if (publishFn_)
-        publishFn_(publishCtx_, req, false);
+        publishFn_(publishCtx_, PublishReq, false);
       dedupClear(req.funcIndex, req.generation);
       finishPgoOnFailure();
       if (releaseFn_)
@@ -3855,9 +3897,9 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
                 realFuncIndex);
       return;
     }
-    EJitPublishStatus Staged = cacheStagePending(req, fn);
+    EJitPublishStatus Staged = cacheStagePending(PublishReq, fn);
     if (Staged == EJitPublishStatus::Published) {
-      pendingPublishes_.push_back({req, fn});
+      pendingPublishes_.push_back({PublishReq, fn});
       dedupClear(req.funcIndex, req.generation);
       EJIT_DIAG_DEBUG("shared worker batch staged func=%u fn=%p pending=%zu",
                       req.funcIndex, fn, pendingPublishes_.size());
@@ -3869,7 +3911,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
     // A bucket containing only other Pending identities has no safe eviction
     // victim. Keep the result owner-private with its coarse in-flight claim;
     // the explicit publish call seals all code and then inserts this identity.
-    pendingPublishes_.push_back({req, fn});
+    pendingPublishes_.push_back({PublishReq, fn});
     EJIT_DIAG_VERBOSE(
         "shared worker batch retained unstaged func=%u pending=%zu",
         req.funcIndex, pendingPublishes_.size());
@@ -3877,12 +3919,12 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
   }
   if (info.codeSize == 0 && codeRangeFn_)
     (void)codeRangeFn_(codeRangeCtx_, fn, &info);
-  EJitPublishStatus PS = cachePublish(req, fn, &info, pgoClearExclusive);
+  EJitPublishStatus PS = cachePublish(PublishReq, fn, &info, pgoClearExclusive);
   switch (PS) {
   case EJitPublishStatus::Published:
     EJIT_STAT_INC(state_->counters.asyncCompiles);
     if (publishFn_)
-      publishFn_(publishCtx_, req, true);
+      publishFn_(publishCtx_, PublishReq, true);
     dedupClear(req.funcIndex, req.generation);
     if (tier == kEJitTierInstrumented) {
       EJIT_STAT_INC(state_->counters.tier1Compiles);
@@ -3898,7 +3940,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
     return;
   case EJitPublishStatus::VersionMismatch:
     if (publishFn_)
-      publishFn_(publishCtx_, req, false);
+      publishFn_(publishCtx_, PublishReq, false);
     dedupClear(req.funcIndex, req.generation);
     if (req.generation == state_->generation.loadAcquire() &&
         (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse))
@@ -3913,7 +3955,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
   case EJitPublishStatus::InvalidParam:
   case EJitPublishStatus::Failed:
     if (publishFn_)
-      publishFn_(publishCtx_, req, false);
+      publishFn_(publishCtx_, PublishReq, false);
     dedupClear(req.funcIndex, req.generation);
     finishPgoOnFailure();
     if (releaseFn_)

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -146,6 +146,51 @@ static MDNode *getBoundArgumentMetadata(const Function &F,
   return nullptr;
 }
 
+static bool hasMatchingBoundArgumentContract(
+    const Function &F, unsigned ArgIndex, StringRef PeriodName,
+    uint64_t BaseOffset, uint64_t RootSize,
+    ArrayRef<std::pair<uint64_t, uint64_t>> RootFields) {
+  MDNode *MD = getBoundArgumentMetadata(F, ArgIndex);
+  if (!MD)
+    return false;
+
+  auto *Period = dyn_cast<MDString>(MD->getOperand(1));
+  auto *Size = mdconst::dyn_extract<ConstantInt>(MD->getOperand(3));
+  if (!Period || Period->getString() != PeriodName || !Size)
+    return false;
+  const uint64_t BoundSize = Size->getZExtValue();
+  if (!BoundSize || BaseOffset > RootSize || BoundSize > RootSize - BaseOffset)
+    return false;
+
+  SmallVector<std::pair<uint64_t, uint64_t>, 4> DeclaredFields;
+  for (unsigned I = 4; I < MD->getNumOperands(); ++I) {
+    auto *Field = dyn_cast<MDNode>(MD->getOperand(I));
+    if (!Field || Field->getNumOperands() != 2)
+      return false;
+    auto *Offset = mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
+    auto *FieldSize = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
+    if (!Offset || !FieldSize || !FieldSize->getZExtValue() ||
+        Offset->getZExtValue() > BoundSize ||
+        FieldSize->getZExtValue() > BoundSize - Offset->getZExtValue())
+      return false;
+    DeclaredFields.emplace_back(Offset->getZExtValue(),
+                                FieldSize->getZExtValue());
+  }
+
+  SmallVector<std::pair<uint64_t, uint64_t>, 4> ExpectedFields;
+  for (const auto &[Offset, FieldSize] : RootFields) {
+    if (Offset < BaseOffset)
+      continue;
+    const uint64_t Relative = Offset - BaseOffset;
+    if (Relative > BoundSize || FieldSize > BoundSize - Relative)
+      continue;
+    ExpectedFields.emplace_back(Relative, FieldSize);
+  }
+  llvm::sort(DeclaredFields);
+  llvm::sort(ExpectedFields);
+  return DeclaredFields == ExpectedFields;
+}
+
 static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
                                                         const Value *PtrOp,
                                                         const Argument *Root);
@@ -416,7 +461,10 @@ void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
               continue;
             auto Offset = getBoundPointerOffset(CB->getArgOperand(ArgIndex),
                                                 State.boundArguments, DL);
-            if (!Offset || *Offset >= View.size)
+            if (!Offset || *Offset >= View.size ||
+                !hasMatchingBoundArgumentContract(
+                    *Callee, ArgIndex, BoundPeriodName, *Offset, View.size,
+                    State.mayConstFields))
               continue;
             Changed |= State.boundArguments.try_emplace(Formal, *Offset).second;
           }
@@ -440,7 +488,10 @@ void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
           }
           auto CalleeDimension =
               getMatchingBoundEntryDimensionArg(*Callee, BoundPeriodName);
-          if (!CalleeDimension) {
+          if (!CalleeDimension ||
+              !hasMatchingBoundArgumentContract(
+                  *Callee, Formal->getArgNo(), BoundPeriodName, ExpectedOffset,
+                  View.size, State.mayConstFields)) {
             Invalid.push_back(Formal);
             continue;
           }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -18,8 +18,10 @@
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
+#include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <limits>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -76,6 +78,7 @@ void EJitStructFieldPass::initFromModule(Module &M) {
       mayConstFieldMap_[&GV] = std::move(offsets);
   }
 
+  initBoundArgumentPropagation(M);
   mapsBuilt_ = true;
 #ifdef EJIT_DIAG_ENABLE
   EJIT_DIAG_DEBUG("struct-field initFromModule module=%s globals=%zu "
@@ -125,55 +128,27 @@ static bool functionBindsArgument(const Function &F, unsigned ArgIndex) {
   return false;
 }
 
-static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
-                                                        const Value *PtrOp,
-                                                        const Argument *Root);
-
-static bool isBoundMayConstLoad(LoadInst *LI, const Function &F,
-                                unsigned ArgIndex, const DataLayout &DL) {
-  if (LI->isVolatile() || LI->isAtomic() || ArgIndex >= F.arg_size())
-    return false;
-  const Argument *Root = findRootArgument(LI->getPointerOperand());
-  if (!Root || Root->getArgNo() != ArgIndex)
-    return false;
-  if (LI->hasMetadata(MD_EJIT_MAY_CONST))
-    return true;
-
-  auto Offset = accumulateArgumentOffset(DL, LI->getPointerOperand(), Root);
-  TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
-  if (!Offset || AccessSize.isScalable())
-    return false;
-
+static MDNode *getBoundArgumentMetadata(const Function &F,
+                                        unsigned ArgIndex) {
   MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
   if (!MD)
-    return false;
+    return nullptr;
   for (const MDOperand &Op : MD->operands()) {
     auto *Sub = dyn_cast<MDNode>(Op.get());
     if (!Sub || Sub->getNumOperands() < 4)
       continue;
     auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
     auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
-    if (!Tag || Tag->getString() != TAG_EJIT_BOUND_PTR || !Idx ||
-        Idx->getZExtValue() != ArgIndex)
-      continue;
-    for (unsigned I = 4; I < Sub->getNumOperands(); ++I) {
-      auto *Field = dyn_cast<MDNode>(Sub->getOperand(I));
-      if (!Field || Field->getNumOperands() != 2)
-        continue;
-      auto *FieldOffset =
-          mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
-      auto *FieldSize = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
-      if (FieldOffset && FieldSize) {
-        uint64_t Begin = FieldOffset->getZExtValue();
-        uint64_t Size = FieldSize->getZExtValue();
-        if (*Offset >= Begin && *Offset - Begin <= Size &&
-            AccessSize.getFixedValue() <= Size - (*Offset - Begin))
-          return true;
-      }
-    }
+    if (Tag && Tag->getString() == TAG_EJIT_BOUND_PTR && Idx &&
+        Idx->getZExtValue() == ArgIndex)
+      return Sub;
   }
-  return false;
+  return nullptr;
 }
+
+static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
+                                                        const Value *PtrOp,
+                                                        const Argument *Root);
 
 /// If all GEP indices are ConstantInt, compute the cumulative byte offset.
 /// Returns std::nullopt if any index is not constant.
@@ -233,6 +208,173 @@ static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
     PtrOp = GEP->getPointerOperand();
   }
   return std::nullopt;
+}
+
+static std::optional<uint64_t> getBoundSnapshotOffset(
+    const Value *V, const DenseMap<const Argument *, uint64_t> &BoundArguments,
+    const DataLayout &DL) {
+  const Argument *Root = findRootArgument(V);
+  if (!Root)
+    return std::nullopt;
+  auto It = BoundArguments.find(Root);
+  if (It == BoundArguments.end())
+    return std::nullopt;
+  auto Relative = accumulateArgumentOffset(DL, V, Root);
+  if (!Relative ||
+      It->second > std::numeric_limits<uint64_t>::max() - *Relative)
+    return std::nullopt;
+  return It->second + *Relative;
+}
+
+static Function *getDirectCallee(CallBase &CB) {
+  return dyn_cast<Function>(CB.getCalledOperand()->stripPointerCasts());
+}
+
+void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
+  boundArguments_.clear();
+  boundMayConstFields_.clear();
+  if (!boundData_ || !boundSize_)
+    return;
+
+  Function *Root = nullptr;
+  if (!boundRootFunction_.empty()) {
+    Root = M.getFunction(boundRootFunction_);
+  } else {
+    // Direct pass users may omit the root name. Infer it only when the module
+    // contains a unique matching bound parameter.
+    for (Function &F : M) {
+      if (!functionBindsArgument(F, boundArgIndex_))
+        continue;
+      if (Root) {
+        Root = nullptr;
+        break;
+      }
+      Root = &F;
+    }
+  }
+  if (!Root || Root->isDeclaration() || boundArgIndex_ >= Root->arg_size() ||
+      !functionBindsArgument(*Root, boundArgIndex_))
+    return;
+
+  Argument *RootArgument = Root->getArg(boundArgIndex_);
+  if (!RootArgument->getType()->isPointerTy())
+    return;
+  boundArguments_[RootArgument] = 0;
+
+  if (MDNode *BoundMD = getBoundArgumentMetadata(*Root, boundArgIndex_)) {
+    for (unsigned I = 4; I < BoundMD->getNumOperands(); ++I) {
+      auto *Field = dyn_cast<MDNode>(BoundMD->getOperand(I));
+      if (!Field || Field->getNumOperands() != 2)
+        continue;
+      auto *Offset = mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
+      auto *Size = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
+      if (Offset && Size)
+        boundMayConstFields_.push_back(
+            {Offset->getZExtValue(), Size->getZExtValue()});
+    }
+  }
+
+  const DataLayout &DL = M.getDataLayout();
+  SmallVector<CallBase *, 32> DirectCalls;
+  DenseMap<const Function *, SmallVector<CallBase *, 4>> CallsByCallee;
+  for (Function &Caller : M) {
+    if (Caller.isDeclaration())
+      continue;
+    for (BasicBlock &BB : Caller) {
+      for (Instruction &I : BB) {
+        auto *CB = dyn_cast<CallBase>(&I);
+        if (!CB)
+          continue;
+        Function *Callee = getDirectCallee(*CB);
+        if (!Callee || Callee->isDeclaration())
+          continue;
+        DirectCalls.push_back(CB);
+        CallsByCallee[Callee].push_back(CB);
+      }
+    }
+  }
+
+  bool Changed;
+  do {
+    Changed = false;
+    for (CallBase *CB : DirectCalls) {
+      Function *Callee = getDirectCallee(*CB);
+      unsigned Count =
+          std::min<unsigned>(CB->arg_size(), Callee->arg_size());
+      for (unsigned ArgIndex = 0; ArgIndex < Count; ++ArgIndex) {
+        Argument *Formal = Callee->getArg(ArgIndex);
+        if (!Formal->getType()->isPointerTy())
+          continue;
+        auto Offset = getBoundSnapshotOffset(CB->getArgOperand(ArgIndex),
+                                             boundArguments_, DL);
+        if (!Offset || *Offset >= boundSize_)
+          continue;
+        Changed |= boundArguments_.try_emplace(Formal, *Offset).second;
+      }
+    }
+  } while (Changed);
+
+  // A callee is safe only if every call represented in this specialization
+  // module passes the same snapshot-derived pointer to that formal argument.
+  // Prune to a fixed point so ambiguity in an upper helper also removes all
+  // mappings derived through it further down the chain.
+  do {
+    Changed = false;
+    SmallVector<const Argument *, 8> Invalid;
+    for (const auto &[Formal, ExpectedOffset] : boundArguments_) {
+      if (Formal == RootArgument)
+        continue;
+      const Function *Callee = Formal->getParent();
+      if (Callee->hasAddressTaken()) {
+        Invalid.push_back(Formal);
+        continue;
+      }
+      bool SawCall = false;
+      bool AllMatch = true;
+      auto CallsIt = CallsByCallee.find(Callee);
+      if (CallsIt != CallsByCallee.end()) {
+        for (CallBase *CB : CallsIt->second) {
+          SawCall = true;
+          unsigned ArgIndex = Formal->getArgNo();
+          if (ArgIndex >= CB->arg_size()) {
+            AllMatch = false;
+            continue;
+          }
+          auto ActualOffset = getBoundSnapshotOffset(
+              CB->getArgOperand(ArgIndex), boundArguments_, DL);
+          if (!ActualOffset || *ActualOffset != ExpectedOffset)
+            AllMatch = false;
+        }
+      }
+      if (!SawCall || !AllMatch)
+        Invalid.push_back(Formal);
+    }
+    for (const Argument *Formal : Invalid)
+      Changed |= boundArguments_.erase(Formal);
+  } while (Changed);
+}
+
+static bool isBoundMayConstLoad(
+    LoadInst *LI, const DenseMap<const Argument *, uint64_t> &BoundArguments,
+    ArrayRef<std::pair<uint64_t, uint64_t>> MayConstFields,
+    const DataLayout &DL) {
+  if (LI->isVolatile() || LI->isAtomic())
+    return false;
+  auto Offset =
+      getBoundSnapshotOffset(LI->getPointerOperand(), BoundArguments, DL);
+  if (!Offset)
+    return false;
+  if (LI->hasMetadata(MD_EJIT_MAY_CONST))
+    return true;
+
+  TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
+  if (AccessSize.isScalable())
+    return false;
+  for (const auto &[Begin, Size] : MayConstFields)
+    if (*Offset >= Begin && *Offset - Begin <= Size &&
+        AccessSize.getFixedValue() <= Size - (*Offset - Begin))
+      return true;
+  return false;
 }
 
 /// Check whether a load is (or can be treated as) a may_const access.
@@ -516,17 +658,14 @@ static Constant *tryReplacePeriodAbsoluteAddress(
   return nullptr;
 }
 
-static Constant *tryReplaceBoundPointer(LoadInst *LI, const Function &F,
-                                        const uint8_t *Data, uint32_t Size,
-                                        uint32_t ArgIndex,
-                                        const DataLayout &DL) {
-  if (!Data || !Size || ArgIndex >= F.arg_size() ||
-      !functionBindsArgument(F, ArgIndex))
+static Constant *tryReplaceBoundPointer(
+    LoadInst *LI, const uint8_t *Data, uint32_t Size,
+    const DenseMap<const Argument *, uint64_t> &BoundArguments,
+    const DataLayout &DL) {
+  if (!Data || !Size)
     return nullptr;
-  const Argument *Root = findRootArgument(LI->getPointerOperand());
-  if (!Root || Root->getArgNo() != ArgIndex)
-    return nullptr;
-  auto Offset = accumulateArgumentOffset(DL, LI->getPointerOperand(), Root);
+  auto Offset =
+      getBoundSnapshotOffset(LI->getPointerOperand(), BoundArguments, DL);
   TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
   if (!Offset || AccessSize.isScalable() || *Offset > Size ||
       AccessSize.getFixedValue() > Size - *Offset)
@@ -745,7 +884,8 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
         continue;
       }
 
-      bool BoundMayConst = isBoundMayConstLoad(LI, F, boundArgIndex_, DL);
+      bool BoundMayConst = isBoundMayConstLoad(
+          LI, boundArguments_, boundMayConstFields_, DL);
       if (!BoundMayConst && !isMayConstLoad(LI, mayConstFieldMap_, DL))
         continue;
 #ifdef EJIT_DIAG_ENABLE
@@ -762,8 +902,8 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
       // from the owned snapshot; the pointer argument and all dynamic fields
       // remain live inputs to the specialization.
       if (!C)
-        C = tryReplaceBoundPointer(LI, F, boundData_, boundSize_,
-                                   boundArgIndex_, DL);
+        C = tryReplaceBoundPointer(LI, boundData_, boundSize_, boundArguments_,
+                                   DL);
 
       // Pattern 1: direct GlobalVariable load (scalar static variable).
       if (!C) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -210,7 +210,7 @@ static std::optional<uint64_t> accumulateArgumentOffset(const DataLayout &DL,
   return std::nullopt;
 }
 
-static std::optional<uint64_t> getBoundSnapshotOffset(
+static std::optional<uint64_t> getBoundPointerOffset(
     const Value *V, const DenseMap<const Argument *, uint64_t> &BoundArguments,
     const DataLayout &DL) {
   const Argument *Root = findRootArgument(V);
@@ -230,49 +230,100 @@ static Function *getDirectCallee(CallBase &CB) {
   return dyn_cast<Function>(CB.getCalledOperand()->stripPointerCasts());
 }
 
+/// A bound pointer may cross a call edge only when the callee is itself an
+/// EJIT entry with the same dimension in its cache identity. Without this
+/// contract, a private helper could be specialized in the caller's module
+/// even though it has no independently addressable cell version.
+static std::optional<unsigned>
+getMatchingBoundEntryDimensionArg(const Function &F,
+                                  StringRef BoundPeriodName) {
+  if (!hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY))
+    return std::nullopt;
+
+  MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
+  std::optional<unsigned> MatchingArg;
+  for (const MDOperand &Op : MD->operands()) {
+    auto *Sub = dyn_cast<MDNode>(Op.get());
+    if (!Sub || Sub->getNumOperands() < 3)
+      continue;
+    auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
+    auto *Period = dyn_cast<MDString>(Sub->getOperand(1));
+    auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
+    if (!Tag || Tag->getString() != TAG_EJIT_PERIOD_ARR_IND || !Period ||
+        Period->getString() != BoundPeriodName)
+      continue;
+    uint64_t ArgIndex = Idx ? Idx->getZExtValue() : 0;
+    if (!Idx || ArgIndex >= F.arg_size() ||
+        !F.getArg(static_cast<unsigned>(ArgIndex))->getType()->isIntegerTy())
+      return std::nullopt;
+    if (MatchingArg)
+      return std::nullopt;
+    MatchingArg = static_cast<unsigned>(ArgIndex);
+  }
+  return MatchingArg;
+}
+
+/// Strip integer casts from a dimension value. preReplacePeriodIndices leaves
+/// the Argument object in place, but replaces all of its uses with a constant;
+/// before that pass, direct calls commonly carry the caller's formal through a
+/// zext/trunc. Both forms are accepted below.
+static const Value *stripDimensionCasts(const Value *V) {
+  while (V) {
+    const Value *Stripped = V->stripPointerCasts();
+    if (Stripped != V) {
+      V = Stripped;
+      continue;
+    }
+
+    auto *Op = dyn_cast<Operator>(V);
+    if (!Op || Op->getNumOperands() != 1 || !Op->getType()->isIntegerTy() ||
+        !Op->getOperand(0)->getType()->isIntegerTy())
+      break;
+    switch (Op->getOpcode()) {
+    case Instruction::Trunc:
+    case Instruction::ZExt:
+    case Instruction::SExt:
+    case Instruction::BitCast:
+      V = Op->getOperand(0);
+      continue;
+    default:
+      break;
+    }
+    break;
+  }
+  return V;
+}
+
+static bool isSpecializedDimensionConstant(const Value *V, uint8_t Expected) {
+  V = stripDimensionCasts(V);
+  auto *CI = dyn_cast_or_null<ConstantInt>(V);
+  if (!CI || CI->getValue().getActiveBits() > 8)
+    return false;
+  return CI->getZExtValue() == Expected;
+}
+
+static bool
+callUsesSameBoundDimension(const CallBase &CB, StringRef BoundPeriodName,
+                           unsigned CalleeDimensionArg,
+                           std::optional<uint8_t> ExpectedInstance) {
+  const Function *Caller = CB.getFunction();
+  auto CallerDimension =
+      getMatchingBoundEntryDimensionArg(*Caller, BoundPeriodName);
+  if (!CallerDimension || CalleeDimensionArg >= CB.arg_size())
+    return false;
+
+  const Value *Actual = CB.getArgOperand(CalleeDimensionArg);
+  const Argument *CallerArg = Caller->getArg(*CallerDimension);
+  if (stripDimensionCasts(Actual) == CallerArg)
+    return true;
+  return ExpectedInstance &&
+         isSpecializedDimensionConstant(Actual, *ExpectedInstance);
+}
+
 void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
-  boundArguments_.clear();
-  boundMayConstFields_.clear();
-  if (!boundData_ || !boundSize_)
+  boundStates_.clear();
+  if (boundPointers_.empty())
     return;
-
-  Function *Root = nullptr;
-  if (!boundRootFunction_.empty()) {
-    Root = M.getFunction(boundRootFunction_);
-  } else {
-    // Direct pass users may omit the root name. Infer it only when the module
-    // contains a unique matching bound parameter.
-    for (Function &F : M) {
-      if (!functionBindsArgument(F, boundArgIndex_))
-        continue;
-      if (Root) {
-        Root = nullptr;
-        break;
-      }
-      Root = &F;
-    }
-  }
-  if (!Root || Root->isDeclaration() || boundArgIndex_ >= Root->arg_size() ||
-      !functionBindsArgument(*Root, boundArgIndex_))
-    return;
-
-  Argument *RootArgument = Root->getArg(boundArgIndex_);
-  if (!RootArgument->getType()->isPointerTy())
-    return;
-  boundArguments_[RootArgument] = 0;
-
-  if (MDNode *BoundMD = getBoundArgumentMetadata(*Root, boundArgIndex_)) {
-    for (unsigned I = 4; I < BoundMD->getNumOperands(); ++I) {
-      auto *Field = dyn_cast<MDNode>(BoundMD->getOperand(I));
-      if (!Field || Field->getNumOperands() != 2)
-        continue;
-      auto *Offset = mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
-      auto *Size = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
-      if (Offset && Size)
-        boundMayConstFields_.push_back(
-            {Offset->getZExtValue(), Size->getZExtValue()});
-    }
-  }
 
   const DataLayout &DL = M.getDataLayout();
   SmallVector<CallBase *, 32> DirectCalls;
@@ -280,7 +331,7 @@ void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
   for (Function &Caller : M) {
     if (Caller.isDeclaration())
       continue;
-    for (BasicBlock &BB : Caller) {
+    for (BasicBlock &BB : Caller)
       for (Instruction &I : BB) {
         auto *CB = dyn_cast<CallBase>(&I);
         if (!CB)
@@ -291,67 +342,145 @@ void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
         DirectCalls.push_back(CB);
         CallsByCallee[Callee].push_back(CB);
       }
-    }
   }
 
-  bool Changed;
-  do {
-    Changed = false;
-    for (CallBase *CB : DirectCalls) {
-      Function *Callee = getDirectCallee(*CB);
-      unsigned Count =
-          std::min<unsigned>(CB->arg_size(), Callee->arg_size());
-      for (unsigned ArgIndex = 0; ArgIndex < Count; ++ArgIndex) {
-        Argument *Formal = Callee->getArg(ArgIndex);
-        if (!Formal->getType()->isPointerTy())
+  for (const EJitBoundPointerView &View : boundPointers_) {
+    if (!View.rawPtr || !View.size)
+      continue;
+
+    Function *Root = nullptr;
+    if (!boundRootFunction_.empty()) {
+      Root = M.getFunction(boundRootFunction_);
+    } else {
+      // Infer a root only when this argument index identifies one function.
+      // With multiple bound pointers the same function is intentionally found
+      // once per distinct metadata argument.
+      for (Function &F : M) {
+        if (!functionBindsArgument(F, View.argIndex))
           continue;
-        auto Offset = getBoundSnapshotOffset(CB->getArgOperand(ArgIndex),
-                                             boundArguments_, DL);
-        if (!Offset || *Offset >= boundSize_)
-          continue;
-        Changed |= boundArguments_.try_emplace(Formal, *Offset).second;
+        if (Root) {
+          Root = nullptr;
+          break;
+        }
+        Root = &F;
       }
     }
-  } while (Changed);
+    if (!Root || Root->isDeclaration() || View.argIndex >= Root->arg_size() ||
+        !functionBindsArgument(*Root, View.argIndex))
+      continue;
 
-  // A callee is safe only if every call represented in this specialization
-  // module passes the same snapshot-derived pointer to that formal argument.
-  // Prune to a fixed point so ambiguity in an upper helper also removes all
-  // mappings derived through it further down the chain.
-  do {
-    Changed = false;
-    SmallVector<const Argument *, 8> Invalid;
-    for (const auto &[Formal, ExpectedOffset] : boundArguments_) {
-      if (Formal == RootArgument)
-        continue;
-      const Function *Callee = Formal->getParent();
-      if (Callee->hasAddressTaken()) {
-        Invalid.push_back(Formal);
-        continue;
+    Argument *RootArgument = Root->getArg(View.argIndex);
+    if (!RootArgument->getType()->isPointerTy())
+      continue;
+
+    BoundPointerState State;
+    State.view = View;
+    State.boundArguments[RootArgument] = 0;
+    StringRef BoundPeriodName;
+    if (MDNode *BoundMD = getBoundArgumentMetadata(*Root, View.argIndex)) {
+      if (auto *Period = dyn_cast<MDString>(BoundMD->getOperand(1)))
+        BoundPeriodName = Period->getString();
+      for (unsigned I = 4; I < BoundMD->getNumOperands(); ++I) {
+        auto *Field = dyn_cast<MDNode>(BoundMD->getOperand(I));
+        if (!Field || Field->getNumOperands() != 2)
+          continue;
+        auto *Offset = mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
+        auto *Size = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
+        if (Offset && Size)
+          State.mayConstFields.push_back(
+              {Offset->getZExtValue(), Size->getZExtValue()});
       }
-      bool SawCall = false;
-      bool AllMatch = true;
-      auto CallsIt = CallsByCallee.find(Callee);
-      if (CallsIt != CallsByCallee.end()) {
-        for (CallBase *CB : CallsIt->second) {
-          SawCall = true;
-          unsigned ArgIndex = Formal->getArgNo();
-          if (ArgIndex >= CB->arg_size()) {
-            AllMatch = false;
+    }
+
+    if (!BoundPeriodName.empty()) {
+      bool Changed;
+      do {
+        Changed = false;
+        for (CallBase *CB : DirectCalls) {
+          Function *Callee = getDirectCallee(*CB);
+          auto CalleeDimension =
+              getMatchingBoundEntryDimensionArg(*Callee, BoundPeriodName);
+          if (!CalleeDimension ||
+              !callUsesSameBoundDimension(
+                  *CB, BoundPeriodName, *CalleeDimension,
+                  View.periodInstance == std::numeric_limits<uint32_t>::max()
+                      ? std::nullopt
+                      : std::optional<uint8_t>(
+                            static_cast<uint8_t>(View.periodInstance))))
+            continue;
+          unsigned Count =
+              std::min<unsigned>(CB->arg_size(), Callee->arg_size());
+          for (unsigned ArgIndex = 0; ArgIndex < Count; ++ArgIndex) {
+            Argument *Formal = Callee->getArg(ArgIndex);
+            if (!Formal->getType()->isPointerTy())
+              continue;
+            auto Offset = getBoundPointerOffset(CB->getArgOperand(ArgIndex),
+                                                State.boundArguments, DL);
+            if (!Offset || *Offset >= View.size)
+              continue;
+            Changed |= State.boundArguments.try_emplace(Formal, *Offset).second;
+          }
+        }
+      } while (Changed);
+
+      // Every mapped helper formal must be reached only through calls that
+      // carry both the same bound object and the same period identity. This
+      // fixed-point prune makes a single ambiguous edge conservatively remove
+      // the whole downstream chain.
+      do {
+        Changed = false;
+        SmallVector<const Argument *, 8> Invalid;
+        for (const auto &[Formal, ExpectedOffset] : State.boundArguments) {
+          if (Formal == RootArgument)
+            continue;
+          const Function *Callee = Formal->getParent();
+          if (Callee->hasAddressTaken()) {
+            Invalid.push_back(Formal);
             continue;
           }
-          auto ActualOffset = getBoundSnapshotOffset(
-              CB->getArgOperand(ArgIndex), boundArguments_, DL);
-          if (!ActualOffset || *ActualOffset != ExpectedOffset)
-            AllMatch = false;
+          auto CalleeDimension =
+              getMatchingBoundEntryDimensionArg(*Callee, BoundPeriodName);
+          if (!CalleeDimension) {
+            Invalid.push_back(Formal);
+            continue;
+          }
+          bool SawCall = false;
+          bool AllMatch = true;
+          auto CallsIt = CallsByCallee.find(Callee);
+          if (CallsIt != CallsByCallee.end()) {
+            for (CallBase *CB : CallsIt->second) {
+              SawCall = true;
+              unsigned ArgIndex = Formal->getArgNo();
+              if (ArgIndex >= CB->arg_size()) {
+                AllMatch = false;
+                continue;
+              }
+              if (!callUsesSameBoundDimension(
+                      *CB, BoundPeriodName, *CalleeDimension,
+                      View.periodInstance ==
+                              std::numeric_limits<uint32_t>::max()
+                          ? std::nullopt
+                          : std::optional<uint8_t>(
+                                static_cast<uint8_t>(View.periodInstance)))) {
+                AllMatch = false;
+                continue;
+              }
+              auto ActualOffset = getBoundPointerOffset(
+                  CB->getArgOperand(ArgIndex), State.boundArguments, DL);
+              if (!ActualOffset || *ActualOffset != ExpectedOffset)
+                AllMatch = false;
+            }
+          }
+          if (!SawCall || !AllMatch)
+            Invalid.push_back(Formal);
         }
-      }
-      if (!SawCall || !AllMatch)
-        Invalid.push_back(Formal);
+        for (const Argument *Formal : Invalid)
+          Changed |= State.boundArguments.erase(Formal);
+      } while (Changed);
     }
-    for (const Argument *Formal : Invalid)
-      Changed |= boundArguments_.erase(Formal);
-  } while (Changed);
+
+    boundStates_.push_back(std::move(State));
+  }
 }
 
 static bool isBoundMayConstLoad(
@@ -361,7 +490,7 @@ static bool isBoundMayConstLoad(
   if (LI->isVolatile() || LI->isAtomic())
     return false;
   auto Offset =
-      getBoundSnapshotOffset(LI->getPointerOperand(), BoundArguments, DL);
+      getBoundPointerOffset(LI->getPointerOperand(), BoundArguments, DL);
   if (!Offset)
     return false;
   if (LI->hasMetadata(MD_EJIT_MAY_CONST))
@@ -570,10 +699,20 @@ static Constant *createConstantFromMemory(const void *addr, Type *Ty,
     return ConstantFP::get(Ty, v);
   }
   if (Ty->isPointerTy()) {
+    const unsigned PointerSize = DL.getPointerSize(Ty->getPointerAddressSpace());
+    if (PointerSize == 0 || PointerSize > sizeof(uint64_t))
+      return nullptr;
+
     uint64_t raw = 0;
-    std::memcpy(&raw, addr, sizeof(raw));
+    const auto *Bytes = static_cast<const uint8_t *>(addr);
+    if (DL.isLittleEndian()) {
+      std::memcpy(&raw, Bytes, PointerSize);
+    } else {
+      for (unsigned I = 0; I < PointerSize; ++I)
+        raw = (raw << 8) | Bytes[I];
+    }
     return ConstantExpr::getIntToPtr(
-        ConstantInt::get(Type::getInt64Ty(Ctx), raw), Ty);
+        ConstantInt::get(IntegerType::get(Ctx, PointerSize * 8), raw), Ty);
   }
   return nullptr;
 }
@@ -665,7 +804,7 @@ static Constant *tryReplaceBoundPointer(
   if (!Data || !Size)
     return nullptr;
   auto Offset =
-      getBoundSnapshotOffset(LI->getPointerOperand(), BoundArguments, DL);
+      getBoundPointerOffset(LI->getPointerOperand(), BoundArguments, DL);
   TypeSize AccessSize = DL.getTypeStoreSize(LI->getType());
   if (!Offset || AccessSize.isScalable() || *Offset > Size ||
       AccessSize.getFixedValue() > Size - *Offset)
@@ -884,8 +1023,10 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
         continue;
       }
 
-      bool BoundMayConst = isBoundMayConstLoad(
-          LI, boundArguments_, boundMayConstFields_, DL);
+      bool BoundMayConst = false;
+      for (const BoundPointerState &State : boundStates_)
+        BoundMayConst |= isBoundMayConstLoad(LI, State.boundArguments,
+                                             State.mayConstFields, DL);
       if (!BoundMayConst && !isMayConstLoad(LI, mayConstFieldMap_, DL))
         continue;
 #ifdef EJIT_DIAG_ENABLE
@@ -899,11 +1040,16 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
           LI, gvPeriodMap_, mayConstFieldMap_, registry_, DL);
 
       // Pattern 0: an ejit_bound_ptr parameter. Only the marked load is read
-      // from the owned snapshot; the pointer argument and all dynamic fields
+      // from the shared object; the pointer argument and all dynamic fields
       // remain live inputs to the specialization.
-      if (!C)
-        C = tryReplaceBoundPointer(LI, boundData_, boundSize_, boundArguments_,
-                                   DL);
+      if (!C) {
+        for (const BoundPointerState &State : boundStates_) {
+          C = tryReplaceBoundPointer(LI, State.view.rawPtr, State.view.size,
+                                     State.boundArguments, DL);
+          if (C)
+            break;
+        }
+      }
 
       // Pattern 1: direct GlobalVariable load (scalar static variable).
       if (!C) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -10,6 +10,20 @@
 using namespace llvm;
 using namespace llvm::ejit;
 
+namespace {
+
+// Bound pointers are transport-only. A publish notification happens after
+// compilation, so it must not expose a borrowed object to callback code.
+EJitCompileRequest requestForPublication(const EJitCompileRequest &Req) {
+  EJitCompileRequest Published = Req;
+  Published.boundCount = 0;
+  for (EJitBoundPtrDescriptor &Bound : Published.boundPointers)
+    Bound = {};
+  return Published;
+}
+
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // EJitSwitchController (§5.1)
 //
@@ -489,13 +503,21 @@ EJitTaskPool::tryCacheHit4D(uint32_t funcIndex, uint32_t dim0, uint32_t inst0,
 EJitTaskPool::CompileOrGetResult
 EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                            uint32_t numDims, void *fallback,
-                           const void *boundData, uint32_t boundSize,
-                           uint32_t boundArgIndex) {
+                           const EJitBoundPtrDescriptor *boundPointers,
+                           uint32_t boundCount) {
   EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex,
                     numDims, fallback);
 
   // Parameter check already done by the C API layer
   // (ejit_taskpool_compile_or_get).
+  if (!validateBoundPtrDescriptors(boundPointers, boundCount)) {
+    EJIT_DIAG("taskpool bound pointer reject func=%u count=%u", funcIndex,
+              boundCount);
+    CompileOrGetResult Invalid;
+    Invalid.fnPtr = fallback;
+    Invalid.status = EJitCompileOrGetStatus::InvalidParam;
+    return Invalid;
+  }
 
   // Fast cache-hit path (§5.2 steps 0-1). On a terminal outcome (hit or a
   // disabled instance) return directly.
@@ -515,11 +537,14 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       T2.funcIndex = encodeReqTier(funcIndex, kEJitTierPgoUse);
       T2.numDims = numDims;
       T2.fallbackPtr = reinterpret_cast<uintptr_t>(fallback);
+      T2.boundCount = boundCount;
       for (uint32_t i = 0; i < numDims; ++i) {
         T2.dims[i] = dims[i];
         T2.versions[i] =
             switch_.getInstanceVersion(dims[i].dimType, dims[i].instanceId);
       }
+      for (uint32_t i = 0; i < boundCount; ++i)
+        T2.boundPointers[i] = boundPointers[i];
       if (queue_.tryEnqueue(T2) == EJitTaskQueue::EnqueueResult::Enqueued)
         EJIT_DIAG_VERBOSE("taskpool PGO Tier-2 armed func=%u", funcIndex);
     }
@@ -527,14 +552,6 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   }
   // True miss: continue the slow path with the caller's fallback.
   R.fnPtr = fallback;
-
-  if ((boundSize != 0 && !boundData) || boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
-    EJIT_DIAG("taskpool bound snapshot reject func=%u size=%u max=%u",
-              funcIndex, boundSize,
-              static_cast<unsigned>(EJIT_BOUND_PTR_MAX_BYTES));
-    R.status = EJitCompileOrGetStatus::InvalidParam;
-    return R;
-  }
 
   // 3. Off mode (§5.2 step 2) — fall back, never enqueue/compile.
   if (switch_.getMode() == EJitCompileMode::Off) {
@@ -560,12 +577,11 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       Req.versions[i] =
           switch_.getInstanceVersion(dims[i].dimType, dims[i].instanceId);
     }
-    Req.boundArgIndex = boundArgIndex;
-    Req.boundSize = boundSize;
-    if (boundSize)
-      std::memcpy(Req.boundData, boundData, boundSize);
+    Req.boundCount = boundCount;
+    for (uint32_t i = 0; i < boundCount; ++i)
+      Req.boundPointers[i] = boundPointers[i];
     if (!versionsMatch(Req)) {
-      EJIT_DIAG("taskpool sync snapshot drop func=%u: version changed",
+      EJIT_DIAG("taskpool sync bound request drop func=%u: version changed",
                 funcIndex);
       R.status = EJitCompileOrGetStatus::CompileFailed;
       return R;
@@ -624,12 +640,11 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     Req.versions[i] =
         switch_.getInstanceVersion(dims[i].dimType, dims[i].instanceId);
   }
-  Req.boundArgIndex = boundArgIndex;
-  Req.boundSize = boundSize;
-  if (boundSize)
-    std::memcpy(Req.boundData, boundData, boundSize);
+  Req.boundCount = boundCount;
+  for (uint32_t i = 0; i < boundCount; ++i)
+    Req.boundPointers[i] = boundPointers[i];
   if (!versionsMatch(Req)) {
-    EJIT_DIAG("taskpool async snapshot drop func=%u: version changed",
+    EJIT_DIAG("taskpool async bound request drop func=%u: version changed",
               funcIndex);
     R.status = EJitCompileOrGetStatus::CompileFailed;
     return R;
@@ -692,11 +707,12 @@ void EJitTaskPool::runCompile(const EJitCompileRequest &req) {
               static_cast<unsigned>(ok), fn);
     return;
   }
+  const EJitCompileRequest PublishReq = requestForPublication(req);
 
   // Checkpoint 2 (§5.3): a toggle during compilation invalidates the result.
   if (!versionsMatch(req)) {
     if (publishFn_)
-      publishFn_(publishCtx_, req, false);
+      publishFn_(publishCtx_, PublishReq, false);
     cache_.retireCode(fn); // Retire the now-stale code (real callback only).
     queue_.release(req.funcIndex);
     EJIT_STAT_INC(counters_.compileFailed);
@@ -714,13 +730,13 @@ void EJitTaskPool::runCompile(const EJitCompileRequest &req) {
   case EJitPublishStatus::Published:
     EJIT_STAT_INC(counters_.asyncCompiles);
     if (publishFn_)
-      publishFn_(publishCtx_, req, true);
+      publishFn_(publishCtx_, PublishReq, true);
     queue_.release(req.funcIndex);
     EJIT_DIAG_VERBOSE("worker publish ok func=%u fn=%p", req.funcIndex, fn);
     return;
   case EJitPublishStatus::VersionMismatch:
     if (publishFn_)
-      publishFn_(publishCtx_, req, false);
+      publishFn_(publishCtx_, PublishReq, false);
     // Rejected at the commit gate: retire the stale code, do not overwrite any
     // existing entry, release the dedup slot, count as a (cancelled) failure.
     cache_.retireCode(fn);
@@ -731,7 +747,7 @@ void EJitTaskPool::runCompile(const EJitCompileRequest &req) {
   case EJitPublishStatus::InvalidParam:
   case EJitPublishStatus::Failed:
     if (publishFn_)
-      publishFn_(publishCtx_, req, false);
+      publishFn_(publishCtx_, PublishReq, false);
     cache_.retireCode(fn);
     queue_.release(req.funcIndex);
     EJIT_STAT_INC(counters_.publishFailed);

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -16,6 +16,7 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h"
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
@@ -153,10 +154,11 @@ struct BoundPtrInfo {
   uint64_t PointeeSize;
 };
 
-static std::optional<BoundPtrInfo> getBoundPtrInfo(const Function &F) {
+static SmallVector<BoundPtrInfo, 8> getBoundPtrInfos(const Function &F) {
+  SmallVector<BoundPtrInfo, 8> Result;
   MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
   if (!MD)
-    return std::nullopt;
+    return Result;
   for (const MDOperand &Op : MD->operands()) {
     auto *Sub = dyn_cast<MDNode>(Op.get());
     if (!Sub || Sub->getNumOperands() < 4)
@@ -166,11 +168,11 @@ static std::optional<BoundPtrInfo> getBoundPtrInfo(const Function &F) {
     auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
     auto *Size = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(3));
     if (Tag && Tag->getString() == TAG_EJIT_BOUND_PTR && PN && Idx && Size)
-      return BoundPtrInfo{PN->getString().str(),
-                          static_cast<unsigned>(Idx->getZExtValue()),
-                          Size->getZExtValue()};
+      Result.push_back(BoundPtrInfo{PN->getString().str(),
+                                    static_cast<unsigned>(Idx->getZExtValue()),
+                                    Size->getZExtValue()});
   }
-  return std::nullopt;
+  return Result;
 }
 
 static SmallVector<PeriodArrIndInfo, 4> getPeriodArrIndInfo(const Function &F) {
@@ -586,7 +588,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       FN_TASKPOOL_COMPILE_OR_GET,
       FunctionType::get(I32Ty, {I32Ty, PtrTy, I32Ty, PtrTy, PtrTy}, false));
   bool HasBoundPtr = llvm::any_of(EntryFuncs, [](const Function *F) {
-    return getBoundPtrInfo(*F).has_value();
+    return !getBoundPtrInfos(*F).empty();
   });
   if (HasBoundPtr)
     M.getOrInsertFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND,
@@ -594,6 +596,11 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
                                             {I32Ty, PtrTy, I32Ty, PtrTy, I32Ty,
                                              I32Ty, PtrTy, PtrTy},
                                             false));
+  if (HasBoundPtr)
+    M.getOrInsertFunction(
+        FN_TASKPOOL_COMPILE_OR_GET_BOUND_V,
+        FunctionType::get(
+            I32Ty, {I32Ty, PtrTy, I32Ty, PtrTy, I32Ty, PtrTy, PtrTy}, false));
   M.getOrInsertFunction(
       FN_TASKPOOL_RELEASE_READ,
       FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false));
@@ -720,8 +727,16 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       F->addFnAttr(Attribute::NoInline);
 
     auto PeriodInds = getPeriodArrIndInfo(*F);
-    auto BoundPtr = getBoundPtrInfo(*F);
+    SmallVector<BoundPtrInfo, 8> BoundPtrs = getBoundPtrInfos(*F);
     unsigned DimCount = PeriodInds.size();
+
+    if (BoundPtrs.size() > MAX_BOUND_PTR_PARAMS) {
+      F->getContext().emitError("ejit-wrapper-gen: function has " +
+                                Twine(BoundPtrs.size()) +
+                                " ejit_bound_ptr parameters; at most " +
+                                Twine(MAX_BOUND_PTR_PARAMS) + " are supported");
+      continue;
+    }
 
     if (DimCount > EJIT_ICACHE_MAX_DIMS) {
       F->getContext().emitError("ejit-wrapper-gen: more than "
@@ -775,21 +790,25 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     if (Invalid)
       continue;
 
-    if (BoundPtr) {
+    for (const BoundPtrInfo &BoundPtr : BoundPtrs) {
       unsigned MatchingDims =
           llvm::count_if(PeriodInds, [&](const PeriodArrIndInfo &I) {
-            return I.PeriodName == BoundPtr->PeriodName;
+            return I.PeriodName == BoundPtr.PeriodName;
           });
-      if (BoundPtr->ArgIndex >= ArgCount ||
-          !F->getArg(BoundPtr->ArgIndex)->getType()->isPointerTy() ||
-          BoundPtr->PointeeSize == 0 ||
-          BoundPtr->PointeeSize > std::numeric_limits<uint32_t>::max() ||
+      if (BoundPtr.ArgIndex >= ArgCount ||
+          !F->getArg(BoundPtr.ArgIndex)->getType()->isPointerTy() ||
+          BoundPtr.PointeeSize == 0 ||
+          BoundPtr.PointeeSize > std::numeric_limits<uint32_t>::max() ||
           MatchingDims != 1) {
         F->getContext().emitError(
             "ejit-wrapper-gen: invalid ejit_bound_ptr metadata");
-        continue;
+        Invalid = true;
+        break;
       }
     }
+
+    if (Invalid)
+      continue;
 
     // Save original entry block
     BasicBlock &OrigEntry = F->getEntryBlock();
@@ -802,7 +821,8 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
 
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
     auto *I64Ty = Type::getInt64Ty(Ctx);
-    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2 && !BoundPtr;
+    bool UseFixed =
+        EJitWrapperFixedDimEntry && DimCount <= 2 && BoundPtrs.empty();
 
     SmallVector<ReturnInst *, 8> OriginalReturns;
     for (BasicBlock &BB : *F)
@@ -921,6 +941,14 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
           B.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
       Value *OutFnArg = B.CreatePointerCast(OutFnAlloca, PtrTy);
       Value *OutBucketArg = B.CreatePointerCast(OutBucketAlloca, PtrTy);
+      ArrayType *BoundDescArrayTy = nullptr;
+      Value *BoundDescAlloca = nullptr;
+      if (BoundPtrs.size() > 1) {
+        auto *BoundDescTy = StructType::get(PtrTy, I32Ty, I32Ty);
+        BoundDescArrayTy = ArrayType::get(BoundDescTy, BoundPtrs.size());
+        BoundDescAlloca =
+            B.CreateAlloca(BoundDescArrayTy, nullptr, "ejit_bound_ptrs");
+      }
       if (EJitFunctionBodyTiming && !WrapperBegin)
         WrapperBegin = B.CreateCall(TraceNow, {}, "ejit_wrapper_begin");
       Value *FuncIdx = B.CreateLoad(I32Ty, FuncIndexGlobals[F->getName().str()],
@@ -985,14 +1013,41 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         }
         Value *DimsPtr = DimCount > 0 ? B.CreatePointerCast(DimsAlloca, PtrTy)
                                       : ConstantPointerNull::get(PtrTy);
-        if (BoundPtr) {
-          Value *Snapshot = Fn.getArg(BoundPtr->ArgIndex);
+        if (BoundPtrs.size() == 1) {
+          const BoundPtrInfo &BoundPtr = BoundPtrs.front();
+          Value *RawPtr = Fn.getArg(BoundPtr.ArgIndex);
+          if (RawPtr->getType() != PtrTy)
+            RawPtr = B.CreatePointerCast(RawPtr, PtrTy);
           Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND),
                                 {FuncIdx, DimsPtr,
-                                 ConstantInt::get(I32Ty, DimCount), Snapshot,
-                                 ConstantInt::get(I32Ty, BoundPtr->PointeeSize),
-                                 ConstantInt::get(I32Ty, BoundPtr->ArgIndex),
+                                 ConstantInt::get(I32Ty, DimCount), RawPtr,
+                                 ConstantInt::get(I32Ty, BoundPtr.PointeeSize),
+                                 ConstantInt::get(I32Ty, BoundPtr.ArgIndex),
                                  OutFnArg, OutBucketArg});
+        } else if (BoundPtrs.size() > 1) {
+          auto *BoundDescTy =
+              cast<StructType>(BoundDescArrayTy->getElementType());
+          for (unsigned I = 0; I < BoundPtrs.size(); ++I) {
+            const BoundPtrInfo &BoundPtr = BoundPtrs[I];
+            Value *Idxs[] = {ConstantInt::get(I32Ty, 0),
+                             ConstantInt::get(I32Ty, I)};
+            Value *DescPtr =
+                B.CreateInBoundsGEP(BoundDescArrayTy, BoundDescAlloca, Idxs);
+            Value *RawPtr = Fn.getArg(BoundPtr.ArgIndex);
+            if (RawPtr->getType() != PtrTy)
+              RawPtr = B.CreatePointerCast(RawPtr, PtrTy);
+            B.CreateStore(RawPtr, B.CreateStructGEP(BoundDescTy, DescPtr, 0));
+            B.CreateStore(ConstantInt::get(I32Ty, BoundPtr.PointeeSize),
+                          B.CreateStructGEP(BoundDescTy, DescPtr, 1));
+            B.CreateStore(ConstantInt::get(I32Ty, BoundPtr.ArgIndex),
+                          B.CreateStructGEP(BoundDescTy, DescPtr, 2));
+          }
+          Status =
+              B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND_V),
+                           {FuncIdx, DimsPtr, ConstantInt::get(I32Ty, DimCount),
+                            B.CreatePointerCast(BoundDescAlloca, PtrTy),
+                            ConstantInt::get(I32Ty, BoundPtrs.size()), OutFnArg,
+                            OutBucketArg});
         } else {
           Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
                                 {FuncIdx, DimsPtr,

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bound-ptr-max.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bound-ptr-max.ll
@@ -1,0 +1,26 @@
+; RUN: not opt -passes=ejit-wrapper-gen -S %s 2>&1 | FileCheck %s
+
+; Hand-written IR bypasses Clang Sema, so wrapper generation must enforce the
+; same eight-descriptor limit before emitting a runtime-rejected _bound_v call.
+
+; CHECK: error: ejit-wrapper-gen: function has 9 ejit_bound_ptr parameters; at most 8 are supported
+
+define i32 @too_many_bound_ptrs(i32 %cell, ptr %p0, ptr %p1, ptr %p2,
+                                 ptr %p3, ptr %p4, ptr %p5, ptr %p6,
+                                 ptr %p7, ptr %p8) !ejit.metadata !0 {
+entry:
+  ret i32 0
+}
+
+!0 = distinct !{!1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11}
+!1 = !{!"ejit_entry"}
+!2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+!3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4}
+!4 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4}
+!5 = !{!"ejit_bound_ptr", !"cell", i32 3, i64 4}
+!6 = !{!"ejit_bound_ptr", !"cell", i32 4, i64 4}
+!7 = !{!"ejit_bound_ptr", !"cell", i32 5, i64 4}
+!8 = !{!"ejit_bound_ptr", !"cell", i32 6, i64 4}
+!9 = !{!"ejit_bound_ptr", !"cell", i32 7, i64 4}
+!10 = !{!"ejit_bound_ptr", !"cell", i32 8, i64 4}
+!11 = !{!"ejit_bound_ptr", !"cell", i32 9, i64 4}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bound-ptr-multi.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-bound-ptr-multi.ll
@@ -1,0 +1,27 @@
+; RUN: opt -passes=ejit-wrapper-gen -S %s | FileCheck %s
+
+; Multiple bound objects use the fixed raw-pointer descriptor table. The
+; descriptor array is a slow-path alloca; no pointee payload is copied.
+
+; CHECK-LABEL: define i32 @multi_bound_entry(i32 %cell, ptr %cfg_a, ptr %cfg_b, i32 %input)
+; CHECK: alloca [2 x { ptr, i32, i32 }]
+; CHECK: call i32 @ejit_taskpool_compile_or_get_bound_v(
+; CHECK-SAME: i32 2,
+
+define i32 @multi_bound_entry(i32 %cell, ptr %cfg_a, ptr %cfg_b, i32 %input) !ejit.metadata !0 {
+entry:
+  %a = load i32, ptr %cfg_a, !ejit.may_const !4
+  %b = load i32, ptr %cfg_b, !ejit.may_const !4
+  %sum = add i32 %a, %b
+  %result = add i32 %sum, %input
+  ret i32 %result
+}
+
+!0 = distinct !{!1, !2, !3, !5}
+!1 = !{!"ejit_entry"}
+!2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+!3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !6}
+!4 = !{}
+!5 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !7}
+!6 = !{i64 0, i64 4}
+!7 = !{i64 0, i64 4}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-helper-entry-contract.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-helper-entry-contract.ll
@@ -1,0 +1,54 @@
+; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s | FileCheck %s --check-prefix=WRAP
+; RUN: opt -passes=ejit-register-bitcode -S %s | FileCheck %s --check-prefix=REG
+
+; A direct helper that participates in bound-pointer propagation must still be
+; a separately registered EJIT entry. The ordinary helper below is reachable
+; from the closure, but it must not acquire an independent wrapper/cache
+; identity merely because an entry calls it.
+
+; WRAP-DAG: @__ejit_funcidx_root = internal global i32 -1
+; WRAP-DAG: @__ejit_funcidx_helper = internal global i32 -1
+; WRAP-DAG: @__ejit_icache_fn_root = internal global [16 x ptr] zeroinitializer
+; WRAP-DAG: @__ejit_icache_fn_helper = internal global [16 x ptr] zeroinitializer
+; WRAP-LABEL: define i32 @root(i8 %cell, ptr %cfg)
+; WRAP: jit_entry:
+; WRAP: call i32 @ejit_taskpool_compile_or_get_bound
+; WRAP-LABEL: define i32 @helper(i8 %cell, ptr %cfg)
+; WRAP: jit_entry:
+; WRAP: call i32 @ejit_taskpool_compile_or_get_1d
+; WRAP-LABEL: define internal i32 @plain_helper(ptr %cfg)
+; WRAP-NEXT: entry:
+; WRAP-NOT: jit_entry
+
+; REG-COUNT-2: call void @ejit_register_bitcode
+; REG-DAG: c"root\\00"
+; REG-DAG: c"helper\\00"
+; REG-NOT: c"plain_helper\\00"
+
+%Cfg = type { i32 }
+@cfg = global %Cfg zeroinitializer, !ejit.metadata !10
+
+define i32 @root(i8 %cell, ptr %cfg) !ejit.metadata !20 {
+entry:
+  %result = call i32 @helper(i8 %cell, ptr %cfg)
+  ret i32 %result
+}
+
+define i32 @helper(i8 %cell, ptr %cfg) !ejit.metadata !21 {
+entry:
+  %result = call i32 @plain_helper(ptr %cfg)
+  ret i32 %result
+}
+
+define internal i32 @plain_helper(ptr %cfg) {
+entry:
+  %value = load i32, ptr %cfg
+  ret i32 %value
+}
+
+!10 = distinct !{!{!"ejit_period_arr", !"cell", i32 16}}
+!20 = distinct !{!{!"ejit_entry"},
+                  !{!"ejit_period_arr_ind", !"cell", i32 0},
+                  !{!"ejit_bound_ptr", !"cell", i32 1, i64 4}}
+!21 = distinct !{!{!"ejit_entry"},
+                  !{!"ejit_period_arr_ind", !"cell", i32 0}}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-helper-entry-contract.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-wrapper-gen-helper-entry-contract.ll
@@ -1,10 +1,11 @@
 ; RUN: opt -passes=ejit-wrapper-gen -ejit-inline-cache -ejit-icache-section= -S %s | FileCheck %s --check-prefix=WRAP
 ; RUN: opt -passes=ejit-register-bitcode -S %s | FileCheck %s --check-prefix=REG
 
-; A direct helper that participates in bound-pointer propagation must still be
-; a separately registered EJIT entry. The ordinary helper below is reachable
-; from the closure, but it must not acquire an independent wrapper/cache
-; identity merely because an entry calls it.
+; A direct helper that participates in bound-pointer propagation must own both
+; a separately registered EJIT entry identity and its bound-pointer contract.
+; The ordinary helper below is reachable from the closure, but it must not
+; acquire an independent wrapper/cache identity merely because an entry calls
+; it.
 
 ; WRAP-DAG: @__ejit_funcidx_root = internal global i32 -1
 ; WRAP-DAG: @__ejit_funcidx_helper = internal global i32 -1
@@ -15,7 +16,7 @@
 ; WRAP: call i32 @ejit_taskpool_compile_or_get_bound
 ; WRAP-LABEL: define i32 @helper(i8 %cell, ptr %cfg)
 ; WRAP: jit_entry:
-; WRAP: call i32 @ejit_taskpool_compile_or_get_1d
+; WRAP: call i32 @ejit_taskpool_compile_or_get_bound
 ; WRAP-LABEL: define internal i32 @plain_helper(ptr %cfg)
 ; WRAP-NEXT: entry:
 ; WRAP-NOT: jit_entry
@@ -51,4 +52,5 @@ entry:
                   !{!"ejit_period_arr_ind", !"cell", i32 0},
                   !{!"ejit_bound_ptr", !"cell", i32 1, i64 4}}
 !21 = distinct !{!{!"ejit_entry"},
-                  !{!"ejit_period_arr_ind", !"cell", i32 0}}
+                  !{!"ejit_period_arr_ind", !"cell", i32 0},
+                  !{!"ejit_bound_ptr", !"cell", i32 1, i64 4}}

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LLVM_LINK_COMPONENTS
   )
 
 add_llvm_unittest(EJITTests
+  EJitOrcEngineHeaderTest.cpp
   EJitRuntimeTest.cpp
   EJitFieldOffsetTest.cpp
   EJitLinkOptimizationPluginTest.cpp

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEngineHeaderTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEngineHeaderTest.cpp
@@ -1,0 +1,13 @@
+//===-- EJitOrcEngineHeaderTest.cpp - EJitOrcEngine include test ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
+
+static_assert(llvm::ejit::kEJitMaxBoundPointers == 8u,
+              "EJitOrcEngine must include the bound-pointer limit header");

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
+#include <algorithm>
 #ifndef EJIT_FREESTANDING
 #include <thread>
 #endif
@@ -1731,6 +1732,108 @@ TEST(EJitStructFieldPass, BoundPointerUsesOwnedSnapshot) {
   }
   EXPECT_EQ(Loads, 1u) << "dynamic field must remain a runtime load";
   EXPECT_TRUE(SawSnapshotConstant);
+}
+
+TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32, i32 }
+    define i32 @bound_chain(i32 %cell, ptr %cfg) !ejit.metadata !0 {
+    entry:
+      %result = call i32 @bound_helper1(i64 123, ptr %cfg)
+      ret i32 %result
+    }
+    define internal i32 @bound_helper1(i64 %unused, ptr %cfg) noinline {
+    entry:
+      %mode.ptr = getelementptr %Cfg, ptr %cfg, i32 0, i32 1
+      %result = call i32 @bound_helper2(ptr %mode.ptr)
+      ret i32 %result
+    }
+    define internal i32 @bound_helper2(ptr %mode.ptr) noinline {
+    entry:
+      %mode = load i32, ptr %mode.ptr, !ejit.may_const !4
+      ret i32 %mode
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, !5}
+    !4 = !{!"ejit"}
+    !5 = !{i64 4, i64 4}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  struct Config {
+    uint32_t dynamic;
+    uint32_t mode;
+  } Snapshot{99, 17};
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&Snapshot),
+                           sizeof(Snapshot), 1, "bound_chain");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  for (Function &F : *M)
+    if (!F.isDeclaration())
+      Pass.run(F, FAM);
+
+  Function *Leaf = M->getFunction("bound_helper2");
+  ASSERT_NE(Leaf, nullptr);
+  EXPECT_EQ(std::count_if(inst_begin(Leaf), inst_end(Leaf),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            0);
+  auto *Ret = dyn_cast<ReturnInst>(Leaf->getEntryBlock().getTerminator());
+  ASSERT_NE(Ret, nullptr);
+  auto *Value = dyn_cast<ConstantInt>(Ret->getReturnValue());
+  ASSERT_NE(Value, nullptr);
+  EXPECT_EQ(Value->getZExtValue(), 17u);
+}
+
+TEST(EJitStructFieldPass, AmbiguousHelperPointerIsNotSpecialized) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32 }
+    define i32 @bound_ambiguous(i32 %cell, ptr %cfg, ptr %other)
+        !ejit.metadata !0 {
+    entry:
+      %a = call i32 @shared_helper(ptr %cfg)
+      %b = call i32 @shared_helper(ptr %other)
+      %sum = add i32 %a, %b
+      ret i32 %sum
+    }
+    define internal i32 @shared_helper(ptr %cfg) noinline {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !4
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
+    !4 = !{!"ejit"}
+    !5 = !{i64 0, i64 4}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t Snapshot = 23;
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&Snapshot),
+                           sizeof(Snapshot), 1, "bound_ambiguous");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Pass.run(*M->getFunction("shared_helper"), FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(M->getFunction("shared_helper")),
+                          inst_end(M->getFunction("shared_helper")),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -1866,14 +1866,14 @@ TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
     }
     define i32 @bound_helper1(i32 %cell, ptr %cfg) noinline !ejit.metadata !4 {
     entry:
-      %mode.ptr = getelementptr %Cfg, ptr %cfg, i32 0, i32 1
       %cell8 = trunc i32 %cell to i8
-      %result = call i32 @bound_helper2(i8 %cell8, ptr %mode.ptr)
+      %result = call i32 @bound_helper2(i8 %cell8, ptr %cfg)
       ret i32 %result
     }
-    define i32 @bound_helper2(i8 %cell, ptr %mode.ptr) noinline
+    define i32 @bound_helper2(i8 %cell, ptr %cfg) noinline
         !ejit.metadata !7 {
     entry:
+      %mode.ptr = getelementptr %Cfg, ptr %cfg, i32 0, i32 1
       %mode = load i32, ptr %mode.ptr, !ejit.may_const !10
       %tail = call i32 @bound_helper3(ptr %mode.ptr)
       %result = add i32 %mode, %tail
@@ -1888,13 +1888,14 @@ TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, !5}
-    !4 = distinct !{!8, !9}
+    !4 = distinct !{!8, !9, !12}
     !5 = !{i64 4, i64 4}
-    !7 = distinct !{!10, !11}
+    !7 = distinct !{!10, !11, !12}
     !8 = !{!"ejit_entry"}
     !9 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !10 = !{!"ejit"}
     !11 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !12 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, !5}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -1954,11 +1955,12 @@ TEST(EJitStructFieldPass, AmbiguousHelperPointerIsNotSpecialized) {
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
-    !4 = distinct !{!6, !7}
+    !4 = distinct !{!6, !7, !9}
     !5 = !{i64 0, i64 4}
     !6 = !{!"ejit_entry"}
     !7 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !8 = !{!"ejit"}
+    !9 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -1979,7 +1981,7 @@ TEST(EJitStructFieldPass, AmbiguousHelperPointerIsNotSpecialized) {
             1);
 }
 
-TEST(EJitStructFieldPass, UnannotatedHelperIsNotSpecialized) {
+TEST(EJitStructFieldPass, EntryDimensionWithoutBoundPointerIsNotSpecialized) {
   LLVMContext Ctx;
   SMDiagnostic Err;
   auto M = parseAssemblyString(R"(
@@ -1989,7 +1991,8 @@ TEST(EJitStructFieldPass, UnannotatedHelperIsNotSpecialized) {
       %result = call i32 @unannotated_helper(i8 %cell, ptr %cfg)
       ret i32 %result
     }
-    define internal i32 @unannotated_helper(i8 %cell, ptr %cfg) noinline {
+    define i32 @unannotated_helper(i8 %cell, ptr %cfg) noinline
+        !ejit.metadata !6 {
     entry:
       %value = load i32, ptr %cfg, !ejit.may_const !4
       ret i32 %value
@@ -2000,6 +2003,7 @@ TEST(EJitStructFieldPass, UnannotatedHelperIsNotSpecialized) {
     !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
     !4 = !{!"ejit"}
     !5 = !{i64 0, i64 4}
+    !6 = distinct !{!1, !2}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -2041,11 +2045,12 @@ TEST(EJitStructFieldPass, MismatchedHelperDimensionIsNotSpecialized) {
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
-    !4 = distinct !{!6, !8}
+    !4 = distinct !{!6, !8, !9}
     !5 = !{i64 0, i64 4}
     !6 = !{!"ejit_entry"}
     !7 = !{!"ejit"}
     !8 = !{!"ejit_period_arr_ind", !"other", i32 0}
+    !9 = !{!"ejit_bound_ptr", !"other", i32 1, i64 4, !5}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -2089,11 +2094,12 @@ TEST(EJitStructFieldPass, HelperOtherCellIsNotSpecialized) {
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !5}
-    !4 = distinct !{!6, !8}
+    !4 = distinct !{!6, !8, !9}
     !5 = !{i64 0, i64 4}
     !6 = !{!"ejit_entry"}
     !7 = !{!"ejit"}
     !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !9 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -2136,11 +2142,12 @@ TEST(EJitStructFieldPass, HelperDifferentSpecializedConstantIsNotSpecialized) {
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
-    !4 = distinct !{!6, !8}
+    !4 = distinct !{!6, !8, !9}
     !5 = !{i64 0, i64 4}
     !6 = !{!"ejit_entry"}
     !7 = !{!"ejit"}
     !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !9 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -2192,11 +2199,12 @@ TEST(EJitStructFieldPass, InconsistentHelperDimensionSourcesAreNotSpecialized) {
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !5}
-    !4 = distinct !{!6, !8}
+    !4 = distinct !{!6, !8, !9}
     !5 = !{i64 0, i64 4}
     !6 = !{!"ejit_entry"}
     !7 = !{!"ejit"}
     !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !9 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -2237,12 +2245,13 @@ TEST(EJitStructFieldPass, BoundPointerHelperSupportsMultipleCellVersions) {
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !5}
-    !4 = distinct !{!6, !8, !9}
+    !4 = distinct !{!6, !8, !9, !10}
     !5 = !{i64 0, i64 4}
     !6 = !{!"ejit_entry"}
     !7 = !{!"ejit"}
     !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !9 = !{!"ejit_period_arr_ind", !"trp", i32 1}
+    !10 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !5}
   )";
 
   for (uint32_t Cell = 0; Cell < 2; ++Cell) {
@@ -2275,6 +2284,66 @@ TEST(EJitStructFieldPass, BoundPointerHelperSupportsMultipleCellVersions) {
     ASSERT_NE(Value, nullptr);
     EXPECT_EQ(Value->getZExtValue(), BoundObject);
   }
+}
+
+TEST(EJitStructFieldPass, BoundPointerHelperPropagatesCellAndTrpPointers) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %CellCfg = type { i32 }
+    %TrpCfg = type { i32 }
+    define i32 @bound_root(i8 %cell, i8 %trp, ptr %cellCfg, ptr %trpCfg)
+        !ejit.metadata !0 {
+    entry:
+      %result = call i32 @bound_helper(i8 %cell, i8 %trp,
+                                      ptr %cellCfg, ptr %trpCfg)
+      ret i32 %result
+    }
+    define i32 @bound_helper(i8 %cell, i8 %trp, ptr %cellCfg, ptr %trpCfg)
+        noinline !ejit.metadata !1 {
+    entry:
+      %cellValue = load i32, ptr %cellCfg, !ejit.may_const !8
+      %trpValue = load i32, ptr %trpCfg, !ejit.may_const !8
+      %sum = add i32 %cellValue, %trpValue
+      ret i32 %sum
+    }
+    !0 = distinct !{!2, !3, !4, !5, !6}
+    !1 = distinct !{!2, !3, !4, !5, !6}
+    !2 = !{!"ejit_entry"}
+    !3 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !4 = !{!"ejit_period_arr_ind", !"trp", i32 1}
+    !5 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !7}
+    !6 = !{!"ejit_bound_ptr", !"trp", i32 3, i64 4, !7}
+    !7 = !{i64 0, i64 4}
+    !8 = !{!"ejit"}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t CellConfig = 13;
+  uint32_t TrpConfig = 29;
+  SmallVector<EJitBoundPointerView, 2> Views{
+      {reinterpret_cast<const uint8_t *>(&CellConfig), sizeof(CellConfig), 2,
+       1},
+      {reinterpret_cast<const uint8_t *>(&TrpConfig), sizeof(TrpConfig), 3,
+       2}};
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry, Views, "bound_root");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Function *Helper = M->getFunction("bound_helper");
+  ASSERT_NE(Helper, nullptr);
+  Pass.run(*Helper, FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(Helper), inst_end(Helper),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            0);
+  auto *Sum = dyn_cast<BinaryOperator>(
+      Helper->getEntryBlock().getTerminator()->getOperand(0));
+  ASSERT_NE(Sum, nullptr);
+  EXPECT_EQ(cast<ConstantInt>(Sum->getOperand(0))->getZExtValue(), CellConfig);
+  EXPECT_EQ(cast<ConstantInt>(Sum->getOperand(1))->getZExtValue(), TrpConfig);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -348,6 +348,42 @@ TEST(EJitModuleLoader, NullOrZeroPayloadRejected) {
   EXPECT_FALSE(loader.registerBitcode("zero_fn", d, 0));
 }
 
+TEST(EJitModuleLoader, CachesBoundPointerFormalIndices) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    define i32 @loader_bound_meta(ptr %cfg, i32 %not_a_pointer)
+        !ejit.metadata !0 {
+    entry:
+      ret i32 0
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_bound_ptr", !"cell", i32 0, i64 8}
+    !2 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8}
+    !3 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+
+  std::string Bitcode;
+  raw_string_ostream OS(Bitcode);
+  WriteBitcodeToFile(*M, OS);
+  OS.flush();
+
+  constexpr const char *Name = "loader_bound_meta";
+  EJitModuleLoader Loader;
+  EXPECT_TRUE(Loader.registerBitcode(
+      Name, reinterpret_cast<const uint8_t *>(Bitcode.data()),
+      Bitcode.size()));
+  uint32_t FuncIndex = EJitFuncRegistry::instance().lookup(Name);
+  ASSERT_NE(FuncIndex, kEJitInvalidFuncIndex);
+
+  const auto &Meta = Loader.getOrCacheFuncMeta(FuncIndex);
+  ASSERT_EQ(Meta.boundPointerArgIndices.size(), 1u)
+      << "non-pointer formals must not become valid bound descriptor targets";
+  EXPECT_EQ(Meta.boundPointerArgIndices.front(), 0u);
+}
+
 TEST(EJitModuleLoader, SameNameSamePayloadIdempotent) {
   EJitModuleLoader loader;
   const uint8_t d[] = {0x10, 0x11};
@@ -761,6 +797,10 @@ TEST(EJit, TaskpoolRegistrationFrozenAfterConstruction) {
 extern "C" {
 typedef enum { EJIT_OK_C = 0 } ejit_status_test_t;
 typedef struct {
+  uint32_t dimType;
+  uint32_t instanceId;
+} ejit_dim_pair_test_t;
+typedef struct {
   uint64_t count;
   uint64_t total;
   uint64_t min;
@@ -789,6 +829,9 @@ extern void ejit_register_lifecycle(const char *, uint32_t *);
 // for branchless-probe slots (null keeps the guarded form's 0 semantics).
 extern void ejit_register_funcindex(const char *, uint32_t *);
 extern void ejit_register_icache_slot(const char *, void *, uint32_t, void *);
+extern int ejit_taskpool_compile_or_get_bound(
+    uint32_t, const ejit_dim_pair_test_t *, uint32_t, const void *, uint32_t,
+    uint32_t, void **, uint32_t *);
 extern void ejit_set_log_level(int level);
 extern int ejit_get_log_level(void);
 extern void ejit_print_registry(void);
@@ -1018,6 +1061,29 @@ void resetTaskpoolRegState() {
   llvm::ejit::EJitRegistrationStore::instance().consumeError();
 }
 } // namespace
+
+TEST(EJitCApiTaskpool, SingleBoundRejectsEmptyObject) {
+  resetTaskpoolRegState();
+  ASSERT_EQ(ejit_init(nullptr), EJIT_OK_C);
+
+  uint32_t value = 1;
+  void *Fn = reinterpret_cast<void *>(0x1);
+  uint32_t Bucket = 7;
+  EXPECT_EQ(ejit_taskpool_compile_or_get_bound(
+                0, nullptr, 0, &value, 0, 0, &Fn, &Bucket),
+            -1);
+  EXPECT_EQ(Fn, nullptr);
+  EXPECT_EQ(Bucket, 0u);
+
+  Fn = reinterpret_cast<void *>(0x1);
+  Bucket = 7;
+  EXPECT_EQ(ejit_taskpool_compile_or_get_bound(
+                0, nullptr, 0, nullptr, sizeof(value), 0, &Fn, &Bucket),
+            -1);
+  EXPECT_EQ(Fn, nullptr);
+  EXPECT_EQ(Bucket, 0u);
+  ejit_shutdown();
+}
 
 // Finding (二): in a taskpool build, all registration is frozen after
 // ejit_init; post-init register_* calls are rejected and mutate nothing.
@@ -1682,7 +1748,7 @@ TEST(EJitStructFieldPass, NoMayConstNoChange) {
   EXPECT_TRUE(PA.areAllPreserved());
 }
 
-TEST(EJitStructFieldPass, BoundPointerUsesOwnedSnapshot) {
+TEST(EJitStructFieldPass, BoundPointerReadsBorrowedObject) {
   LLVMContext Ctx;
   SMDiagnostic Err;
   auto M = parseAssemblyString(R"(
@@ -1711,27 +1777,80 @@ TEST(EJitStructFieldPass, BoundPointerUsesOwnedSnapshot) {
     uint32_t stablePrefix;
     uint32_t mode;
     uint32_t dynamic;
-  } Snapshot{3, 7, 99};
+  } Config{3, 7, 99};
   PeriodArrayRegistry Registry;
-  EJitStructFieldPass Pass(Registry,
-                           reinterpret_cast<const uint8_t *>(&Snapshot),
-                           sizeof(Snapshot), 1);
+  EJitStructFieldPass Pass(Registry, reinterpret_cast<const uint8_t *>(&Config),
+                           sizeof(Config), 1);
   Pass.initFromModule(*M);
   FunctionAnalysisManager FAM;
   Pass.run(*M->getFunction("bound"), FAM);
 
   unsigned Loads = 0;
-  bool SawSnapshotConstant = false;
+  bool SawBoundConstant = false;
   for (Instruction &I : instructions(*M->getFunction("bound"))) {
     if (isa<LoadInst>(I))
       ++Loads;
     if (auto *Add = dyn_cast<BinaryOperator>(&I))
       for (Value *Operand : Add->operands())
         if (auto *C = dyn_cast<ConstantInt>(Operand))
-          SawSnapshotConstant |= C->getZExtValue() == 7;
+          SawBoundConstant |= C->getZExtValue() == 7;
   }
   EXPECT_EQ(Loads, 1u) << "dynamic field must remain a runtime load";
-  EXPECT_TRUE(SawSnapshotConstant);
+  EXPECT_TRUE(SawBoundConstant);
+}
+
+TEST(EJitStructFieldPass, PointerConstantUsesTargetWidthAndEndian) {
+  for (bool LittleEndian : {true, false}) {
+    LLVMContext Ctx;
+    SMDiagnostic Err;
+    auto M = parseAssemblyString(R"(
+      @period_ptr = external global ptr, !ejit.metadata !0
+      define ptr @read_period_ptr() {
+      entry:
+        %value = load ptr, ptr @period_ptr
+        ret ptr %value
+      }
+      !0 = !{!1}
+      !1 = !{!"ejit_period", !"period_ptr"}
+    )",
+                                 Err, Ctx);
+    ASSERT_TRUE(M) << Err.getMessage().str();
+    M->setDataLayout(LittleEndian ? "e-p:32:32-i64:64-n32-S128"
+                                  : "E-p:32:32-i64:64-n32-S128");
+
+    uint8_t PointerSlot[8] = {0};
+    if (LittleEndian) {
+      PointerSlot[0] = 0x78;
+      PointerSlot[1] = 0x56;
+      PointerSlot[2] = 0x34;
+      PointerSlot[3] = 0x12;
+    } else {
+      PointerSlot[0] = 0x12;
+      PointerSlot[1] = 0x34;
+      PointerSlot[2] = 0x56;
+      PointerSlot[3] = 0x78;
+    }
+    PointerSlot[4] = PointerSlot[5] = PointerSlot[6] = PointerSlot[7] = 0xA5;
+
+    PeriodArrayRegistry Registry;
+    Registry.registerStaticVar("period_ptr", PointerSlot);
+    EJitStructFieldPass Pass(Registry);
+    Pass.initFromModule(*M);
+    FunctionAnalysisManager FAM;
+    Function *F = M->getFunction("read_period_ptr");
+    ASSERT_NE(F, nullptr);
+    Pass.run(*F, FAM);
+
+    auto *Ret = dyn_cast<ReturnInst>(&F->back().back());
+    ASSERT_NE(Ret, nullptr);
+    auto *IntToPtr = dyn_cast<ConstantExpr>(Ret->getReturnValue());
+    ASSERT_NE(IntToPtr, nullptr);
+    ASSERT_EQ(IntToPtr->getOpcode(), Instruction::IntToPtr);
+    auto *Address = dyn_cast<ConstantInt>(IntToPtr->getOperand(0));
+    ASSERT_NE(Address, nullptr);
+    EXPECT_EQ(cast<IntegerType>(Address->getType())->getBitWidth(), 32u);
+    EXPECT_EQ(Address->getZExtValue(), 0x12345678u);
+  }
 }
 
 TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
@@ -1739,28 +1858,43 @@ TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
   SMDiagnostic Err;
   auto M = parseAssemblyString(R"(
     %Cfg = type { i32, i32 }
-    define i32 @bound_chain(i32 %cell, ptr %cfg) !ejit.metadata !0 {
+    define i32 @bound_chain(i8 %cell, ptr %cfg) !ejit.metadata !0 {
     entry:
-      %result = call i32 @bound_helper1(i64 123, ptr %cfg)
+      %cell32 = zext i8 %cell to i32
+      %result = call i32 @bound_helper1(i32 %cell32, ptr %cfg)
       ret i32 %result
     }
-    define internal i32 @bound_helper1(i64 %unused, ptr %cfg) noinline {
+    define i32 @bound_helper1(i32 %cell, ptr %cfg) noinline !ejit.metadata !4 {
     entry:
       %mode.ptr = getelementptr %Cfg, ptr %cfg, i32 0, i32 1
-      %result = call i32 @bound_helper2(ptr %mode.ptr)
+      %cell8 = trunc i32 %cell to i8
+      %result = call i32 @bound_helper2(i8 %cell8, ptr %mode.ptr)
       ret i32 %result
     }
-    define internal i32 @bound_helper2(ptr %mode.ptr) noinline {
+    define i32 @bound_helper2(i8 %cell, ptr %mode.ptr) noinline
+        !ejit.metadata !7 {
     entry:
-      %mode = load i32, ptr %mode.ptr, !ejit.may_const !4
+      %mode = load i32, ptr %mode.ptr, !ejit.may_const !10
+      %tail = call i32 @bound_helper3(ptr %mode.ptr)
+      %result = add i32 %mode, %tail
+      ret i32 %result
+    }
+    define internal i32 @bound_helper3(ptr %mode.ptr) noinline {
+    entry:
+      %mode = load i32, ptr %mode.ptr, !ejit.may_const !10
       ret i32 %mode
     }
     !0 = distinct !{!1, !2, !3}
     !1 = !{!"ejit_entry"}
     !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
     !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, !5}
-    !4 = !{!"ejit"}
+    !4 = distinct !{!8, !9}
     !5 = !{i64 4, i64 4}
+    !7 = distinct !{!10, !11}
+    !8 = !{!"ejit_entry"}
+    !9 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !10 = !{!"ejit"}
+    !11 = !{!"ejit_period_arr_ind", !"cell", i32 0}
   )",
                                Err, Ctx);
   ASSERT_TRUE(M) << Err.getMessage().str();
@@ -1769,11 +1903,11 @@ TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
   struct Config {
     uint32_t dynamic;
     uint32_t mode;
-  } Snapshot{99, 17};
+  } BoundObject{99, 17};
   PeriodArrayRegistry Registry;
   EJitStructFieldPass Pass(Registry,
-                           reinterpret_cast<const uint8_t *>(&Snapshot),
-                           sizeof(Snapshot), 1, "bound_chain");
+                           reinterpret_cast<const uint8_t *>(&BoundObject),
+                           sizeof(BoundObject), 1, "bound_chain");
   Pass.initFromModule(*M);
   FunctionAnalysisManager FAM;
   for (Function &F : *M)
@@ -1787,9 +1921,14 @@ TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
             0);
   auto *Ret = dyn_cast<ReturnInst>(Leaf->getEntryBlock().getTerminator());
   ASSERT_NE(Ret, nullptr);
-  auto *Value = dyn_cast<ConstantInt>(Ret->getReturnValue());
-  ASSERT_NE(Value, nullptr);
-  EXPECT_EQ(Value->getZExtValue(), 17u);
+  EXPECT_TRUE(isa<BinaryOperator>(Ret->getReturnValue()));
+
+  Function *Unannotated = M->getFunction("bound_helper3");
+  ASSERT_NE(Unannotated, nullptr);
+  EXPECT_EQ(std::count_if(inst_begin(Unannotated), inst_end(Unannotated),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1)
+      << "the unannotated nested helper is a propagation boundary";
 }
 
 TEST(EJitStructFieldPass, AmbiguousHelperPointerIsNotSpecialized) {
@@ -1797,15 +1936,60 @@ TEST(EJitStructFieldPass, AmbiguousHelperPointerIsNotSpecialized) {
   SMDiagnostic Err;
   auto M = parseAssemblyString(R"(
     %Cfg = type { i32 }
-    define i32 @bound_ambiguous(i32 %cell, ptr %cfg, ptr %other)
+    define i32 @bound_ambiguous(i8 %cell, ptr %cfg, ptr %other)
         !ejit.metadata !0 {
     entry:
-      %a = call i32 @shared_helper(ptr %cfg)
-      %b = call i32 @shared_helper(ptr %other)
+      %a = call i32 @shared_helper(i8 %cell, ptr %cfg)
+      %b = call i32 @shared_helper(i8 %cell, ptr %other)
       %sum = add i32 %a, %b
       ret i32 %sum
     }
-    define internal i32 @shared_helper(ptr %cfg) noinline {
+    define i32 @shared_helper(i8 %cell, ptr %cfg) noinline
+        !ejit.metadata !4 {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !8
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
+    !4 = distinct !{!6, !7}
+    !5 = !{i64 0, i64 4}
+    !6 = !{!"ejit_entry"}
+    !7 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !8 = !{!"ejit"}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t BoundObject = 23;
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&BoundObject),
+                           sizeof(BoundObject), 1, "bound_ambiguous");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Pass.run(*M->getFunction("shared_helper"), FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(M->getFunction("shared_helper")),
+                          inst_end(M->getFunction("shared_helper")),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1);
+}
+
+TEST(EJitStructFieldPass, UnannotatedHelperIsNotSpecialized) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32 }
+    define i32 @bound_root(i8 %cell, ptr %cfg) !ejit.metadata !0 {
+    entry:
+      %result = call i32 @unannotated_helper(i8 %cell, ptr %cfg)
+      ret i32 %result
+    }
+    define internal i32 @unannotated_helper(i8 %cell, ptr %cfg) noinline {
     entry:
       %value = load i32, ptr %cfg, !ejit.may_const !4
       ret i32 %value
@@ -1821,19 +2005,276 @@ TEST(EJitStructFieldPass, AmbiguousHelperPointerIsNotSpecialized) {
   ASSERT_TRUE(M) << Err.getMessage().str();
   M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
 
-  uint32_t Snapshot = 23;
+  uint32_t BoundObject = 31;
   PeriodArrayRegistry Registry;
   EJitStructFieldPass Pass(Registry,
-                           reinterpret_cast<const uint8_t *>(&Snapshot),
-                           sizeof(Snapshot), 1, "bound_ambiguous");
+                           reinterpret_cast<const uint8_t *>(&BoundObject),
+                           sizeof(BoundObject), 1, "bound_root");
   Pass.initFromModule(*M);
   FunctionAnalysisManager FAM;
-  Pass.run(*M->getFunction("shared_helper"), FAM);
+  Function *Helper = M->getFunction("unannotated_helper");
+  ASSERT_NE(Helper, nullptr);
+  Pass.run(*Helper, FAM);
 
-  EXPECT_EQ(std::count_if(inst_begin(M->getFunction("shared_helper")),
-                          inst_end(M->getFunction("shared_helper")),
+  EXPECT_EQ(std::count_if(inst_begin(Helper), inst_end(Helper),
                           [](Instruction &I) { return isa<LoadInst>(I); }),
             1);
+}
+
+TEST(EJitStructFieldPass, MismatchedHelperDimensionIsNotSpecialized) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32 }
+    define i32 @bound_root(i8 %cell, ptr %cfg) !ejit.metadata !0 {
+    entry:
+      %result = call i32 @wrong_dimension_helper(i8 %cell, ptr %cfg)
+      ret i32 %result
+    }
+    define i32 @wrong_dimension_helper(i8 %cell, ptr %cfg) noinline
+        !ejit.metadata !4 {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !7
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
+    !4 = distinct !{!6, !8}
+    !5 = !{i64 0, i64 4}
+    !6 = !{!"ejit_entry"}
+    !7 = !{!"ejit"}
+    !8 = !{!"ejit_period_arr_ind", !"other", i32 0}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t BoundObject = 37;
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&BoundObject),
+                           sizeof(BoundObject), 1, "bound_root");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Function *Helper = M->getFunction("wrong_dimension_helper");
+  ASSERT_NE(Helper, nullptr);
+  Pass.run(*Helper, FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(Helper), inst_end(Helper),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1)
+      << "a helper with a different dimension is a boundary";
+}
+
+TEST(EJitStructFieldPass, HelperOtherCellIsNotSpecialized) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32 }
+    define i32 @bound_root(i8 %cell, i8 %otherCell, ptr %cfg)
+        !ejit.metadata !0 {
+    entry:
+      %result = call i32 @bound_helper(i8 %otherCell, ptr %cfg)
+      ret i32 %result
+    }
+    define i32 @bound_helper(i8 %cell, ptr %cfg) noinline
+        !ejit.metadata !4 {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !7
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !5}
+    !4 = distinct !{!6, !8}
+    !5 = !{i64 0, i64 4}
+    !6 = !{!"ejit_entry"}
+    !7 = !{!"ejit"}
+    !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t BoundObject = 41;
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&BoundObject),
+                           sizeof(BoundObject), 2, "bound_root");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Function *Helper = M->getFunction("bound_helper");
+  ASSERT_NE(Helper, nullptr);
+  Pass.run(*Helper, FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(Helper), inst_end(Helper),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1)
+      << "the helper must use the caller's cell identity";
+}
+
+TEST(EJitStructFieldPass, HelperDifferentSpecializedConstantIsNotSpecialized) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32 }
+    define i32 @bound_root(i8 %cell, ptr %cfg) !ejit.metadata !0 {
+    entry:
+      %result = call i32 @bound_helper(i8 9, ptr %cfg)
+      ret i32 %result
+    }
+    define i32 @bound_helper(i8 %cell, ptr %cfg) noinline
+        !ejit.metadata !4 {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !7
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !5}
+    !4 = distinct !{!6, !8}
+    !5 = !{i64 0, i64 4}
+    !6 = !{!"ejit_entry"}
+    !7 = !{!"ejit"}
+    !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  PeriodArrayRegistry Registry;
+  SpecializationContext CtxSpec;
+  CtxSpec.fnName = "bound_root";
+  CtxSpec.dimensions.push_back({"cell", 3});
+  EJitOptimizerTestAccess Opt(Registry);
+  Opt.preReplacePeriodIndices(*M, CtxSpec);
+
+  uint32_t BoundObject = 43;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&BoundObject),
+                           sizeof(BoundObject), 1, "bound_root", 3);
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Function *Helper = M->getFunction("bound_helper");
+  ASSERT_NE(Helper, nullptr);
+  Pass.run(*Helper, FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(Helper), inst_end(Helper),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1)
+      << "a different specialized cell constant is not equivalent";
+}
+
+TEST(EJitStructFieldPass, InconsistentHelperDimensionSourcesAreNotSpecialized) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    %Cfg = type { i32 }
+    define i32 @bound_root(i8 %cell, i8 %otherCell, ptr %cfg)
+        !ejit.metadata !0 {
+    entry:
+      %a = call i32 @bound_helper(i8 %cell, ptr %cfg)
+      %b = call i32 @bound_helper(i8 %otherCell, ptr %cfg)
+      %sum = add i32 %a, %b
+      ret i32 %sum
+    }
+    define i32 @bound_helper(i8 %cell, ptr %cfg) noinline
+        !ejit.metadata !4 {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !7
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !5}
+    !4 = distinct !{!6, !8}
+    !5 = !{i64 0, i64 4}
+    !6 = !{!"ejit_entry"}
+    !7 = !{!"ejit"}
+    !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t BoundObject = 47;
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry,
+                           reinterpret_cast<const uint8_t *>(&BoundObject),
+                           sizeof(BoundObject), 2, "bound_root");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Function *Helper = M->getFunction("bound_helper");
+  ASSERT_NE(Helper, nullptr);
+  Pass.run(*Helper, FAM);
+
+  EXPECT_EQ(std::count_if(inst_begin(Helper), inst_end(Helper),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            1)
+      << "all callsites must agree on the helper cell identity";
+}
+
+TEST(EJitStructFieldPass, BoundPointerHelperSupportsMultipleCellVersions) {
+  constexpr const char *IR = R"(
+    %Cfg = type { i32 }
+    define i32 @bound_root(i8 %cell, i8 %trp, ptr %cfg) !ejit.metadata !0 {
+    entry:
+      %result = call i32 @bound_helper(i8 %cell, i8 %trp, ptr %cfg)
+      ret i32 %result
+    }
+    define i32 @bound_helper(i8 %cell, i8 %trp, ptr %cfg) noinline
+        !ejit.metadata !4 {
+    entry:
+      %value = load i32, ptr %cfg, !ejit.may_const !7
+      ret i32 %value
+    }
+    !0 = distinct !{!1, !2, !3}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !5}
+    !4 = distinct !{!6, !8, !9}
+    !5 = !{i64 0, i64 4}
+    !6 = !{!"ejit_entry"}
+    !7 = !{!"ejit"}
+    !8 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !9 = !{!"ejit_period_arr_ind", !"trp", i32 1}
+  )";
+
+  for (uint32_t Cell = 0; Cell < 2; ++Cell) {
+    LLVMContext Ctx;
+    SMDiagnostic Err;
+    auto M = parseAssemblyString(IR, Err, Ctx);
+    ASSERT_TRUE(M) << Err.getMessage().str();
+    M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+    uint32_t BoundObject = 17 + Cell * 10;
+    PeriodArrayRegistry Registry;
+    SpecializationContext CtxSpec;
+    CtxSpec.fnName = "bound_root";
+    CtxSpec.dimensions.push_back({"cell", static_cast<uint8_t>(Cell)});
+    EJitOptimizerTestAccess Opt(Registry);
+    Opt.preReplacePeriodIndices(*M, CtxSpec);
+
+    EJitStructFieldPass Pass(
+        Registry, reinterpret_cast<const uint8_t *>(&BoundObject),
+        sizeof(BoundObject), 2, "bound_root", static_cast<uint8_t>(Cell));
+    Pass.initFromModule(*M);
+    FunctionAnalysisManager FAM;
+    Function *Helper = M->getFunction("bound_helper");
+    ASSERT_NE(Helper, nullptr);
+    Pass.run(*Helper, FAM);
+
+    auto *Ret = dyn_cast<ReturnInst>(Helper->getEntryBlock().getTerminator());
+    ASSERT_NE(Ret, nullptr);
+    auto *Value = dyn_cast<ConstantInt>(Ret->getReturnValue());
+    ASSERT_NE(Value, nullptr);
+    EXPECT_EQ(Value->getZExtValue(), BoundObject);
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <thread>
 #include <type_traits>
@@ -56,18 +57,25 @@ bool mockCompile(void * /*ctx*/, const EJitCompileRequest &req, void **outFn) {
   return true;
 }
 
-struct BoundSnapshotLog {
+struct BoundPointerLog {
   uint32_t argIndex = 0;
   uint32_t size = 0;
   uint32_t value = 0;
+  const void *rawPtr = nullptr;
+  uint32_t boundCount = 0;
 };
-bool mockCompileBoundSnapshot(void *ctx, const EJitCompileRequest &req,
-                              void **outFn) {
-  auto *log = static_cast<BoundSnapshotLog *>(ctx);
-  log->argIndex = req.boundArgIndex;
-  log->size = req.boundSize;
-  if (req.boundSize >= sizeof(log->value))
-    std::memcpy(&log->value, req.boundData, sizeof(log->value));
+bool mockCompileBoundPointer(void *ctx, const EJitCompileRequest &req,
+                             void **outFn) {
+  auto *log = static_cast<BoundPointerLog *>(ctx);
+  log->boundCount = req.boundCount;
+  if (req.boundCount == 1) {
+    const auto &Bound = req.boundPointers[0];
+    log->argIndex = Bound.argIndex;
+    log->size = Bound.size;
+    log->rawPtr = Bound.rawPtr;
+    if (Bound.size >= sizeof(log->value))
+      std::memcpy(&log->value, Bound.rawPtr, sizeof(log->value));
+  }
   *outFn = codeFor(req.funcIndex);
   return true;
 }
@@ -361,11 +369,15 @@ bool mockCompileSeq(void *ctx, const EJitCompileRequest & /*req*/,
 struct PublishObserver {
   uint32_t calls = 0;
   bool lastPublished = false;
+  uint32_t lastBoundCount = 0;
+  const void *lastRawPtr = nullptr;
 
-  static void notify(void *ctx, const EJitCompileRequest &, bool published) {
+  static void notify(void *ctx, const EJitCompileRequest &req, bool published) {
     auto *self = static_cast<PublishObserver *>(ctx);
     ++self->calls;
     self->lastPublished = published;
+    self->lastBoundCount = req.boundCount;
+    self->lastRawPtr = req.boundCount ? req.boundPointers[0].rawPtr : nullptr;
   }
 };
 
@@ -908,11 +920,11 @@ TEST_F(SharedTaskPoolTest, MultiProducerSharedQueue) {
   EXPECT_EQ(d.asyncCompiles, 3u);
 }
 
-TEST_F(SharedTaskPoolTest, BoundSnapshotOwnedAcrossCores) {
+TEST_F(SharedTaskPoolTest, BoundPointerSharedAcrossCores) {
   EJitSharedTaskPool owner;
   bringUpOwner(owner);
-  BoundSnapshotLog log;
-  owner.setCompiler(&mockCompileBoundSnapshot, &log);
+  BoundPointerLog log;
+  owner.setCompiler(&mockCompileBoundPointer, &log);
 
   EJitCoreId::setCurrentForTest(2);
   uint32_t callerValue = 0x12345678u;
@@ -920,13 +932,93 @@ TEST_F(SharedTaskPoolTest, BoundSnapshotOwnedAcrossCores) {
                               sizeof(callerValue), 3);
   ASSERT_EQ(r.status, EJitCompileOrGetStatus::EnqueuedPending);
 
-  // The producer may reuse or destroy its object before the owner runs.
-  callerValue = 0;
+  // The producer keeps the shared object alive until the worker callback
+  // returns. The queue carries its address and size, not a payload copy.
   EJitCoreId::setCurrentForTest(0);
   ASSERT_TRUE(owner.pollOne());
+  EXPECT_EQ(log.boundCount, 1u);
+  EXPECT_EQ(log.rawPtr, static_cast<const void *>(&callerValue));
   EXPECT_EQ(log.argIndex, 3u);
   EXPECT_EQ(log.size, sizeof(callerValue));
   EXPECT_EQ(log.value, 0x12345678u);
+}
+
+TEST_F(SharedTaskPoolTest, BoundPointerDescriptorsAreFixedAndValidated) {
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  BoundPointerLog log;
+  owner.setCompiler(&mockCompileBoundPointer, &log);
+
+  uint8_t Data[kEJitMaxBoundPointers][2048] = {};
+  EJitBoundPtrDescriptor Bounds[kEJitMaxBoundPointers] = {};
+  for (uint32_t I = 0; I < kEJitMaxBoundPointers; ++I)
+    Bounds[I] = {Data[I], sizeof(Data[I]), I};
+
+  EJitCoreId::setCurrentForTest(3);
+  auto accepted = owner.compileOrGet(102, nullptr, 0, codeFor(102), Bounds,
+                                     kEJitMaxBoundPointers);
+  ASSERT_EQ(accepted.status, EJitCompileOrGetStatus::EnqueuedPending);
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_TRUE(owner.pollOne());
+  EXPECT_EQ(log.boundCount, kEJitMaxBoundPointers);
+
+  EJitBoundPtrDescriptor Invalid{nullptr, sizeof(Data[0]), 0};
+  EXPECT_EQ(
+      owner.compileOrGet(103, nullptr, 0, codeFor(103), &Invalid, 1).status,
+      EJitCompileOrGetStatus::InvalidParam);
+  Invalid = {Data[0], 0, 0};
+  EXPECT_EQ(
+      owner.compileOrGet(104, nullptr, 0, codeFor(104), &Invalid, 1).status,
+      EJitCompileOrGetStatus::InvalidParam);
+  Invalid = {reinterpret_cast<const void *>(
+                 std::numeric_limits<uintptr_t>::max() - 3u),
+             8, 0};
+  EXPECT_EQ(
+      owner.compileOrGet(105, nullptr, 0, codeFor(105), &Invalid, 1).status,
+      EJitCompileOrGetStatus::InvalidParam);
+}
+
+TEST_F(SharedTaskPoolTest, PgoBoundPointerIsReadOnlyDuringCompile) {
+  EJitSharedTaskPool owner;
+  BatchPublishCtx Batch;
+  PublishObserver Observer;
+  EJitCoreId::setCurrentForTest(0);
+  owner.bind(state_.get());
+  owner.setCompiler(&mockBatchCompile, &Batch);
+  owner.setPublishCallback(&PublishObserver::notify, &Observer);
+  owner.setCodeBatchCallbacks(&mockBatchReady, &mockBatchFlush, &Batch);
+  owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  owner.setPgoEnabled(true, 1);
+
+  uint8_t Data[2048] = {};
+  Data[0] = 0x5a;
+  EJitBoundPtrDescriptor Bound{Data, sizeof(Data), 1};
+  ASSERT_EQ(owner.compileOrGet(106, nullptr, 0, codeFor(106), &Bound, 1).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(owner.pollOne());
+  ASSERT_EQ(Batch.compileOrder.size(), 1u);
+  EXPECT_EQ(Batch.compileOrder[0].boundCount, 1u);
+  EXPECT_EQ(Batch.compileOrder[0].boundPointers[0].rawPtr, Data);
+  ASSERT_EQ(owner.pendingPublishCount(), 1u);
+  ASSERT_TRUE(owner.flushCodeBatch());
+  EXPECT_EQ(Observer.lastBoundCount, 0u);
+  EXPECT_EQ(Observer.lastRawPtr, nullptr);
+
+  auto hit = owner.compileOrGet(106, nullptr, 0, codeFor(106), &Bound, 1);
+  ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  if (hit.hasReadToken)
+    owner.releaseRead(hit.bucketIndex);
+  ASSERT_EQ(owner.pendingCount(), 1u);
+
+  ASSERT_TRUE(owner.pollOne());
+  ASSERT_EQ(Batch.compileOrder.size(), 2u);
+  EXPECT_EQ(Batch.compileOrder[1].boundCount, 1u);
+  EXPECT_EQ(Batch.compileOrder[1].boundPointers[0].rawPtr, Data);
+  Data[0] = 0xa5;
+  ASSERT_TRUE(owner.flushCodeBatch());
+  EXPECT_EQ(Observer.lastBoundCount, 0u);
+  EXPECT_EQ(Observer.lastRawPtr, nullptr);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3030,10 +3122,10 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // address by every core, so a layout change that slips through unversioned is
   // a silent cross-core corruption.
   // v10-v13 add PGO controls, writable ranges, staged admission, and audit
-  // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
+  // requests; v14 introduced bound-pointer transport, and v15 adds
   // per-version post-publish reuse tracking; v16 adds near/far placement.
   // v17 adds explicit batch publish state.
-  EXPECT_EQ(kEJitSharedAbiVersion, 17u);
+  EXPECT_EQ(kEJitSharedAbiVersion, 18u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
@@ -27,6 +27,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h"
 #include "gtest/gtest.h"
 #include <cstring>
+#include <limits>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -77,27 +78,38 @@ struct MockCompiler {
 struct PublishObserver {
   uint32_t calls = 0;
   bool lastPublished = false;
+  uint32_t lastBoundCount = 0;
+  const void *lastRawPtr = nullptr;
 
-  static void notify(void *ctx, const EJitCompileRequest &, bool published) {
+  static void notify(void *ctx, const EJitCompileRequest &req, bool published) {
     auto *self = static_cast<PublishObserver *>(ctx);
     ++self->calls;
     self->lastPublished = published;
+    self->lastBoundCount = req.boundCount;
+    self->lastRawPtr = req.boundCount ? req.boundPointers[0].rawPtr : nullptr;
   }
 };
 
-struct SnapshotCompiler {
+struct BoundPointerCompiler {
   uint32_t first = 0;
   uint32_t second = 0;
   uint32_t argIndex = 0;
+  const void *rawPtr = nullptr;
+  uint32_t boundCount = 0;
 
   static bool compile(void *ctx, const EJitCompileRequest &req, void **outFn) {
-    auto *self = static_cast<SnapshotCompiler *>(ctx);
-    if (req.boundSize >= 2 * sizeof(uint32_t)) {
-      std::memcpy(&self->first, req.boundData, sizeof(uint32_t));
-      std::memcpy(&self->second, req.boundData + sizeof(uint32_t),
+    auto *self = static_cast<BoundPointerCompiler *>(ctx);
+    self->boundCount = req.boundCount;
+    if (req.boundCount == 1 &&
+        req.boundPointers[0].size >= 2 * sizeof(uint32_t)) {
+      const auto &Bound = req.boundPointers[0];
+      self->rawPtr = Bound.rawPtr;
+      std::memcpy(&self->first, Bound.rawPtr, sizeof(uint32_t));
+      std::memcpy(&self->second,
+                  static_cast<const uint8_t *>(Bound.rawPtr) + sizeof(uint32_t),
                   sizeof(uint32_t));
+      self->argIndex = Bound.argIndex;
     }
-    self->argIndex = req.boundArgIndex;
     *outFn = reinterpret_cast<void *>(&DummyFn0);
     return true;
   }
@@ -125,11 +137,10 @@ TEST(EJitTaskPoolLayout, RequestIsFlatPod) {
   static_assert(std::is_standard_layout<EJitCompileRequest>::value,
                 "EJitCompileRequest must be standard layout");
   EXPECT_LE(alignof(EJitCompileRequest), 8u);
-  // The fixed request owns its optional bound-pointer bytes inline. See the
-  // cross-pointer-width layout assertion in EJitSreQueue.h.
-  EXPECT_EQ(sizeof(EJitCompileRequest), sizeof(uintptr_t) == 8
-                                            ? 80u + EJIT_BOUND_PTR_MAX_BYTES
-                                            : 72u + EJIT_BOUND_PTR_MAX_BYTES);
+  // The fixed request carries descriptors only; its size is independent of
+  // every pointee's payload size. See the cross-pointer-width assertion in
+  // EJitSreQueue.h.
+  EXPECT_EQ(sizeof(EJitCompileRequest), sizeof(uintptr_t) == 8 ? 200u : 164u);
 }
 
 //===----------------------------------------------------------------------===//
@@ -953,39 +964,83 @@ TEST(EJitTaskPoolTest, InvalidParam) {
   // already-validated inputs.
 }
 
-TEST(EJitTaskPoolTest, BoundSnapshotOutlivesCallerObject) {
+TEST(EJitTaskPoolTest, BoundPointerIsReadDuringCompile) {
   EJitTaskPool P(8, false);
   P.switchController().setMode(EJitCompileMode::Async);
-  SnapshotCompiler C;
-  P.setCompiler(&SnapshotCompiler::compile, &C);
+  BoundPointerCompiler C;
   EJitDimPair D[1] = {{0, 3}};
+
   struct Config {
     uint32_t mode;
     uint32_t scale;
-  };
-
-  {
-    Config Local{7, 5};
-    auto R = P.compileOrGet(17, D, 1, nullptr, &Local, sizeof(Local), 2);
-    ASSERT_EQ(R.status, EJitCompileOrGetStatus::EnqueuedPending);
-    Local.mode = 99;
-    Local.scale = 99;
-  }
+  } Local{7, 5};
+  P.setCompiler(&BoundPointerCompiler::compile, &C);
+  auto R = P.compileOrGet(17, D, 1, nullptr, &Local, sizeof(Local), 2);
+  ASSERT_EQ(R.status, EJitCompileOrGetStatus::EnqueuedPending);
 
   ASSERT_TRUE(P.pollOne());
+  EXPECT_EQ(C.boundCount, 1u);
+  EXPECT_EQ(C.rawPtr, static_cast<const void *>(&Local));
   EXPECT_EQ(C.first, 7u);
   EXPECT_EQ(C.second, 5u);
   EXPECT_EQ(C.argIndex, 2u);
 }
 
-TEST(EJitTaskPoolTest, OversizeBoundSnapshotFallsBack) {
+TEST(EJitTaskPoolTest, BoundPointerDescriptorsAreFixedAndValidated) {
   EJitTaskPool P(8, false);
   P.switchController().setMode(EJitCompileMode::Async);
-  uint8_t Data[EJIT_BOUND_PTR_MAX_BYTES + 1] = {};
+  uint8_t Data[kEJitMaxBoundPointers][2048] = {};
   EJitDimPair D[1] = {{0, 3}};
-  auto R = P.compileOrGet(18, D, 1, nullptr, Data, sizeof(Data), 1);
-  EXPECT_EQ(R.status, EJitCompileOrGetStatus::InvalidParam);
-  EXPECT_EQ(P.pendingCount(), 0u);
+  EJitBoundPtrDescriptor Bounds[kEJitMaxBoundPointers] = {};
+  for (uint32_t I = 0; I < kEJitMaxBoundPointers; ++I)
+    Bounds[I] = {Data[I], sizeof(Data[I]), I};
+  auto Accepted =
+      P.compileOrGet(18, D, 1, nullptr, Bounds, kEJitMaxBoundPointers);
+  EXPECT_EQ(Accepted.status, EJitCompileOrGetStatus::EnqueuedPending);
+
+  Bounds[1].argIndex = Bounds[0].argIndex;
+  auto Rejected =
+      P.compileOrGet(19, D, 1, nullptr, Bounds, kEJitMaxBoundPointers);
+  EXPECT_EQ(Rejected.status, EJitCompileOrGetStatus::InvalidParam);
+  EXPECT_EQ(P.pendingCount(), 1u);
+
+  EJitBoundPtrDescriptor Invalid{Data, sizeof(Data), 0};
+  Invalid.rawPtr = nullptr;
+  EXPECT_EQ(P.compileOrGet(20, D, 1, nullptr, &Invalid, 1).status,
+            EJitCompileOrGetStatus::InvalidParam);
+  Invalid.rawPtr = Data;
+  Invalid.size = 0;
+  EXPECT_EQ(P.compileOrGet(21, D, 1, nullptr, &Invalid, 1).status,
+            EJitCompileOrGetStatus::InvalidParam);
+  Invalid.size = 8;
+  Invalid.rawPtr = reinterpret_cast<const void *>(
+      std::numeric_limits<uintptr_t>::max() - 3u);
+  EXPECT_EQ(P.compileOrGet(22, D, 1, nullptr, &Invalid, 1).status,
+            EJitCompileOrGetStatus::InvalidParam);
+  EXPECT_EQ(
+      P.compileOrGet(23, D, 1, nullptr, Bounds, kEJitMaxBoundPointers + 1u)
+          .status,
+      EJitCompileOrGetStatus::InvalidParam);
+}
+
+TEST(EJitTaskPoolTest, BoundPointerPublishCallbackDoesNotBorrowAfterCompile) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  MockCompiler C;
+  PublishObserver O;
+  P.setCompiler(&MockCompiler::compile, &C);
+  P.setPublishCallback(&PublishObserver::notify, &O);
+  uint32_t Config[2] = {7, 5};
+  EJitBoundPtrDescriptor Bound{Config, sizeof(Config), 1};
+  EJitDimPair D[1] = {{0, 3}};
+
+  ASSERT_EQ(P.compileOrGet(24, D, 1, nullptr, &Bound, 1).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(P.pollOne());
+  EXPECT_EQ(O.calls, 1u);
+  EXPECT_TRUE(O.lastPublished);
+  EXPECT_EQ(O.lastBoundCount, 0u);
+  EXPECT_EQ(O.lastRawPtr, nullptr);
 }
 
 TEST(EJitTaskPoolTest, OutOfRangeFuncIndexRejected) {


### PR DESCRIPTION
## Summary

- Restore propagation of bound-pointer snapshots through direct helper calls.
- Keep the bound compile/get APIs and module dump API in the lipo image.
- Make the board demo submit the two cell specializations serially so function-level in-flight dedup cannot drop the second version.
- Use the configured worker/producer core IDs in demo diagnostics.

## Board validation

Validated with worker core 6 and producer core 16:

- cell 1: AOT/JIT = 153/253
- cell 2: AOT/JIT = 194/294
- 2 baseline versions compiled and both reused through cache hits
- generated IR removed the bound `algorithm`/`scale` loads and branch
- the intentionally dynamic `runtimeBias` load remained

中文：已确认两个 cell 会分别生成并命中对应 JIT 版本；绑定结构体中的稳定字段和分支被优化掉，动态字段仍保留，板端用例通过。