### PR TITLE
[EJIT] Raise diagnostic print throttle to 50 ticks

### DIFF
--- a/jit_design_doc/EJIT_DIAG.md
+++ b/jit_design_doc/EJIT_DIAG.md
@@ -1,7 +1,7 @@
 # EmbeddedJIT 诊断 dump：逐行打印延时
 
 > 适用分支：`ejit-print-compiled-fmt-djq`
-> 开关：`EJIT_DIAG_PRINT_THROTTLE_TICKS`（CMake 缓存变量，默认 20，0 关闭）
+> 开关：`EJIT_DIAG_PRINT_THROTTLE_TICKS`（CMake 缓存变量，默认 50，0 关闭）
 > 目标平台：`aarch64_be`（SRE，shell 环形 buffer 串口日志）
 
 ---
@@ -17,10 +17,10 @@ SRE 串口日志经 shell 环形 buffer 转发，相关平台参数只有两条�
 
 诊断 dump API 的**循环打印**（每个数据项一行）在每打印一行后调用 `ejitDiagPrintThrottle()`（`EJitDiag.h`），即**每循环一轮延时一次**：
 
-- 每次延时 `EJIT_DIAG_PRINT_THROTTLE_TICKS` 个调度 tick（`SRE_TaskDelay`，默认 **20** tick = 20 ms = 2 个消费者排空周期：第一个周期完成排空，第二个周期是吸收消费者抖动与多核日志交错的裕量）
+- 每次延时 `EJIT_DIAG_PRINT_THROTTLE_TICKS` 个调度 tick（`SRE_TaskDelay`，默认 **50** tick = 50 ms = 5 个消费者排空周期，为长 ranking 行、消费者抖动与多核日志交错留出裕量）
 - 仅在 `EJIT_DIAG_ENABLE` + `EJIT_FREESTANDING` 下生效；host 构建与诊断关闭时为零开销 no-op
 - 行未实际打印（日志级别低于 INFO）时不延时
-- 参数经 CMake 缓存变量传递（`llvm/CMakeLists.txt`，非负整数校验，0 关闭），`ejit-minimal-aarch64_be` 预设配 20
+- 参数经 CMake 缓存变量传递（`llvm/CMakeLists.txt`，非负整数校验，0 关闭），`ejit-minimal-aarch64_be` 预设配 50
 
 ## 3. 覆盖的循环
 
@@ -48,5 +48,5 @@ SRE 串口日志经 shell 环形 buffer 转发，相关平台参数只有两条�
 
 - `llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h` — `ejitDiagPrintThrottle()`、`EJIT_DIAG_PRINT_THROTTLE_TICKS` 默认值
 - `llvm/CMakeLists.txt` — `EJIT_DIAG_PRINT_THROTTLE_TICKS` 缓存变量与校验
-- `llvm/CMakePresets.json` — `ejit-minimal-aarch64_be` 预设（20）
+- `llvm/CMakePresets.json` — `ejit-minimal-aarch64_be` 预设（50）
 - `llvm/lib/ExecutionEngine/EJIT/` — `EJit.cpp` / `EJitRuntime.cpp` / `EJitOrcEngine.cpp` / `EJitSharedTaskPool.cpp` 中的循环调用点

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -568,11 +568,11 @@ endif()
 # list, captured IR/ASM, icache slots): after each printed line the producer
 # delays EJIT_DIAG_PRINT_THROTTLE_TICKS scheduler ticks (SRE_TaskDelay) so the
 # serial-log shell consumer (ring buffer ~7 lines, 10 ms drain period) keeps
-# up. Default 20 ticks = 2 drain periods per line: the first performs the
-# drain, the second is margin for consumer jitter and interleaved multi-core
-# logs. Freestanding + EJIT_DIAG_ENABLE only; 0 disables. Consumed by
+# up. Default 50 ticks = 5 drain periods per line, leaving margin for long
+# ranking rows, consumer jitter, and interleaved multi-core logs. Freestanding
+# + EJIT_DIAG_ENABLE only; 0 disables. Consumed by
 # ejitDiagPrintThrottle() in EJitDiag.h.
-set(EJIT_DIAG_PRINT_THROTTLE_TICKS "20" CACHE STRING
+set(EJIT_DIAG_PRINT_THROTTLE_TICKS "50" CACHE STRING
   "EmbeddedJIT diagnostic dump print delay: SRE_TaskDelay scheduler ticks per printed line (0 disables)")
 if(EJIT_DIAG_ENABLE)
   if(NOT EJIT_DIAG_PRINT_THROTTLE_TICKS MATCHES "^[0-9]+$")

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -90,7 +90,7 @@
         "EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT": "10",
         "EJIT_SHARED_SECTION_ATTR": "__attribute__((section(\".mc_shared\")))",
         "EJIT_DIAG_ENABLE": "ON",
-        "EJIT_DIAG_PRINT_THROTTLE_TICKS": "20",
+        "EJIT_DIAG_PRINT_THROTTLE_TICKS": "50",
         "EJIT_SRE_DIAG": "ON",
         "EJIT_DUMP_ASM": "ON",
         "EJIT_STATS_ENABLE": "ON",

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitDiag.h
@@ -57,15 +57,14 @@ extern int gEJitDiagLevel;
 // 1 ms), so those loops call ejitDiagPrintThrottle() once per printed line:
 // each call delays the producer by EJIT_DIAG_PRINT_THROTTLE_TICKS scheduler
 // ticks (SRE_TaskDelay), letting the consumer drain between lines. The
-// default of 20 ticks buys 2 drain periods per printed line: the first
-// performs the drain, the second is margin for consumer jitter and
-// interleaved multi-core logs (measured: 2 ticks/line drops lines; 50
-// ticks/line is 5 drain periods and needlessly slow).
+// default of 50 ticks buys 5 drain periods per printed line, leaving enough
+// margin for long ranking rows, consumer jitter, and interleaved multi-core
+// logs (measured: 2 ticks/line drops lines).
 // Compile-time configurable; 0 disables. Hosted builds do not delay;
 // diagnostics compiled out (no EJIT_DIAG_ENABLE) => pure no-op.
 
 #ifndef EJIT_DIAG_PRINT_THROTTLE_TICKS
-#define EJIT_DIAG_PRINT_THROTTLE_TICKS 20
+#define EJIT_DIAG_PRINT_THROTTLE_TICKS 50
 #endif
 
 #if defined(EJIT_DIAG_ENABLE) && defined(EJIT_FREESTANDING)


### PR DESCRIPTION
## Summary

- raise the global EJIT diagnostic per-line print throttle from 20 to 50 scheduler ticks
- update the freestanding fallback macro, CMake cache default, and aarch64_be preset consistently
- update diagnostic documentation and rationale for long ranking rows and interleaved multi-core logs

## Scope

This changes only diagnostic dump pacing. Hosted builds, diagnostics-disabled builds, and configurations that explicitly override EJIT_DIAG_PRINT_THROTTLE_TICKS are unchanged.

## Validation

- CMakePresets.json JSON validation passed
- no stale default-20 references remain in the affected configuration and documentation files
- git diff --check passed