### PR TITLE
[EJIT] Route temporary Tier-1 code to a far pool

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -366,7 +366,8 @@ def doit_gc_merge(args):
         # EJIT_SRE_TASKPOOL ifdef in EJitRuntime.cpp).
         "ejit_set_log_level", "ejit_get_log_level",
         "ejit_print_registry", "ejit_print_func_meta",
-        "ejit_get_code_pool_stats", "ejit_print_code_pool_stats",
+        "ejit_get_code_pool_stats", "ejit_get_code_pool_stats_v2",
+        "ejit_print_code_pool_stats",
         "ejit_print_active",
         # Build identity (LLVM version + git commit). Called from user app
         # code, never from AOT, so it needs a GC root to survive --gc-sections.

--- a/jit_design_doc/EJIT_DIAGNOSTICS.md
+++ b/jit_design_doc/EJIT_DIAGNOSTICS.md
@@ -128,7 +128,7 @@ unsigned      ejit_taskpool_pending_count(void); // 在途数量
 
 > 若 `cacheHits` 等逐调用计数全为零，说明运行库未启用逐调用统计（这些计数有热点路径开销，默认关闭）；`print_compiled()`、`get_worker_core()`、`pending_count()` 不受此影响，始终可用。
 
-`ejit_taskpool_print_compiled()` 的摘要中，`entries` 是本次尽力遍历到的 Ready 特化数，`slots` 是 cache 占用，`buckets skipped` 表示遍历时因并发竞争而跳过的 bucket；因此它不是强一致快照。明细中的 `dims=[d:i,...]` 表示 `dimType:instanceId`。VERBOSE 级额外显示各维度版本 `ver`、代码大小 `size`、代码池 `pool` 和发布代数 `gen`。
+`ejit_taskpool_print_compiled()` 的摘要中，`entries` 是本次尽力遍历到的 Ready 特化数，`slots` 是 cache 占用，`buckets skipped` 表示遍历时因并发竞争而跳过的 bucket；因此它不是强一致快照。摘要分别统计 `baseline/tier1_collecting/tier2` 和 `near/far/unknown`。明细中的 `dims=[d:i,...]` 表示 `dimType:instanceId`，`pool=near|far` 表示代码实际落点。VERBOSE 级额外显示各维度版本 `ver`、代码大小 `size`、池内编号 `pool_id` 和发布代数 `gen`。
 
 ### 2.3 代码池统计
 
@@ -145,11 +145,18 @@ typedef struct ejit_code_pool_stats_t {
   uint64_t finalizedRangeCount; // 记录的可执行区间数
 } ejit_code_pool_stats_t;
 
+typedef struct ejit_code_pool_stats_v2_t {
+  ejit_code_pool_stats_t total; // 两个池合计，与旧接口相同
+  ejit_code_pool_stats_t near;  // 最终 Baseline / Tier-2 固定近端池
+  ejit_code_pool_stats_t far;   // 临时 Instrumented Tier-1 动态池
+} ejit_code_pool_stats_v2_t;
+
 ejit_status_t ejit_get_code_pool_stats(ejit_code_pool_stats_t *out);
+ejit_status_t ejit_get_code_pool_stats_v2(ejit_code_pool_stats_v2_t *out);
 void          ejit_print_code_pool_stats(void);
 ```
 
-**作用**：监控 JIT 代码内存占用与是否趋近耗尽（`usedBytes` vs `reservedBytes`）。返回值：`EJIT_OK` 成功；`EJIT_ERR_NOT_ACTIVE` 运行时未初始化；`EJIT_ERR_INVALID_PARAM` 入参为空；`EJIT_ERR_DISABLED` 运行库未含代码池支持。
+**作用**：监控 JIT 代码内存占用与是否趋近耗尽（`usedBytes` vs `reservedBytes`）。旧接口保持 ABI 不变并返回两池合计；v2 接口进一步区分 near/far。`ejit_print_code_pool_stats()` 同时打印 `total`、`near(final)` 和 `far(tier1)`。返回值：`EJIT_OK` 成功；`EJIT_ERR_NOT_ACTIVE` 运行时未初始化；`EJIT_ERR_INVALID_PARAM` 入参为空；`EJIT_ERR_DISABLED` 运行库未含代码池支持。
 
 **结构体解读**：
 

--- a/jit_design_doc/EJIT_DIAGNOSTICS.md
+++ b/jit_design_doc/EJIT_DIAGNOSTICS.md
@@ -193,7 +193,7 @@ void ejit_print_dumped(const char *name);// 打印 entry 函数视图；NULL/"" 
 void ejit_print_dumped_module(const char *name); // 打印完整特化模块视图
 ```
 
-运行时按函数名过滤捕获后续 JIT 编译产生的**优化后 IR 与汇编**，再通过 RAW 诊断输出逐行回读。`ejit_print_dumped(name)` 只显示指定 entry 函数，便于聚焦单函数；`ejit_print_dumped_module(name)` 显示该 entry 对应的完整特化模块，包括模块中保留的被调函数。
+运行时按函数名过滤捕获后续 JIT 编译产生的**优化后 IR 与汇编**，再通过 RAW 诊断输出逐行回读。在线 PGO 开启时会跳过临时 Tier-1 插桩代码，只捕获最终发布的 Tier-2；这样不会因诊断汇编生成而额外拉长 Tier-1 的生命周期竞争窗口。`ejit_print_dumped(name)` 只显示指定 entry 函数，便于聚焦单函数；`ejit_print_dumped_module(name)` 显示该 entry 对应的完整特化模块，包括模块中保留的被调函数。
 
 > - 捕获为**精确名匹配**，`"*"` 例外（捕获全部）。
 > - 每次捕获同时保存单函数视图和完整模块视图；同名函数重新编译时替换旧记录。

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -21,6 +21,7 @@
 // C++ core. C language linkage to match the definition in EJitRuntime.h.
 extern "C" {
 struct ejit_code_pool_stats_t;
+struct ejit_code_pool_stats_v2_t;
 }
 
 namespace llvm {
@@ -157,6 +158,9 @@ public:
   /// Fill \p out with code pool usage stats. Returns false if not initialized
   /// or built without EJIT_SRE_CODE_POOL. For ejit_get_code_pool_stats().
   bool getCodePoolStats(ejit_code_pool_stats_t *out) const;
+
+  /// Fill aggregate plus near/far placement-specific code-pool statistics.
+  bool getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const;
 
   /// Print code pool usage stats through EJIT_DIAG. For
   /// ejit_print_code_pool_stats().

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -115,6 +115,8 @@ public:
   using EnableRwFn = std::function<unsigned(void *va)>;
 
   struct Options {
+    /// Diagnostic placement class propagated with finalized code ranges.
+    EJitCodePoolKind kind = EJitCodePoolKind::Unknown;
     /// Usable bytes per pool (EJIT_SRE_CODE_POOL_SIZE). Default 2MiB. In 4K
     /// seal mode this is rounded up to a multiple of poolAlign.
     size_t poolSize = static_cast<size_t>(2) * 1024 * 1024;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
@@ -36,6 +36,8 @@ namespace ejit {
 class EJitCodePoolMemoryManager : public jitlink::JITLinkMemoryManager {
 public:
   EJitCodePoolMemoryManager(EJitCodePoolManager &Pool, size_t PageSize);
+  EJitCodePoolMemoryManager(EJitCodePoolManager &NearPool,
+                            EJitCodePoolManager &FarPool, size_t PageSize);
 
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;
@@ -47,13 +49,16 @@ public:
   using JITLinkMemoryManager::allocate;
   using JITLinkMemoryManager::deallocate;
 
-  EJitCodePoolManager &getPool() { return Pool_; }
+  EJitCodePoolManager &getPool() { return NearPool_; }
 
 private:
   class InFlightAllocImpl;
   struct FinalizedInfo;
 
-  EJitCodePoolManager &Pool_;
+  EJitCodePoolManager &selectPool(const jitlink::JITLinkDylib *JD) const;
+
+  EJitCodePoolManager &NearPool_;
+  EJitCodePoolManager *FarPool_ = nullptr;
   size_t PageSize_;
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
@@ -32,6 +32,12 @@
 namespace llvm {
 namespace ejit {
 
+enum class EJitCodePoolKind : uint32_t {
+  Unknown = 0,
+  Near = 1,
+  Far = 2,
+};
+
 /// Maximum number of runtime-writable ranges carried with one finalized
 /// compilation. A finalized allocation normally has a single writable data
 /// segment (the Tier-1 __profc_ counters); the small fixed bound leaves head
@@ -88,8 +94,9 @@ struct EJitCompiledCodeInfo {
   /// The runtime-writable extents a peer core must enable_rw before executing.
   /// Only the first writableCount entries are meaningful.
   EJitWritableRange writableRanges[kEJitMaxWritableRanges] = {};
-  /// Reserved (must be 0). Keeps the struct's tail explicit.
-  uint32_t reserved = 0;
+  /// Placement class of the owning pool. Near is the fixed .text.ejit region;
+  /// Far is the dynamic SRE_MemDbgAlloc region used by temporary Tier-1 code.
+  EJitCodePoolKind poolKind = EJitCodePoolKind::Unknown;
 };
 
 } // namespace ejit

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -30,6 +30,14 @@ class Module;
 
 namespace ejit {
 
+#ifdef EJIT_SRE_CODE_POOL
+struct EJitTieredCodePoolStats {
+  EJitCodePoolManager::Stats total;
+  EJitCodePoolManager::Stats near;
+  EJitCodePoolManager::Stats far;
+};
+#endif
+
 class PeriodArrayRegistry;
 class EJitRuntimeState;
 struct EJitSharedTaskPoolState;
@@ -177,6 +185,10 @@ public:
   /// zeroed snapshot if no pool is active. Available only with
   /// EJIT_SRE_CODE_POOL.
   EJitCodePoolManager::Stats getCodePoolStats() const;
+
+  /// Snapshot aggregate and placement-specific statistics. Tier-1 uses the
+  /// far dynamic pool; final Baseline/Tier-2 code uses the near fixed pool.
+  EJitTieredCodePoolStats getTieredCodePoolStats() const;
 
   /// Resolve a compiled function pointer to its real, finalized executable
   /// range + owning code pool (for cross-core 4K execute-permission

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -34,6 +34,7 @@ class PeriodArrayRegistry;
 class EJitRuntimeState;
 struct EJitSharedTaskPoolState;
 struct EJitVpFunctionInfo; // defined in EJitOptimizer.h (value-profile capture)
+enum class CompileTier : uint8_t;
 
 namespace detail {
 /// Render one function definition without the rest of its specialization
@@ -41,6 +42,9 @@ namespace detail {
 /// ejit_dump_* APIs.
 bool renderDumpFunctionIR(const Module &M, StringRef fnName, std::string &out);
 void renderDumpModuleIR(const Module &M, std::string &out);
+/// Return whether a filtered dump should capture this compilation tier.
+/// Instrumented Tier-1 is temporary and must never replace a final dump.
+bool shouldCaptureDump(CompileTier tier, StringRef filter, StringRef fnName);
 } // namespace detail
 
 /// Set a function-name filter for JIT IR+ASM diagnostic capture. When non-

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -47,9 +47,10 @@ void renderDumpModuleIR(const Module &M, std::string &out);
 /// empty, the engine captures (saves in memory) the post-optimization IR and
 /// emitted assembly for both the matching entry function and its complete
 /// specialization module, the next time it is compiled. "*" matches every
-/// specialization. Empty/null disables further capture (already-captured
-/// entries are retained). Use printDumped() for the entry-only view and
-/// printDumpedModule() for the complete module.
+/// specialization. With staged PGO, temporary Instrumented code is skipped and
+/// the final Tier-2 code is captured. Empty/null disables further capture
+/// (already-captured entries are retained). Use printDumped() for the entry-only
+/// view and printDumpedModule() for the complete module.
 void setDumpFuncFilter(const std::string &name);
 
 /// Bind the optional shared taskpool dump state. In a shared-taskpool build

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -436,10 +436,11 @@ ejit_status_t ejit_get_code_pool_stats(ejit_code_pool_stats_t *out);
 void ejit_print_code_pool_stats(void);
 
 /// Print a ranking for every sampled ejit_entry function. The ranking is
-/// ordered by the average number of may_const loads removed across its JIT
-/// specializations. Call this explicitly after the audit sampling windows have
-/// completed. In a shared-taskpool build, a non-owner core forwards the request
-/// to the compile-owner worker and waits for printing to finish.
+/// ordered by dynamically removed may_const load executions per million
+/// platform timestamp units (removed work per entry times entry frequency).
+/// Call this explicitly after the audit sampling windows have completed. In a
+/// shared-taskpool build, a non-owner core forwards the request to the
+/// compile-owner worker and waits for printing to finish.
 void ejit_print_mayconst_ranking(void);
 
 /// Print the currently-active time-window instances through the platform log:

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -137,6 +137,15 @@ typedef struct ejit_code_pool_stats_t {
   uint64_t finalizedRangeCount; ///< distinct executable ranges recorded
 } ejit_code_pool_stats_t;
 
+/// Placement-aware code-pool statistics. The original stats API remains ABI
+/// stable and returns `total`; use this v2 shape to distinguish final code in
+/// the near fixed pool from temporary Tier-1 code in the far dynamic pool.
+typedef struct ejit_code_pool_stats_v2_t {
+  ejit_code_pool_stats_t total;
+  ejit_code_pool_stats_t near;
+  ejit_code_pool_stats_t far;
+} ejit_code_pool_stats_v2_t;
+
 typedef struct {
   int code;
   char message[256];
@@ -430,6 +439,9 @@ void ejit_print_func_meta(const char *funcName);
 /// runtime was built without EJIT_SRE_CODE_POOL (no pool). For monitoring
 /// embedded code-memory exhaustion. Mirrors EJitCodePoolManager::Stats.
 ejit_status_t ejit_get_code_pool_stats(ejit_code_pool_stats_t *out);
+
+/// Placement-aware counterpart of ejit_get_code_pool_stats().
+ejit_status_t ejit_get_code_pool_stats_v2(ejit_code_pool_stats_v2_t *out);
 
 /// Print code pool usage statistics through the platform log. Paired with
 /// ejit_get_code_pool_stats() (human-readable form).

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -338,6 +338,9 @@ typedef struct {
 ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out);
 
 void ejit_taskpool_print_stats();
+/// Print every published shared-cache version and its dimensions. Stats builds
+/// also report whether a later taskpool lookup reused each published version;
+/// wrapper inline-cache calls after that first reuse remain intentionally free.
 void ejit_taskpool_print_compiled();
 uint32_t ejit_taskpool_get_worker_core();
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -99,7 +99,9 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// v13: non-owner cores can post a may_const-ranking diagnostic request to the
 /// owner worker and wait for its completion without sharing optimizer objects.
 /// v14: EJitCompileRequest owns an inline bound-pointer snapshot.
-constexpr uint32_t kEJitSharedAbiVersion = 14u;
+/// v15: each cache slot records whether its published JIT pointer was resolved
+/// by a later taskpool lookup, diagnosing compiled versions with no reuse.
+constexpr uint32_t kEJitSharedAbiVersion = 15u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -101,7 +101,9 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// v14: EJitCompileRequest owns an inline bound-pointer snapshot.
 /// v15: each cache slot records whether its published JIT pointer was resolved
 /// by a later taskpool lookup, diagnosing compiled versions with no reuse.
-constexpr uint32_t kEJitSharedAbiVersion = 15u;
+/// v16: code ranges identify near/far placement and the shared code-pool
+/// diagnostic mirror publishes aggregate plus placement-specific statistics.
+constexpr uint32_t kEJitSharedAbiVersion = 16u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -1098,6 +1098,10 @@ private:
   /// Result of a shared-cache lookup, including the cross-core fnPtr gate.
   struct SharedLookup {
     void *fnPtr = nullptr;
+    /// Matched shared slot for post-validation diagnostics. A token-bearing
+    /// hit keeps it stable; NO_RECLAIM marks it only after the outer seqlock
+    /// validation has accepted the lookup.
+    EJitSharedCacheSlot *slot = nullptr;
     uint32_t bucketIndex = 0;
     bool hasReadToken = false;
     bool readyButNotShareable = false;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -744,7 +744,9 @@ public:
     return pgoEnabled_.loadRelaxed() != 0;
   }
 
-  /// Return true when this miss may start/continue a staged PGO function.
+  /// Return true when this miss may start a staged PGO function. Only one
+  /// specialization of a funcIndex may own admission at a time; later versions
+  /// stay on AOT until the current Tier-2 finishes.
   bool admitPgoFunction(uint32_t funcIndex, bool &newlyAdmitted);
 
   //--- compile mode: CROSS-CORE SHARED runtime state --------------------------
@@ -1263,7 +1265,8 @@ private:
   /// Release staged-PGO ownership if \p funcIndex still owns it. Tier-2
   /// completion and terminal worker failures call this; transient queue-full
   /// leaves ownership intact so the next hit can retry.
-  void finishPgoFunction(uint32_t funcIndex, bool completed);
+  void finishPgoFunction(uint32_t funcIndex, bool completed,
+                         const char *reason = nullptr);
 
   /// Owner-only: snapshot the owner-core code-pool stats via the registered
   /// provider and storeRelaxed them into the shared mirror. Called after every

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -196,8 +196,8 @@ struct EJitSharedCacheSlot {
   uint64_t codeSize;      ///< size in bytes of that allocation (0 = none)
   uintptr_t poolBase;     ///< 2MiB pool base (split_2m_to_4k granule)
   uint64_t poolSize;      ///< usable pool size
-  uint32_t poolId;        ///< stable pool index (diagnostic / convenience key)
-  uint32_t rangeReserved; ///< reserved, keeps the tail explicit (must be 0)
+  uint32_t poolId;   ///< stable pool index within its near/far manager
+  uint32_t poolKind; ///< EJitCodePoolKind: unknown=0, near=1, far=2
   /// Runtime-writable extents of the published code (v9): the pages the JIT
   /// body writes at runtime (e.g. Tier-1 __profc_ counters). A non-owner core
   /// in 4K-seal mode MUST enable_rw exactly these in its own translation
@@ -359,6 +359,17 @@ struct EJitSharedCodePoolStats {
   EJitAtomicU64 sealInvocations;
   EJitAtomicU64 splitInvocations;
   EJitAtomicU64 finalizedRangeCount;
+  struct Detail {
+    EJitAtomicU64 poolCount;
+    EJitAtomicU64 sealedCount;
+    EJitAtomicU64 activeCount;
+    EJitAtomicU64 usedBytes;
+    EJitAtomicU64 reservedBytes;
+    EJitAtomicU64 wastedBytes;
+    EJitAtomicU64 sealInvocations;
+    EJitAtomicU64 splitInvocations;
+    EJitAtomicU64 finalizedRangeCount;
+  } near, far;
 };
 
 /// Plain (non-atomic) snapshot of code-pool stats, used as the callback
@@ -366,6 +377,17 @@ struct EJitSharedCodePoolStats {
 /// Mirrors EJitCodePoolManager::Stats field-for-field but stays decoupled from
 /// the code-pool header so the shared-taskpool ABI does not depend on it.
 struct EJitCodePoolStatsOut {
+  struct Detail {
+    uint64_t poolCount = 0;
+    uint64_t sealedCount = 0;
+    uint64_t activeCount = 0;
+    uint64_t usedBytes = 0;
+    uint64_t reservedBytes = 0;
+    uint64_t wastedBytes = 0;
+    uint64_t sealInvocations = 0;
+    uint64_t splitInvocations = 0;
+    uint64_t finalizedRangeCount = 0;
+  };
   uint64_t poolCount = 0;
   uint64_t sealedCount = 0;
   uint64_t activeCount = 0;
@@ -375,6 +397,8 @@ struct EJitCodePoolStatsOut {
   uint64_t sealInvocations = 0;
   uint64_t splitInvocations = 0;
   uint64_t finalizedRangeCount = 0;
+  Detail near;
+  Detail far;
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -231,6 +231,11 @@ struct EJitSharedCacheSlot {
   /// Used to suppress the Tier-2 auto-trigger on slots that are already
   /// Tier-2 — a Tier-2 hit should never request another Tier-2 compile.
   EJitAtomicU8 tier;
+  /// Diagnostics (v14): set once when this published version successfully
+  /// returns its JIT pointer through the taskpool lookup path. The async call
+  /// that requested compilation does not set it, so zero identifies a version
+  /// that has not been reused after publish. Compiled out unless stats are on.
+  EJitAtomicU8 postPublishSeen;
 };
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -231,10 +231,11 @@ struct EJitSharedCacheSlot {
   /// Used to suppress the Tier-2 auto-trigger on slots that are already
   /// Tier-2 — a Tier-2 hit should never request another Tier-2 compile.
   EJitAtomicU8 tier;
-  /// Diagnostics (v14): set once when this published version successfully
+  /// Diagnostics (v15): set once when this published version successfully
   /// returns its JIT pointer through the taskpool lookup path. The async call
   /// that requested compilation does not set it, so zero identifies a version
-  /// that has not been reused after publish. Compiled out unless stats are on.
+  /// that has not been reused after publish. The ABI field is always present;
+  /// it is meaningful only when EJIT_STATS_ENABLE updates it.
   EJitAtomicU8 postPublishSeen;
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
@@ -24,11 +24,14 @@
 namespace llvm {
 namespace ejit {
 
+enum class EJitCodePoolPlacement { NearFixed, FarDynamic };
+
 /// Construct an EJitCodePoolManager wired to the SRE platform: raw memory from
 /// SRE_MemDbgAlloc (partition EJIT_SRE_CODE_POOL_PTNO) and sealing via
 /// enable_ex. On a host without real SRE symbols, weak fallbacks make this a
 /// link-safe no-op-seal / aligned-host-alloc manager (see EJitSrePlatform.cpp).
-std::unique_ptr<EJitCodePoolManager> makeSreCodePoolManager();
+std::unique_ptr<EJitCodePoolManager> makeSreCodePoolManager(
+    EJitCodePoolPlacement Placement = EJitCodePoolPlacement::NearFixed);
 
 /// Install execute permission for the legacy 2MiB code pool containing
 /// \p FnPtr in the calling core's translation context. This is intentionally a

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -45,6 +45,7 @@ enum class EJitCompileOrGetStatus : uint32_t {
   InstanceDisabled,
   EnqueuedPending,
   AlreadyPending,
+  PgoAdmissionDeferred,
   QueueFullFallback,
   CompileFailed,
   InvalidParam,

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -947,6 +947,44 @@ void EJit::printFuncMeta(const std::string &funcName) {
 bool EJit::getCodePoolStats(ejit_code_pool_stats_t *out) const {
   if (!out)
     return false;
+  ejit_code_pool_stats_v2_t Tiered{};
+  if (!getCodePoolStatsV2(&Tiered))
+    return false;
+  *out = Tiered.total;
+  return true;
+}
+
+bool EJit::getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const {
+  if (!out)
+    return false;
+#if defined(EJIT_SRE_SHARED_TASKPOOL) && defined(EJIT_SRE_CODE_POOL)
+  auto CopyShared = [](ejit_code_pool_stats_t &Dst,
+                       const EJitCodePoolStatsOut::Detail &Src) {
+    Dst.poolCount = Src.poolCount;
+    Dst.sealedCount = Src.sealedCount;
+    Dst.activeCount = Src.activeCount;
+    Dst.usedBytes = Src.usedBytes;
+    Dst.reservedBytes = Src.reservedBytes;
+    Dst.wastedBytes = Src.wastedBytes;
+    Dst.sealInvocations = Src.sealInvocations;
+    Dst.splitInvocations = Src.splitInvocations;
+    Dst.finalizedRangeCount = Src.finalizedRangeCount;
+  };
+#endif
+#ifdef EJIT_SRE_CODE_POOL
+  auto CopyManager = [](ejit_code_pool_stats_t &Dst,
+                        const EJitCodePoolManager::Stats &Src) {
+    Dst.poolCount = Src.poolCount;
+    Dst.sealedCount = Src.sealedCount;
+    Dst.activeCount = Src.activeCount;
+    Dst.usedBytes = Src.usedBytes;
+    Dst.reservedBytes = Src.reservedBytes;
+    Dst.wastedBytes = Src.wastedBytes;
+    Dst.sealInvocations = Src.sealInvocations;
+    Dst.splitInvocations = Src.splitInvocations;
+    Dst.finalizedRangeCount = Src.finalizedRangeCount;
+  };
+#endif
 #if defined(EJIT_SRE_SHARED_TASKPOOL) && defined(EJIT_SRE_CODE_POOL)
   // Shared build: read the owner-published mirror so every core (owner and
   // non-owner) sees the SAME code-pool stats. The real pools are owner-private,
@@ -955,15 +993,19 @@ bool EJit::getCodePoolStats(ejit_code_pool_stats_t *out) const {
   if (const EJitSharedTaskPool *sp = sharedTaskPool()) {
     EJitCodePoolStatsOut s{};
     if (sp->readCodePoolStats(&s)) {
-      out->poolCount = s.poolCount;
-      out->sealedCount = s.sealedCount;
-      out->activeCount = s.activeCount;
-      out->usedBytes = s.usedBytes;
-      out->reservedBytes = s.reservedBytes;
-      out->wastedBytes = s.wastedBytes;
-      out->sealInvocations = s.sealInvocations;
-      out->splitInvocations = s.splitInvocations;
-      out->finalizedRangeCount = s.finalizedRangeCount;
+      EJitCodePoolStatsOut::Detail Total;
+      Total.poolCount = s.poolCount;
+      Total.sealedCount = s.sealedCount;
+      Total.activeCount = s.activeCount;
+      Total.usedBytes = s.usedBytes;
+      Total.reservedBytes = s.reservedBytes;
+      Total.wastedBytes = s.wastedBytes;
+      Total.sealInvocations = s.sealInvocations;
+      Total.splitInvocations = s.splitInvocations;
+      Total.finalizedRangeCount = s.finalizedRangeCount;
+      CopyShared(out->total, Total);
+      CopyShared(out->near, s.near);
+      CopyShared(out->far, s.far);
       return true;
     }
   }
@@ -974,16 +1016,10 @@ bool EJit::getCodePoolStats(ejit_code_pool_stats_t *out) const {
   EJitOrcEngine *engine = compileDriver_->getJitEngine();
   if (!engine)
     return false;
-  EJitCodePoolManager::Stats s = engine->getCodePoolStats();
-  out->poolCount = s.poolCount;
-  out->sealedCount = s.sealedCount;
-  out->activeCount = s.activeCount;
-  out->usedBytes = s.usedBytes;
-  out->reservedBytes = s.reservedBytes;
-  out->wastedBytes = s.wastedBytes;
-  out->sealInvocations = s.sealInvocations;
-  out->splitInvocations = s.splitInvocations;
-  out->finalizedRangeCount = s.finalizedRangeCount;
+  EJitTieredCodePoolStats s = engine->getTieredCodePoolStats();
+  CopyManager(out->total, s.total);
+  CopyManager(out->near, s.near);
+  CopyManager(out->far, s.far);
   return true;
 #else
   return false;
@@ -992,36 +1028,33 @@ bool EJit::getCodePoolStats(ejit_code_pool_stats_t *out) const {
 
 void EJit::printCodePoolStats() const {
 #ifdef EJIT_SRE_CODE_POOL
-  ejit_code_pool_stats_t s{};
-  if (!getCodePoolStats(&s)) {
+  ejit_code_pool_stats_v2_t s{};
+  if (!getCodePoolStatsV2(&s)) {
     EJIT_DIAG_RAW("code pool: not available (no engine)");
     return;
   }
-  EJIT_DIAG_RAW("code pool: pools=%llu sealed=%llu active=%llu",
-                (unsigned long long)s.poolCount,
-                (unsigned long long)s.sealedCount,
-                (unsigned long long)s.activeCount);
-  EJIT_DIAG_RAW("  bytes used=%llu reserved=%llu wasted=%llu",
-                (unsigned long long)s.usedBytes,
-                (unsigned long long)s.reservedBytes,
-                (unsigned long long)s.wastedBytes);
-  EJIT_DIAG_RAW("  sealInvocations=%llu splitInvocations=%llu finalizedRanges=%llu",
-                (unsigned long long)s.sealInvocations,
-                (unsigned long long)s.splitInvocations,
-                (unsigned long long)s.finalizedRangeCount);
-  // Whole-pool usage summary, derived at print time (no new counters):
-  // total = reservedBytes = capacity of every carved pool. Caveats:
-  //  - 4K-seal mode rounds usedBytes up per allocation (page-aligned bump
-  //    cursor in EJitCodePool.cpp allocateCode), slightly over-reporting
-  //    usage;
-  //  - fixed-region mode counts only carved pools, so un-carved region
-  //    space is not reflected in total.
-  const uint64_t permille = ejitDiagPermille(s.usedBytes, s.reservedBytes);
-  EJIT_DIAG_RAW("  total=%llu used=%llu usage=%llu.%u%%",
-                (unsigned long long)s.reservedBytes,
-                (unsigned long long)s.usedBytes,
-                (unsigned long long)(permille / 10), (unsigned)(permille % 10));
-  (void)permille; // consumed by EJIT_DIAG_RAW only; silence DIAG-off builds
+  auto PrintOne = [](const char *Kind, const ejit_code_pool_stats_t &S) {
+    const uint64_t Permille = ejitDiagPermille(S.usedBytes, S.reservedBytes);
+    EJIT_DIAG_RAW("code pool %s: pools=%llu sealed=%llu active=%llu "
+                  "used=%llu reserved=%llu wasted=%llu usage=%llu.%u%%",
+                  Kind, (unsigned long long)S.poolCount,
+                  (unsigned long long)S.sealedCount,
+                  (unsigned long long)S.activeCount,
+                  (unsigned long long)S.usedBytes,
+                  (unsigned long long)S.reservedBytes,
+                  (unsigned long long)S.wastedBytes,
+                  (unsigned long long)(Permille / 10),
+                  (unsigned)(Permille % 10));
+    EJIT_DIAG_RAW("  %s sealInvocations=%llu splitInvocations=%llu "
+                  "finalizedRanges=%llu",
+                  Kind, (unsigned long long)S.sealInvocations,
+                  (unsigned long long)S.splitInvocations,
+                  (unsigned long long)S.finalizedRangeCount);
+    (void)Permille;
+  };
+  PrintOne("total", s.total);
+  PrintOne("near(final)", s.near);
+  PrintOne("far(tier1)", s.far);
 #else
   EJIT_DIAG_RAW("code pool: EJIT_SRE_CODE_POOL not enabled");
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -650,12 +650,13 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
       // dynamic SRE_MemDbgAlloc pool is already RW, so the ranges are then
       // diagnostic only.
       Out.requiresPeerEnableRw = Opts_.needsEnableRw ? 1u : 0u;
-      Out.reserved = 0;
+      Out.poolKind = Opts_.kind;
       EJIT_DIAG("findRange OK: ptr=%p codeStart=0x%llx codeSize=%llu poolId=%u "
-                "writable=%u peerRw=%u",
+                "kind=%u writable=%u peerRw=%u",
                 Ptr, static_cast<unsigned long long>(Out.codeStart),
                 static_cast<unsigned long long>(Out.codeSize), Out.poolId,
-                Out.writableCount, Out.requiresPeerEnableRw);
+                static_cast<unsigned>(Out.poolKind), Out.writableCount,
+                Out.requiresPeerEnableRw);
       return true;
     }
   }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -9,6 +9,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
 #include "llvm/ExecutionEngine/Orc/Shared/AllocationActions.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
 #include "llvm/Support/MathExtras.h"
@@ -43,11 +44,11 @@ struct EJitCodePoolMemoryManager::FinalizedInfo {
 class EJitCodePoolMemoryManager::InFlightAllocImpl
     : public JITLinkMemoryManager::InFlightAlloc {
 public:
-  InFlightAllocImpl(EJitCodePoolMemoryManager &MM, LinkGraph &G, BasicLayout BL,
+  InFlightAllocImpl(EJitCodePoolManager &Pool, LinkGraph &G, BasicLayout BL,
                     void *Base, size_t Size,
                     std::vector<ExecSegRange> ExecRanges,
                     std::vector<EJitWritableRange> WritableRanges)
-      : Pool(&MM.getPool()), G(&G), BL(std::move(BL)), Base(Base), Size(Size),
+      : Pool(&Pool), G(&G), BL(std::move(BL)), Base(Base), Size(Size),
         ExecRanges(std::move(ExecRanges)),
         WritableRanges(std::move(WritableRanges)) {}
 
@@ -145,10 +146,23 @@ private:
 
 EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(EJitCodePoolManager &Pool,
                                                      size_t PageSize)
-    : Pool_(Pool), PageSize_(PageSize) {}
+    : NearPool_(Pool), PageSize_(PageSize) {}
+
+EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(
+    EJitCodePoolManager &NearPool, EJitCodePoolManager &FarPool,
+    size_t PageSize)
+    : NearPool_(NearPool), FarPool_(&FarPool), PageSize_(PageSize) {}
+
+EJitCodePoolManager &EJitCodePoolMemoryManager::selectPool(
+    const JITLinkDylib *JD) const {
+  if (FarPool_ && JD && StringRef(JD->getName()).starts_with("spec_t1_"))
+    return *FarPool_;
+  return NearPool_;
+}
 
 void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
                                          OnAllocatedFunction OnAllocated) {
+  EJitCodePoolManager &Pool = selectPool(JD);
   BasicLayout BL(G);
 
   auto SegsSizes = BL.getContiguousPageBasedLayoutSizes(PageSize_);
@@ -160,13 +174,14 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   }
 
   uint64_t Total = SegsSizes->total();
-  EJIT_DIAG("allocate: graph=%s total=%llu pageSize=%zu",
-            G.getName().c_str(),
+  const char *Placement = FarPool_ == &Pool ? "far" : "near";
+  EJIT_DIAG("allocate: graph=%s pool=%s total=%llu pageSize=%zu",
+            G.getName().c_str(), Placement,
             static_cast<unsigned long long>(Total), PageSize_);
 
   void *Slab = nullptr;
   if (Total > 0) {
-    auto MemOrErr = Pool_.allocateCode(static_cast<size_t>(Total), PageSize_);
+    auto MemOrErr = Pool.allocateCode(static_cast<size_t>(Total), PageSize_);
     if (!MemOrErr) {
       EJIT_DIAG("allocate FAIL: pool allocateCode total=%llu",
                 static_cast<unsigned long long>(Total));
@@ -178,7 +193,7 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     // so make its pages writable (RX -> RW via enable_rw) BEFORE any write. In
     // data-region placement this is a no-op (already RW). Failure means the slab
     // is not writable - do not hand it back for JITLink to write into.
-    if (auto Err = Pool_.enableRwRange(Slab, static_cast<size_t>(Total))) {
+    if (auto Err = Pool.enableRwRange(Slab, static_cast<size_t>(Total))) {
       EJIT_DIAG("allocate FAIL: enableRwRange total=%llu",
                 static_cast<unsigned long long>(Total));
       OnAllocated(std::move(Err));
@@ -249,7 +264,7 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
             "EJitCodePool: allocation has more runtime-writable segments than "
             "the fixed cross-core bound",
             inconvertibleErrorCode()),
-        Pool_.restoreRxRange(Slab, static_cast<size_t>(Total))));
+        Pool.restoreRxRange(Slab, static_cast<size_t>(Total))));
     return;
   }
 
@@ -258,7 +273,7 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
               G.getName().c_str());
     OnAllocated(
         joinErrors(std::move(Err),
-                   Pool_.restoreRxRange(Slab, static_cast<size_t>(Total))));
+                   Pool.restoreRxRange(Slab, static_cast<size_t>(Total))));
     return;
   }
 
@@ -266,7 +281,7 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
             Slab, static_cast<unsigned long long>(Total), ExecRanges.size(),
             WritableRanges.size());
   OnAllocated(std::make_unique<InFlightAllocImpl>(
-      *this, G, std::move(BL), Slab, static_cast<size_t>(Total),
+      Pool, G, std::move(BL), Slab, static_cast<size_t>(Total),
       std::move(ExecRanges), std::move(WritableRanges)));
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -88,7 +88,8 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
   auto *drv = static_cast<EJitCompileDriver *>(ctx);
   EJitOrcEngine *eng = drv->getJitEngine();
   if (eng && out) {
-    EJitCodePoolManager::Stats s = eng->getCodePoolStats();
+    EJitTieredCodePoolStats tiered = eng->getTieredCodePoolStats();
+    const EJitCodePoolManager::Stats &s = tiered.total;
     out->poolCount = s.poolCount;
     out->sealedCount = s.sealedCount;
     out->activeCount = s.activeCount;
@@ -98,6 +99,20 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
     out->sealInvocations = s.sealInvocations;
     out->splitInvocations = s.splitInvocations;
     out->finalizedRangeCount = s.finalizedRangeCount;
+    auto CopyDetail = [](EJitCodePoolStatsOut::Detail &Dst,
+                         const EJitCodePoolManager::Stats &Src) {
+      Dst.poolCount = Src.poolCount;
+      Dst.sealedCount = Src.sealedCount;
+      Dst.activeCount = Src.activeCount;
+      Dst.usedBytes = Src.usedBytes;
+      Dst.reservedBytes = Src.reservedBytes;
+      Dst.wastedBytes = Src.wastedBytes;
+      Dst.sealInvocations = Src.sealInvocations;
+      Dst.splitInvocations = Src.splitInvocations;
+      Dst.finalizedRangeCount = Src.finalizedRangeCount;
+    };
+    CopyDetail(out->near, tiered.near);
+    CopyDetail(out->far, tiered.far);
     return true;
   }
   return false;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -88,10 +88,11 @@ static void collectReferencedExternalDecls(
 
 struct EJitOrcEngine::Impl {
 #ifdef EJIT_SRE_CODE_POOL
-  /// Dedicated 2MiB code pools backing all JIT machine code. Declared before
-  /// J so it outlives the LLJIT (and the memory manager the object linking
-  /// layer owns, which references it).
-  std::unique_ptr<EJitCodePoolManager> codePool;
+  /// Final Baseline/Tier-2 code stays near AOT .text; temporary instrumented
+  /// Tier-1 code uses the previous dynamic SRE allocation path. Both outlive
+  /// LLJIT and its routing memory manager.
+  std::unique_ptr<EJitCodePoolManager> nearCodePool;
+  std::unique_ptr<EJitCodePoolManager> farCodePool;
 #endif
   std::unique_ptr<orc::LLJIT> J;
   PeriodArrayRegistry *periodReg = nullptr;
@@ -667,19 +668,23 @@ EJitOrcEngine::Create(const Config &config,
   // engine (so it outlives the LLJIT); the object linking layer owns a memory
   // manager that references it. Pages are kept RW here and sealed to RX later,
   // at lookup time, by the pool manager's enable_ex sealing.
-  engine->P->codePool = makeSreCodePoolManager();
+  engine->P->nearCodePool =
+      makeSreCodePoolManager(EJitCodePoolPlacement::NearFixed);
+  engine->P->farCodePool =
+      makeSreCodePoolManager(EJitCodePoolPlacement::FarDynamic);
   {
-    EJitCodePoolManager *Pool = engine->P->codePool.get();
+    EJitCodePoolManager *NearPool = engine->P->nearCodePool.get();
+    EJitCodePoolManager *FarPool = engine->P->farCodePool.get();
     Builder.setObjectLinkingLayerCreator(
-        [Pool](orc::ExecutionSession &ES)
+        [NearPool, FarPool](orc::ExecutionSession &ES)
             -> Expected<std::unique_ptr<orc::ObjectLayer>> {
           // Page size only affects per-segment layout padding; we never apply
           // per-segment protections (sealing is done per 2MiB pool), so a
           // conservative 4KiB is sufficient and portable.
           constexpr size_t JitPageSize = 4096;
           return std::make_unique<orc::ObjectLinkingLayer>(
-              ES, std::make_unique<EJitCodePoolMemoryManager>(*Pool,
-                                                              JitPageSize));
+              ES, std::make_unique<EJitCodePoolMemoryManager>(
+                      *NearPool, *FarPool, JitPageSize));
         });
   }
 #endif
@@ -1002,7 +1007,13 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData,
     P->specDylibs.erase(it);
   }
 
-  auto JDOrErr = P->J->createJITDylib("spec_" + std::to_string(cacheKey));
+  const char *TierTag =
+      P->activeCtx && P->activeCtx->tier == CompileTier::Instrumented
+          ? "t1"
+          : P->activeCtx && P->activeCtx->tier == CompileTier::PGOUse ? "t2"
+                                                                      : "base";
+  auto JDOrErr = P->J->createJITDylib("spec_" + std::string(TierTag) + "_" +
+                                      std::to_string(cacheKey));
   if (!JDOrErr) {
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: create JITDylib error", cacheKey);
     return JDOrErr.takeError();
@@ -1136,9 +1147,13 @@ Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
   //
   // In 4K page-seal mode the seal already happened per-page at finalize (in the
   // code-pool memory manager), so nothing is done here.
-  if (P->codePool && !P->codePool->usesPageSeal() &&
-      P->codePool->contains(Ptr)) {
-    if (auto Err = P->codePool->sealPoolContaining(Ptr)) {
+  EJitCodePoolManager *OwningPool = nullptr;
+  if (P->nearCodePool && P->nearCodePool->contains(Ptr))
+    OwningPool = P->nearCodePool.get();
+  else if (P->farCodePool && P->farCodePool->contains(Ptr))
+    OwningPool = P->farCodePool.get();
+  if (OwningPool && !OwningPool->usesPageSeal()) {
+    if (auto Err = OwningPool->sealPoolContaining(Ptr)) {
       EJIT_DIAG("lookup FAIL key=0x%016lx ptr=%p: seal pool error", cacheKey,
                 Ptr);
       return std::move(Err);
@@ -1190,17 +1205,38 @@ void EJitOrcEngine::addUserSymbol(const std::string &name, void *addr) {
 
 #ifdef EJIT_SRE_CODE_POOL
 EJitCodePoolManager::Stats EJitOrcEngine::getCodePoolStats() const {
-  if (P->codePool)
-    return P->codePool->getStats();
-  return EJitCodePoolManager::Stats{};
+  return getTieredCodePoolStats().total;
+}
+
+EJitTieredCodePoolStats EJitOrcEngine::getTieredCodePoolStats() const {
+  EJitTieredCodePoolStats Out;
+  if (P->nearCodePool)
+    Out.near = P->nearCodePool->getStats();
+  if (P->farCodePool)
+    Out.far = P->farCodePool->getStats();
+#define EJIT_SUM_STAT(Field) Out.total.Field = Out.near.Field + Out.far.Field
+  EJIT_SUM_STAT(poolCount);
+  EJIT_SUM_STAT(sealedCount);
+  EJIT_SUM_STAT(activeCount);
+  EJIT_SUM_STAT(usedBytes);
+  EJIT_SUM_STAT(reservedBytes);
+  EJIT_SUM_STAT(wastedBytes);
+  EJIT_SUM_STAT(sealInvocations);
+  EJIT_SUM_STAT(splitInvocations);
+  EJIT_SUM_STAT(rwEnableInvocations);
+  EJIT_SUM_STAT(finalizedRangeCount);
+#undef EJIT_SUM_STAT
+  return Out;
 }
 
 bool EJitOrcEngine::findCodeRange(const void *FnPtr,
                                   EJitCompiledCodeInfo &Out) const {
-  if (!P->codePool) {
+  if (!P->nearCodePool && !P->farCodePool) {
     EJIT_DIAG("findCodeRange FAIL: no code pool (fnPtr=%p)", FnPtr);
     return false;
   }
-  return P->codePool->findRange(FnPtr, Out);
+  if (P->nearCodePool && P->nearCodePool->findRange(FnPtr, Out))
+    return true;
+  return P->farCodePool && P->farCodePool->findRange(FnPtr, Out);
 }
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -256,6 +256,7 @@ static bool getActiveDumpFilter(std::string &out) {
 /// Saved IR+ASM for a captured specialization (latest per function name).
 struct DumpEntry {
   uint64_t cacheKey = 0;
+  CompileTier tier = CompileTier::Baseline;
   std::string FunctionIR;
   std::string FunctionASM;
   std::string ModuleIR;
@@ -405,6 +406,7 @@ static bool printSharedDumpHint(const char *name) {
 /// Called from the IR transform layer when the filter matches: save the
 /// post-optimization IR and emitted ASM for later selective printing.
 static void captureDump(const std::string &fnName, uint64_t cacheKey,
+                        CompileTier tier,
                         std::string FunctionIR, std::string FunctionASM,
                         std::string ModuleIR, std::string ModuleASM) {
   EJIT_DIAG_DEBUG(
@@ -416,7 +418,7 @@ static void captureDump(const std::string &fnName, uint64_t cacheKey,
   std::lock_guard<DumpMutexType> lock(gDumpMutex);
   EJIT_DIAG_DEBUG("capture store_size before=%u", (unsigned)gDumpStore.size());
   gDumpStore[fnName] =
-      DumpEntry{cacheKey, std::move(FunctionIR), std::move(FunctionASM),
+      DumpEntry{cacheKey, tier, std::move(FunctionIR), std::move(FunctionASM),
                 std::move(ModuleIR), std::move(ModuleASM)};
   EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
@@ -485,10 +487,13 @@ static void printOneDumpSafe(const char *requestedName,
   uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
   (void)keyHi;
   (void)keyLo;
-  EJIT_DIAG_RAW("print_dumped hit requested=%s stored=%s key_hi=0x%08x "
-                "key_lo=0x%08x ir_size=%u asm_size=%u",
+  const char *Tier = e.tier == CompileTier::PGOUse ? "tier2"
+                     : e.tier == CompileTier::Instrumented ? "tier1"
+                                                          : "baseline";
+  EJIT_DIAG_RAW("print_dumped hit requested=%s stored=%s tier=%s "
+                "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u",
                 requestedName ? requestedName : "(list)", storedName.c_str(),
-                keyHi, keyLo, (unsigned)e.FunctionIR.size(),
+                Tier, keyHi, keyLo, (unsigned)e.FunctionIR.size(),
                 (unsigned)e.FunctionASM.size());
   if (!e.FunctionIR.empty())
     dumpLinesSafe("dump IR", e.FunctionIR);
@@ -503,10 +508,13 @@ static void printOneModuleDumpSafe(const char *requestedName,
   uint32_t keyLo = (uint32_t)(e.cacheKey & 0xffffffffu);
   (void)keyHi;
   (void)keyLo;
-  EJIT_DIAG_RAW("print_dumped_module hit requested=%s stored=%s "
+  const char *Tier = e.tier == CompileTier::PGOUse ? "tier2"
+                     : e.tier == CompileTier::Instrumented ? "tier1"
+                                                          : "baseline";
+  EJIT_DIAG_RAW("print_dumped_module hit requested=%s stored=%s tier=%s "
                 "key_hi=0x%08x key_lo=0x%08x ir_size=%u asm_size=%u",
                 requestedName ? requestedName : "(list)", storedName.c_str(),
-                keyHi, keyLo, (unsigned)e.ModuleIR.size(),
+                Tier, keyHi, keyLo, (unsigned)e.ModuleIR.size(),
                 (unsigned)e.ModuleASM.size());
   if (!e.ModuleIR.empty())
     dumpLinesSafe("dump module IR", e.ModuleIR);
@@ -788,8 +796,13 @@ EJitOrcEngine::Create(const Config &config,
           {
             std::string DumpFilter;
             bool hasFilter = getActiveDumpFilter(DumpFilter);
-            bool match =
-                hasFilter && (DumpFilter == "*" || ctx->fnName == DumpFilter);
+            // Tier-1 is temporary profiling code. Capturing it doubles the
+            // already expensive diagnostic ASM codegen and lengthens the
+            // lifecycle race window before publish. The public dump APIs show
+            // executable final code: Baseline when PGO is off, Tier-2 when on.
+            bool finalTier = ctx->tier != CompileTier::Instrumented;
+            bool match = finalTier && hasFilter &&
+                         (DumpFilter == "*" || ctx->fnName == DumpFilter);
             EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
                             "key_lo=0x%08x match=%d &filter=%p",
                             hasFilter ? DumpFilter.c_str() : "(off)",
@@ -846,7 +859,7 @@ EJitOrcEngine::Create(const Config &config,
                               "EJIT_DUMP_ASM off) fn=%s; IR captured",
                               ctx->fnName.c_str());
 #endif
-              captureDump(ctx->fnName, ctx->cacheKey,
+              captureDump(ctx->fnName, ctx->cacheKey, ctx->tier,
                           std::move(FunctionIR), std::move(FunctionAsm),
                           std::move(ModuleIR), std::move(ModuleAsm));
             }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -451,6 +451,12 @@ void detail::renderDumpModuleIR(const Module &M, std::string &out) {
   OS.flush();
 }
 
+bool detail::shouldCaptureDump(CompileTier tier, StringRef filter,
+                               StringRef fnName) {
+  return tier != CompileTier::Instrumented && !filter.empty() &&
+         (filter == "*" || filter == fnName);
+}
+
 /// Clone a diagnostic codegen module with only the requested function body.
 /// Other function definitions become declarations, preserving the target
 /// function's calls while avoiding a second codegen of its whole closure.
@@ -800,9 +806,8 @@ EJitOrcEngine::Create(const Config &config,
             // already expensive diagnostic ASM codegen and lengthens the
             // lifecycle race window before publish. The public dump APIs show
             // executable final code: Baseline when PGO is off, Tier-2 when on.
-            bool finalTier = ctx->tier != CompileTier::Instrumented;
-            bool match = finalTier && hasFilter &&
-                         (DumpFilter == "*" || ctx->fnName == DumpFilter);
+            bool match = hasFilter && detail::shouldCaptureDump(
+                                          ctx->tier, DumpFilter, ctx->fnName);
             EJIT_DIAG_DEBUG("dump check filter=%s fn=%s key_hi=0x%08x "
                             "key_lo=0x%08x match=%d &filter=%p",
                             hasFilter ? DumpFilter.c_str() : "(off)",

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1650,6 +1650,14 @@ void ejit_taskpool_print_stats() {
                   static_cast<unsigned long long>(d.workerTaskId),
                   static_cast<unsigned long long>(d.registrationFingerprint),
                   static_cast<unsigned long long>(d.executePrepareFailed));
+    EJIT_DIAG_RAW("  pgo active=%u/%u completed=%llu deferred=%llu "
+                  "tier1=%llu tier2=%llu mergeFailed=%llu",
+                  d.pgoActiveFunctionCount, d.pgoMaxActiveFunctions,
+                  static_cast<unsigned long long>(d.pgoCompletedFunctions),
+                  static_cast<unsigned long long>(d.pgoDeferredMisses),
+                  static_cast<unsigned long long>(d.tier1Compiles),
+                  static_cast<unsigned long long>(d.tier2Compiles),
+                  static_cast<unsigned long long>(d.profileMergeFails));
   }
   // Diagnostic: dump the inline-cache slot registry to help diagnose
   // why cacheHits keeps growing despite icache being enabled. Hand the
@@ -1688,8 +1696,9 @@ void ejit_taskpool_print_compiled() {
   // diverge by the same margin as any walk-based dump.
   struct CountCtx {
     uint32_t byDims[kEJitSharedMaxDims + 1];
-    uint32_t postPublishSeen;
-  } count = {{0}, 0};
+    uint32_t byTier[3];
+    uint32_t finalPostPublishSeen;
+  } count = {{0}, {0}, 0};
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
@@ -1697,8 +1706,12 @@ void ejit_taskpool_print_compiled() {
         uint32_t n = slot.numDims < kEJitSharedMaxDims ? slot.numDims
                                                        : kEJitSharedMaxDims;
         ++static_cast<CountCtx *>(cbCtx)->byDims[n];
-        if (slot.postPublishSeen.loadRelaxed() != 0)
-          ++static_cast<CountCtx *>(cbCtx)->postPublishSeen;
+        uint8_t tier = slot.tier.loadRelaxed();
+        if (tier <= kEJitTierPgoUse)
+          ++static_cast<CountCtx *>(cbCtx)->byTier[tier];
+        if (tier != kEJitTierInstrumented &&
+            slot.postPublishSeen.loadRelaxed() != 0)
+          ++static_cast<CountCtx *>(cbCtx)->finalPostPublishSeen;
       },
       &count);
   // Summary line first (fixed line count, so no throttle): total, cache
@@ -1721,13 +1734,21 @@ void ejit_taskpool_print_compiled() {
                 st.visitedSlots, st.visitedSlots,
                 kEJitSharedCacheBuckets * kEJitSharedCacheSlots,
                 st.skippedBuckets, byDims[0] ? " byDims: " : "", byDims);
+  EJIT_DIAG_RAW("compiled tiers: baseline=%u tier1_collecting=%u tier2=%u",
+                count.byTier[kEJitTierBaseline],
+                count.byTier[kEJitTierInstrumented],
+                count.byTier[kEJitTierPgoUse]);
 #ifdef EJIT_STATS_ENABLE
   constexpr bool ReuseTrackingEnabled = true;
-  EJIT_DIAG_RAW("compiled reuse: post_publish_seen=%u unseen=%u",
-                count.postPublishSeen,
-                st.visitedSlots >= count.postPublishSeen
-                    ? st.visitedSlots - count.postPublishSeen
-                    : 0);
+  const uint32_t FinalVersions = count.byTier[kEJitTierBaseline] +
+                                 count.byTier[kEJitTierPgoUse];
+  EJIT_DIAG_RAW("compiled final reuse: post_publish_seen=%u unseen=%u "
+                "(tier1_collecting_excluded=%u)",
+                count.finalPostPublishSeen,
+                FinalVersions >= count.finalPostPublishSeen
+                    ? FinalVersions - count.finalPostPublishSeen
+                    : 0,
+                count.byTier[kEJitTierInstrumented]);
 #else
   constexpr bool ReuseTrackingEnabled = false;
   EJIT_DIAG_RAW("compiled reuse: disabled (build with EJIT_STATS_ENABLE)");
@@ -1768,6 +1789,11 @@ void ejit_taskpool_print_compiled() {
             !ctx.reuseTrackingEnabled
                 ? "disabled"
                 : (slot.postPublishSeen.loadRelaxed() != 0 ? "yes" : "no");
+        const uint8_t SlotTier = slot.tier.loadRelaxed();
+        const char *Tier = SlotTier == kEJitTierPgoUse ? "tier2"
+                           : SlotTier == kEJitTierInstrumented
+                               ? "tier1-collecting"
+                               : "baseline";
         if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
           // Same shape for the per-instance version snapshot (uint32 x
           // kEJitSharedMaxDims + separators + NUL).
@@ -1780,19 +1806,19 @@ void ejit_taskpool_print_compiled() {
           if (p >= end)
             p = end - 1;
           *p = '\0';
-          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
+          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
                         "post_publish_seen=%s ver=[%s] size=%llu pool=%u "
                         "gen=%u",
                         slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(),
+                        name.empty() ? "<unknown>" : name.c_str(), Tier,
                         slot.numDims, dims, fn, PostPublishSeen, ver,
                         static_cast<unsigned long long>(slot.codeSize),
                         slot.poolId, slot.generation);
         } else {
-          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
+          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
                         "post_publish_seen=%s",
                         slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(),
+                        name.empty() ? "<unknown>" : name.c_str(), Tier,
                         slot.numDims, dims, fn, PostPublishSeen);
         }
         ejitDiagPrintThrottle();

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -796,6 +796,10 @@ static ejit_status_t taskpoolStatus(EJitCompileOrGetStatus s) {
   case EJitCompileOrGetStatus::EnqueuedPending:
   case EJitCompileOrGetStatus::AlreadyPending:
     return EJIT_PENDING;
+  case EJitCompileOrGetStatus::PgoAdmissionDeferred:
+    // No work was queued. Surface a clean resource-limit fallback instead of
+    // claiming that an asynchronous compilation is pending.
+    return EJIT_ERR_QUEUE_FULL;
   case EJitCompileOrGetStatus::QueueFullFallback:
     return EJIT_ERR_QUEUE_FULL;
   case EJitCompileOrGetStatus::OffMode:

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1688,7 +1688,8 @@ void ejit_taskpool_print_compiled() {
   // diverge by the same margin as any walk-based dump.
   struct CountCtx {
     uint32_t byDims[kEJitSharedMaxDims + 1];
-  } count = {{0}};
+    uint32_t postPublishSeen;
+  } count = {{0}, 0};
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
@@ -1696,6 +1697,8 @@ void ejit_taskpool_print_compiled() {
         uint32_t n = slot.numDims < kEJitSharedMaxDims ? slot.numDims
                                                        : kEJitSharedMaxDims;
         ++static_cast<CountCtx *>(cbCtx)->byDims[n];
+        if (slot.postPublishSeen.loadRelaxed() != 0)
+          ++static_cast<CountCtx *>(cbCtx)->postPublishSeen;
       },
       &count);
   // Summary line first (fixed line count, so no throttle): total, cache
@@ -1718,11 +1721,27 @@ void ejit_taskpool_print_compiled() {
                 st.visitedSlots, st.visitedSlots,
                 kEJitSharedCacheBuckets * kEJitSharedCacheSlots,
                 st.skippedBuckets, byDims[0] ? " byDims: " : "", byDims);
+#ifdef EJIT_STATS_ENABLE
+  constexpr bool ReuseTrackingEnabled = true;
+  EJIT_DIAG_RAW("compiled reuse: post_publish_seen=%u unseen=%u",
+                count.postPublishSeen,
+                st.visitedSlots >= count.postPublishSeen
+                    ? st.visitedSlots - count.postPublishSeen
+                    : 0);
+#else
+  constexpr bool ReuseTrackingEnabled = false;
+  EJIT_DIAG_RAW("compiled reuse: disabled (build with EJIT_STATS_ENABLE)");
+#endif
   // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
   // each printed line.
+  struct PrintCtx {
+    EJitModuleLoader &loader;
+    bool reuseTrackingEnabled;
+  } printCtx{loader, ReuseTrackingEnabled};
   EJitSharedTaskPool::ForEachCompiledStats st2 = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
-        EJitModuleLoader &ld = *static_cast<EJitModuleLoader *>(cbCtx);
+        PrintCtx &ctx = *static_cast<PrintCtx *>(cbCtx);
+        EJitModuleLoader &ld = ctx.loader;
         const std::string &name =
             ld.getFuncNameByFuncIdx(slot.funcIndex);
         // Per the publish protocol: fnPtr is read with acquire only after
@@ -1745,6 +1764,10 @@ void ejit_taskpool_print_compiled() {
         if (p >= end)
           p = end - 1;
         *p = '\0';
+        const char *PostPublishSeen =
+            !ctx.reuseTrackingEnabled
+                ? "disabled"
+                : (slot.postPublishSeen.loadRelaxed() != 0 ? "yes" : "no");
         if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
           // Same shape for the per-instance version snapshot (uint32 x
           // kEJitSharedMaxDims + separators + NUL).
@@ -1758,21 +1781,23 @@ void ejit_taskpool_print_compiled() {
             p = end - 1;
           *p = '\0';
           EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
-                        "ver=[%s] size=%llu pool=%u gen=%u",
+                        "post_publish_seen=%s ver=[%s] size=%llu pool=%u "
+                        "gen=%u",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(),
-                        slot.numDims, dims, fn, ver,
+                        slot.numDims, dims, fn, PostPublishSeen, ver,
                         static_cast<unsigned long long>(slot.codeSize),
                         slot.poolId, slot.generation);
         } else {
-          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p",
+          EJIT_DIAG_RAW("funcIdx=%u name=%s numDims=%u dims=[%s] fn=%p "
+                        "post_publish_seen=%s",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(),
-                        slot.numDims, dims, fn);
+                        slot.numDims, dims, fn, PostPublishSeen);
         }
         ejitDiagPrintThrottle();
       },
-      &loader);
+      &printCtx);
   // The summary counted the first walk; if the entry walk itself skipped
   // contended buckets, its lines are incomplete relative to it — report the
   // shortfall (fixed line count, so no throttle) instead of dropping it.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1701,8 +1701,9 @@ void ejit_taskpool_print_compiled() {
   struct CountCtx {
     uint32_t byDims[kEJitSharedMaxDims + 1];
     uint32_t byTier[3];
+    uint32_t byPool[3];
     uint32_t finalPostPublishSeen;
-  } count = {{0}, {0}, 0};
+  } count = {{0}, {0}, {0}, 0};
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
@@ -1713,6 +1714,8 @@ void ejit_taskpool_print_compiled() {
         uint8_t tier = slot.tier.loadRelaxed();
         if (tier <= kEJitTierPgoUse)
           ++static_cast<CountCtx *>(cbCtx)->byTier[tier];
+        if (slot.poolKind <= static_cast<uint32_t>(EJitCodePoolKind::Far))
+          ++static_cast<CountCtx *>(cbCtx)->byPool[slot.poolKind];
         if (tier != kEJitTierInstrumented &&
             slot.postPublishSeen.loadRelaxed() != 0)
           ++static_cast<CountCtx *>(cbCtx)->finalPostPublishSeen;
@@ -1742,6 +1745,10 @@ void ejit_taskpool_print_compiled() {
                 count.byTier[kEJitTierBaseline],
                 count.byTier[kEJitTierInstrumented],
                 count.byTier[kEJitTierPgoUse]);
+  EJIT_DIAG_RAW("compiled pools: near=%u far=%u unknown=%u",
+                count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Near)],
+                count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Far)],
+                count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Unknown)]);
 #ifdef EJIT_STATS_ENABLE
   constexpr bool ReuseTrackingEnabled = true;
   const uint32_t FinalVersions = count.byTier[kEJitTierBaseline] +
@@ -1798,6 +1805,12 @@ void ejit_taskpool_print_compiled() {
                            : SlotTier == kEJitTierInstrumented
                                ? "tier1-collecting"
                                : "baseline";
+        const char *PoolKind =
+            slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
+                ? "near"
+                : slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
+                      ? "far"
+                      : "unknown";
         if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
           // Same shape for the per-instance version snapshot (uint32 x
           // kEJitSharedMaxDims + separators + NUL).
@@ -1811,19 +1824,20 @@ void ejit_taskpool_print_compiled() {
             p = end - 1;
           *p = '\0';
           EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "post_publish_seen=%s ver=[%s] size=%llu pool=%u "
+                        "post_publish_seen=%s ver=[%s] size=%llu "
+                        "pool=%s pool_id=%u "
                         "gen=%u",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(), Tier,
                         slot.numDims, dims, fn, PostPublishSeen, ver,
                         static_cast<unsigned long long>(slot.codeSize),
-                        slot.poolId, slot.generation);
+                        PoolKind, slot.poolId, slot.generation);
         } else {
           EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "post_publish_seen=%s",
+                        "pool=%s post_publish_seen=%s",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PostPublishSeen);
+                        slot.numDims, dims, fn, PoolKind, PostPublishSeen);
         }
         ejitDiagPrintThrottle();
       },
@@ -1932,6 +1946,23 @@ ejit_status_t ejit_get_code_pool_stats(ejit_code_pool_stats_t *out) {
   }
   if (!gEJIT->getCodePoolStats(out)) {
     EJIT_DIAG("get_code_pool_stats: no code pool (EJIT_SRE_CODE_POOL off or no engine)");
+    return EJIT_ERR_DISABLED;
+  }
+  return EJIT_OK;
+}
+
+ejit_status_t ejit_get_code_pool_stats_v2(ejit_code_pool_stats_v2_t *out) {
+  if (!out) {
+    EJIT_DIAG("get_code_pool_stats_v2: null out pointer");
+    return EJIT_ERR_INVALID_PARAM;
+  }
+  if (!gEJIT) {
+    EJIT_DIAG("get_code_pool_stats_v2: not initialized");
+    return EJIT_ERR_NOT_ACTIVE;
+  }
+  if (!gEJIT->getCodePoolStatsV2(out)) {
+    EJIT_DIAG("get_code_pool_stats_v2: no code pool "
+              "(EJIT_SRE_CODE_POOL off or no engine)");
     return EJIT_ERR_DISABLED;
   }
   return EJIT_OK;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -186,6 +186,17 @@ constexpr uint32_t kReady = static_cast<uint32_t>(EJitSharedInitState::Ready);
 /// cacheLookupNd block can also reference it.
 constexpr uint64_t kHashMul = 0x9e3779b97f4a7c15ULL;
 
+inline void markPostPublishSeen(EJitSharedCacheSlot &Slot) {
+#ifdef EJIT_STATS_ENABLE
+  if (Slot.postPublishSeen.loadRelaxed() != 0)
+    return;
+  uint8_t Expected = 0;
+  (void)Slot.postPublishSeen.compareExchange(Expected, 1);
+#else
+  (void)Slot;
+#endif
+}
+
 // Per-function inline-cache slot registry (multi-version direct-indexed). Each
 // entry records the wrapper's per-function @__ejit_icache_fn_<name> global base
 // (a uintptr_t cell, or a [D]^numDims array of them for a multi-version entry)
@@ -1460,6 +1471,7 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   // publishing). Return directly while holding the read token.
   if (self == owner) {
     R.fnPtr = fn;
+    R.slot = &Slot;
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
     R.noTokenHit = true;
     R.bucketIndex = kEJitSharedCacheBuckets; // sentinel -> releaseRead no-op
@@ -1477,6 +1489,7 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   const uint64_t CoreBit = CanMemoize ? (uint64_t{1} << self) : uint64_t{0};
   if (CanMemoize && (Slot.executableCoreMask.loadAcquire() & CoreBit) != 0) {
     R.fnPtr = fn;
+    R.slot = &Slot;
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
     R.noTokenHit = true;
     R.bucketIndex = kEJitSharedCacheBuckets; // sentinel -> releaseRead no-op
@@ -1679,6 +1692,7 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
   if (CanMemoize)
     S2.executableCoreMask.fetchOr(CoreBit);
   R.fnPtr = Snap.fn;
+  R.slot = &S2;
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
   // NO_RECLAIM: this cold path already fully re-validated
   // identity/versions/fnPtr above under a load-only re-read, so it hands back a
@@ -2273,6 +2287,7 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   // slots (§4 repeat-trigger).  Under the write lock + before state=Ready.
   target->hitCount.storeRelaxed(0);
   target->tier.storeRelaxed(static_cast<uint8_t>(tier));
+  target->postPublishSeen.storeRelaxed(0);
   const uint32_t OwnerCore = state_->ownerCoreId.loadAcquire();
   target->executableCoreMask.storeRelease(
       OwnerCore < 64 ? (uint64_t{1} << OwnerCore) : 0);
@@ -2477,6 +2492,7 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
       // hotness state or tier-tracking from a prior generation.
       Slot.hitCount.storeRelaxed(0);
       Slot.tier.storeRelaxed(0);
+      Slot.postPublishSeen.storeRelaxed(0);
     }
   }
 }
@@ -2701,6 +2717,8 @@ __attribute__((always_inline)) EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   CompileOrGetResult R;
   if (Hit.hasReadToken && Hit.fnPtr) {
+    if (Hit.slot)
+      markPostPublishSeen(*Hit.slot);
     EJIT_STAT_INC(state_->counters.cacheHits);
     R.status = EJitCompileOrGetStatus::CacheHit;
     R.fnPtr = Hit.fnPtr;
@@ -2714,6 +2732,8 @@ EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   // bucketIndex is the out-of-range sentinel, so the wrapper's releaseRead()
   // cleanly no-ops. Safe because published code is never freed in this build.
   if (Hit.noTokenHit && Hit.fnPtr) {
+    if (Hit.slot)
+      markPostPublishSeen(*Hit.slot);
     EJIT_STAT_INC(state_->counters.cacheHits);
     R.status = EJitCompileOrGetStatus::CacheHit;
     R.fnPtr = Hit.fnPtr;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -190,8 +190,7 @@ inline void markPostPublishSeen(EJitSharedCacheSlot &Slot) {
 #ifdef EJIT_STATS_ENABLE
   if (Slot.postPublishSeen.loadRelaxed() != 0)
     return;
-  uint8_t Expected = 0;
-  (void)Slot.postPublishSeen.compareExchange(Expected, 1);
+  Slot.postPublishSeen.storeRelaxed(1);
 #else
   (void)Slot;
 #endif
@@ -3073,7 +3072,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     // All profiling slots are occupied. Keep this miss on the AOT fallback
     // and do not add work to the compiler queue.
     dedupClear(funcIndex, gen);
-    R.status = EJitCompileOrGetStatus::AlreadyPending;
+    R.status = EJitCompileOrGetStatus::PgoAdmissionDeferred;
     return R;
   }
 #ifdef EJIT_SRE_TASKPOOL_TESTING

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -2255,6 +2255,7 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
     target->poolBase = info->poolBase;
     target->poolSize = info->poolSize;
     target->poolId = info->poolId;
+    target->poolKind = static_cast<uint32_t>(info->poolKind);
     // Runtime-writable extents (v9): copy the bounded set the peer may need to
     // enable_rw. The over-bound case was already rejected at entry, so this
     // never truncates. requiresPeerEnableRw records whether the peer must
@@ -2278,6 +2279,7 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
     target->poolBase = 0;
     target->poolSize = 0;
     target->poolId = 0;
+    target->poolKind = static_cast<uint32_t>(EJitCodePoolKind::Unknown);
     target->writableCount = 0;
     target->requiresPeerEnableRw = 0;
     for (uint32_t i = 0; i < kEJitSharedMaxWritableRanges; ++i) {
@@ -2285,7 +2287,6 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
       target->writableRanges[i].size = 0;
     }
   }
-  target->rangeReserved = 0;
   target->fnPtr.storeRelease(reinterpret_cast<uintptr_t>(fnPtr));
   // PGO: reset hitCount on every publish.  Record the compile tier so
   // resolveMatchedSlot can suppress the Tier-2 trigger on already-Tier-2
@@ -2433,6 +2434,19 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
   st->codePoolStats.sealInvocations.storeRelaxed(0);
   st->codePoolStats.splitInvocations.storeRelaxed(0);
   st->codePoolStats.finalizedRangeCount.storeRelaxed(0);
+  auto ClearPoolDetail = [](EJitSharedCodePoolStats::Detail &D) {
+    D.poolCount.storeRelaxed(0);
+    D.sealedCount.storeRelaxed(0);
+    D.activeCount.storeRelaxed(0);
+    D.usedBytes.storeRelaxed(0);
+    D.reservedBytes.storeRelaxed(0);
+    D.wastedBytes.storeRelaxed(0);
+    D.sealInvocations.storeRelaxed(0);
+    D.splitInvocations.storeRelaxed(0);
+    D.finalizedRangeCount.storeRelaxed(0);
+  };
+  ClearPoolDetail(st->codePoolStats.near);
+  ClearPoolDetail(st->codePoolStats.far);
   // Per-core, per-pool 4K split readiness (ABI v5). MUST be cleared on every
   // (re)initialization: a stale splitDone bit from an earlier generation would
   // otherwise make a peer skip split_2m_to_4k for a pool the new generation
@@ -2484,7 +2498,7 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
       Slot.poolBase = 0;
       Slot.poolSize = 0;
       Slot.poolId = 0;
-      Slot.rangeReserved = 0;
+      Slot.poolKind = static_cast<uint32_t>(EJitCodePoolKind::Unknown);
       // Runtime-writable ranges (ABI v9): cleared so a re-init never leaves a
       // stale writable extent a peer could enable_rw for retired code.
       Slot.writableCount = 0;
@@ -3137,6 +3151,20 @@ void EJitSharedTaskPool::publishCodePoolStats() {
   state_->codePoolStats.sealInvocations.storeRelaxed(s.sealInvocations);
   state_->codePoolStats.splitInvocations.storeRelaxed(s.splitInvocations);
   state_->codePoolStats.finalizedRangeCount.storeRelaxed(s.finalizedRangeCount);
+  auto PublishDetail = [](EJitSharedCodePoolStats::Detail &Dst,
+                          const EJitCodePoolStatsOut::Detail &Src) {
+    Dst.poolCount.storeRelaxed(Src.poolCount);
+    Dst.sealedCount.storeRelaxed(Src.sealedCount);
+    Dst.activeCount.storeRelaxed(Src.activeCount);
+    Dst.usedBytes.storeRelaxed(Src.usedBytes);
+    Dst.reservedBytes.storeRelaxed(Src.reservedBytes);
+    Dst.wastedBytes.storeRelaxed(Src.wastedBytes);
+    Dst.sealInvocations.storeRelaxed(Src.sealInvocations);
+    Dst.splitInvocations.storeRelaxed(Src.splitInvocations);
+    Dst.finalizedRangeCount.storeRelaxed(Src.finalizedRangeCount);
+  };
+  PublishDetail(state_->codePoolStats.near, s.near);
+  PublishDetail(state_->codePoolStats.far, s.far);
 }
 
 bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
@@ -3152,6 +3180,20 @@ bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
   out->splitInvocations = state_->codePoolStats.splitInvocations.loadRelaxed();
   out->finalizedRangeCount =
       state_->codePoolStats.finalizedRangeCount.loadRelaxed();
+  auto ReadDetail = [](const EJitSharedCodePoolStats::Detail &Src,
+                       EJitCodePoolStatsOut::Detail &Dst) {
+    Dst.poolCount = Src.poolCount.loadRelaxed();
+    Dst.sealedCount = Src.sealedCount.loadRelaxed();
+    Dst.activeCount = Src.activeCount.loadRelaxed();
+    Dst.usedBytes = Src.usedBytes.loadRelaxed();
+    Dst.reservedBytes = Src.reservedBytes.loadRelaxed();
+    Dst.wastedBytes = Src.wastedBytes.loadRelaxed();
+    Dst.sealInvocations = Src.sealInvocations.loadRelaxed();
+    Dst.splitInvocations = Src.splitInvocations.loadRelaxed();
+    Dst.finalizedRangeCount = Src.finalizedRangeCount.loadRelaxed();
+  };
+  ReadDetail(state_->codePoolStats.near, out->near);
+  ReadDetail(state_->codePoolStats.far, out->far);
   return true;
 }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -1547,7 +1547,12 @@ bool EJitSharedTaskPool::admitPgoFunction(uint32_t funcIndex,
     uint32_t active = state_->pgoActiveFunctions[i].loadRelaxed();
     if (active == encoded) {
       state_->pgoAdmissionLock.storeRelease(0);
-      return true;
+      // Admission is per function, while cache entries are per specialization.
+      // Letting another identity of the same funcIndex proceed would make both
+      // versions share one progress/ownership slot: either one's failure or
+      // Tier-2 completion could then release the other version prematurely.
+      state_->pgoDeferredMisses.fetchAdd(1);
+      return false;
     }
     if (active == 0 && freeSlot == kEJitSharedMaxConcurrentProfiles)
       freeSlot = i;
@@ -1572,7 +1577,8 @@ bool EJitSharedTaskPool::admitPgoFunction(uint32_t funcIndex,
   return true;
 }
 
-void EJitSharedTaskPool::finishPgoFunction(uint32_t funcIndex, bool completed) {
+void EJitSharedTaskPool::finishPgoFunction(uint32_t funcIndex, bool completed,
+                                           const char *reason) {
   const uint32_t encoded = funcIndex + 1;
   uint32_t expected = 0;
   while (!state_->pgoAdmissionLock.compareExchange(expected, 1))
@@ -1600,8 +1606,8 @@ void EJitSharedTaskPool::finishPgoFunction(uint32_t funcIndex, bool completed) {
               static_cast<unsigned long long>(
                   state_->pgoDeferredMisses.loadRelaxed()));
   } else {
-    EJIT_DIAG("PGO profile aborted func=%u; next function may start",
-              funcIndex);
+    EJIT_DIAG("PGO profile aborted func=%u reason=%s; next function may start",
+              funcIndex, reason ? reason : "unspecified");
   }
 }
 
@@ -3040,12 +3046,33 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.status = EJitCompileOrGetStatus::CompileFailed;
     return R;
   }
-  // Dedup + enqueue (§5.2 step 3) — Async path.
-  bool newlyAdmitted = false;
+  // Dedup + enqueue (§5.2 step 3) — Async path. Claim the per-function
+  // in-flight slot BEFORE staged-PGO admission. Otherwise a request already in
+  // the queue makes us log "profile start 0/N", only for dedupMark below to
+  // reject it and immediately log "profile aborted" even though no profiling
+  // ever started.
   const bool pgoForRequest = state_->pgoEnabled.loadAcquire() != 0;
+  const uint32_t gen = state_->generation.loadAcquire();
+  switch (dedupMark(funcIndex, gen)) {
+  case EJitDedupResult::AlreadyPending:
+    EJIT_STAT_INC(state_->counters.alreadyPending);
+    EJIT_DIAG_VERBOSE("shared taskpool coalesced func=%u: already pending",
+                      funcIndex);
+    R.status = EJitCompileOrGetStatus::AlreadyPending;
+    return R;
+  case EJitDedupResult::InvalidFuncIndex:
+    EJIT_DIAG("shared taskpool reject func=%u: out of range", funcIndex);
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    return R;
+  case EJitDedupResult::Claimed:
+    break;
+  }
+
+  bool newlyAdmitted = false;
   if (pgoForRequest && !admitPgoFunction(funcIndex, newlyAdmitted)) {
     // All profiling slots are occupied. Keep this miss on the AOT fallback
     // and do not add work to the compiler queue.
+    dedupClear(funcIndex, gen);
     R.status = EJitCompileOrGetStatus::AlreadyPending;
     return R;
   }
@@ -3053,7 +3080,6 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (pgoForRequest && pgoAdmissionTestHook_)
     pgoAdmissionTestHook_(pgoAdmissionTestHookCtx_);
 #endif
-  uint32_t gen = state_->generation.loadAcquire();
   EJitCompileRequest Req{};
   Req.funcIndex = pgoForRequest
                       ? encodeReqTier(funcIndex, kEJitTierInstrumented)
@@ -3070,33 +3096,19 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (boundSize)
     std::memcpy(Req.boundData, boundData, boundSize);
   if (!versionsCurrent(Req) || state_->generation.loadAcquire() != gen) {
+    dedupClear(funcIndex, gen);
+    if (newlyAdmitted)
+      finishPgoFunction(funcIndex, /*completed=*/false,
+                        "lifecycle-changed-during-admission");
     EJIT_DIAG("shared taskpool async snapshot drop func=%u: lifecycle changed",
               funcIndex);
     R.status = EJitCompileOrGetStatus::CompileFailed;
     return R;
   }
-  switch (dedupMark(funcIndex, gen)) {
-  case EJitDedupResult::AlreadyPending:
-    if (newlyAdmitted)
-      finishPgoFunction(funcIndex, /*completed=*/false);
-    EJIT_STAT_INC(state_->counters.alreadyPending);
-    EJIT_DIAG_VERBOSE("shared taskpool coalesced func=%u: already pending",
-                      funcIndex);
-    R.status = EJitCompileOrGetStatus::AlreadyPending;
-    return R;
-  case EJitDedupResult::InvalidFuncIndex:
-    if (newlyAdmitted)
-      finishPgoFunction(funcIndex, /*completed=*/false);
-    EJIT_DIAG("shared taskpool reject func=%u: out of range", funcIndex);
-    R.status = EJitCompileOrGetStatus::InvalidParam;
-    return R;
-  case EJitDedupResult::Claimed:
-    break;
-  }
   if (!queuePush(Req)) {
-    if (newlyAdmitted)
-      finishPgoFunction(funcIndex, /*completed=*/false);
     dedupClear(funcIndex, gen); // queue full → roll back the in-flight slot.
+    if (newlyAdmitted)
+      finishPgoFunction(funcIndex, /*completed=*/false, "tier1-queue-full");
     EJIT_STAT_INC(state_->counters.queueFull);
     EJIT_DIAG("shared taskpool fallback func=%u: queue full", funcIndex);
     R.status = EJitCompileOrGetStatus::QueueFullFallback;
@@ -3155,7 +3167,8 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   const bool pgoClearExclusive = tier == kEJitTierPgoUse;
   auto finishPgoOnFailure = [&]() {
     if (tier == kEJitTierInstrumented) {
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "tier1-compile-or-publish-failed");
     } else if (tier == kEJitTierPgoUse) {
       // Tier-1 is still published and instrumented. Retain admission so a
       // later hit retries Tier-2 instead of freeing this admission slot while
@@ -3179,9 +3192,10 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   }
   // Checkpoint 1: invalidated before compile started.
   if (!versionsCurrent(req)) {
-    if (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse)
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
     dedupClear(req.funcIndex, req.generation);
+    if (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse)
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "version-changed-before-compile");
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG(
         "shared worker compile drop func=%u: version changed before compile",
@@ -3191,8 +3205,8 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   void *fn = nullptr;
   bool ok = compileFn_ && compileFn_(compileCtx_, req, &fn);
   if (!ok || !fn) {
-    finishPgoOnFailure();
     dedupClear(req.funcIndex, req.generation);
+    finishPgoOnFailure();
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG("shared worker compile failed func=%u ok=%u fn=%p", req.funcIndex,
               static_cast<unsigned>(ok), fn);
@@ -3212,12 +3226,13 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
       !versionsCurrent(req)) {
     if (publishFn_)
       publishFn_(publishCtx_, req, false);
+    dedupClear(req.funcIndex, req.generation);
     if (req.generation == state_->generation.loadAcquire() &&
         (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse))
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "version-changed-after-compile");
     if (releaseFn_)
       releaseFn_(releaseCtx_, fn);
-    dedupClear(req.funcIndex, req.generation);
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG(
         "shared worker compile drop func=%u: version/gen changed after compile",
@@ -3230,6 +3245,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
     EJIT_STAT_INC(state_->counters.asyncCompiles);
     if (publishFn_)
       publishFn_(publishCtx_, req, true);
+    dedupClear(req.funcIndex, req.generation);
     if (tier == kEJitTierInstrumented) {
       EJIT_STAT_INC(state_->counters.tier1Compiles);
       EJIT_DIAG("PGO Tier-1 published func=%u: collecting 0/%u hits",
@@ -3239,19 +3255,19 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
       finishPgoFunction(realFuncIndex, /*completed=*/true);
     }
     publishCodePoolStats();
-    dedupClear(req.funcIndex, req.generation);
     EJIT_DIAG_VERBOSE("shared worker publish ok func=%u fn=%p", req.funcIndex,
                       fn);
     return;
   case EJitPublishStatus::VersionMismatch:
     if (publishFn_)
       publishFn_(publishCtx_, req, false);
+    dedupClear(req.funcIndex, req.generation);
     if (req.generation == state_->generation.loadAcquire() &&
         (tier == kEJitTierInstrumented || tier == kEJitTierPgoUse))
-      finishPgoFunction(realFuncIndex, /*completed=*/false);
+      finishPgoFunction(realFuncIndex, /*completed=*/false,
+                        "version-mismatch-at-publish");
     if (releaseFn_)
       releaseFn_(releaseCtx_, fn);
-    dedupClear(req.funcIndex, req.generation);
     EJIT_STAT_INC(state_->counters.compileFailed);
     EJIT_DIAG("shared worker publish drop func=%u: version mismatch",
               req.funcIndex);
@@ -3260,10 +3276,10 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req) {
   case EJitPublishStatus::Failed:
     if (publishFn_)
       publishFn_(publishCtx_, req, false);
+    dedupClear(req.funcIndex, req.generation);
     finishPgoOnFailure();
     if (releaseFn_)
       releaseFn_(releaseCtx_, fn);
-    dedupClear(req.funcIndex, req.generation);
     EJIT_STAT_INC(state_->counters.publishFailed);
     EJIT_DIAG("shared worker publish failed func=%u status=%u", req.funcIndex,
               static_cast<unsigned>(PS));

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -183,13 +183,18 @@ unsigned sealAndSyncCache(uintptr_t Va, size_t Size) {
 } // namespace
 
 std::unique_ptr<llvm::ejit::EJitCodePoolManager>
-llvm::ejit::makeSreCodePoolManager() {
+llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement) {
   EJitCodePoolManager::Options Opts;
+  Opts.kind = Placement == EJitCodePoolPlacement::NearFixed
+                  ? EJitCodePoolKind::Near
+                  : EJitCodePoolKind::Far;
   Opts.poolSize = static_cast<size_t>(kSrePoolSize);
   Opts.poolAlign = k2MiB; // large-page / split granularity
   Opts.minCodeAlign = 64;
-  EJIT_DIAG_VERBOSE("makeSreCodePoolManager: poolSize=%llu poolAlign=%zu",
-                    kSrePoolSize, k2MiB);
+  EJIT_DIAG_VERBOSE(
+      "makeSreCodePoolManager: kind=%s poolSize=%llu poolAlign=%zu",
+      Placement == EJitCodePoolPlacement::NearFixed ? "near" : "far",
+      kSrePoolSize, k2MiB);
 #ifdef EJIT_CODE_POOL_4K_SEAL
   // Adapt to the platform's 4K execute-permission interface: the 2MiB pool is
   // split into 4K mappings at creation and sealed one 4KiB page at a time.
@@ -208,7 +213,7 @@ llvm::ejit::makeSreCodePoolManager() {
   // fall back to SRE_MemDbgAlloc (a too-small fixed region would exhaust on
   // every compile). A fixed region gives a stable JIT address range and, when
   // placed within +-128MiB of .text, lets codegen use direct bl/adrp.
-  {
+  if (Placement == EJitCodePoolPlacement::NearFixed) {
     uintptr_t FBase = reinterpret_cast<uintptr_t>(__ejit_code_start);
     uintptr_t FEnd = reinterpret_cast<uintptr_t>(__ejit_code_end);
     uintptr_t AlignedBase =

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -17,6 +17,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
+#include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/ExecutionEngine/Orc/SymbolStringPool.h"
 #include "llvm/Support/Error.h"
@@ -119,6 +120,51 @@ TEST(EJitCodePoolMemMgr, CodeMemoryComesFromPool) {
 
   auto FA = cantFail(IFA->finalize());
   cantFail(MM.deallocate(std::move(FA)));
+}
+
+TEST(EJitCodePoolMemMgr, RoutesTemporaryTier1ToFarPool) {
+  MockSre M;
+  auto NearOpts = poolOpts(/*PoolSize=*/256 * 1024);
+  NearOpts.kind = EJitCodePoolKind::Near;
+  auto FarOpts = poolOpts(/*PoolSize=*/256 * 1024);
+  FarOpts.kind = EJitCodePoolKind::Far;
+  EJitCodePoolManager Near(
+      NearOpts, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); });
+  EJitCodePoolManager Far(
+      FarOpts, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *B) { return M.seal(B); });
+  EJitCodePoolMemoryManager MM(Near, Far, /*PageSize=*/4096);
+
+  JITLinkDylib Tier1("spec_t1_1");
+  auto G1 = makeCodeGraph(64, 0x1000);
+  auto IFA1 = cantFail(MM.allocate(&Tier1, *G1));
+  void *Tier1Addr = firstBlockAddr(*G1);
+  auto FA1 = cantFail(IFA1->finalize());
+
+  EXPECT_FALSE(Near.contains(Tier1Addr));
+  EXPECT_TRUE(Far.contains(Tier1Addr));
+  EXPECT_EQ(Near.getStats().poolCount, 0u);
+  EXPECT_EQ(Far.getStats().poolCount, 1u);
+  EJitCompiledCodeInfo Tier1Info;
+  ASSERT_TRUE(Far.findRange(Tier1Addr, Tier1Info));
+  EXPECT_EQ(Tier1Info.poolKind, EJitCodePoolKind::Far);
+
+  JITLinkDylib Tier2("spec_t2_1");
+  auto G2 = makeCodeGraph(64, 0x2000);
+  auto IFA2 = cantFail(MM.allocate(&Tier2, *G2));
+  void *Tier2Addr = firstBlockAddr(*G2);
+  auto FA2 = cantFail(IFA2->finalize());
+
+  EXPECT_TRUE(Near.contains(Tier2Addr));
+  EXPECT_FALSE(Far.contains(Tier2Addr));
+  EXPECT_EQ(Near.getStats().poolCount, 1u);
+  EJitCompiledCodeInfo Tier2Info;
+  ASSERT_TRUE(Near.findRange(Tier2Addr, Tier2Info));
+  EXPECT_EQ(Tier2Info.poolKind, EJitCodePoolKind::Near);
+
+  cantFail(MM.deallocate(std::move(FA1)));
+  cantFail(MM.deallocate(std::move(FA2)));
 }
 
 // finalize() does NOT seal: the pool stays RW so JITLink can keep writing.

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -124,6 +124,47 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
   }
 }
 
+TEST(EJitDump, SkipsTemporaryPgoTier1Capture) {
+  std::string Bitcode;
+  {
+    LLVMContext Ctx;
+    Module M("dump_pgo_tiers", Ctx);
+    auto *FT = FunctionType::get(Type::getInt32Ty(Ctx), {}, false);
+    auto *F = Function::Create(FT, Function::ExternalLinkage,
+                               "dump_temporary_tier1", &M);
+    IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
+    B.CreateRet(B.getInt32(1));
+    raw_string_ostream OS(Bitcode);
+    WriteBitcodeToFile(M, OS);
+    OS.flush();
+  }
+
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  EJitRuntimeState State;
+  Config Cfg;
+  Cfg.enablePgo = true;
+  auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
+  ASSERT_TRUE(static_cast<bool>(EngineOrErr));
+  auto Engine = std::move(*EngineOrErr);
+
+  setDumpFuncFilter("*");
+  SpecializationContext Ctx;
+  Ctx.fnName = "dump_temporary_tier1";
+  Ctx.cacheKey = 0xd711;
+  Ctx.tier = CompileTier::Instrumented;
+  Engine->setActiveContext(&Ctx);
+  ASSERT_FALSE(errorToBool(
+      Engine->loadBitcodeModule(Bitcode, Ctx.cacheKey, Ctx.fnName)));
+  auto FnOrErr = Engine->lookup(Ctx.cacheKey, Ctx.fnName);
+  ASSERT_TRUE(static_cast<bool>(FnOrErr));
+  Engine->setActiveContext(nullptr);
+  setDumpFuncFilter("");
+
+  EXPECT_FALSE(printDumped("dump_temporary_tier1"));
+  EXPECT_FALSE(printDumpedModule("dump_temporary_tier1"));
+}
+
 namespace llvm {
 namespace ejit {
 // Test-only accessor. EJitOptimizer deliberately keeps its individual pipeline

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -796,6 +796,7 @@ extern void ejit_print_func_meta(const char *funcName);
 // (the real ejit_status_t) with literal status values (0=OK, -1=INVALID_PARAM,
 // -2=NOT_ACTIVE, -9=DISABLED) so the test need not include the C API header.
 extern int ejit_get_code_pool_stats(void *out);
+extern int ejit_get_code_pool_stats_v2(void *out);
 extern void ejit_print_code_pool_stats(void);
 extern void ejit_print_mayconst_ranking(void);
 extern void ejit_print_active(void);
@@ -3512,6 +3513,7 @@ TEST(EJitDiagnostics, PrintFuncMetaMissingName) {
 // it deterministically returns INVALID_PARAM (-1) regardless of init state.
 TEST(EJitDiagnostics, CodePoolStatsNullOutRejected) {
   EXPECT_EQ(ejit_get_code_pool_stats(nullptr), -1);
+  EXPECT_EQ(ejit_get_code_pool_stats_v2(nullptr), -1);
 }
 
 // With a valid out pointer the call either succeeds (0) or reports a clean

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -125,44 +125,17 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
 }
 
 TEST(EJitDump, SkipsTemporaryPgoTier1Capture) {
-  std::string Bitcode;
-  {
-    LLVMContext Ctx;
-    Module M("dump_pgo_tiers", Ctx);
-    auto *FT = FunctionType::get(Type::getInt32Ty(Ctx), {}, false);
-    auto *F = Function::Create(FT, Function::ExternalLinkage,
-                               "dump_temporary_tier1", &M);
-    IRBuilder<> B(BasicBlock::Create(Ctx, "entry", F));
-    B.CreateRet(B.getInt32(1));
-    raw_string_ostream OS(Bitcode);
-    WriteBitcodeToFile(M, OS);
-    OS.flush();
-  }
-
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
-  EJitRuntimeState State;
-  Config Cfg;
-  Cfg.enablePgo = true;
-  auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
-  ASSERT_TRUE(static_cast<bool>(EngineOrErr));
-  auto Engine = std::move(*EngineOrErr);
-
-  setDumpFuncFilter("*");
-  SpecializationContext Ctx;
-  Ctx.fnName = "dump_temporary_tier1";
-  Ctx.cacheKey = 0xd711;
-  Ctx.tier = CompileTier::Instrumented;
-  Engine->setActiveContext(&Ctx);
-  ASSERT_FALSE(errorToBool(
-      Engine->loadBitcodeModule(Bitcode, Ctx.cacheKey, Ctx.fnName)));
-  auto FnOrErr = Engine->lookup(Ctx.cacheKey, Ctx.fnName);
-  ASSERT_TRUE(static_cast<bool>(FnOrErr));
-  Engine->setActiveContext(nullptr);
-  setDumpFuncFilter("");
-
-  EXPECT_FALSE(printDumped("dump_temporary_tier1"));
-  EXPECT_FALSE(printDumpedModule("dump_temporary_tier1"));
+  EXPECT_FALSE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::Instrumented, "*", "dump_temporary_tier1"));
+  EXPECT_FALSE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::Instrumented, "dump_temporary_tier1",
+      "dump_temporary_tier1"));
+  EXPECT_TRUE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::Baseline, "*", "dump_temporary_tier1"));
+  EXPECT_TRUE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::PGOUse, "dump_temporary_tier1", "dump_temporary_tier1"));
+  EXPECT_FALSE(llvm::ejit::detail::shouldCaptureDump(
+      CompileTier::PGOUse, "other", "dump_temporary_tier1"));
 }
 
 namespace llvm {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -4952,6 +4952,46 @@ TEST_F(SharedTaskPoolTest, SharedPgoProfilesFunctionsSequentially) {
   EXPECT_EQ(state_->pgoActiveFunctions[0].loadAcquire(), 7u);
 }
 
+TEST_F(SharedTaskPoolTest, SharedPgoProfilesOneVersionPerFunctionAtATime) {
+  EJitSharedTaskPool pool;
+  bringUpOwner(pool);
+  EJitCoreId::setCurrentForTest(0);
+  pool.setPgoEnabled(true, 2, /*maxConcurrentProfiles=*/2);
+  pool.setInstanceEnabled(1, 4, true);
+  pool.setInstanceEnabled(1, 5, true);
+  EJitDimPair d0[1] = {dim(1, 4)};
+  EJitDimPair d1[1] = {dim(1, 5)};
+
+  ASSERT_EQ(pool.compileOrGet(5, d0, 1, codeFor(5)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  auto deferred = pool.compileOrGet(5, d1, 1, codeFor(5));
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.fnPtr, codeFor(5));
+  EXPECT_EQ(pool.pendingCount(), 1u);
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 1u);
+  EXPECT_EQ(state_->pgoDeferredMisses.loadRelaxed(), 0u);
+
+  ASSERT_TRUE(pool.pollOne()); // Publish d0 Tier-1.
+  deferred = pool.compileOrGet(5, d1, 1, codeFor(5));
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(pool.pendingCount(), 0u);
+  EXPECT_EQ(state_->pgoDeferredMisses.loadRelaxed(), 1u);
+
+  for (unsigned i = 0; i < 2; ++i) {
+    auto hit = pool.compileOrGet(5, d0, 1, codeFor(5));
+    ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (hit.hasReadToken)
+      pool.releaseRead(hit.bucketIndex);
+  }
+  ASSERT_EQ(pool.pendingCount(), 1u);
+  ASSERT_TRUE(pool.pollOne()); // Publish d0 Tier-2 and release admission.
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 0u);
+
+  EXPECT_EQ(pool.compileOrGet(5, d1, 1, codeFor(5)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 1u);
+}
+
 TEST_F(SharedTaskPoolTest, SharedPgoReleasesAdmissionForPreexistingWork) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
@@ -4960,9 +5000,14 @@ TEST_F(SharedTaskPoolTest, SharedPgoReleasesAdmissionForPreexistingWork) {
   ASSERT_EQ(pool.compileOrGet(5, nullptr, 0, codeFor(5)).status,
             EJitCompileOrGetStatus::EnqueuedPending);
   pool.setPgoEnabled(true, 2);
+  uint32_t admissionHooks = 0;
+  pool.setPgoAdmissionTestHook(
+      [](void *ctx) { ++*static_cast<uint32_t *>(ctx); }, &admissionHooks);
 
   EXPECT_EQ(pool.compileOrGet(5, nullptr, 0, codeFor(5)).status,
             EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(admissionHooks, 0u)
+      << "an already-pending request must not transiently start PGO";
   EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 0u);
   EXPECT_EQ(state_->pgoActiveFunctions[0].loadAcquire(), 0u);
 

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -167,6 +167,7 @@ struct RangeCtx {
   uintptr_t codeStart = 0x40000000ull;
   uint64_t codeSize = 64;
   uint32_t poolId = 0;
+  EJitCodePoolKind poolKind = EJitCodePoolKind::Near;
   bool provide = true;
   // Runtime-writable ranges (v9): 0 => none (non-PGO / Tier-2). When set,
   // models the Tier-1 __profc_ counter pages a peer core must enable_rw.
@@ -188,6 +189,7 @@ bool mockCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
   out->poolBase = r->poolBase;
   out->poolSize = r->poolSize;
   out->poolId = r->poolId;
+  out->poolKind = r->poolKind;
   out->writableCount = r->writableCount;
   out->requiresPeerEnableRw = r->requiresPeerEnableRw;
   for (uint32_t i = 0; i < kEJitSharedMaxWritableRanges; ++i) {
@@ -2372,8 +2374,8 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // a silent cross-core corruption.
   // v10-v13 add PGO controls, writable ranges, staged admission, and audit
   // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
-  // per-version post-publish reuse tracking.
-  EXPECT_EQ(kEJitSharedAbiVersion, 15u);
+  // per-version post-publish reuse tracking; v16 adds near/far placement.
+  EXPECT_EQ(kEJitSharedAbiVersion, 16u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -2404,7 +2406,8 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   EXPECT_EQ(slot->poolBase, 0x40000000ull);
   EXPECT_EQ(slot->poolSize, 0x200000ull);
   EXPECT_EQ(slot->poolId, 7u);
-  EXPECT_EQ(slot->rangeReserved, 0u);
+  EXPECT_EQ(slot->poolKind,
+            static_cast<uint32_t>(EJitCodePoolKind::Near));
   // Runtime-writable ranges (v9): published verbatim from the code-range info.
   EXPECT_EQ(slot->writableCount, 1u);
   EXPECT_EQ(slot->requiresPeerEnableRw, 1u); // RangeCtx default: fixed RX pool
@@ -2503,7 +2506,7 @@ TEST_F(SharedTaskPoolTest, FourKReinitScrubsStaleV5Fields) {
       Slot.poolBase = 0x3333;
       Slot.poolSize = 0x4444;
       Slot.poolId = 0x5555;
-      Slot.rangeReserved = 0x6666;
+      Slot.poolKind = static_cast<uint32_t>(EJitCodePoolKind::Far);
       Slot.writableCount = 0x7777;
       Slot.requiresPeerEnableRw = 0x8888;
       for (uint32_t i = 0; i < kEJitSharedMaxWritableRanges; ++i) {
@@ -2536,7 +2539,8 @@ TEST_F(SharedTaskPoolTest, FourKReinitScrubsStaleV5Fields) {
       EXPECT_EQ(Slot.poolBase, 0u);
       EXPECT_EQ(Slot.poolSize, 0u);
       EXPECT_EQ(Slot.poolId, 0u);
-      EXPECT_EQ(Slot.rangeReserved, 0u);
+      EXPECT_EQ(Slot.poolKind,
+                static_cast<uint32_t>(EJitCodePoolKind::Unknown));
       EXPECT_EQ(Slot.writableCount, 0u);
       EXPECT_EQ(Slot.requiresPeerEnableRw, 0u);
       for (uint32_t i = 0; i < kEJitSharedMaxWritableRanges; ++i) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -4919,7 +4919,7 @@ TEST_F(SharedTaskPoolTest, SharedPgoProfilesFunctionsSequentially) {
 
   // A different function stays on its AOT fallback and adds no compiler work.
   auto deferred = pool.compileOrGet(6, nullptr, 0, codeFor(6));
-  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(deferred.fnPtr, codeFor(6));
   EXPECT_EQ(state_->enqueuePos.loadRelaxed() - state_->dequeuePos.loadRelaxed(),
             1u);
@@ -4973,7 +4973,7 @@ TEST_F(SharedTaskPoolTest, SharedPgoProfilesOneVersionPerFunctionAtATime) {
 
   ASSERT_TRUE(pool.pollOne()); // Publish d0 Tier-1.
   deferred = pool.compileOrGet(5, d1, 1, codeFor(5));
-  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(pool.pendingCount(), 0u);
   EXPECT_EQ(state_->pgoDeferredMisses.loadRelaxed(), 1u);
 
@@ -5031,7 +5031,7 @@ TEST_F(SharedTaskPoolTest, SharedPgoHonorsConcurrentProfileLimit) {
   EXPECT_EQ(state_->pgoMaxActiveFunctions.loadAcquire(), 2u);
 
   auto deferred = pool.compileOrGet(7, nullptr, 0, codeFor(7));
-  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(deferred.status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(deferred.fnPtr, codeFor(7));
   ASSERT_TRUE(pool.pollOne());
   ASSERT_TRUE(pool.pollOne());
@@ -5108,7 +5108,7 @@ TEST_F(SharedTaskPoolTest,
     if (first[i].status == EJitCompileOrGetStatus::EnqueuedPending) {
       ++admitted;
     } else {
-      EXPECT_EQ(first[i].status, EJitCompileOrGetStatus::AlreadyPending);
+      EXPECT_EQ(first[i].status, EJitCompileOrGetStatus::PgoAdmissionDeferred);
       EXPECT_EQ(first[i].fnPtr, codeFor(kFuncIndices[i]));
       deferred = i;
     }
@@ -5162,7 +5162,7 @@ TEST_F(SharedTaskPoolTest,
     producer.join();
 
   EXPECT_EQ(profile[deferred][0].status,
-            EJitCompileOrGetStatus::AlreadyPending);
+            EJitCompileOrGetStatus::PgoAdmissionDeferred);
   EXPECT_EQ(profile[deferred][0].fnPtr, codeFor(kFuncIndices[deferred]));
   EXPECT_EQ(owner.pendingCount(), 2u);
   uint32_t profilesAtThreshold = 0;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -2371,8 +2371,9 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // address by every core, so a layout change that slips through unversioned is
   // a silent cross-core corruption.
   // v10-v13 add PGO controls, writable ranges, staged admission, and audit
-  // requests; v14 adds the owned bound-pointer snapshot.
-  EXPECT_EQ(kEJitSharedAbiVersion, 14u);
+  // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
+  // per-version post-publish reuse tracking.
+  EXPECT_EQ(kEJitSharedAbiVersion, 15u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -5215,10 +5216,9 @@ TEST_F(SharedTaskPoolTest, SharedPgoTier2DiscardedOnVersionBump) {
   }
 }
 
-// PGO off → no hitCount increment and no Tier-2 enqueue.
-// Baseline guards: compileOrGet hits are ordinary cache hits with zero
-// PGO behaviour when setPgoEnabled was never called.
-TEST_F(SharedTaskPoolTest, SharedPgoOffZeroOverhead) {
+// PGO off → no hitCount increment and no Tier-2 enqueue. Stats builds still
+// set the independent one-shot postPublishSeen diagnostic on the first reuse.
+TEST_F(SharedTaskPoolTest, SharedPgoOffTracksPostPublishReuse) {
   EJitSharedTaskPool pool;
   bringUpOwner(pool);
   EJitCoreId::setCurrentForTest(0);
@@ -5232,6 +5232,9 @@ TEST_F(SharedTaskPoolTest, SharedPgoOffZeroOverhead) {
   ASSERT_EQ(pool.compileOrGet(5, d0, 1, codeFor(5)).status,
             EJitCompileOrGetStatus::EnqueuedPending);
   ASSERT_TRUE(pool.pollOne());
+  EJitSharedCacheSlot *slot = findReadySlot(5);
+  ASSERT_NE(slot, nullptr);
+  EXPECT_EQ(slot->postPublishSeen.loadRelaxed(), 0u);
 
   // Hits remain ordinary cache hits and do not enqueue Tier-2.
   for (int i = 0; i < 10; ++i) {
@@ -5243,9 +5246,8 @@ TEST_F(SharedTaskPoolTest, SharedPgoOffZeroOverhead) {
   EXPECT_EQ(pool.pendingCount(), 0u); // no Tier-2 enqueued
 
   // hitCount stays at 0 (threshold was never set).
-  EJitSharedCacheSlot *slot = findReadySlot(5);
-  ASSERT_NE(slot, nullptr);
   EXPECT_EQ(slot->hitCount.loadRelaxed(), 0u);
+  EXPECT_EQ(slot->postPublishSeen.loadRelaxed(), 1u);
 }
 
 // PGO threshold=0 (setPgoEnabled(true,0)) → counting disabled, no trigger.


### PR DESCRIPTION
## Summary
- route temporary online-PGO Tier-1 instrumented code to the dynamic far code pool
- keep final Tier-2 PGOUse code and ordinary baseline JIT code in the fixed near code pool
- expose aggregate and per-pool statistics, plus per-version tier/pool diagnostics

## Dependency

**Depends on #179.** This is a stacked PR based on commit `8ae6b021a47742` from #179.

Until #179 merges, GitHub will show its first two commits in this PR as well. The review scope for this PR is the final commit, `9107544ee126b1` (`[EJIT] Route temporary Tier-1 code to a far pool`). Once #179 lands, this PR diff should automatically shrink to that commit.

## Interface and compatibility
- preserves the existing `ejit_get_code_pool_stats()` ABI and reports aggregate totals
- adds `ejit_get_code_pool_stats_v2()` with `total`, `near`, and `far` views
- updates compiled-version diagnostics to report `tier` and `pool`
- bumps the shared taskpool ABI from 15 to 16; producer and runtime must be rebuilt together
- preserves the new API symbol in the lipo GC root list

## Validation
- syntax-compiled changed production translation units with fixed codepool, 4K sealing, shared taskpool, and cross-core pointer support enabled
- syntax-compiled the production paths without codepool support
- syntax-compiled the modified unit-test sources
- `git diff --check` passed

Linked unit tests were not run in this Windows shell because the existing build lacks the Visual Studio SDK library paths (`kernel32.lib` / `psapi.lib`). Board/AArch64 validation remains required.

## Review follow-up
The PGO-admission status issue is fixed in the updated #179 dependency: a denied admission queues no work and no longer reports pending.
