### PR TITLE
[EJIT] Report compiled versions without reuse

### DIFF
--- a/jit_design_doc/EJIT_DIAGNOSTICS.md
+++ b/jit_design_doc/EJIT_DIAGNOSTICS.md
@@ -193,7 +193,7 @@ void ejit_print_dumped(const char *name);// 打印 entry 函数视图；NULL/"" 
 void ejit_print_dumped_module(const char *name); // 打印完整特化模块视图
 ```
 
-运行时按函数名过滤捕获后续 JIT 编译产生的**优化后 IR 与汇编**，再通过 RAW 诊断输出逐行回读。`ejit_print_dumped(name)` 只显示指定 entry 函数，便于聚焦单函数；`ejit_print_dumped_module(name)` 显示该 entry 对应的完整特化模块，包括模块中保留的被调函数。
+运行时按函数名过滤捕获后续 JIT 编译产生的**优化后 IR 与汇编**，再通过 RAW 诊断输出逐行回读。在线 PGO 开启时会跳过临时 Tier-1 插桩代码，只捕获最终发布的 Tier-2；这样不会因诊断汇编生成而额外拉长 Tier-1 的生命周期竞争窗口。`ejit_print_dumped(name)` 只显示指定 entry 函数，便于聚焦单函数；`ejit_print_dumped_module(name)` 显示该 entry 对应的完整特化模块，包括模块中保留的被调函数。
 
 > - 捕获为**精确名匹配**，`"*"` 例外（捕获全部）。
 > - 每次捕获同时保存单函数视图和完整模块视图；同名函数重新编译时替换旧记录。

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -34,6 +34,7 @@ class PeriodArrayRegistry;
 class EJitRuntimeState;
 struct EJitSharedTaskPoolState;
 struct EJitVpFunctionInfo; // defined in EJitOptimizer.h (value-profile capture)
+enum class CompileTier : uint8_t;
 
 namespace detail {
 /// Render one function definition without the rest of its specialization
@@ -41,6 +42,9 @@ namespace detail {
 /// ejit_dump_* APIs.
 bool renderDumpFunctionIR(const Module &M, StringRef fnName, std::string &out);
 void renderDumpModuleIR(const Module &M, std::string &out);
+/// Return whether a filtered dump should capture this compilation tier.
+/// Instrumented Tier-1 is temporary and must never replace a final dump.
+bool shouldCaptureDump(CompileTier tier, StringRef filter, StringRef fnName);
 } // namespace detail
 
 /// Set a function-name filter for JIT IR+ASM diagnostic capture. When non-

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -47,9 +47,10 @@ void renderDumpModuleIR(const Module &M, std::string &out);
 /// empty, the engine captures (saves in memory) the post-optimization IR and
 /// emitted assembly for both the matching entry function and its complete
 /// specialization module, the next time it is compiled. "*" matches every
-/// specialization. Empty/null disables further capture (already-captured
-/// entries are retained). Use printDumped() for the entry-only view and
-/// printDumpedModule() for the complete module.
+/// specialization. With staged PGO, temporary Instrumented code is skipped and
+/// the final Tier-2 code is captured. Empty/null disables further capture
+/// (already-captured entries are retained). Use printDumped() for the entry-only
+/// view and printDumpedModule() for the complete module.
 void setDumpFuncFilter(const std::string &name);
 
 /// Bind the optional shared taskpool dump state. In a shared-taskpool build

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -436,10 +436,11 @@ ejit_status_t ejit_get_code_pool_stats(ejit_code_pool_stats_t *out);
 void ejit_print_code_pool_stats(void);
 
 /// Print a ranking for every sampled ejit_entry function. The ranking is
-/// ordered by the average number of may_const loads removed across its JIT
-/// specializations. Call this explicitly after the audit sampling windows have
-/// completed. In a shared-taskpool build, a non-owner core forwards the request
-/// to the compile-owner worker and waits for printing to finish.
+/// ordered by dynamically removed may_const load executions per million
+/// platform timestamp units (removed work per entry times entry frequency).
+/// Call this explicitly after the audit sampling windows have completed. In a
+/// shared-taskpool build, a non-owner core forwards the request to the
+/// compile-owner worker and waits for printing to finish.
 void ejit_print_mayconst_ranking(void);
 
 /// Print the currently-active time-window instances through the platform log:

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -338,6 +338,9 @@ typedef struct {
 ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out);
 
 void ejit_taskpool_print_stats();
+/// Print every published shared-cache version and its dimensions. Stats builds
+/// also report whether a later taskpool lookup reused each published version;
+/// wrapper inline-cache calls after that first reuse remain intentionally free.
 void ejit_taskpool_print_compiled();
 uint32_t ejit_taskpool_get_worker_core();
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -99,7 +99,9 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// v13: non-owner cores can post a may_const-ranking diagnostic request to the
 /// owner worker and wait for its completion without sharing optimizer objects.
 /// v14: EJitCompileRequest owns an inline bound-pointer snapshot.
-constexpr uint32_t kEJitSharedAbiVersion = 14u;
+/// v15: each cache slot records whether its published JIT pointer was resolved
+/// by a later taskpool lookup, diagnosing compiled versions with no reuse.
+constexpr uint32_t kEJitSharedAbiVersion = 15u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -1098,6 +1098,10 @@ private:
   /// Result of a shared-cache lookup, including the cross-core fnPtr gate.
   struct SharedLookup {
     void *fnPtr = nullptr;
+    /// Matched shared slot for post-validation diagnostics. A token-bearing
+    /// hit keeps it stable; NO_RECLAIM marks it only after the outer seqlock
+    /// validation has accepted the lookup.
+    EJitSharedCacheSlot *slot = nullptr;
     uint32_t bucketIndex = 0;
     bool hasReadToken = false;
     bool readyButNotShareable = false;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -744,7 +744,9 @@ public:
     return pgoEnabled_.loadRelaxed() != 0;
   }
 
-  /// Return true when this miss may start/continue a staged PGO function.
+  /// Return true when this miss may start a staged PGO function. Only one
+  /// specialization of a funcIndex may own admission at a time; later versions
+  /// stay on AOT until the current Tier-2 finishes.
   bool admitPgoFunction(uint32_t funcIndex, bool &newlyAdmitted);
 
   //--- compile mode: CROSS-CORE SHARED runtime state --------------------------
@@ -1263,7 +1265,8 @@ private:
   /// Release staged-PGO ownership if \p funcIndex still owns it. Tier-2
   /// completion and terminal worker failures call this; transient queue-full
   /// leaves ownership intact so the next hit can retry.
-  void finishPgoFunction(uint32_t funcIndex, bool completed);
+  void finishPgoFunction(uint32_t funcIndex, bool completed,
+                         const char *reason = nullptr);
 
   /// Owner-only: snapshot the owner-core code-pool stats via the registered
   /// provider and storeRelaxed them into the shared mirror. Called after every

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -231,6 +231,11 @@ struct EJitSharedCacheSlot {
   /// Used to suppress the Tier-2 auto-trigger on slots that are already
   /// Tier-2 — a Tier-2 hit should never request another Tier-2 compile.
   EJitAtomicU8 tier;
+  /// Diagnostics (v14): set once when this published version successfully
+  /// returns its JIT pointer through the taskpool lookup path. The async call
+  /// that requested compilation does not set it, so zero identifies a version
+  /// that has not been reused after publish. Compiled out unless stats are on.
+  EJitAtomicU8 postPublishSeen;
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -231,10 +231,11 @@ struct EJitSharedCacheSlot {
   /// Used to suppress the Tier-2 auto-trigger on slots that are already
   /// Tier-2 — a Tier-2 hit should never request another Tier-2 compile.
   EJitAtomicU8 tier;
-  /// Diagnostics (v14): set once when this published version successfully
+  /// Diagnostics (v15): set once when this published version successfully
   /// returns its JIT pointer through the taskpool lookup path. The async call
   /// that requested compilation does not set it, so zero identifies a version
-  /// that has not been reused after publish. Compiled out unless stats are on.
+  /// that has not been reused after publish. The ABI field is always present;
+  /// it is meaningful only when EJIT_STATS_ENABLE updates it.
   EJitAtomicU8 postPublishSeen;
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -45,6 +45,7 @@ enum class EJitCompileOrGetStatus : uint32_t {
   InstanceDisabled,
   EnqueuedPending,
   AlreadyPending,
+  PgoAdmissionDeferred,
   QueueFullFallback,
   CompileFailed,
   InvalidParam,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -256,6 +256,7 @@ static bool getActiveDumpFilter(std::string &out) {
 /// Saved IR+ASM for a captured specialization (latest per function name).
 struct DumpEntry {
   uint64_t cacheKey = 0;
+  CompileTier tier = CompileTier::Baseline;
   std::string FunctionIR;
   std::string FunctionASM;
   std::string ModuleIR;
@@ -405,6 +406,7 @@ static bool printSharedDumpHint(const char *name) {
 /// Called from the IR transform layer when the filter matches: save the
 /// post-optimization IR and emitted ASM for later selective printing.
 static void captureDump(const std::string &fnName, uint64_t cacheKey,
+                        CompileTier tier,
                         std::string FunctionIR, std::string FunctionASM,
                         std::string ModuleIR, std::string ModuleASM) {
   EJIT_DIAG_DEBUG(
@@ -416,7 +418,7 @@ static void captureDump(const std::string &fnName, uint64_t cacheKey,
   std::lock_guard<DumpMutexType> lock(gDumpMutex);
   EJIT_DIAG_DEBUG("capture store_size before=%u", (unsigned)gDumpStore.size());
   gDumpStore[fnName] =
-      DumpEntry{cacheKey, std::move(FunctionIR), std::move(FunctionASM),
+      DumpEntry{cacheKey, tier, std::move(FunctionIR), std::move(FunctionASM),
                 std::move(ModuleIR), std::move(ModuleASM)};
   EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
@@ -485,10 +487,13 @@ static void printOneDumpSafe(const char *requestedName,
   uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
   (void)keyHi;
   (void)keyLo;
-  EJIT_DIAG_RAW("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
-                "key_lo=0x%08x ir_size=%u asm_size=%u",
+  const char *Tier = e.tier == CompileTier::PGOUse ? "tier2"
+                     : e.tier == CompileTier::Instrumented ? "tier1"
+                                                          : "baseline";
+  EJIT_DIAG_RAW("print_dumped hit requested=%s stored=%s tier=%s "
+                "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u",
                 requestedName ? requestedName : "(list)", storedName.c_str(),
-                keyHi, keyLo, (unsigned)e.FunctionIR.size(),
+                Tier, keyHi, keyLo, (unsigned)e.FunctionIR.size(),
                 (unsigned)e.FunctionASM.size());
   if (!e.FunctionIR.empty())
     dumpLinesSafe("dump IR", e.FunctionIR);
@@ -503,10 +508,13 @@ static void printOneModuleDumpSafe(const char *requestedName,
   uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
   (void)keyHi;
   (void)keyLo;
-  EJIT_DIAG_RAW("print_dumped_module hit requested=%s stored=%s "
+  const char *Tier = e.tier == CompileTier::PGOUse ? "tier2"
+                     : e.tier == CompileTier::Instrumented ? "tier1"
+                                                          : "baseline";
+  EJIT_DIAG_RAW("print_dumped_module hit requested=%s stored=%s tier=%s "
                 "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u",
                 requestedName ? requestedName : "(list)", storedName.c_str(),
-                keyHi, keyLo, (unsigned)e.ModuleIR.size(),
+                Tier, keyHi, keyLo, (unsigned)e.ModuleIR.size(),
                 (unsigned)e.ModuleASM.size());
   if (!e.ModuleIR.empty())
     dumpLinesSafe("dump module IR", e.ModuleIR);
@@ -788,8 +796,13 @@ EJitOrcEngine::Create(const Config &config,
           {
             std::string DumpFilter;
             bool hasFilter = getActiveDumpFilter(DumpFilter);
-            bool match =
-                hasFilter && (DumpFilter == "*" || ctx->fnName == DumpFilter);
+            // Tier-1 is temporary profiling code. Capturing it doubles the
+            // already expensive diagnostic ASM codegen and lengthens the
+            // lifecycle race window before publish. The public dump APIs show
+            // executable final code: Baseline when PGO is off, Tier-2 when on.
+            bool finalTier = ctx->tier != CompileTier::Instrumented;
+            bool match = finalTier && hasFilter &&
+                         (DumpFilter == "*" || ctx->fnName == DumpFilter);
             EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
                             "key_lo=0x%08x match=%d &filter=%p",
                             hasFilter ? DumpFilter.c_str() : "(off)",
@@ -846,7 +859,7 @@ EJitOrcEngine::Create(const Config &config,
                               "EJIT_DUMP_ASM off) fn=%s; IR captured",
                               ctx->fnName.c_str());
 #endif
-              captureDump(ctx->fnName, ctx->cacheKey,
+              captureDump(ctx->fnName, ctx->cacheKey, ctx->tier,
                           std::move(FunctionIR), std::move(FunctionAsm),
                           std::move(ModuleIR), std::move(ModuleAsm));
             }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -451,6 +451,12 @@ void detail::renderDumpModuleIR(const Module &M, std::string &out) {
   OS.flush();
 }
 
+bool detail::shouldCaptureDump(CompileTier tier, StringRef filter,
+                               StringRef fnName) {
+  return tier != CompileTier::Instrumented && !filter.empty() &&
+         (filter == "*" || filter == fnName);
+}
+
 /// Clone a diagnostic codegen module with only the requested function body.
 /// Other function definitions become declarations, preserving the target
 /// function's calls while avoiding a second codegen of its whole closure.
@@ -800,9 +806,8 @@ EJitOrcEngine::Create(const Config &config,
             // already expensive diagnostic ASM codegen and lengthens the
             // lifecycle race window before publish. The public dump APIs show
             // executable final code: Baseline when PGO is off, Tier-2 when on.
-            bool finalTier = ctx->tier != CompileTier::Instrumented;
-            bool match = finalTier && hasFilter &&
-                         (DumpFilter == "*" || ctx->fnName == DumpFilter);
+            bool match = hasFilter && detail::shouldCaptureDump(
+                                          ctx->tier, DumpFilter, ctx->fnName);
             EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
                             "key_lo=0x%08x match=%d &filter=%p",
                             hasFilter ? DumpFilter.c_str() : "(off)",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1650,6 +1650,14 @@ void ejit_taskpool_print_stats() {
                   static_cast<unsigned long long>(d.workerTaskId),
                   static_cast<unsigned long long>(d.registrationFingerprint),
                   static_cast<unsigned long long>(d.executePrepareFailed));
+    EJIT_DIAG_RAW("  pgo active=%u/%u completed=%llu deferred=%llu "
+                  "tier1=%llu tier2=%llu mergeFailed=%llu",
+                  d.pgoActiveFunctionCount, d.pgoMaxActiveFunctions,
+                  static_cast<unsigned long long>(d.pgoCompletedFunctions),
+                  static_cast<unsigned long long>(d.pgoDeferredMisses),
+                  static_cast<unsigned long long>(d.tier1Compiles),
+                  static_cast<unsigned long long>(d.tier2Compiles),
+                  static_cast<unsigned long long>(d.profileMergeFails));
   }
   // Diagnostic: dump the inline-cache slot registry to help diagnose
   // why cacheHits keeps growing despite icache being enabled. Hand the
@@ -1688,8 +1696,9 @@ void ejit_taskpool_print_compiled() {
   // diverge by the same margin as any walk-based dump.
   struct CountCtx {
     uint32_t byDims[kEJitSharedMaxDims + 1];
-    uint32_t postPublishSeen;
-  } count = {{0}, 0};
+    uint32_t byTier[3];
+    uint32_t finalPostPublishSeen;
+  } count = {{0}, {0}, 0};
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
@@ -1697,8 +1706,12 @@ void ejit_taskpool_print_compiled() {
         uint32_t n = slot.numDims < kEJitSharedMaxDims ? slot.numDims
                                                        : kEJitSharedMaxDims;
         ++static_cast<CountCtx *>(cbCtx)->byDims[n];
-        if (slot.postPublishSeen.loadRelaxed() != 0)
-          ++static_cast<CountCtx *>(cbCtx)->postPublishSeen;
+        uint8_t tier = slot.tier.loadRelaxed();
+        if (tier <= kEJitTierPgoUse)
+          ++static_cast<CountCtx *>(cbCtx)->byTier[tier];
+        if (tier != kEJitTierInstrumented &&
+            slot.postPublishSeen.loadRelaxed() != 0)
+          ++static_cast<CountCtx *>(cbCtx)->finalPostPublishSeen;
       },
       &count);
   // Summary line first (fixed line count, so no throttle): total, cache
@@ -1721,13 +1734,21 @@ void ejit_taskpool_print_compiled() {
                 st.visitedSlots, st.visitedSlots,
                 kEJitSharedCacheBuckets * kEJitSharedCacheSlots,
                 st.skippedBuckets, byDims[0] ? " byDims: " : "", byDims);
+  EJIT_DIAG_RAW("compiled tiers: baseline=%u tier1_collecting=%u tier2=%u",
+                count.byTier[kEJitTierBaseline],
+                count.byTier[kEJitTierInstrumented],
+                count.byTier[kEJitTierPgoUse]);
 #ifdef EJIT_STATS_ENABLE
   constexpr bool ReuseTrackingEnabled = true;
-  EJIT_DIAG_RAW("compiled reuse: post_publish_seen=%u unseen=%u",
-                count.postPublishSeen,
-                st.visitedSlots >= count.postPublishSeen
-                    ? st.visitedSlots - count.postPublishSeen
-                    : 0);
+  const uint32_t FinalVersions = count.byTier[kEJitTierBaseline] +
+                                 count.byTier[kEJitTierPgoUse];
+  EJIT_DIAG_RAW("compiled final reuse: post_publish_seen=%u unseen=%u "
+                "(tier1_collecting_excluded=%u)",
+                count.finalPostPublishSeen,
+                FinalVersions >= count.finalPostPublishSeen
+                    ? FinalVersions - count.finalPostPublishSeen
+                    : 0,
+                count.byTier[kEJitTierInstrumented]);
 #else
   constexpr bool ReuseTrackingEnabled = false;
   EJIT_DIAG_RAW("compiled reuse: disabled (build with EJIT_STATS_ENABLE)");
@@ -1768,6 +1789,11 @@ void ejit_taskpool_print_compiled() {
             !ctx.reuseTrackingEnabled
                 ? "disabled"
                 : (slot.postPublishSeen.loadRelaxed() != 0 ? "yes" : "no");
+        const uint8_t SlotTier = slot.tier.loadRelaxed();
+        const char *Tier = SlotTier == kEJitTierPgoUse ? "tier2"
+                           : SlotTier == kEJitTierInstrumented
+                               ? "tier1-collecting"
+                               : "baseline";
         if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
           // Same shape for the per-instance version snapshot (uint32 x
           // kEJitSharedMaxDims + separators + NUL).
@@ -1780,19 +1806,19 @@ void ejit_taskpool_print_compiled() {
           if (p >= end)
             p = end - 1;
           *p = '\0';
-          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
+          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
                         "post_publish_seen=%s ver=[%s] size=%llu pool=%u "
                         "gen=%u",
                         slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(),
+                        name.empty() ? "<unknown>" : name.c_str(), Tier,
                         slot.numDims, dims, fn, PostPublishSeen, ver,
                         static_cast<unsigned long long>(slot.codeSize),
                         slot.poolId, slot.generation);
         } else {
-          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
+          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
                         "post_publish_seen=%s",
                         slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(),
+                        name.empty() ? "<unknown>" : name.c_str(), Tier,
                         slot.numDims, dims, fn, PostPublishSeen);
         }
         ejitDiagPrintThrottle();

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -796,6 +796,10 @@ static ejit_status_t taskpoolStatus(EJitCompileOrGetStatus s) {
   case EJitCompileOrGetStatus::EnqueuedPending:
   case EJitCompileOrGetStatus::AlreadyPending:
     return EJIT_PENDING;
+  case EJitCompileOrGetStatus::PgoAdmissionDeferred:
+    // No work was queued. Surface a clean resource-limit fallback instead of
+    // claiming that an asynchronous compilation is pending.
+    return EJIT_ERR_QUEUE_FULL;
   case EJitCompileOrGetStatus::QueueFullFallback:
     return EJIT_ERR_QUEUE_FULL;
   case EJitCompileOrGetStatus::OffMode:

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1688,7 +1688,8 @@ void ejit_taskpool_print_compiled() {
   // diverge by the same margin as any walk-based dump.
   struct CountCtx {
     uint32_t byDims[kEJitSharedMaxDims + 1];
-  } count = {{0}};
+    uint32_t postPublishSeen;
+  } count = {{0}, 0};
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
@@ -1696,6 +1697,8 @@ void ejit_taskpool_print_compiled() {
         uint32_t n = slot.numDims < kEJitSharedMaxDims ? slot.numDims
                                                        : kEJitSharedMaxDims;
         ++static_cast<CountCtx *>(cbCtx)->byDims[n];
+        if (slot.postPublishSeen.loadRelaxed() != 0)
+          ++static_cast<CountCtx *>(cbCtx)->postPublishSeen;
       },
       &count);
   // Summary line first (fixed line count, so no throttle): total, cache
@@ -1718,11 +1721,27 @@ void ejit_taskpool_print_compiled() {
                 st.visitedSlots, st.visitedSlots,
                 kEJitSharedCacheBuckets * kEJitSharedCacheSlots,
                 st.skippedBuckets, byDims[0] ? " byDims: " : "", byDims);
+#ifdef EJIT_STATS_ENABLE
+  constexpr bool ReuseTrackingEnabled = true;
+  EJIT_DIAG_RAW("compiled reuse: post_publish_seen=%u unseen=%u",
+                count.postPublishSeen,
+                st.visitedSlots >= count.postPublishSeen
+                    ? st.visitedSlots - count.postPublishSeen
+                    : 0);
+#else
+  constexpr bool ReuseTrackingEnabled = false;
+  EJIT_DIAG_RAW("compiled reuse: disabled (build with EJIT_STATS_ENABLE)");
+#endif
   // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
   // each printed line.
+  struct PrintCtx {
+    EJitModuleLoader &loader;
+    bool reuseTrackingEnabled;
+  } printCtx{loader, ReuseTrackingEnabled};
   EJitSharedTaskPool::ForEachCompiledStats st2 = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
-        EJitModuleLoader &ld = *static_cast<EJitModuleLoader *>(cbCtx);
+        PrintCtx &ctx = *static_cast<PrintCtx *>(cbCtx);
+        EJitModuleLoader &ld = ctx.loader;
         const std::string &name =
             ld.getFuncNameByFuncIdx(slot.funcIndex);
         // Per the publish protocol: fnPtr is read with acquire only after
@@ -1745,6 +1764,10 @@ void ejit_taskpool_print_compiled() {
         if (p >= end)
           p = end - 1;
         *p = '\0';
+        const char *PostPublishSeen =
+            !ctx.reuseTrackingEnabled
+                ? "disabled"
+                : (slot.postPublishSeen.loadRelaxed() != 0 ? "yes" : "no");
         if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
           // Same shape for the per-instance version snapshot (uint32 x
           // kEJitSharedMaxDims + separators + NUL).
@@ -1758,21 +1781,23 @@ void ejit_taskpool_print_compiled() {
             p = end - 1;
           *p = '\0';
           EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
-                        "ver=[%s] size=%llu pool=%u gen=%u",
+                        "post_publish_seen=%s ver=[%s] size=%llu pool=%u "
+                        "gen=%u",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(),
-                        slot.numDims, dims, fn, ver,
+                        slot.numDims, dims, fn, PostPublishSeen, ver,
                         static_cast<unsigned long long>(slot.codeSize),
                         slot.poolId, slot.generation);
         } else {
-          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p",
+          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
+                        "post_publish_seen=%s",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(),
-                        slot.numDims, dims, fn);
+                        slot.numDims, dims, fn, PostPublishSeen);
         }
         ejitDiagPrintThrottle();
       },
-      &loader);
+      &printCtx);
   // The summary counted the first walk; if the entry walk itself skipped
   // contended buckets, its lines are incomplete relative to it — report the
   // shortfall (fixed line count, so no throttle) instead of dropping it.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -186,6 +186,17 @@ constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 /// cacheLookupNd block can also reference it.
 constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
+inline void markPostPublishSeen(EJitSharedCacheSlot &Slot) {
+#ifdef EJIT_STATS_ENABLE
+  if (Slot.postPublishSeen.loadRelaxed() != 0)
+    return;
+  uint8_t Expected = 0;
+  (void)Slot.postPublishSeen.compareExchange(Expected, 1);
+#else
+  (void)Slot;
+#endif
+}
+
 // Per-function inline-cache slot registry (multi-version direct-indexed). Each
 // entry records the wrapper's per-function @__ejit_icache_fn_<name> global base
 // (a uintptr_t cell, or a [D]^numDims array of them for a multi-version entry)
@@ -1460,6 +1471,7 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   // publishing). Return directly while holding the read token.
   if (self == owner) {
     R.fnPtr = fn;
+    R.slot = &Slot;
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
     R.noTokenHit = true;
     R.bucketIndex = kEJitSharedCacheBuckets; // sentinel -> releaseRead no-op
@@ -1477,6 +1489,7 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : uint64_t{0};
   if (CanMemoize && (Slot.executableCoreMask.loadAcquire() & CoreBit) != 0) {
     R.fnPtr = fn;
+    R.slot = &Slot;
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
     R.noTokenHit = true;
     R.bucketIndex = kEJitSharedCacheBuckets; // sentinel -> releaseRead no-op
@@ -1679,6 +1692,7 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
   if (CanMemoize)
     S2.executableCoreMask.fetchOr(CoreBit);
   R.fnPtr = Snap.fn;
+  R.slot = &S2;
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
   // NO_RECLAIM: this cold path already fully re-validated
   // identity/versions/fnPtr above under a load-only re-read, so it hands back a
@@ -2273,6 +2287,7 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   // slots (§4 repeat-trigger).  Under the write lock + before state=Ready.
   target->hitCount.storeRelaxed(0);
   target->tier.storeRelaxed(static_cast<uint8_t>(tier));
+  target->postPublishSeen.storeRelaxed(0);
   const uint32_t OwnerCore = state_->ownerCoreId.loadAcquire();
   target->executableCoreMask.storeRelease(
       OwnerCore < 64 ? (uint64_t{1} << OwnerCore) : 0);
@@ -2477,6 +2492,7 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
       // hotness state or tier-tracking from a prior generation.
       Slot.hitCount.storeRelaxed(0);
       Slot.tier.storeRelaxed(0);
+      Slot.postPublishSeen.storeRelaxed(0);
     }
   }
 }
@@ -2701,6 +2717,8 @@ __attribute__((always_inline)) EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   CompileOrGetResult R;
   if (Hit.hasReadToken && Hit.fnPtr) {
+    if (Hit.slot)
+      markPostPublishSeen(*Hit.slot);
     EJIT_STAT_INC(state_->counters.cacheHits);
     R.status = EJitCompileOrGetStatus::CacheHit;
     R.fnPtr = Hit.fnPtr;
@@ -2714,6 +2732,8 @@ EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   // bucketIndex is the out-of-range sentinel, so the wrapper's releaseRead()
   // cleanly no-ops. Safe because published code is never freed in this build.
   if (Hit.noTokenHit && Hit.fnPtr) {
+    if (Hit.slot)
+      markPostPublishSeen(*Hit.slot);
     EJIT_STAT_INC(state_->counters.cacheHits);
     R.status = EJitCompileOrGetStatus::CacheHit;
     R.fnPtr = Hit.fnPtr;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -190,8 +190,7 @@ inline void markPostPublishSeen(EJitSharedCacheSlot &Slot) {
 #ifdef EJIT_STATS_ENABLE
   if (Slot.postPublishSeen.loadRelaxed() != 0)
     return;
-  uint8_t Expected = 0;
-  (void)Slot.postPublishSeen.compareExchange(Expected, 1);
+  Slot.postPublishSeen.storeRelaxed(1);
 #else
   (void)Slot;
 #endif
@@ -3073,7 +3072,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     // All profiling slots are occupied. Keep this miss on the AOT fallback
     // and do not add work to the compiler queue.
     dedupClear(funcIndex, gen);
-    R.status = EJitCompileOrGetStatus::AlreadyPending;
+    R.status = EJitCompileOrGetStatus::PgoAdmissionDeferred;
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_TESTING

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -1547,7 +1547,12 @@ bool EJitSharedTaskPool::admitPgoFunction(uint32_t funcIndex,
     uint32_t active = state_->pgoActiveFunctions[i].loadRelaxed();
     if (active == encoded) {
       state_->pgoAdmissionLock.storeRelease(0);
-      return true;
+      // Admission is per function, while cache entries are per specialization.
+      // Letting another identity of the same funcIndex proceed would make both
+      // versions share one progress/ownership slot: either one's failure or
+      // Tier-2 completion could then release the other version prematurely.
+      state_->pgoDeferredMisses.fetchAdd(1);
+      return false;
     }
     if (active == 0 && freeSlot == kEJitSharedMaxConcurrentProfiles)
       freeSlot = i;
@@ -1572,7 +1577,8 @@ bool EJitSharedTaskPool::admitPgoFunction(uint32_t funcIndex,
   return true;
 }
 
-void EJitSharedTaskPool::finishPgoFunction(uint32_t funcIndex, bool completed) {
+void EJitSharedTaskPool::finishPgoFunction(uint32_t funcIndex, bool completed,
+                                           const char *reason) {
   const uint32_t encoded = funcIndex + 1;
   uint32_t expected = 0;
   while (!state_->pgoAdmissionLock.compareExchange(expected, 1))
@@ -1600,8 +1606,8 @@ void EJitSharedTaskPool::finishPgoFunction(uint32_t funcIndex, bool completed) {
               static_cast<unsigned long long>(
                   state_->pgoDeferredMisses.loadRelaxed()));
   } else {
-    EJIT_DIAG("PGO profile aborted func=%u; next function may start",
-              funcIndex);
+    EJIT_DIAG("PGO profile aborted func=%u reason=%s; next function may start",
+              funcIndex, reason ? reason : "unspecified");
   }
 }
 
@@ -3040,12 +3046,33 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.status = EJitCompileOrGetStatus::CompileFailed;
     return R;
   }
-  // Dedup + enqueue (§5.2 step 3) — Async path.
-  bool newlyAdmitted = false;
+  // Dedup + enqueue (§5.2 step 3) — Async path. Claim the per-function
+  // in-flight slot BEFORE staged-PGO admission. Otherwise a request already in
+  // the queue makes us log "profile start 0/N", only for dedupMark below to
+  // reject it and immediately log "profile aborted" even though no profiling
+  // ever started.
   const bool pgoForRequest = state_->pgoEnabled.loadAcquire() != 0;
+  const uint32_t gen = state_->generation.loadAcquire();
+  switch (dedupMark(funcIndex, gen)) {
+  case EJitDedupResult::AlreadyPending:
+    EJIT_STAT_INC(state_->counters.alreadyPending);
+    EJIT_DIAG_VERBOSE("shared taskpool coalesced func=%u: already pending",
+                      funcIndex);
+    R.status = EJitCompileOrGetStatus::AlreadyPending;
+    return R;
+  case EJitDedupResult::InvalidFuncIndex:
+    EJIT_DIAG("shared taskpool reject func=%u: out of range", funcIndex);
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    return R;
+  case EJitDedupResult::Claimed:
+    break;
+  }
+
+  bool newlyAdmitted = false;
   if (pgoForRequest && !admitPgoFunction(funcIndex, newlyAdmitted)) {
     // All profiling slots are occupied. Keep this miss on the AOT fallback
     // and do not add work to the compiler queue.
+    dedupClear(funcIndex, gen);
     R.status = EJitCompileOrGetStatus::AlreadyPending;
     return R;
   }
@@ -3053,7 +3080,6 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (pgoForRequest && pgoAdmissionTestHook_)
     pgoAdmissionTestHook_(pgoAdmissionTestHookCtx_);
 #endif
-  uint32_t gen = state_->generation.loadAcquire();
   EJitCompileRequest Req{};
   Req.funcIndex = pgoForRequest
                       ? encodeReqTier(funcIndex, kEJitTierInstrumented)
@@ -3070,33 +3096,19 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (boundSize)
     std::memcpy(Req.boundData, boundData, boundSize);
   if (!versionsCurrent(Req) || state_->generation.loadAcquire() != gen) {
+    dedupClear(funcIndex, gen);
+    if (newlyAdmitted)
+      finishPgoFunction(funcIndex, /*completed=*/false,
+                        "lifecycle-changed-during-admission");
     EJIT_DIAG("shared taskpool async snapshot drop func=%u: lifecycle changed",
               funcIndex);
     R.status = EJitCompileOrGetStatus::CompileFailed;
     return R;
   }
-  switch (dedupMark(funcIndex, gen)) {
-  case EJitDedupResult::AlreadyPending:
-    if (newlyAdmitted)
-      finishPgoFunction(funcIndex, /*completed=*/false);
-    EJIT_STAT_INC(state_->counters.alreadyPending);
-    EJIT_DIAG_VERBOSE("shared taskpool coalesced func=%u: already pending",
-                      funcIndex);
-    R.status = EJitCompileOrGetStatus::AlreadyPending;
-    return R;
-  case EJitDedupResult::InvalidFuncIndex:
-    if (newlyAdmitted)
-      finishPgoFunction(funcIndex, /*completed=*/false);
-    EJIT_DIAG("shared taskpool reject func=%u: out of range", funcIndex);
-    R.status = EJitCompileOrGetStatus::InvalidParam;
-    return R;
-  case EJitDedupResult::Claimed:
-    break;
-  }
   if (!queuePush(Req)) {
-    if (newlyAdmitted)
-      finishPgoFunction(funcIndex, /*completed=*/false);
     dedupClear(funcIndex, gen); // queue full → roll back the in-flight slot.
+    if (newlyAdmitted)
+      finishPgoFunction(funcIndex, /*completed=*/false, "tier1-queue-full");
     EJIT_STAT_INC(state_->counters.queueFull);
     EJIT_DIAG("shared taskpool fallback func=%u: queue full", funcIndex);
     R.status = EJitCompileOrGetStatus::QueueFullFallback;
@@ -3155,7 +3167,8 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   const bool pgoClearExclusive = tier == kEJitTierPgoUse;
   auto finishPgoOnFailure = [&]() {
     if (tier == kEJitTierInstrumented) {
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "tier1-compile-or-publish-failed");
     } else if (tier == kEJitTierPgoUse) {
       // Tier-1 is still published and instrumented. Retain admission so a
       // later hit retries Tier-2 instead of freeing this admission slot while
@@ -3179,9 +3192,10 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   }
   // Checkpoint 1: invalidated before compile started.
   if (!versionsCurrent(req)) {
-    if (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse)
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
     dedupClear(req.funcIndex, req.generation);
+    if (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse)
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "version-changed-before-compile");
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG(
         "shared worker compile drop func=%u: version changed before compile",
@@ -3191,8 +3205,8 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   void *fn = nullptr;
   bool ok = compileFn_ && compileFn_(compileCtx_, req, &fn);
   if (!ok || !fn) {
-    finishPgoOnFailure();
     dedupClear(req.funcIndex, req.generation);
+    finishPgoOnFailure();
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG("shared worker compile failed func=%u ok=%u fn=%p", req.funcIndex,
               static_cast<unsigned>(ok), fn);
@@ -3212,12 +3226,13 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
       !versionsCurrent(req)) {
     if (publishFn_)
       publishFn_(publishCtx_, req, false);
+    dedupClear(req.funcIndex, req.generation);
     if (req.generation == state_->generation.loadAcquire() &&
         (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse))
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "version-changed-after-compile");
     if (releaseFn_)
       releaseFn_(releaseCtx_, fn);
-    dedupClear(req.funcIndex, req.generation);
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG(
         "shared worker compile drop func=%u: version/gen changed after compile",
@@ -3230,6 +3245,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
     EJIT_STAT_INC(state_->counters.asyncCompiles);
     if (publishFn_)
       publishFn_(publishCtx_, req, true);
+    dedupClear(req.funcIndex, req.generation);
     if (tier == kEJitTierInstrumented) {
       EJIT_STAT_INC(state_->counters.tier1Compiles);
       EJIT_DIAG("PGO Tier-1 published func=%u: collecting 0/%u hits",
@@ -3239,19 +3255,19 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
       finishPgoFunction(realFuncIndex, /*completed=*/true);
     }
     publishCodePoolStats();
-    dedupClear(req.funcIndex, req.generation);
     EJIT_DIAG_VERBOSE("shared worker publish ok func=%u fn=%p", req.funcIndex,
                       fn);
     return;
   case EJitPublishStatus::VersionMismatch:
     if (publishFn_)
       publishFn_(publishCtx_, req, false);
+    dedupClear(req.funcIndex, req.generation);
     if (req.generation == state_->generation.loadAcquire() &&
         (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse))
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "version-mismatch-at-publish");
     if (releaseFn_)
       releaseFn_(releaseCtx_, fn);
-    dedupClear(req.funcIndex, req.generation);
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG("shared worker publish drop func=%u: version mismatch",
               req.funcIndex);
@@ -3260,10 +3276,10 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   case EJitPublishStatus::Failed:
     if (publishFn_)
       publishFn_(publishCtx_, req, false);
+    dedupClear(req.funcIndex, req.generation);
     finishPgoOnFailure();
     if (releaseFn_)
       releaseFn_(releaseCtx_, fn);
-    dedupClear(req.funcIndex, req.generation);
     EJIT_STAT_INC(state_->counters.publishFailed);
     EJIT_DIAG("shared worker publish failed func=%u status=%u", req.funcIndex,
               static_cast<unsigned>(PS));

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -124,6 +124,47 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
   }
 }
 
+TEST(EJitDump, SkipsTemporaryPgoTier1Capture) {
+  std::string Bitcode;
+  {
+    LLVMContext Ctx;
+    Module M("dump_pgo_tiers", Ctx);
+    auto *FT = FunctionType::get(Type::getInt32Ty(Ctx), {}, false);
+    auto *F = Function::Create(FT, Function::ExternalLinkage,
+                               "dump_temporary_tier1", &M);
+    IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
+    B.CreateRet(B.getInt32(1));
+    raw_string_ostream OS(Bitcode);
+    WriteBitcodeToFile(M, OS);
+    OS.flush();
+  }
+
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  EJitRuntimeState State;
+  Config Cfg;
+  Cfg.enablePgo = true;
+  auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
+  ASSERT_TRUE(static_cast<bool>(EngineOrErr));
+  auto Engine = std::move(*EngineOrErr);
+
+  setDumpFuncFilter("*");
+  SpecializationContext Ctx;
+  Ctx.fnName = "dump_temporary_tier1";
+  Ctx.cacheKey = 0xd711;
+  Ctx.tier = CompileTier::Instrumented;
+  Engine->setActiveContext(&Ctx);
+  ASSERT_FALSE(errorToBool(
+      Engine->loadBitcodeModule(Bitcode, Ctx.cacheKey, Ctx.fnName)));
+  auto FnOrErr = Engine->lookup(Ctx.cacheKey, Ctx.fnName);
+  ASSERT_TRUE(static_cast<bool>(FnOrErr));
+  Engine->setActiveContext(nullptr);
+  setDumpFuncFilter("");
+
+  EXPECT_FALSE(printDumped("dump_temporary_tier1"));
+  EXPECT_FALSE(printDumpedModule("dump_temporary_tier1"));
+}
+
 namespace llvm {
 namespace ejit {
 // Test-only accessor. EJitOptimizer deliberately keeps its individual pipeline

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -125,44 +125,17 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
 }
 
 TEST(EJitDump, SkipsTemporaryPgoTier1Capture) {
-  std::string Bitcode;
-  {
-    LLVMContext Ctx;
-    Module M("dump_pgo_tiers", Ctx);
-    auto *FT = FunctionType::get(Type::getInt32Ty(Ctx), {}, false);
-    auto *F = Function::Create(FT, Function::ExternalLinkage,
-                               "dump_temporary_tier1", &M);
-    IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
-    B.CreateRet(B.getInt32(1));
-    raw_string_ostream OS(Bitcode);
-    WriteBitcodeToFile(M, OS);
-    OS.flush();
-  }
-
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
-  EJitRuntimeState State;
-  Config Cfg;
-  Cfg.enablePgo = true;
-  auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
-  ASSERT_TRUE(static_cast<bool>(EngineOrErr));
-  auto Engine = std::move(*EngineOrErr);
-
-  setDumpFuncFilter("*");
-  SpecializationContext Ctx;
-  Ctx.fnName = "dump_temporary_tier1";
-  Ctx.cacheKey = 0xd711;
-  Ctx.tier = CompileTier::Instrumented;
-  Engine->setActiveContext(&Ctx);
-  ASSERT_FALSE(errorToBool(
-      Engine->loadBitcodeModule(Bitcode, Ctx.cacheKey, Ctx.fnName)));
-  auto FnOrErr = Engine->lookup(Ctx.cacheKey, Ctx.fnName);
-  ASSERT_TRUE(static_cast<bool>(FnOrErr));
-  Engine->setActiveContext(nullptr);
-  setDumpFuncFilter("");
-
-  EXPECT_FALSE(printDumped("dump_temporary_tier1"));
-  EXPECT_FALSE(printDumpedModule("dump_temporary_tier1"));
+  EXPECT_FALSE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::Instrumented, "*", "dump_temporary_tier1"));
+  EXPECT_FALSE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::Instrumented, "dump_temporary_tier1",
+      "dump_temporary_tier1"));
+  EXPECT_TRUE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::Baseline, "*", "dump_temporary_tier1"));
+  EXPECT_TRUE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::PGOUse, "dump_temporary_tier1", "dump_temporary_tier1"));
+  EXPECT_FALSE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::PGOUse, "other", "dump_temporary_tier1"));
 }
 
 namespace llvm {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -4952,6 +4952,46 @@ TEST_F(SharedTaskPoolTest, SharedPgoProfilesFunctionsSequentially) {
   EXPECT_EQ(state_->pgoActiveFunctions[0].loadAcquire(), 7u);
 }
 
+TEST_F(SharedTaskPoolTest, SharedPgoProfilesOneVersionPerFunctionAtATime) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  EJitCoreId::setCurrentForTest(0);
+  pool.setPgoEnabled(true, 2, /*maxConcurrentProfiles=*/2);
+  pool.setInstanceEnabled(1, 4, true);
+  pool.setInstanceEnabled(1, 5, true);
+  EJitDimPair d0[1] = {dim(1, 4)};
+  EJitDimPair d1[1] = {dim(1, 5)};
+
+  ASSERT_EQ(pool.compileOrGet(5, d0, 1, codeFor(5)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  auto deferred = pool.compileOrGet(5, d1, 1, codeFor(5));
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.fnPtr, codeFor(5));
+  EXPECT_EQ(pool.pendingCount(), 1u);
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 1u);
+  EXPECT_EQ(state_->pgoDeferredMisses.loadRelaxed(), 0u);
+
+  ASSERT_TRUE(pool.pollOne()); // Publish d0 Tier-1.
+  deferred = pool.compileOrGet(5, d1, 1, codeFor(5));
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(pool.pendingCount(), 0u);
+  EXPECT_EQ(state_->pgoDeferredMisses.loadRelaxed(), 1u);
+
+  for (unsigned i = 0; i < 2; ++i) {
+    auto hit = pool.compileOrGet(5, d0, 1, codeFor(5));
+    ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (hit.hasReadToken)
+      pool.releaseRead(hit.bucketIndex);
+  }
+  ASSERT_EQ(pool.pendingCount(), 1u);
+  ASSERT_TRUE(pool.pollOne()); // Publish d0 Tier-2 and release admission.
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 0u);
+
+  EXPECT_EQ(pool.compileOrGet(5, d1, 1, codeFor(5)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 1u);
+}
+
 TEST_F(SharedTaskPoolTest, SharedPgoReleasesAdmissionForPreexistingWork) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
@@ -4960,9 +5000,14 @@ TEST_F(SharedTaskPoolTest, SharedPgoReleasesAdmissionForPreexistingWork) {
   ASSERT_EQ(pool.compileOrGet(5, nullptr, 0, codeFor(5)).status,
             EJitCompileOrGetStatus::EnqueuedPending);
   pool.setPgoEnabled(true, 2);
+  uint32_t admissionHooks = 0;
+  pool.setPgoAdmissionTestHook(
+      [](void *ctx) { ++*static_cast<uint32_t *>(ctx); }, &admissionHooks);
 
   EXPECT_EQ(pool.compileOrGet(5, nullptr, 0, codeFor(5)).status,
             EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(admissionHooks, 0u)
+      << "an already-pending request must not transiently start PGO";
   EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 0u);
   EXPECT_EQ(state_->pgoActiveFunctions[0].loadAcquire(), 0u);
 

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -4919,7 +4919,7 @@ TEST_F(SharedTaskPoolTest, SharedPgoProfilesFunctionsSequentially) {
 
   // A different function stays on its AOT fallback and adds no compiler work.
   auto deferred = pool.compileOrGet(6, nullptr, 0, codeFor(6));
-  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(deferred.fnPtr, codeFor(6));
   EXPECT_EQ(state_->enqueuePos.loadRelaxed() - state_->dequeuePos.loadRelaxed(),
             1u);
@@ -4973,7 +4973,7 @@ TEST_F(SharedTaskPoolTest, SharedPgoProfilesOneVersionPerFunctionAtATime) {
 
   ASSERT_TRUE(pool.pollOne()); // Publish d0 Tier-1.
   deferred = pool.compileOrGet(5, d1, 1, codeFor(5));
-  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(pool.pendingCount(), 0u);
   EXPECT_EQ(state_->pgoDeferredMisses.loadRelaxed(), 1u);
 
@@ -5031,7 +5031,7 @@ TEST_F(SharedTaskPoolTest, SharedPgoHonorsConcurrentProfileLimit) {
   EXPECT_EQ(state_->pgoMaxActiveFunctions.loadAcquire(), 2u);
 
   auto deferred = pool.compileOrGet(7, nullptr, 0, codeFor(7));
-  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(deferred.fnPtr, codeFor(7));
   ASSERT_TRUE(pool.pollOne());
   ASSERT_TRUE(pool.pollOne());
@@ -5108,7 +5108,7 @@ TEST_F(SharedTaskPoolTest,
     if (first[i].status == EJitCompileOrGetStatus::EnqueuedPending) {
       ++admitted;
     } else {
-      EXPECT_EQ(first[i].status, EJitCompileOrGetStatus::AlreadyPending);
+      EXPECT_EQ(first[i].status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
       EXPECT_EQ(first[i].fnPtr, codeFor(kFuncIndices[i]));
       deferred = i;
     }
@@ -5162,7 +5162,7 @@ TEST_F(SharedTaskPoolTest,
     producer.join();
 
   EXPECT_EQ(profile[deferred][0].status,
-            EJitCompileOrGetStatus::AlreadyPending);
+            EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(profile[deferred][0].fnPtr, codeFor(kFuncIndices[deferred]));
   EXPECT_EQ(owner.pendingCount(), 2u);
   uint32_t profilesAtThreshold = 0;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2371,8 +2371,9 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // address by every core, so a layout change that slips through unversioned is
   // a silent cross-core corruption.
   // v10-v13 add PGO controls, writable ranges, staged admission, and audit
-  // requests; v14 adds the owned bound-pointer snapshot.
-  EXPECT_EQ(kEJitSharedAbiVersion, 14u);
+  // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
+  // per-version post-publish reuse tracking.
+  EXPECT_EQ(kEJitSharedAbiVersion, 15u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -5215,10 +5216,9 @@ TEST_F(SharedTaskPoolTest, SharedPgoTier2DiscardedOnVersionBump) {
   }
 }
 
-// PGO off → no hitCount increment and no Tier-2 enqueue.
-// Baseline guards: compileOrGet hits are ordinary cache hits with zero
-// PGO behaviour when setPgoEnabled was never called.
-TEST_F(SharedTaskPoolTest, SharedPgoOffZeroOverhead) {
+// PGO off → no hitCount increment and no Tier-2 enqueue. Stats builds still
+// set the independent one-shot postPublishSeen diagnostic on the first reuse.
+TEST_F(SharedTaskPoolTest, SharedPgoOffTracksPostPublishReuse) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   EJitCoreId::setCurrentForTest(0);
@@ -5232,6 +5232,9 @@ TEST_F(SharedTaskPoolTest, SharedPgoOffZeroOverhead) {
   ASSERT_EQ(pool.compileOrGet(5, d0, 1, codeFor(5)).status,
             EJitCompileOrGetStatus::EnqueuedPending);
   ASSERT_TRUE(pool.pollOne());
+  EJitSharedCacheSlot *slot = findReadySlot(5);
+  ASSERT_NE(slot, nullptr);
+  EXPECT_EQ(slot->postPublishSeen.loadRelaxed(), 0u);
 
   // Hits remain ordinary cache hits and do not enqueue Tier-2.
   for (int i = 0; i < 10; ++i) {
@@ -5243,9 +5246,8 @@ TEST_F(SharedTaskPoolTest, SharedPgoOffZeroOverhead) {
   EXPECT_EQ(pool.pendingCount(), 0u); // no Tier-2 enqueued
 
   // hitCount stays at 0 (threshold was never set).
-  EJitSharedCacheSlot *slot = findReadySlot(5);
-  ASSERT_NE(slot, nullptr);
   EXPECT_EQ(slot->hitCount.loadRelaxed(), 0u);
+  EXPECT_EQ(slot->postPublishSeen.loadRelaxed(), 1u);
 }
 
 // PGO threshold=0 (setPgoEnabled(true,0)) → counting disabled, no trigger.


### PR DESCRIPTION
## Summary
- track whether each published shared-cache version is resolved by a later taskpool lookup
- print aggregate seen/unseen counts and per-function/per-dimension post_publish_seen=yes/no from ^[jit_taskpool_print_compiled()
- keep wrapper inline-cache hits unchanged; tracking is a one-shot stats-only update on the taskpool path
- bump the shared taskpool ABI to v15

## Example
`	ext
compiled reuse: post_publish_seen=76 unseen=15
funcIdx=12 name=FuncA numDims=2 dims=[1:3,2:7] fn=0x... post_publish_seen=no
`

## Validation
- syntax-checked stats-on, stats-off, and NO_RECLAIM configurations
- targeted ABI and post-publish-reuse tests pass
- temporary full shared-taskpool harness: 139/144 pass; the five failures are pre-existing configuration mismatches from forcing EJIT_SRE_SHARED_CODE_POINTERS on tests that explicitly exercise the off path
- git diff --check


## Review follow-up
- 8ae6b021a47742 replaces the stats-only strong CAS with a relaxed monotonic store and corrects the v15 ABI documentation.
- PGO admission deferral now has a distinct internal status and maps to an AOT fallback instead of EJIT_PENDING.
- the Tier-1 dump regression now tests the capture predicate directly without requiring profile-runtime linkage.
