### PR TITLE
[EJIT] Add the may_const substitution verifier, behind EJIT_VERIFY_SUBSTITUTION (rebase of #160)

### DIFF
--- a/ejit_test/build.sh
+++ b/ejit_test/build.sh
@@ -211,6 +211,15 @@ ALL_TESTS=(
   ejit_sentinel_smoke_test
 )
 
+# Substitution-verifier test: the ejit_verify_* entry points exist only in a
+# runtime built with EJIT_VERIFY_SUBSTITUTION, so building it against a normal
+# runtime is an undefined-reference link failure, not a skip.
+if [[ -f "${BUILD_DIR}/CMakeCache.txt" ]] && \
+   grep -q "^EJIT_VERIFY_SUBSTITUTION:BOOL=ON" "${BUILD_DIR}/CMakeCache.txt" 2>/dev/null; then
+  ALL_TESTS+=(ejit_verify_subst_test)
+  echo "Verifier:       EJIT_VERIFY_SUBSTITUTION=ON (ejit_verify_subst_test enabled)"
+fi
+
 # Per-test compile flags (e.g. for disabling global constructors)
 declare -A COMPILE_FLAGS
 COMPILE_FLAGS[ejit_manual_register_test]="-mllvm -enable-ejit-global-ctors=false"

--- a/ejit_test/ejit_verify_subst_test.c
+++ b/ejit_test/ejit_verify_subst_test.c
@@ -1,0 +1,271 @@
+/**
+ * Substitution verifier test (config.verifySubstitution). See EJitVerify.h.
+ *
+ * Two fields, deliberately different in kind:
+ *   stableField   — written once at configuration time, never again
+ *   volatileField — rewritten from live state after the JIT read it
+ *
+ * Asserts the verifier stays quiet for the first and fires for the second, per
+ * site rather than in the totals, since a total cannot tell one moving field
+ * from a whole unstable set; and that verify mode is behaviourally transparent,
+ * because the loads survive.
+ *
+ * Section F asserts the emitted IR itself, via dumpJITDir. PASS6 runs inside
+ * the runtime against a live PeriodArrayRegistry, so it is not opt-runnable and
+ * cannot be covered by a lit test; the post-pipeline .ll dump is the only place
+ * the instrumentation is observable as IR.
+ *
+ * Needs a runtime built with EJIT_VERIFY_SUBSTITUTION — build.sh reads
+ * CMakeCache and only adds this test when the flag is on.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ejit_test_helpers.h"
+
+//===-- Period data -------------------------------------------------------===//
+
+#define N_CELLS 4
+
+struct Cfg {
+    ejit_may_const uint32_t stableField;
+    ejit_may_const uint32_t volatileField;
+    uint32_t pad;
+};
+
+ejit_period_arr(cell) struct Cfg g_cfg[N_CELLS];
+
+ejit_entry
+uint32_t probe(ejit_period_arr_ind(cell) uint8_t ci) {
+    const struct Cfg *p = &g_cfg[ci];
+    return p->stableField * 100u + p->volatileField;
+}
+
+extern void ejit_shutdown(void);
+
+//===-- Assertions --------------------------------------------------------===//
+
+static int g_fail = 0;
+#define T(cond, fmt, ...) do {                                    \
+    if (cond) printf("  OK   " fmt "\n", ##__VA_ARGS__);          \
+    else      printf("  FAIL " fmt "\n", ##__VA_ARGS__), g_fail++; \
+} while (0)
+
+// Under async the first call falls back to AOT while the compile is enqueued,
+// so the instrumented body is only reached on a later call.
+static uint32_t settle(uint8_t ci) {
+    (void)probe(ci);
+    ejit_drain_taskpool();
+    return probe(ci);
+}
+
+static void snapshot(ejit_verify_stats_t *s) {
+    memset(s, 0, sizeof(*s));
+    ejit_verify_get_stats(s);
+}
+
+//===-- Per-site lookup ---------------------------------------------------===//
+
+#define MAX_SITES 16
+
+// Sites are named "<func>:<global>+<byteOffset>"; the field is identified by
+// the tail, which is what stays stable across builds.
+static int site_ends_with(const ejit_verify_site_t *s, const char *suffix) {
+    size_t n = strlen(s->site), m = strlen(suffix);
+    return m <= n && strcmp(s->site + n - m, suffix) == 0;
+}
+
+static const ejit_verify_site_t *
+find_site(const ejit_verify_site_t *sites, size_t n, const char *suffix) {
+    for (size_t i = 0; i < n; i++)
+        if (site_ends_with(&sites[i], suffix))
+            return &sites[i];
+    return NULL;
+}
+
+static void dump_sites(const ejit_verify_site_t *sites, size_t n) {
+    for (size_t i = 0; i < n; i++)
+        printf("    site[%zu] %-24s checks=%llu mismatches=%llu "
+               "lastFrozen=0x%llx lastActual=0x%llx\n",
+               i, sites[i].site,
+               (unsigned long long)sites[i].checks,
+               (unsigned long long)sites[i].mismatches,
+               (unsigned long long)sites[i].lastFrozen,
+               (unsigned long long)sites[i].lastActual);
+}
+
+// Does any post-pipeline dump contain \p needle? Shells out rather than
+// walking the directory: the dump file name carries a cache key this test has
+// no way to predict.
+static int opt_ir_has(const char *dir, const char *needle) {
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "grep -qF -- \"%s\" %s/*_opt.ll 2>/dev/null",
+             needle, dir);
+    return system(cmd) == 0;
+}
+
+int main(int argc, char **argv) {
+    const int verifyOn = !(argc >= 2 && argv[1][0] == 'o');
+    const uint8_t ci = 0;
+    ejit_verify_stats_t st;
+    ejit_verify_site_t sites[MAX_SITES];
+    size_t nsites;
+    uint32_t r;
+
+    printf("=== EJIT Substitution Verifier Test (verify=%d) ===\n\n", verifyOn);
+
+    const char *tmp = getenv("TMPDIR");
+    char dumpDir[256], cmd[512];
+    if (!tmp) tmp = "/tmp";
+    snprintf(dumpDir, sizeof(dumpDir), "%s/ejit_verify_subst_ir_%d", tmp,
+             verifyOn);
+    snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", dumpDir, dumpDir);
+    if (system(cmd) != 0)
+        printf("  NOTE: could not prepare %s; section F will be skipped\n",
+               dumpDir);
+
+    ejit_config_t cfg;
+    ejit_default_config(&cfg);
+    cfg.verifySubstitution = verifyOn;
+    cfg.dumpJITDir = dumpDir;
+    ejit_init(&cfg);
+    ejit_verify_reset_stats();
+
+    //===-- A: instrumentation is emitted and executed -------------------===//
+    printf("--- A: memory untouched since the JIT read it ---\n");
+
+    g_cfg[ci].stableField = 4;
+    g_cfg[ci].volatileField = 0;
+    ejit_activate("cell", ci);
+
+    r = settle(ci);
+    T(r == 400, "probe = %u (expected 400)", r);
+
+    snapshot(&st);
+    T(st.mismatches == 0, "no mismatch while memory is untouched (%llu)",
+      (unsigned long long)st.mismatches);
+
+    if (!verifyOn) {
+        // Substitution mode: the frozen value is what the JIT serves. Prove it,
+        // so this run documents the failure the verifier exists to find.
+        T(st.sites == 0, "verify off: nothing instrumented (%llu)",
+          (unsigned long long)st.sites);
+        g_cfg[ci].volatileField = 7;
+        r = probe(ci);
+        T(r == 400, "verify off: serves the frozen value: %u (expected 400)", r);
+        T(!opt_ir_has(dumpDir, "__ejit_verify_check"),
+          "verify off: no check call in the IR");
+        T(!opt_ir_has(dumpDir, "!ejit.may_const"),
+          "verify off: the may_const loads are substituted away");
+        ejit_shutdown();
+        printf("\n=== Result: %d failures ===\n", g_fail);
+        return g_fail ? 1 : 0;
+    }
+
+    // sites>0 with checks==0 means the pass instrumented the module but the
+    // specialized body never ran — the wrapper served AOT for every call, so
+    // nothing was verified at all. That is a failure of this test's premise,
+    // not a clean run: report it as one rather than passing on an empty check.
+    T(st.sites > 0, "instrumented %llu may_const site(s)",
+      (unsigned long long)st.sites);
+    T(st.checks > 0, "executed %llu check(s)", (unsigned long long)st.checks);
+    if (st.checks == 0) {
+        printf("\n  The JIT never served the instrumented body, so nothing was\n"
+               "  verified. Check that the runtime dispatches JIT code at all\n"
+               "  (ejit_jit_verify_test) before reading anything into this.\n");
+        printf("\n=== Result: %d failures (B/C/D unreachable) ===\n", g_fail);
+        ejit_shutdown();
+        return 1;
+    }
+
+    //===-- B: a field moves after the JIT read it -> mismatch ------------===//
+    printf("\n--- B: volatileField rewritten, no activate cycle ---\n");
+
+    const uint64_t before = st.mismatches;
+    g_cfg[ci].volatileField = 7;   // exactly what a live-state field does
+
+    r = probe(ci);
+    // Verify mode kept the load, so the answer still tracks memory. In a
+    // normal build this call would return the frozen 400.
+    T(r == 407, "still tracks live memory: %u (expected 407)", r);
+
+    snapshot(&st);
+    T(st.mismatches > before,
+      "verifier flagged the change: %llu mismatch(es)",
+      (unsigned long long)st.mismatches);
+
+    //===-- C: the stable field never trips it ---------------------------===//
+    printf("\n--- C: repeated calls, stableField untouched ---\n");
+
+    const uint64_t mid = st.mismatches;
+    for (int i = 0; i < 4; i++)
+        (void)probe(ci);
+
+    snapshot(&st);
+    // volatileField diverges on every call; stableField must not add to it.
+    // Four calls, one diverging field -> exactly four new mismatches.
+    T(st.mismatches == mid + 4,
+      "only the volatile field diverges: %llu new over 4 calls (expected 4)",
+      (unsigned long long)(st.mismatches - mid));
+
+    //===-- D: the report names the field --------------------------------===//
+    printf("\n--- D: per-site classification ---\n");
+
+    memset(sites, 0, sizeof(sites));
+    nsites = ejit_verify_get_sites(sites, MAX_SITES);
+    dump_sites(sites, nsites);
+    T(nsites == 2, "two sites recorded (actual %zu)", nsites);
+
+    // stableField is at offset 0 of the struct, volatileField at 4.
+    const ejit_verify_site_t *stable = find_site(sites, nsites, "g_cfg+0");
+    const ejit_verify_site_t *moving = find_site(sites, nsites, "g_cfg+4");
+
+    T(stable != NULL, "stableField site recorded (…g_cfg+0)");
+    T(moving != NULL, "volatileField site recorded (…g_cfg+4)");
+
+    if (stable) {
+        T(stable->checks > 0, "stableField checked %llu time(s)",
+          (unsigned long long)stable->checks);
+        T(stable->mismatches == 0,
+          "stableField never diverged (%llu) — safe to freeze",
+          (unsigned long long)stable->mismatches);
+    }
+    if (moving) {
+        T(moving->mismatches > 0,
+          "volatileField diverged %llu time(s) — must not be ejit_may_const",
+          (unsigned long long)moving->mismatches);
+        T(moving->lastActual == 7 && moving->lastFrozen != moving->lastActual,
+          "records the evidence: frozen=0x%llx actual=0x%llx",
+          (unsigned long long)moving->lastFrozen,
+          (unsigned long long)moving->lastActual);
+    }
+
+    //===-- E: reset ------------------------------------------------------===//
+    printf("\n--- E: counter reset ---\n");
+
+    ejit_verify_reset_stats();
+    snapshot(&st);
+    T(st.checks == 0 && st.mismatches == 0 && st.sites == 0,
+      "counters cleared (sites=%llu checks=%llu mismatches=%llu)",
+      (unsigned long long)st.sites, (unsigned long long)st.checks,
+      (unsigned long long)st.mismatches);
+    nsites = ejit_verify_get_sites(sites, MAX_SITES);
+    T(nsites == 0, "site records cleared (%zu)", nsites);
+
+    //===-- F: the emitted IR ---------------------------------------------===//
+    printf("\n--- F: instrumented IR ---\n");
+
+    T(opt_ir_has(dumpDir, "call void @__ejit_verify_check("),
+      "post-pipeline IR calls __ejit_verify_check");
+    T(opt_ir_has(dumpDir, "!ejit.verified"),
+      "the checked load survives, marked !ejit.verified");
+    T(opt_ir_has(dumpDir, "@.ejit.verify.site"),
+      "the site name is emitted as a private constant");
+
+    ejit_shutdown();
+
+    printf("\n=== Result: %d failures ===\n", g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -373,6 +373,12 @@ def doit_gc_merge(args):
         "ejit_print_version",
     ]
     optional_api = [
+        # Substitution verifier: only in an EJIT_VERIFY_SUBSTITUTION build,
+        # hence optional. Called from user code, never from the runtime or AOT,
+        # so it needs a GC root. __ejit_verify_check does not — EJitLibcallStubs
+        # takes its address, which keeps it reachable.
+        "ejit_verify_get_stats", "ejit_verify_reset_stats",
+        "ejit_verify_available", "ejit_verify_get_sites",
         "ejit_register_lifecycle", "ejit_register_funcindex",
         "ejit_taskpool_compile_or_get", "ejit_taskpool_release_read",
         "ejit_taskpool_compile_or_get_0d", "ejit_taskpool_compile_or_get_1d",

--- a/jit_design_doc/PASS6_EJitStructFieldPass.md
+++ b/jit_design_doc/PASS6_EJitStructFieldPass.md
@@ -1,11 +1,13 @@
 # EJitStructFieldPass 设计文档
 
-**版本**: 1.6
-**日期**: 2026-05-11
+**版本**: 1.7
+**日期**: 2026-08-19
 **关联**: SPEC4.md, PLAN4.md
 **类型**: JIT Module Pass
 **顺序**: JIT Pipeline 第 4 步 (参数预处理 → InstCombine → Inline 之后)
 
+> **v1.7 新增**: 替换验证器（`Config::verifySubstitution`）。本 Pass 冻结的值只在"内存此后不再改变"的前提下正确，而该前提无法在编译期证明。验证模式保留 may_const load 并在其后插入运行时比对，用一次真实业务运行把已标注字段按测量结果分类。详见 §11。
+>
 > **v1.6 变更**: v1.5 设计的间接指针访问路径已全部实现。支持 `ejit_period_arr` 指针型全局变量（§2.1 模式 5/5b）和 `ejit_period` 指针型静态变量。当 `findRootGV` 沿 GEP 链遇到 `LoadInst` 阻隔时，回退到间接路径：扫描 GEP 链找到 `LoadInst` → 解析其来源 GV → 通过 `resolveBase` 获取运行时地址 → 读取 `*(void**)&GV` 得到实际数据指针 → 累加字段偏移 → 读取常量值。
 >
 > **v1.5 变更**: 设计指针全局变量支持方案。当 GEP 基址是间接 load（load ptr from GV）时，PASS6 多追溯一层 —— 先从 GV 读取指针值作为真正的基地址，再加字段偏移。详见 §2.1 模式 5、§3.2。
@@ -831,6 +833,79 @@ EJitStructFieldPass 本身不受优化等级影响 — 常量替换是基础操�
 
 ---
 
-*文档版本: 1.5*
+## 11. 替换验证器 (Config::verifySubstitution) — v1.7 新增
+
+### 11.1 要解决的问题
+
+本 Pass 把一个 `ejit_may_const` load 换成它在编译时从进程内存里读到的值。只有当那块内存此后一直保持该值，替换才是正确的 —— 而 Pipeline 中没有任何环节能证明这一点：一个由实时状态写入的字段（负载统计、队列深度）和一个只在配置阶段写一次的字段，被冻结得同样干脆。失败是静默的：内存本身仍然正确，只是特化后的代码不再去读它。
+
+验证器不去猜哪个字段安全，而是**测量**：跑一遍真实业务，每一个报出 mismatch 的字段就是不该标 `ejit_may_const` 的字段。
+
+比对同时覆盖两类错误：load 走的是源码算出的地址（AOT 全局符号），冻结值来自 PASS6 经时间窗注册表推导的地址。两者不一致时（注册的 baseAddr 错误、字段偏移算错），同样表现为 mismatch。
+
+### 11.2 两级开关
+
+| 开关 | 位置 | 默认 | 作用 |
+|------|------|------|------|
+| `EJIT_VERIFY_SUBSTITUTION` | CMake（`cmake -S llvm -B <build> -DEJIT_VERIFY_SUBSTITUTION=ON`） | OFF | 是否把验证器编进运行时 |
+| `config.verifySubstitution` | `ejit_init()` 的 `ejit_config_t` | false | 本次运行是否启用 |
+
+CMake 开关 OFF 时，插桩代码、per-site 表、运行时 helper 都不进 `ejit.o`（aarch64 -Os 实测约省 6.6 KB text + 6.7 KB bss）；此时 `ejit_init()` **拒绝** `config.verifySubstitution` 并记录一条 diag，`ejit_verify_available()` 返回 0。这是刻意的：若静默降级为普通替换，所有计数器都会是 0，与"没有任何字段发生漂移"这一结论无法区分 —— 而这恰恰是本模式绝不能误报的答案。
+
+宏用 `target_compile_definitions(LLVMEJIT PRIVATE ...)` 挂在 LLVMEJIT 上（而非 `add_definitions`），切换它不会触发整棵 LLVM 树重编。
+
+### 11.3 验证模式下的 Pass 行为
+
+替换被整体让位给插桩：
+
+```llvm
+; 普通模式（替换）
+%v = <被删除>                      ; 所有使用点换成 i32 4
+
+; 验证模式（保留 + 比对）
+%2 = load i32, ptr @g_cfg, !ejit.may_const !18, !ejit.verified !18
+%3 = zext i32 %2 to i64
+call void @__ejit_verify_check(ptr @.ejit.verify.site, i64 4, i64 %3)
+```
+
+- **site 命名**: `"<函数名>:<全局变量>+<字节偏移>"`，例如 `probe:g_cfg+4`。间接指针模式没有可达的根全局变量，退化为 `"<函数名>:<indirect>+<解引用后的偏移>"`，仍能区分同一结构体的不同字段。名字在模块内按字符串去重，一个热函数对同一字段的多次访问只生成一个字符串常量。
+- **类型**: 整数/浮点/指针统一 zext 到 i64 后传给 helper。浮点走同宽 bitcast —— 比的是 bit 相等，NaN payload 和 ±0 必须保留。宽度 > 64 位的类型不插桩，与 `createConstantFromMemory` 无法materialize 的集合一致。
+- **重复插桩防护**: 插桩过的 load 打上 `!ejit.verified`。`runPipeline` 会跑两次本 Pass（阶段 1c / 1f），而验证模式下 load 不被消耗，没有这个标记第二次就会重复插桩并让所有计数翻倍。
+- **`dso_local` 清除**: 验证模式保留了 load，特化代码因此仍要在运行时够到 AOT 全局。`dso_local` 声明走直接寻址（AArch64 上 ADRP+LDR），只在 JIT 代码池落在程序数据的 PC 相对范围内才可解析；超出时**整个编译失败**，验证器一条结论都给不出来。故验证模式清除外部全局的 `dso_local`，访问改走 JITLink 就近生成的 GOT 表项。诊断模式每个全局多一次 load，替换模式不受影响（它的 load 已经没了）。
+
+### 11.4 运行时 API
+
+```c
+int    ejit_verify_available(void);                 /* 是否编进了这个 runtime */
+void   ejit_verify_get_stats(ejit_verify_stats_t *);/* sites / checks / mismatches 总计 */
+size_t ejit_verify_get_sites(ejit_verify_site_t *, size_t max);  /* 逐 site 明细 */
+void   ejit_verify_reset_stats(void);               /* 用于框定一段 workload */
+```
+
+`ejit_verify_site_t` 记录 site 名、checks、mismatches 以及最近一次 mismatch 的 frozen/actual 值。**总计数只说明"有东西漂移了"，分类要靠逐 site 明细** —— 而且在没开 `EJIT_DIAG_ENABLE` 的构建里，逐条 mismatch 的日志根本不存在，明细是唯一可读的形式。
+
+per-site 表是固定容量（64 条，名字 64 字节，超长截断）：验证模式要能在不允许诊断路径分配内存的目标上运行。超出容量的 site 仍计入总计，只是没有单独记录。
+
+### 11.5 结果判读
+
+| 观察 | 结论 |
+|------|------|
+| 某 site `mismatches > 0` | 该字段在 JIT 读过之后被改写，**不能**标 `ejit_may_const` |
+| 某 site `checks > 0, mismatches == 0` | 这次运行里该字段没漂移（覆盖范围内） |
+| `sites > 0` 但 `checks == 0` | 特化代码根本没被执行（wrapper 一直走 AOT），本次结论无效 —— 先用 `ejit_jit_verify_test` 确认运行时确实在派发 JIT 代码 |
+
+### 11.6 限制
+
+1. **只是诊断**: load 保留 ⇒ 常量不折叠、分支不消除，特化收益为零。验证模式用来判定标注是否正确，不产出快代码，不应进生产镜像。
+2. **覆盖率等于执行率**: 没被执行到的 site 什么也证明不了；LICM 把 load 提出循环时，检查次数会少于迭代次数。
+3. **只覆盖能被替换的 load**: 未能 materialize 成常量的 load 本来就不会被替换，也就不插桩。
+
+### 11.7 测试
+
+`ejit_test/ejit_verify_subst_test.c`：一个 `stableField`（配置期写一次）和一个 `volatileField`（JIT 读过之后被改写），断言验证器对前者保持沉默、对后者报警，并且断言到 **site 粒度** —— 总计数无法区分"一个字段在动"和"一批字段在动"。同时断言验证模式的行为透明性（load 还在，每次调用返回内存当前值），以及关闭验证时同一字段确实被冻结（`… o` 参数）。
+
+---
+
+*文档版本: 1.7*
 *创建日期: 2026-04-26*
-*最后更新: 2026-04-29*
+*最后更新: 2026-08-19*

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -598,6 +598,12 @@ if(EJIT_STATS_ENABLE)
   add_definitions(-DEJIT_STATS_ENABLE)
 endif()
 
+# Bring-up diagnostic, never wanted in a shipping image: see EJitVerify.h. OFF
+# keeps all of it out of ejit.o. Defined on the LLVMEJIT target (see the EJIT
+# CMakeLists) rather than via add_definitions, so toggling it does not recompile
+# the whole LLVM tree.
+option(EJIT_VERIFY_SUBSTITUTION "Build the EJIT may_const substitution verifier (diagnostic; default OFF)" OFF)
+
 option(EJIT_TRIM_LLVM_BACKEND "Trim LLVM backend pieces used by EJIT: disable heavyweight debug info, GlobalISel, and optional AArch64 SME/SVE passes" OFF)
 if(EJIT_TRIM_LLVM_BACKEND)
   add_definitions(-DEJIT_TRIM_LLVM_BACKEND)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -47,7 +47,9 @@ struct EJitVpFunctionInfo {
 /// every compilation.
 class EJitOptimizer {
 public:
-  EJitOptimizer(PeriodArrayRegistry &reg);
+  /// \p verifySubstitution forwards the EJitStructFieldPass diagnostic mode
+  /// (EJitVerify.h): check the may_const values instead of freezing them.
+  EJitOptimizer(PeriodArrayRegistry &reg, bool verifySubstitution = false);
 
   /// Run the full JIT specialization pipeline:
   ///   1. Parameter substitution (ejit_period_arr_ind → constants)
@@ -154,6 +156,7 @@ private:
   FunctionPassManager &simplifyFPMForLevel(OptimizationLevel level);
 
   PeriodArrayRegistry &registry_;
+  bool verifySubstitution_ = false;
 
   // Persistent analysis managers — registered once, reused across compilations.
   // Invalidated per-function by the pass infrastructure as needed.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
@@ -53,6 +53,11 @@ struct Config {
 #else
   bool enableProfileAudit = false;
 #endif
+  /// Diagnostic: instead of freezing may_const values, keep the loads and
+  /// check them against what would have been frozen (EJitVerify.h). Every
+  /// mismatch names a field that must not be ejit_may_const. Disables
+  /// specialization while on — the loads survive, so nothing folds.
+  bool verifySubstitution = false;
 };
 
 } // namespace ejit

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -111,6 +111,9 @@ typedef struct {
   bool forceStaticRegistry;
   /// If non-NULL, dump JIT-optimized LLVM IR (.ll) to this directory.
   const char *dumpJITDir;
+  /// Diagnostic: check ejit_may_const values at run time instead of freezing
+  /// them (EJitVerify.h). Disables specialization while on.
+  bool verifySubstitution;
 } ejit_config_t;
 
 typedef struct {
@@ -142,6 +145,48 @@ typedef struct {
   char message[256];
   char funcName[128];
 } ejit_error_t;
+
+/// Substitution-verifier counters (config.verifySubstitution). A non-zero
+/// `mismatches` means at least one ejit_may_const field changed after the
+/// JIT read it — that field is not safe to freeze.
+typedef struct {
+  uint64_t sites;      ///< instrumented may_const load sites emitted
+  uint64_t checks;     ///< instrumented loads executed
+  uint64_t mismatches; ///< executions where memory != the frozen value
+} ejit_verify_stats_t;
+
+/// Longest site name kept per record, including the terminator. Must match
+/// llvm::ejit::kVerifySiteNameMax.
+#define EJIT_VERIFY_SITE_NAME_MAX 64
+
+/// One instrumented may_const access, named "<func>:<global>+<byteOffset>".
+/// The totals say something diverged; this says which field did — and without
+/// EJIT_DIAG_ENABLE it is the only form that says so.
+typedef struct {
+  char site[EJIT_VERIFY_SITE_NAME_MAX];
+  uint64_t checks;      ///< executions of this site
+  uint64_t mismatches;  ///< executions where memory != the frozen value
+  uint64_t lastFrozen;  ///< frozen value at the most recent mismatch
+  uint64_t lastActual;  ///< memory value at the most recent mismatch
+} ejit_verify_site_t;
+
+/// The four entry points below are DEFINED only under EJIT_VERIFY_SUBSTITUTION;
+/// linking them otherwise is an undefined reference. They are declared
+/// unconditionally because a caller cannot see the runtime's build flags —
+/// test for the symbol at build time (ejit_test/build.sh reads CMakeCache)
+/// rather than calling one to find out.
+
+/// Always 1 where defined at all.
+int ejit_verify_available(void);
+
+void ejit_verify_get_stats(ejit_verify_stats_t *out);
+
+/// Copy up to \p max per-site records into \p out, returning the number
+/// written (ordered by first execution). Sites past the runtime's fixed table
+/// capacity are counted in the totals but have no record.
+size_t ejit_verify_get_sites(ejit_verify_site_t *out, size_t max);
+
+void ejit_verify_reset_stats(void);
 
 // Initialization
 ejit_status_t ejit_init(const ejit_config_t *config);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
@@ -38,11 +38,14 @@ using MayConstOffsetMap =
 /// constants.
 class EJitStructFieldPass : public PassInfoMixin<EJitStructFieldPass> {
 public:
+  /// \p verify selects the diagnostic mode described in EJitVerify.h: keep
+  /// each may_const load and check it at run time instead of substituting it.
   EJitStructFieldPass(PeriodArrayRegistry &reg,
                       const uint8_t *boundData = nullptr,
-                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0)
+                      uint32_t boundSize = 0, uint32_t boundArgIndex = 0,
+                      bool verify = false)
       : registry_(reg), boundData_(boundData), boundSize_(boundSize),
-        boundArgIndex_(boundArgIndex) {}
+        boundArgIndex_(boundArgIndex), verify_(verify) {}
 
   /// Pre-build GV metadata maps from the Module (call once before run()).
   void initFromModule(Module &M);
@@ -74,6 +77,9 @@ private:
   const uint8_t *boundData_ = nullptr;
   uint32_t boundSize_ = 0;
   uint32_t boundArgIndex_ = 0;
+  /// Unread without EJIT_VERIFY_SUBSTITUTION; kept in the interface so callers
+  /// need no #ifdef.
+  [[maybe_unused]] bool verify_ = false;
 
   // Cached metadata maps — built once per module, reused across functions.
   GVPeriodMap gvPeriodMap_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitVerify.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitVerify.h
@@ -1,0 +1,114 @@
+//===-- EJitVerify.h - may_const substitution verifier --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Diagnostic support for Config::verifySubstitution.
+//
+// PASS6 replaces an ejit_may_const load with the value it reads out of process
+// memory at compile time. That is correct only for as long as the memory keeps
+// that value, and nothing in the pipeline can prove it will: a field written
+// from live state (a load metric, a queue depth) is frozen just as readily as
+// one written once at configuration time. The failure is silent — the memory
+// stays correct, but the specialized code no longer reads it.
+//
+// Under verifySubstitution the pass keeps the load and emits a call to
+// __ejit_verify_check comparing the value actually in memory against the one
+// it WOULD have frozen. Every divergence reported is a field that must not
+// carry ejit_may_const. Running a real workload this way classifies the marked
+// fields by measurement rather than by inspection.
+//
+// The comparison covers more than value stability. The load reads through the
+// address the source computes, from the AOT global; the frozen value comes
+// from the address PASS6 derives out of the period registry. A mismatch is
+// therefore also how a wrong registered base or a mis-computed field offset
+// shows up — cases where substitution would bake in a value from the wrong
+// place.
+//
+// The loads survive, so nothing folds: this validates the frozen values, it
+// does not produce fast code. Coverage is limited to sites that execute.
+//
+// Built only under -DEJIT_VERIFY_SUBSTITUTION (default OFF). Without it nothing
+// here is declared or defined and no caller is compiled — pass instrumentation,
+// runtime helper, libcall entry and the ejit_verify_* C API all disappear — and
+// ejit_init() refuses config.verifySubstitution.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITVERIFY_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITVERIFY_H
+
+#include <cstddef>
+#include <cstdint>
+
+#ifdef EJIT_VERIFY_SUBSTITUTION
+
+namespace llvm {
+namespace ejit {
+
+/// Counters accumulated by the substitution verifier. Relaxed atomics: these
+/// are diagnostic totals, never a control input.
+struct VerifyStats {
+  uint64_t sites;      ///< instrumented load sites emitted by the pass
+  uint64_t checks;     ///< instrumented loads executed
+  uint64_t mismatches; ///< executions where memory != the frozen value
+};
+
+/// Longest site name retained per record, including the terminator. Names are
+/// "<func>:<global>+<byteOffset>"; anything longer is truncated rather than
+/// dropped, since the leading text is what locates the field.
+constexpr size_t kVerifySiteNameMax = 64;
+
+/// Number of distinct sites the runtime can account for individually. A
+/// fixed table: verify mode runs on targets where a diagnostic must not
+/// allocate. Sites past the limit still count toward the totals above.
+constexpr size_t kVerifyMaxSites = 64;
+
+/// Per-site accounting, the form the classification is actually read in: which
+/// marked field diverged, how often, and against what. The totals alone cannot
+/// separate one moving field from a genuinely unstable set, and the log lines
+/// that name a site exist only in EJIT_DIAG_ENABLE builds.
+struct VerifySite {
+  char site[kVerifySiteNameMax]; ///< "<func>:<global>+<byteOffset>"
+  uint64_t checks;               ///< executions of this site
+  uint64_t mismatches;           ///< executions where memory != frozen
+  uint64_t lastFrozen;           ///< frozen value at the most recent mismatch
+  uint64_t lastActual;           ///< memory value at the most recent mismatch
+};
+
+/// Snapshot the counters. \p out must be non-null.
+void ejitVerifyGetStats(VerifyStats *out);
+
+/// Number of per-site records held, i.e. distinct sites that have executed.
+/// Records are appended in order of first execution and never move, so an
+/// index below this bound stays valid until the next reset.
+size_t ejitVerifySiteCount();
+
+/// Copy record \p index into \p out. False when the index is out of range or
+/// the record is not yet fully claimed. One record at a time, deliberately:
+/// a batch copy would need a table-sized buffer on the caller's stack.
+bool ejitVerifyGetSite(size_t index, VerifySite *out);
+
+/// Zero the counters and drop every per-site record. Intended for tests
+/// bracketing a workload.
+void ejitVerifyResetStats();
+
+/// Record that the pass emitted one instrumented site.
+void ejitVerifyNoteSite();
+
+} // namespace ejit
+} // namespace llvm
+
+/// Called from JIT-compiled code, once per execution of an instrumented
+/// may_const load. \p site names the access as "<func>:<global>+<byteOffset>".
+/// \p baked is the value PASS6 would have frozen; \p actual is what the load
+/// just returned. Values are zero-extended (floats bitcast) to 64 bits.
+extern "C" void __ejit_verify_check(const char *site, uint64_t baked,
+                                    uint64_t actual);
+
+#endif // EJIT_VERIFY_SUBSTITUTION
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITVERIFY_H

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -109,6 +109,7 @@ set(EJIT_SOURCES
   EJitModuleLoader.cpp
   EJitRegistrationStore.cpp
   EJitStructFieldPass.cpp
+  EJitVerify.cpp
   EJitOptimizer.cpp
   EJitPassBuilder.cpp
   EJitProfileMerge.cpp
@@ -202,6 +203,17 @@ if(EJIT_SRE_TASKPOOL_NO_RECLAIM)
     EJIT_SRE_TASKPOOL_NO_RECLAIM)
   message(STATUS
     "EmbeddedJIT: NO_RECLAIM shared-cache hot path enabled (JIT code must never be physically reclaimed)")
+endif()
+
+# may_const substitution verifier (option declared in llvm/CMakeLists.txt). The
+# users of this macro are the JIT-side pass, the runtime helper, and the libcall
+# table — all inside LLVMEJIT — so scope it to the target instead of a global
+# add_definitions, like EJIT_CODE_POOL_4K_SEAL above.
+if(EJIT_VERIFY_SUBSTITUTION)
+  target_compile_definitions(LLVMEJIT PRIVATE EJIT_VERIFY_SUBSTITUTION)
+  message(STATUS
+    "EmbeddedJIT: may_const substitution verifier built in (diagnostic; "
+    "enable per run with config.verifySubstitution)")
 endif()
 
 # Propagate the target triple setting to the C++ code

--- a/llvm/lib/ExecutionEngine/EJIT/EJitLibcallStubs.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitLibcallStubs.cpp
@@ -28,6 +28,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/ExecutionEngine/EJIT/EJitVerify.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -89,6 +90,11 @@ ArrayRef<LibcallSymbol> getLibcallSymbols() {
 #endif
       {"__llvm_profile_instrument_target",
        reinterpret_cast<void *>(&__llvm_profile_instrument_target)},
+#ifdef EJIT_VERIFY_SUBSTITUTION
+      // Only a verifier build's pass emits calls to this, and only that build
+      // defines it.
+      {"__ejit_verify_check", reinterpret_cast<void *>(&__ejit_verify_check)},
+#endif
 #if defined(_WIN32)
       {"__stack_chk_guard", reinterpret_cast<void *>(&HostStackChkGuard)},
 #else

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -71,7 +71,9 @@ static bool mayConstSitesCorrespond(const EJitMayConstLoadSite &L,
 }
 #endif
 
-EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg) : registry_(reg) {
+EJitOptimizer::EJitOptimizer(PeriodArrayRegistry &reg,
+                             bool verifySubstitution)
+    : registry_(reg), verifySubstitution_(verifySubstitution) {
   // Use the real llvm::PassBuilder to register the FULL analysis set. The O2
   // function-simplification pipeline (GVN, CorrelatedValuePropagation, etc.)
   // needs analyses the minimal EJitPassBuilder does not register (~13 vs ~40).
@@ -165,8 +167,17 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
   }
 #endif
 
-  // Phase 1 - specialize (common to all tiers): turn the period index and
-  // every may_const field into a compile-time constant.
+
+#ifdef EJIT_VERIFY_SUBSTITUTION
+  if (verifySubstitution_)
+    EJIT_DIAG("verify mode: checking may_const values instead of freezing "
+              "them; this specialization is NOT optimized");
+#endif
+
+
+  // Phase 1 — specialize: turn the period index and every may_const field into
+  // a compile-time constant.
+  //   (a) Substitute the ejit_period_arr_ind argument with its constant index.
   preReplacePeriodIndices(M, ctx);
   runInstCombine(M);
   EJIT_DIAG_DEBUG("pipeline phase1b done: InstCombine");
@@ -766,7 +777,8 @@ void EJitOptimizer::runStructFieldPass(Module &M,
                                        const SpecializationContext &ctx) {
   EJitStructFieldPass structField(
       registry_, ctx.boundData.empty() ? nullptr : ctx.boundData.data(),
-      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex);
+      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex,
+      verifySubstitution_);
   structField.initFromModule(M);
   for (Function &F : M.functions())
     if (!F.isDeclaration())

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -709,7 +709,8 @@ EJitOrcEngine::Create(const Config &config,
 
   // Create persistent optimizer — analysis managers are registered once here
   // and reused across compilations (cleared between runs).
-  engine->P->optimizer = std::make_unique<EJitOptimizer>(periodReg);
+  engine->P->optimizer =
+      std::make_unique<EJitOptimizer>(periodReg, config.verifySubstitution);
 
   // Register all known global variable addresses from the PeriodArrayRegistry
   // so that external global references in any loaded bitcode module resolve

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h" // ejit_reg_entry_t layout
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h" // EJitDimPair layout
+#include "llvm/ExecutionEngine/EJIT/EJitVerify.h"
 // Build-time-generated: EJIT_GIT_COMMIT / EJIT_GIT_BRANCH (git HEAD of the
 // llvm-project source tree). Lives in the LLVMEJIT build directory.
 #include "EJitVersion.h"
@@ -331,6 +332,17 @@ static void parseConfig(const ejit_config_t *src, Config &dst) {
     dst.maxCacheSize = src->maxCacheSize;
   dst.enableLogger = src->enableLogger;
   dst.forceStaticRegistry = src->forceStaticRegistry;
+#ifdef EJIT_VERIFY_SUBSTITUTION
+  dst.verifySubstitution = src->verifySubstitution;
+#else
+  // Refused rather than honoured: the pass would substitute as usual and every
+  // counter would read zero, which is indistinguishable from "nothing
+  // diverged" — the one answer this mode must never give by accident.
+  dst.verifySubstitution = false;
+  if (src->verifySubstitution)
+    EJIT_DIAG("verifySubstitution requested but this runtime was built "
+              "without EJIT_VERIFY_SUBSTITUTION: ignored");
+#endif
   if (src->dumpJITDir && src->dumpJITDir[0])
     dst.dumpJITDir = src->dumpJITDir;
   // NOTE: online PGO is NOT read from ejit_config_t. The public struct keeps
@@ -343,17 +355,27 @@ static void parseConfig(const ejit_config_t *src, Config &dst) {
 #endif
 }
 
-// Compile-time regression guard: the public ejit_config_t layout MUST stay
-// exactly as originally released (no new tail field), so ejit_init() never
-// over-reads an old caller's smaller struct. Online PGO is exposed additively
-// via ejit_init_pgo(), never by growing this struct. If a field is added,
-// these asserts fire and force an explicit, versioned ABI decision.
+// Compile-time regression guard: the public ejit_config_t layout is part of
+// the C ABI. The original layout ended at dumpJITDir, and online PGO is
+// exposed additively via ejit_init_pgo(), never by growing this struct, so
+// ejit_init() never over-reads an old caller's smaller struct. The one
+// accepted tail addition since is verifySubstitution (EJitVerify.h):
+// diagnostic-only, and callers compile against this tree's headers together
+// with the static runtime, so no version skew exists in practice. Anything
+// further must go through a dedicated entry point, as ejit_init_pgo did. If
+// a field is added anyway, these asserts fire and force an explicit,
+// versioned ABI decision.
 static_assert(offsetof(ejit_config_t, compileMode) == 0,
               "ejit_config_t.compileMode must stay first (ABI)");
+// verifySubstitution is a bool, so the struct legitimately carries tail
+// padding after it; the assert pins the size to the alignment-rounded end of
+// the field, which still trips on any pointer/size_t-sized append.
 static_assert(sizeof(ejit_config_t) ==
-                  offsetof(ejit_config_t, dumpJITDir) + sizeof(const char *),
-              "ejit_config_t must end at dumpJITDir (no online-PGO tail field "
-              "may be appended; use ejit_init_pgo instead)");
+                  (offsetof(ejit_config_t, verifySubstitution) + sizeof(bool) +
+                   alignof(ejit_config_t) - 1) /
+                      alignof(ejit_config_t) * alignof(ejit_config_t),
+              "ejit_config_t must end at verifySubstitution; new options "
+              "belong in dedicated entry points (see ejit_init_pgo)");
 static_assert(std::is_standard_layout<ejit_config_t>::value,
               "ejit_config_t must be standard-layout for a stable C ABI");
 
@@ -411,6 +433,18 @@ ejit_status_t ejit_init_pgo(const ejit_config_t *config) {
 
 void ejit_shutdown(void) {
   EJIT_DIAG("shutting down");
+#ifdef EJIT_VERIFY_SUBSTITUTION
+  {
+    // The totals are the whole point of the run, and a caller that forgets to
+    // read them would otherwise get nothing.
+    llvm::ejit::VerifyStats vs;
+    llvm::ejit::ejitVerifyGetStats(&vs);
+    if (vs.sites || vs.checks)
+      EJIT_DIAG("verify totals: sites=%llu checks=%llu mismatches=%llu",
+                (unsigned long long)vs.sites, (unsigned long long)vs.checks,
+                (unsigned long long)vs.mismatches);
+  }
+#endif
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   setDumpSharedState(nullptr);
 #endif
@@ -712,6 +746,51 @@ void *ejit_compile_or_get(uint64_t cacheKey, void **out_pfn) {
   EJIT_DIAG("compile_or_get(key=0x%016lx): retired, use taskpool API", cacheKey);
   return nullptr;
 }
+
+#ifdef EJIT_VERIFY_SUBSTITUTION
+
+void ejit_verify_get_stats(ejit_verify_stats_t *out) {
+  if (!out)
+    return;
+  // Deliberately NOT gated on gEJIT: the counters live in the verifier's own
+  // storage, so a caller can still read a completed run after ejit_shutdown.
+  llvm::ejit::VerifyStats st;
+  llvm::ejit::ejitVerifyGetStats(&st);
+  out->sites = st.sites;
+  out->checks = st.checks;
+  out->mismatches = st.mismatches;
+}
+
+int ejit_verify_available(void) { return 1; }
+
+size_t ejit_verify_get_sites(ejit_verify_site_t *out, size_t max) {
+  if (!out || max == 0)
+    return 0;
+  static_assert(sizeof(out->site) == llvm::ejit::kVerifySiteNameMax,
+                "EJIT_VERIFY_SITE_NAME_MAX must match kVerifySiteNameMax");
+
+  // Copied field by field rather than reinterpreted: the C struct is an ABI
+  // the caller compiles against, not the runtime's internal record.
+  const size_t have = llvm::ejit::ejitVerifySiteCount();
+  size_t n = 0;
+  for (size_t i = 0; i < have && n < max; ++i) {
+    llvm::ejit::VerifySite tmp;
+    if (!llvm::ejit::ejitVerifyGetSite(i, &tmp))
+      continue;
+    std::memcpy(out[n].site, tmp.site, sizeof(out[n].site));
+    out[n].site[sizeof(out[n].site) - 1] = '\0';
+    out[n].checks = tmp.checks;
+    out[n].mismatches = tmp.mismatches;
+    out[n].lastFrozen = tmp.lastFrozen;
+    out[n].lastActual = tmp.lastActual;
+    ++n;
+  }
+  return n;
+}
+
+void ejit_verify_reset_stats(void) { llvm::ejit::ejitVerifyResetStats(); }
+
+#endif // EJIT_VERIFY_SUBSTITUTION
 
 void ejit_clear_cache(void) {
   EJIT_DIAG("clear_cache");

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -2,8 +2,10 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitVerify.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DebugInfoMetadata.h"
@@ -29,6 +31,20 @@ using namespace llvm::ejit;
 void EJitStructFieldPass::initFromModule(Module &M) {
   EJIT_DIAG_VERBOSE("struct-field initFromModule module=%s globals=%zu",
                     M.getName().str().c_str(), M.global_size());
+
+  // Verify mode keeps the loads, so the code must still reach the AOT globals.
+  // dso_local means direct addressing (ADRP+LDR), which only resolves while the
+  // code pool is in PC-relative range of the program's data; out of range the
+  // compile fails and the verifier reports nothing at all. Going through a GOT
+  // entry JITLink puts next to the code resolves either way, at one extra load
+  // per global. Substitution mode never gets here — its loads are gone.
+#ifdef EJIT_VERIFY_SUBSTITUTION
+  if (verify_)
+    for (GlobalVariable &GV : M.globals())
+      if (GV.isDeclaration())
+        GV.setDSOLocal(false);
+#endif
+
   // Build GV period map.
   for (GlobalVariable &GV : M.globals()) {
     MDNode *MD = GV.getMetadata(MD_EJIT_METADATA);
@@ -654,6 +670,142 @@ tryReplaceIndirect(LoadInst *LI, const Value *PtrOp,
 }
 
 //===----------------------------------------------------------------------===//
+// Substitution verifier (Config::verifySubstitution) — see EJitVerify.h
+//===----------------------------------------------------------------------===//
+#ifdef EJIT_VERIFY_SUBSTITUTION
+
+/// Marks a load already instrumented. The pass runs twice (phases 1c and 1f)
+/// and verify mode does not consume the load, so without this the second run
+/// would double every counter.
+static constexpr const char *MD_EJIT_VERIFIED = "ejit.verified";
+
+/// Zero-extend \p V to i64 so every checked type reaches the helper through one
+/// signature. Floats go via a same-width bitcast: the check is bit equality, so
+/// NaN payloads and signed zeroes must survive. Null for types that do not fit,
+/// matching createConstantFromMemory, which cannot materialize them either.
+static Value *widenToI64(IRBuilder<> &B, Value *V) {
+  Type *Ty = V->getType();
+  Type *I64 = B.getInt64Ty();
+
+  if (Ty->isPointerTy())
+    return B.CreatePtrToInt(V, I64);
+
+  if (Ty->isFloatingPointTy()) {
+    unsigned Bits = Ty->getPrimitiveSizeInBits();
+    if (Bits > 64)
+      return nullptr;
+    return B.CreateZExt(B.CreateBitCast(V, B.getIntNTy(Bits)), I64);
+  }
+
+  if (Ty->isIntegerTy()) {
+    if (Ty->getIntegerBitWidth() > 64)
+      return nullptr;
+    return B.CreateZExt(V, I64);
+  }
+
+  return nullptr;
+}
+
+/// Private constant string naming an access, deduplicated per module run so a
+/// hot function with many accesses to one field does not emit one global each.
+static Constant *getSiteString(Module &M, StringRef S,
+                               StringMap<Constant *> &Cache) {
+  auto It = Cache.find(S);
+  if (It != Cache.end())
+    return It->second;
+
+  Constant *Init =
+      ConstantDataArray::getString(M.getContext(), S, /*AddNull=*/true);
+  auto *GV = new GlobalVariable(M, Init->getType(), /*isConstant=*/true,
+                                GlobalValue::PrivateLinkage, Init,
+                                ".ejit.verify.site");
+  GV->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
+  Cache[S] = GV;
+  return GV;
+}
+
+/// Sum the constant byte offsets along the GEP chain feeding \p Ptr, whatever
+/// the chain is rooted at. accumulateFullOffset() insists on reaching a global
+/// and gives up otherwise — which is precisely the indirect-pointer case, where
+/// the offset is still what tells two fields of one pointed-to struct apart.
+static std::optional<uint64_t> sumGEPChain(const Value *Ptr,
+                                           const DataLayout &DL) {
+  uint64_t total = 0;
+  const Value *V = Ptr;
+  while (V) {
+    V = V->stripPointerCasts();
+    auto *GEP = dyn_cast<GEPOperator>(V);
+    if (!GEP)
+      break;
+    auto off = computeGEPOffset(GEP, DL);
+    if (!off)
+      return std::nullopt;
+    total += *off;
+    V = GEP->getPointerOperand();
+  }
+  return total;
+}
+
+/// "<func>:<global>+<byteOffset>" — locates the field from a log line, and is
+/// the per-site table key, so distinct fields must not collide. The
+/// indirect-pointer pattern has no root global; it keeps the offset past the
+/// dereference, which separates fields of the pointed-to struct.
+static std::string makeSiteName(const Function &F, const LoadInst *LI,
+                                const DataLayout &DL) {
+  const Value *Ptr = LI->getPointerOperand();
+  std::string Out = F.getName().str() + ":";
+  if (const GlobalVariable *GV = findRootGV(Ptr)) {
+    Out += GV->getName().str();
+    if (auto Off = accumulateFullOffset(DL, Ptr))
+      Out += "+" + std::to_string(*Off);
+    return Out;
+  }
+  Out += "<indirect>";
+  if (auto Off = sumGEPChain(Ptr, DL))
+    Out += "+" + std::to_string(*Off);
+  return Out;
+}
+
+/// Keep \p LI and append a call comparing what it loads against \p Baked, the
+/// value substitution would have frozen. Returns false when the type cannot be
+/// widened, leaving the load untouched.
+static bool emitVerifyCheck(const Function &F, LoadInst *LI, Constant *Baked,
+                            const DataLayout &DL,
+                            StringMap<Constant *> &SiteCache) {
+  Module &M = *LI->getModule();
+  LLVMContext &Ctx = M.getContext();
+
+  // Insert after the load so the comparison observes the value it produced.
+  IRBuilder<> B(LI->getNextNode());
+
+  Value *Actual = widenToI64(B, LI);
+  Value *Frozen = Actual ? widenToI64(B, Baked) : nullptr;
+  if (!Frozen) {
+    // Left neither substituted nor checked, so it is a hole in the run's
+    // coverage rather than a clean result. Say so: silence here would read as
+    // "this field never diverged".
+    EJIT_DIAG("verify SKIP site=%s: type not checkable (>64-bit or vector)",
+              makeSiteName(F, LI, DL).c_str());
+    return false;
+  }
+
+  Type *PtrTy = PointerType::getUnqual(Ctx);
+  FunctionCallee Check = M.getOrInsertFunction(
+      "__ejit_verify_check",
+      FunctionType::get(Type::getVoidTy(Ctx),
+                        {PtrTy, B.getInt64Ty(), B.getInt64Ty()},
+                        /*isVarArg=*/false));
+
+  B.CreateCall(Check, {getSiteString(M, makeSiteName(F, LI, DL), SiteCache),
+                       Frozen, Actual});
+  LI->setMetadata(MD_EJIT_VERIFIED, MDNode::get(Ctx, {}));
+  ejitVerifyNoteSite();
+  return true;
+}
+
+#endif // EJIT_VERIFY_SUBSTITUTION
+
+//===----------------------------------------------------------------------===//
 // Public interface
 //===----------------------------------------------------------------------===//
 
@@ -713,7 +865,10 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
   //    initFromModule(), reused across all function runs).
 
   // 2. Scan all loads and collect replacements.
-  struct Replacement { LoadInst *LI; Constant *ConstVal; };
+  // A period pointer base is an address root, not a may_const field: verify
+  // mode must still substitute it (see below), so the two kinds are tracked
+  // apart rather than by re-testing the load later.
+  struct Replacement { LoadInst *LI; Constant *ConstVal; bool IsMayConst; };
   SmallVector<Replacement, 16> replacements;
 #ifdef EJIT_DIAG_ENABLE
   size_t totalLoads = 0, mayConstLoads = 0;
@@ -741,7 +896,7 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
       // rounds, including when the field access lives in a non-inlined helper.
       if (Constant *C = tryReplacePeriodPointerBase(
               LI, gvPeriodMap_, registry_, DL)) {
-        replacements.push_back({LI, C});
+        replacements.push_back({LI, C, /*IsMayConst=*/false});
         continue;
       }
 
@@ -750,6 +905,13 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
         continue;
 #ifdef EJIT_DIAG_ENABLE
       ++mayConstLoads;
+#endif
+
+#ifdef EJIT_VERIFY_SUBSTITUTION
+      // Verify mode leaves the load in place, so the pass's second run in
+      // runPipeline sees it again. Skip what the first run already checked.
+      if (verify_ && LI->getMetadata(MD_EJIT_VERIFIED))
+        continue;
 #endif
 
       Value *PtrOp = LI->getPointerOperand();
@@ -780,7 +942,7 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
         C = tryReplaceIndirect(LI, PtrOp, gvPeriodMap_, registry_, DL);
 
       if (C)
-        replacements.push_back({LI, C});
+        replacements.push_back({LI, C, /*IsMayConst=*/true});
 #ifdef EJIT_DIAG_ENABLE
       else
         logReplaceFailure(LI, gvPeriodMap_, registry_, DL);
@@ -788,12 +950,42 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
     }
   }
 
-  // 3. Apply replacements.
+  // 3. Apply: substitute the loads, or — in verify mode — keep them and append
+  //    a runtime comparison against the value substitution would have frozen.
   bool changed = false;
-  for (auto &R : replacements) {
-    R.LI->replaceAllUsesWith(R.ConstVal);
-    R.LI->eraseFromParent();
-    changed = true;
+#ifdef EJIT_VERIFY_SUBSTITUTION
+  if (verify_) {
+    StringMap<Constant *> siteCache;
+    size_t verifyCandidates = 0, verifyInstrumented = 0;
+    for (auto &R : replacements) {
+      // A period pointer base is an address root, not a marked field, so it
+      // is substituted as usual: keeping it would leave IPSCCP nothing to
+      // propagate, and the may_const fields behind a pointer-form period would
+      // never resolve, never be instrumented, and report zero mismatches.
+      if (!R.IsMayConst) {
+        R.LI->replaceAllUsesWith(R.ConstVal);
+        R.LI->eraseFromParent();
+        changed = true;
+        continue;
+      }
+      ++verifyCandidates;
+      if (emitVerifyCheck(F, R.LI, R.ConstVal, DL, siteCache)) {
+        ++verifyInstrumented;
+        changed = true;
+      }
+    }
+    if (verifyCandidates)
+      EJIT_DIAG("verify func=%s: instrumented %zu/%zu may_const load(s)",
+                F.getName().str().c_str(), verifyInstrumented,
+                verifyCandidates);
+  } else
+#endif
+  {
+    for (auto &R : replacements) {
+      R.LI->replaceAllUsesWith(R.ConstVal);
+      R.LI->eraseFromParent();
+      changed = true;
+    }
   }
 
 #ifdef EJIT_DIAG_ENABLE

--- a/llvm/lib/ExecutionEngine/EJIT/EJitVerify.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitVerify.cpp
@@ -1,0 +1,174 @@
+//===-- EJitVerify.cpp - may_const substitution verifier ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Runtime half of Config::verifySubstitution. See EJitVerify.h.
+//
+// Compiled out entirely without EJIT_VERIFY_SUBSTITUTION: the translation unit
+// is empty, and nothing that calls into it is built either.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitVerify.h"
+
+#ifdef EJIT_VERIFY_SUBSTITUTION
+
+#include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
+#include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+
+using namespace llvm::ejit;
+
+namespace {
+
+EJitAtomicU64 gSites;
+EJitAtomicU64 gChecks;
+EJitAtomicU64 gMismatches;
+
+// A diverging field usually diverges on every call, so logging each one buries
+// the run. Report the first few, then count silently — the per-site table is
+// what the classification is read from.
+constexpr uint64_t kMaxReportedMismatches = 32;
+
+/// A record is readable only at Ready: the index is handed out before the name
+/// is written, so a reader must not look at one still being filled in.
+enum : uint32_t { kSlotEmpty = 0, kSlotFilling = 1, kSlotReady = 2 };
+
+struct SiteRecord {
+  EJitAtomicU32 state;
+  EJitAtomicU64 checks;
+  EJitAtomicU64 mismatches;
+  EJitAtomicU64 lastFrozen;
+  EJitAtomicU64 lastActual;
+  // Copied, not pointed at: the pass's string lives in the JIT'd module, freed
+  // when that specialization is evicted or recompiled.
+  char name[kVerifySiteNameMax];
+};
+
+SiteRecord gSiteTable[kVerifyMaxSites];
+EJitAtomicU32 gSiteTableUsed;
+
+bool nameEquals(const char *a, const char *b) {
+  for (size_t i = 0; i < kVerifySiteNameMax; ++i) {
+    if (a[i] != b[i])
+      return false;
+    if (a[i] == '\0')
+      return true;
+  }
+  return true; // both truncated to the cap and equal over it
+}
+
+void copyName(char *dst, const char *src) {
+  size_t i = 0;
+  for (; i + 1 < kVerifySiteNameMax && src[i] != '\0'; ++i)
+    dst[i] = src[i];
+  dst[i] = '\0';
+}
+
+/// Find the record for \p site, claiming a free one on first sight. Returns
+/// null once the table is full — the totals still account for those sites.
+SiteRecord *lookupSite(const char *site) {
+  const uint32_t used = gSiteTableUsed.loadAcquire();
+  for (uint32_t i = 0; i < used && i < kVerifyMaxSites; ++i) {
+    SiteRecord &R = gSiteTable[i];
+    if (R.state.loadAcquire() != kSlotReady)
+      continue; // being filled by another core; a duplicate row is harmless
+    if (nameEquals(R.name, site))
+      return &R;
+  }
+
+  // Not found: claim the next index. Two cores racing on the same new site can
+  // each claim one, which costs a duplicate row and nothing else.
+  const uint32_t idx = gSiteTableUsed.fetchAdd(1);
+  if (idx >= kVerifyMaxSites) {
+    gSiteTableUsed.storeRelease(kVerifyMaxSites); // keep the count honest
+    return nullptr;
+  }
+
+  SiteRecord &R = gSiteTable[idx];
+  R.state.storeRelease(kSlotFilling);
+  copyName(R.name, site);
+  R.checks.storeRelaxed(0);
+  R.mismatches.storeRelaxed(0);
+  R.lastFrozen.storeRelaxed(0);
+  R.lastActual.storeRelaxed(0);
+  R.state.storeRelease(kSlotReady);
+  return &R;
+}
+
+} // namespace
+
+void llvm::ejit::ejitVerifyGetStats(VerifyStats *out) {
+  if (!out)
+    return;
+  out->sites = gSites.loadRelaxed();
+  out->checks = gChecks.loadRelaxed();
+  out->mismatches = gMismatches.loadRelaxed();
+}
+
+size_t llvm::ejit::ejitVerifySiteCount() {
+  const uint32_t used = gSiteTableUsed.loadAcquire();
+  return used > kVerifyMaxSites ? kVerifyMaxSites : used;
+}
+
+bool llvm::ejit::ejitVerifyGetSite(size_t index, VerifySite *out) {
+  if (!out || index >= ejitVerifySiteCount())
+    return false;
+  SiteRecord &R = gSiteTable[index];
+  if (R.state.loadAcquire() != kSlotReady)
+    return false;
+  copyName(out->site, R.name);
+  out->checks = R.checks.loadRelaxed();
+  out->mismatches = R.mismatches.loadRelaxed();
+  out->lastFrozen = R.lastFrozen.loadRelaxed();
+  out->lastActual = R.lastActual.loadRelaxed();
+  return true;
+}
+
+void llvm::ejit::ejitVerifyResetStats() {
+  gSites.storeRelaxed(0);
+  gChecks.storeRelaxed(0);
+  gMismatches.storeRelaxed(0);
+  // Retire the rows before the count, so a check running concurrently with the
+  // reset re-claims a slot instead of reading a half-cleared one.
+  for (size_t i = 0; i < kVerifyMaxSites; ++i)
+    gSiteTable[i].state.storeRelease(kSlotEmpty);
+  gSiteTableUsed.storeRelease(0);
+}
+
+void llvm::ejit::ejitVerifyNoteSite() { gSites.fetchAdd(1); }
+
+extern "C" void __ejit_verify_check(const char *site, uint64_t baked,
+                                    uint64_t actual) {
+  gChecks.fetchAdd(1);
+
+  SiteRecord *R = site ? lookupSite(site) : nullptr;
+  if (R)
+    R->checks.fetchAdd(1);
+
+  if (baked == actual)
+    return;
+
+  if (R) {
+    R->mismatches.fetchAdd(1);
+    R->lastFrozen.storeRelaxed(baked);
+    R->lastActual.storeRelaxed(actual);
+  }
+
+  // fetchAdd returns the PRE-increment value, so the first mismatch sees 0.
+  const uint64_t seen = gMismatches.fetchAdd(1);
+  if (seen < kMaxReportedMismatches) {
+    EJIT_DIAG("verify MISMATCH site=%s frozen=0x%llx actual=0x%llx",
+              site ? site : "(unnamed)",
+              static_cast<unsigned long long>(baked),
+              static_cast<unsigned long long>(actual));
+    if (seen + 1 == kMaxReportedMismatches)
+      EJIT_DIAG("verify: %llu mismatches reported, further ones counted only",
+                static_cast<unsigned long long>(kMaxReportedMismatches));
+  }
+}
+
+#endif // EJIT_VERIFY_SUBSTITUTION


### PR DESCRIPTION
本 PR 是 #160（@bruteforceboy 的 may_const 替换验证器）在当前主干 `ejit_dev_spec4`（db8c9c6）上的 cherry-pick（原提交 504abe4f0fed），解决其与主干后续合入的 PGO / bound-ptr 工作产生的冲突，供测试与后续合入。

## 功能（同 #160）

`EJIT_VERIFY_SUBSTITUTION`（CMake 选项，默认 OFF）构建的运行时在 `cfg.verifySubstitution = 1` 时进入验证模式：PASS6 不再冻结 may_const 负载，而是保留负载并插入 `__ejit_verify_check(site, 冻结值, 实际值)` 调用。每个 mismatch 都点名一个不该标 `ejit_may_const` 的字段——用测量而非检查来分类字段。按站点读结果：`ejit_verify_get_sites()`（"<函数>:<全局>+<字节偏移>"）、`ejit_verify_get_stats()`、`ejit_verify_reset_stats()`。

## 冲突解决（4 个文件）

| 文件 | 解法 |
|------|------|
| `EJitOptions.h` | 两边 Config 字段并存（enablePgo/enableProfileAudit + verifySubstitution） |
| `EJitStructFieldPass.h` | 构造函数合并：主干 bound-ptr 三参数保留，`verify` 作为第 5 参数追加（默认 false），既有调用点零改动 |
| `EJitLibcallStubs.cpp` | `__ejit_verify_check` 插入符号表 `__stack_chk_guard` 之前，保住 guard-last 不变式（Count 丢弃逻辑依赖） |
| `EJitOptimizer.cpp` | 构造函数/runPipeline/runStructFieldPass 三处：审计辅助与 verify 诊断并存，ctx 版调用转发 `verifySubstitution_` |

## 规格变更（显式说明）

1. **`ejit_config_t` C ABI 布局**：主干断言该结构体必须以 `dumpJITDir` 结尾（PGO 走独立入口 `ejit_init_pgo`，不加尾字段，防老调用方被过度读取）；#160 在尾部追加了 `bool verifySubstitution`。本 PR 保留 #160 的 API（`cfg.verifySubstitution`），并将 static_assert 显式更新为固定新末字段（对齐取整算术，仍能拦截指针/size_t 级追加）。这是一次显式 ABI 决策：诊断专用 bool，调用方与运行时同树编译、无版本偏差。若评审倾向主干惯例，可改为独立入口（如 `ejit_init_verify`）——请给出倾向。
2. 其余无规格变更：`verifySubstitution` 默认 false，OFF 构建下全套代码（pass 插桩、运行时 helper、libcall 符号、C API）不编入，行为与主干完全一致；JIT 管线顺序、preset、部署契约均未动。

## 验证

- 构建：`EJIT_VERIFY_SUBSTITUTION` ON / OFF 均编译链接通过（选项为 LLVMEJIT 目标级定义，不重编全树）
- 自带集成测试 `ejit_verify_subst_test`：**0 failures**（A-F 六段全过：插桩确认、易变字段检出、逐站点分类、计数重置、IR 检查）
- 集成套件其余 22 个失败与 EJITTests 的 4 个失败均为主干基线 db8c9c6 既有（重建基线对照验证，典型签名：async 无编译 + JITLink Delta32 超范围），与本 PR 无关
- 子代理逐文件审查确认 5 处冲突解决语义正确（构造函数全部调用点、符号表 4 种条件编译组合、断言 32/64 位算术）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
