### PR TITLE
[EJIT] Retain bound compile and module dump APIs in lipo

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -374,7 +374,8 @@ def doit_gc_merge(args):
     ]
     optional_api = [
         "ejit_register_lifecycle", "ejit_register_funcindex",
-        "ejit_taskpool_compile_or_get", "ejit_taskpool_release_read",
+        "ejit_taskpool_compile_or_get", "ejit_taskpool_compile_or_get_bound",
+        "ejit_taskpool_release_read",
         "ejit_taskpool_compile_or_get_0d", "ejit_taskpool_compile_or_get_1d",
         "ejit_taskpool_compile_or_get_2d", "ejit_taskpool_compile_or_get_3d",
         "ejit_taskpool_compile_or_get_4d",
@@ -382,7 +383,7 @@ def doit_gc_merge(args):
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
         "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped",
-        "ejit_dump_all", "ejit_print_mayconst_ranking",
+        "ejit_print_dumped_module", "ejit_dump_all", "ejit_print_mayconst_ranking",
         # Inline-cache: ejit_register_icache_slot is called from
         # ejit_auto_register (AOT) when -ejit-inline-cache is on, not from the
         # runtime, so gc-merge's --gc-sections would discard it without this GC


### PR DESCRIPTION
## Summary

- add the missing lipo GC root for `ejit_taskpool_compile_or_get_bound`, following the bound-pointer API introduced by #162
- restore the `ejit_print_dumped_module` GC root originally added by #150 but lost from the current mainline
- preserve the existing `ejit_print_mayconst_ranking` root from the latest base

## Why

`gc-merge` runs before the final business object is linked. References from that object are therefore not visible while `--gc-sections` selects the EJIT runtime APIs. Without explicit roots, these externally called APIs may be discarded. On board, a discarded bound compile API can result in a jump to an invalid target.

This is a follow-up to the already merged #162. The module-dump entry is a mainline restoration rather than a new API addition: #150 included it, but a later integration dropped the lipo root.

## Validation

- Python syntax parse passed
- `git diff --check` passed

---

## 中文说明

`gc-merge` 早于最终业务对象链接，因此业务代码对接口的引用不会参与 `--gc-sections` 的根符号判定。本 PR 作为已合并 #162 的后续，补上当时遗漏的 `ejit_taskpool_compile_or_get_bound`；同时恢复 #150 原本已经加入、但在后续主线集成中丢失的 `ejit_print_dumped_module` 保留项。最新主线已有的 `ejit_print_mayconst_ranking` 保持不变。