### PR TITLE
[EJIT] Initialize LLVM only on the fixed compile worker

### DIFF
--- a/jit_design_doc/EJIT_SRE_TASKPOOL.md
+++ b/jit_design_doc/EJIT_SRE_TASKPOOL.md
@@ -1328,6 +1328,34 @@ Uninitialized ──CAS成功──> Initializing ──(建好全部共享状�
 
 - 首个把 `Uninitialized` CAS 成 `Initializing` 的核成为 owner：`initSharedStorage` 逐字段写 → bump `generation` → 写 `ownerCoreId/codeSharingEnabled/header` → 起唯一 worker → **最后 `storeRelease(Ready)`**（发布序：所有内容先就绪，Ready 最后发布）。
 - **固定 worker 核（构建策略 `EJIT_SRE_SHARED_TASKPOOL_WORKER_CORE`，默认空 = 开放竞选）**：配置为核号 N 后竞选关闭——只有核 N 允许执行 `Uninitialized->Initializing` CAS（建引擎、创建 worker 任务；SRE 任务跑在创建它的核上，故"谁赢竞选 = worker 跑在哪个核"）。非指定核观察到 `Uninitialized` 时**绝不尝试 CAS**，以与 `Initializing` 分支相同的有限 yield 等待协议（idle hook / cpuRelax，`kMaxSpins` 预算）等核 N 完成初始化后 attach，bring-up 激活次序无关。预算耗尽（指定核从未激活，违反部署契约：**指定核必须在 bring-up 期间以 Async 模式激活 EJit**；注意预算为 2^20 次 yield，生产注入 idle hook 时即 ~2^20 个调度 tick，指定核若始终不来则各 peer 的 `ejit_init` 会阻塞这么久后才干净失败）返回 `InitInProgress` 干净失败，`EJit.cpp` 的 init 错误消息区分为 "designated worker core never initialized"——**绝不**无界等待挂死，也**绝不**静默改选其它核。`initAttempts` 只计真实 CAS 尝试（非指定核的等待不计）。单一镜像所有核链接同一份库，宏天然全核一致，无需入共享 blob、无 ABI 变化；CMake 定义窄作用域到 LLVMEJIT（消费者：`EJitSharedTaskPool.cpp` 的选举门控 + `EJit.cpp` 的错误消息）。
+
+#### 11.4.1 worker-only LLVM runtime initialization
+
+固定 worker 核的 shared-async 部署允许 producer-only 核跳过 LLVM/EJIT
+专用 `.init_array`：每个核仍必须以 `forceStaticRegistry=true` 调用
+`ejit_init()`，通过静态 registry table 完成本核 wrapper 的 funcIndex、
+lifecycle 和 inline-cache slot 回填；只有指定 worker 核需要在调用
+`ejit_init()` 前完成 LLVM 运行库的 init-array 准备。业务及其它库需要的
+构造函数不属于该豁免范围。
+
+Target 注册位于 `EJitOrcEngine::Create()`，而不是 `EJit::EJit()`。因此：
+
+```
+producer core: ejit_init -> registry fixup -> shared attach
+worker core:   LLVM init-array -> ejit_init -> owner election
+               -> EJitOrcEngine::Create -> target registration -> worker start
+```
+
+普通 baseline、online-PGO Tier-1 和 Tier-2 共用同一个 owner-private ORC
+engine，后两者不会在 producer 核创建额外的 LLVM 编译运行时。Sync 和
+non-shared async 模式不满足这一条件：执行编译的每个核都必须先准备 LLVM
+运行库。开放竞选也不能与“仅一个核准备 LLVM”组合；否则一个未准备的核
+可能合法赢得 owner。AArch64 BE 生产 preset 固定 worker core 后才允许启用
+此启动优化。
+
+EJIT 自身的 dump filter/store 使用按需构造的函数局部状态，不再要求 peer
+核通过 `.init_array` 构造进程级 `std::string`/`std::map`。共享 dump 元数据
+仍是 POD，并继续由 owner 初始化。
 - 其它核 `acquire` 观察：`Ready` 校验 `magic/version/size` 后绑定（`AttachedReady`，**绝不创建第二个 worker**）；`Failed`/`Stopping` → 干净 fallback，**不无限等待**；`Initializing` → 有限自旋后返回 `InitInProgress`（pending，不死锁）。
 - 重复 `init()` 幂等：owner 再次 `init()` 观察到 `Ready` 即 `AttachedReady`，不重选不重建。
 - worker 起动失败传播为 `OwnerFailed`/`Failed` + `lastInitError=WorkerStartFailed`，`ejit_init` 失败并销毁实例，**绝不把 init 失败伪装成 JIT 成功**。

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -1,7 +1,6 @@
 //===-- EJit.cpp - EmbeddedJIT Main C++ API -------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJit.h"
-#include "llvm/Config/Targets.h"
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCompileDriver.h"
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h" // SECT_EJIT_* section names
@@ -24,8 +23,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/TargetParser/Triple.h"
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -59,49 +56,6 @@ extern const ejit_reg_entry_t __start_ejit_period[];
 extern const ejit_reg_entry_t __stop_ejit_period[];
 #endif
 }
-
-namespace {
-
-void initializeEJitTargets() {
-#ifdef EJIT_TRIM_LLVM_BACKEND
-#ifdef EJIT_DEFAULT_TRIPLE
-  Triple TT(EJIT_DEFAULT_TRIPLE);
-#if LLVM_HAS_AARCH64_TARGET
-  if (TT.isAArch64()) {
-    LLVMInitializeAArch64TargetInfo();
-    LLVMInitializeAArch64Target();
-    LLVMInitializeAArch64TargetMC();
-    LLVMInitializeAArch64AsmPrinter();
-    LLVMInitializeAArch64AsmParser();
-    return;
-  }
-#endif
-#if LLVM_HAS_X86_TARGET
-  if (TT.isX86()) {
-    LLVMInitializeX86TargetInfo();
-    LLVMInitializeX86Target();
-    LLVMInitializeX86TargetMC();
-    LLVMInitializeX86AsmPrinter();
-    return;
-  }
-#endif
-#endif
-#ifndef EJIT_FREESTANDING
-  if (!InitializeNativeTarget()) {
-    InitializeNativeTargetAsmPrinter();
-    return;
-  }
-#endif
-#endif
-
-  InitializeAllTargetInfos();
-  InitializeAllTargets();
-  InitializeAllTargetMCs();
-  InitializeAllAsmPrinters();
-  InitializeAllAsmParsers();
-}
-
-} // namespace
 
 EJit::EJit(const Config &config) : config_(config) {
   EJIT_DIAG_VERBOSE("constructing: mode=%d opt=%d maxCache=%zu maxEntries=%u",
@@ -293,10 +247,6 @@ EJit::EJit(const Config &config) : config_(config) {
       reg.registerStaticVar(sv.varName, sv.varAddr);
   }
 
-  // Create sync JIT engine (target must be initialized first).
-  // Use InitializeAll* instead of InitializeNative* so that cross-compiled
-  // builds (e.g. AArch64 target built on x86 host) also work correctly.
-  initializeEJitTargets();
   EJIT_DIAG(
       "registered: bitcodes=%zu periodArrays=%zu staticVars=%zu symbols=%zu",
       data.bitcodes.size(), data.periodArrays.size(), data.staticVars.size(),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -3,6 +3,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitOrcEngine.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Config/Targets.h"
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitLibcallStubs.h"
@@ -23,6 +24,7 @@
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
@@ -50,6 +52,53 @@ using namespace llvm;
 using namespace llvm::ejit;
 
 #define DEBUG_TYPE "ejit-orc-engine"
+
+namespace {
+
+// Target registration belongs to the compile runtime, not to the producer
+// facade. In shared-async builds EJitOrcEngine::Create runs only on the elected
+// worker owner, so peer cores can attach without initializing the LLVM backend
+// or running its init-array entries.
+void initializeEJitTargets() {
+#ifdef EJIT_TRIM_LLVM_BACKEND
+#ifdef EJIT_DEFAULT_TRIPLE
+  Triple TT(EJIT_DEFAULT_TRIPLE);
+#if LLVM_HAS_AARCH64_TARGET
+  if (TT.isAArch64()) {
+    LLVMInitializeAArch64TargetInfo();
+    LLVMInitializeAArch64Target();
+    LLVMInitializeAArch64TargetMC();
+    LLVMInitializeAArch64AsmPrinter();
+    LLVMInitializeAArch64AsmParser();
+    return;
+  }
+#endif
+#if LLVM_HAS_X86_TARGET
+  if (TT.isX86()) {
+    LLVMInitializeX86TargetInfo();
+    LLVMInitializeX86Target();
+    LLVMInitializeX86TargetMC();
+    LLVMInitializeX86AsmPrinter();
+    return;
+  }
+#endif
+#endif
+#ifndef EJIT_FREESTANDING
+  if (!InitializeNativeTarget()) {
+    InitializeNativeTargetAsmPrinter();
+    return;
+  }
+#endif
+#endif
+
+  InitializeAllTargetInfos();
+  InitializeAllTargets();
+  InitializeAllTargetMCs();
+  InitializeAllAsmPrinters();
+  InitializeAllAsmParsers();
+}
+
+} // namespace
 
 static const GlobalVariable *rootGlobal(Value *V) {
   while (V) {
@@ -121,8 +170,8 @@ namespace ejit {
 
 // Mutex type for the dump store. On SRE/freestanding std::mutex is
 // unavailable and BareMetalMutex is a no-op, so use a real CAS spinlock (built
-// on the __atomic wrappers in EJitAtomic.h). gDumpStore is per-core (each core
-// has its own process image, so there is no cross-core race on it), but a
+// on the __atomic wrappers in EJitAtomic.h). The dump store is per-core (each
+// core has its own process image, so there is no cross-core race on it), but a
 // same-core overlap between the worker capture and a producer print must still
 // be guarded. Hosted builds keep std::mutex. The spinlock has a trivial
 // default constructor, so a static instance is zero-initialized (unlocked)
@@ -147,21 +196,31 @@ using DumpMutexType = DumpSpinLock;
 using DumpMutexType = std::mutex;
 #endif
 
-// Process-wide function-name filter and payload store. The mutex protects both
-// because the shell may update/print while the worker captures.
-static DumpMutexType gDumpMutex;
+// These objects are deliberately function-local statics. The SRE deployment
+// may skip LLVM/EJIT init-array execution on producer-only cores; first use
+// still constructs the local diagnostic state correctly, while a peer that
+// never dumps pays no startup cost and has no dynamic initializer dependency.
+static DumpMutexType &dumpMutex() {
+  static DumpMutexType M;
+  return M;
+}
+
+static std::string &dumpFuncFilter() {
+  static std::string Filter;
+  return Filter;
+}
+
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 EJitSharedTaskPoolState *gDumpSharedState = nullptr;
 #endif
-static std::string gDumpFuncFilter;
 
 void setDumpFuncFilter(const std::string &name) {
+  std::string &Filter = dumpFuncFilter();
   {
-    std::lock_guard<DumpMutexType> lock(gDumpMutex);
-    gDumpFuncFilter = name;
+    std::lock_guard<DumpMutexType> lock(dumpMutex());
+    Filter = name;
     EJIT_DIAG_DEBUG("set_dump_filter value=%s &filter=%p",
-                    gDumpFuncFilter.empty() ? "(off)" : gDumpFuncFilter.c_str(),
-                    (void *)&gDumpFuncFilter);
+                    Filter.empty() ? "(off)" : Filter.c_str(), (void *)&Filter);
   }
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   if (gDumpSharedState) {
@@ -206,8 +265,8 @@ void setDumpSharedState(EJitSharedTaskPoolState *state) {
   // even though the producer thinks dump is armed.
   std::string filter;
   {
-    std::lock_guard<DumpMutexType> lock(gDumpMutex);
-    filter = gDumpFuncFilter;
+    std::lock_guard<DumpMutexType> lock(dumpMutex());
+    filter = dumpFuncFilter();
   }
   if (gDumpSharedState && !filter.empty())
     setDumpFuncFilter(filter);
@@ -245,10 +304,11 @@ static bool getActiveDumpFilter(std::string &out) {
   if (getSharedDumpFilter(out))
     return true;
 #endif
-  std::lock_guard<DumpMutexType> lock(gDumpMutex);
-  if (gDumpFuncFilter.empty())
+  std::lock_guard<DumpMutexType> lock(dumpMutex());
+  std::string &Filter = dumpFuncFilter();
+  if (Filter.empty())
     return false;
-  out = gDumpFuncFilter;
+  out = Filter;
   return true;
 }
 
@@ -264,10 +324,14 @@ struct DumpEntry {
 
 // Process-wide store of captured IR+ASM, filled by the IR transform layer
 // (worker thread) when the filter matches, read by ejit_print_dumped() (user
-// thread). Guarded by gDumpMutex. These are ordinary process statics, not part
-// of the shared taskpool state; cross-core visibility depends on the worker
-// running in the same process image (addresses are logged to diagnose this).
-static std::map<std::string, DumpEntry> gDumpStore;
+// thread). Guarded by dumpMutex(). This is ordinary process-local state, not
+// part of the shared taskpool state; cross-core visibility depends on the
+// worker running in the same process image (addresses are logged to diagnose
+// this).
+static std::map<std::string, DumpEntry> &dumpStore() {
+  static std::map<std::string, DumpEntry> Store;
+  return Store;
+}
 
 static void dumpBytesSafe(const char *label, const char *data, size_t n) {
   EJIT_DIAG_RAW("=== %s begin size=%u ===", label, (unsigned)n);
@@ -408,20 +472,21 @@ static void captureDump(const std::string &fnName, uint64_t cacheKey,
                         CompileTier tier,
                         std::string FunctionIR, std::string FunctionASM,
                         std::string ModuleIR, std::string ModuleASM) {
+  auto &Store = dumpStore();
   EJIT_DIAG_DEBUG("capture enter func=%s func_ir=%u func_asm=%u module_ir=%u "
                   "module_asm=%u &store=%p",
                   fnName.c_str(), (unsigned)FunctionIR.size(),
                   (unsigned)FunctionASM.size(), (unsigned)ModuleIR.size(),
-                  (unsigned)ModuleASM.size(), (void *)&gDumpStore);
-  std::lock_guard<DumpMutexType> lock(gDumpMutex);
-  EJIT_DIAG_DEBUG("capture store_size before=%u", (unsigned)gDumpStore.size());
-  gDumpStore[fnName] =
+                  (unsigned)ModuleASM.size(), (void *)&Store);
+  std::lock_guard<DumpMutexType> lock(dumpMutex());
+  EJIT_DIAG_DEBUG("capture store_size before=%u", (unsigned)Store.size());
+  Store[fnName] =
       DumpEntry{cacheKey, tier, std::move(FunctionIR), std::move(FunctionASM),
                 std::move(ModuleIR), std::move(ModuleASM)};
-  EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)gDumpStore.size());
+  EJIT_DIAG_DEBUG("capture store_size after=%u", (unsigned)Store.size());
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   // Publish only small metadata. Full text remains in the worker-local map.
-  const DumpEntry &E = gDumpStore[fnName];
+  const DumpEntry &E = Store[fnName];
   captureSharedDumpMetadata(fnName, cacheKey, E.FunctionIR.size(),
                             E.FunctionASM.size());
 #endif
@@ -529,24 +594,26 @@ static void printOneModuleDumpSafe(const char *requestedName,
 /// Print saved IR+ASM through EJIT_DIAG, one line per IR/ASM line. A null/empty
 /// name prints all payloads available on this core.
 bool printDumped(const char *name) {
+  auto &Filter = dumpFuncFilter();
+  auto &Store = dumpStore();
+  (void)Filter;
   EJIT_DIAG_DEBUG("print_dumped enter name=%s &filter=%p &store=%p",
-                  (name && name[0]) ? name : "(all)", (void *)&gDumpFuncFilter,
-                  (void *)&gDumpStore);
+                  (name && name[0]) ? name : "(all)", (void *)&Filter,
+                  (void *)&Store);
   bool hasName = name && name[0];
   // The complete payloads are worker-local. A specific name prints one entry;
   // an empty name prints every entry captured by this core.
   {
-    std::lock_guard<DumpMutexType> lock(gDumpMutex);
+    std::lock_guard<DumpMutexType> lock(dumpMutex());
     if (hasName) {
-      auto it = gDumpStore.find(name);
-      if (it != gDumpStore.end()) {
+      auto it = Store.find(name);
+      if (it != Store.end()) {
         printOneDumpSafe(name, it->first, it->second);
         return true;
       }
-    } else if (!gDumpStore.empty()) {
-      EJIT_DIAG_RAW("print_dumped saved entries=%u",
-                    (unsigned)gDumpStore.size());
-      for (auto &kv : gDumpStore) {
+    } else if (!Store.empty()) {
+      EJIT_DIAG_RAW("print_dumped saved entries=%u", (unsigned)Store.size());
+      for (auto &kv : Store) {
         printOneDumpSafe(nullptr, kv.first, kv.second);
         ejitDiagPrintThrottle();
       }
@@ -561,32 +628,32 @@ bool printDumped(const char *name) {
 #endif
   if (hasName)
     EJIT_DIAG_DEBUG("print_dumped miss name=%s store_size=%u", name,
-                    (unsigned)gDumpStore.size());
+                    (unsigned)Store.size());
   else
     EJIT_DIAG_RAW("print_dumped: nothing saved");
   return false;
 }
 
 bool printDumpedModule(const char *name) {
+  auto &Store = dumpStore();
   bool hasName = name && name[0];
-  std::lock_guard<DumpMutexType> lock(gDumpMutex);
+  std::lock_guard<DumpMutexType> lock(dumpMutex());
   if (hasName) {
-    auto it = gDumpStore.find(name);
-    if (it != gDumpStore.end()) {
+    auto it = Store.find(name);
+    if (it != Store.end()) {
       printOneModuleDumpSafe(name, it->first, it->second);
       return true;
     }
     EJIT_DIAG_DEBUG("print_dumped_module miss name=%s store_size=%u", name,
-                    (unsigned)gDumpStore.size());
+                    (unsigned)Store.size());
     return false;
   }
-  if (gDumpStore.empty()) {
+  if (Store.empty()) {
     EJIT_DIAG_RAW("print_dumped_module: nothing saved");
     return false;
   }
-  EJIT_DIAG_RAW("print_dumped_module saved entries=%u",
-                (unsigned)gDumpStore.size());
-  for (auto &kv : gDumpStore) {
+  EJIT_DIAG_RAW("print_dumped_module saved entries=%u", (unsigned)Store.size());
+  for (auto &kv : Store) {
     printOneModuleDumpSafe(nullptr, kv.first, kv.second);
     ejitDiagPrintThrottle();
   }
@@ -602,6 +669,10 @@ EJitOrcEngine::~EJitOrcEngine() = default;
 Expected<std::unique_ptr<EJitOrcEngine>>
 EJitOrcEngine::Create(const Config &config, PeriodArrayRegistry &periodReg,
                       EJitRuntimeState &runtimeState) {
+  // This is intentionally inside Create rather than EJit::EJit: shared-async
+  // peers never create an engine, while the fixed worker owner initializes the
+  // LLVM backend before ordinary, Tier-1, or Tier-2 compilation can begin.
+  initializeEJitTargets();
   EJIT_DIAG_VERBOSE("create: opt=%d dump=%s", static_cast<int>(config.optLevel),
                     config.dumpJITDir.empty() ? "(off)"
                                               : config.dumpJITDir.c_str());
@@ -794,7 +865,7 @@ EJitOrcEngine::Create(const Config &config, PeriodArrayRegistry &periodReg,
           // ejit_print_dumped(). Bare-metal-safe (strings only, no
           // raw_fd_ostream). Captures the post-optimization IR and the emitted
           // assembly (from the same TargetMachine the JIT compiles with).
-          // Capture is exact-name only. The local gDumpStore keeps one dynamic
+          // Capture is exact-name only. The local dump store keeps one dynamic
           // IR/ASM payload per captured function name (overwritten on
           // re-compile); the shared dump table keeps cross-core visible dynamic
           // payloads for recent captures.
@@ -813,7 +884,7 @@ EJitOrcEngine::Create(const Config &config, PeriodArrayRegistry &periodReg,
                             ctx->fnName.c_str(),
                             (uint32_t)(ctx->cacheKey >> 32),
                             (uint32_t)(ctx->cacheKey & 0xffffffffu),
-                            match ? 1 : 0, (void *)&gDumpFuncFilter);
+                            match ? 1 : 0, (void *)&dumpFuncFilter());
             if (match) {
               // IR capture always runs first so it succeeds even if the ASM
               // diagnostic path is disabled or fails. Capture only the entry

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitPgoTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitPgoTest.cpp
@@ -25,7 +25,6 @@
 #include "llvm/ProfileData/InstrProfWriter.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/TargetSelect.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "gtest/gtest.h"
 #include <atomic>
@@ -875,10 +874,8 @@ TEST(EJitPgo, OrcLookupAndRealAddrProfileMerge) {
   }
   ASSERT_FALSE(bitcode.empty());
 
-  // Engine + Tier-1 (Instrumented) compile. Initialize the native target
-  // (EJit.cpp does this in ejit_init; a direct engine construct must too).
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
+  // Engine + Tier-1 (Instrumented) compile. Create owns target registration,
+  // matching the worker-only initialization path used by shared online PGO.
   EJitRuntimeState state;
   Config cfg;
   auto engineOrErr = EJitOrcEngine::Create(cfg, state.getRegistry(), state);
@@ -961,8 +958,6 @@ TEST(EJitPgo, Tier1ToTier2FullCycle) {
   }
   ASSERT_FALSE(bitcode.empty());
 
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
   EJitRuntimeState state;
   Config cfg;
   auto engineOrErr = EJitOrcEngine::Create(cfg, state.getRegistry(), state);

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -40,7 +40,6 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gtest/gtest.h"
 #ifndef EJIT_FREESTANDING
@@ -95,10 +94,10 @@ TEST(EJitDump, DumpAllKeepsEachIndependentlyCompiledEntry) {
     OS.flush();
   }
 
-  llvm::InitializeNativeTarget();
-  llvm::InitializeNativeTargetAsmPrinter();
   EJitRuntimeState State;
   Config Cfg;
+  // Direct engine creation owns target registration just like the shared
+  // worker-owner path; callers and producer-only EJit instances do not.
   auto EngineOrErr = EJitOrcEngine::Create(Cfg, State.getRegistry(), State);
   ASSERT_TRUE(static_cast<bool>(EngineOrErr));
   auto Engine = std::move(*EngineOrErr);


### PR DESCRIPTION
## Summary

- move LLVM target registration from every `EJit` facade into `EJitOrcEngine::Create`, so shared-async producer cores attach without initializing the LLVM backend
- make the worker-local dump mutex/filter/store lazy function statics, removing `EJitOrcEngine.cpp` startup dynamic constructors from peer cores
- document the fixed-worker deployment contract, including `forceStaticRegistry=true`, Sync/non-shared exclusions, and online-PGO Tier-1/Tier-2 behavior
- update direct ORC tests so engine creation owns target registration

## Flow change

Before:

`LLVM init-array -> ejit_init -> target registration on every core -> owner election -> ORC only on owner`

After:

- producer: `ejit_init(forceStaticRegistry=true) -> registry fixup -> shared attach`
- fixed worker: `LLVM init-array -> ejit_init -> owner election -> ORC create -> target registration -> worker start`

Baseline, online-PGO Tier-1, and Tier-2 continue to share the same owner-private ORC engine. The AArch64 BE preset already pins the worker to core 6; open election remains unsupported when only one core prepares LLVM.

## Verification

- changed `EJit.cpp` and `EJitOrcEngine.cpp` compile successfully with the existing host LLVM build
- `EJitOrcEngine.cpp.obj`: no `GLOBAL__sub_I`, `.init_array`, or `CRT$XCU`
- PGO integration build (`-j2`) succeeds for `EJITTests`, `EJITSharedTaskPoolTests`, and `EJITValueProfileTests`
- `EJITValueProfileTests`: 11/11 pass
- PGO integration A/B: `EJITTests` is 134/140 both before and after; the same six pre-existing tests fail
- shared-taskpool A/B: 161/166 both before and after; the same five pre-existing code-sharing tests fail

## 中文说明

本 PR 让非 worker 核在 shared-async + 固定 worker 的部署下跳过 LLVM/EJIT 专用 init-array：非 worker 仍正常执行 `ejit_init` 和静态注册表回填，但不再注册 LLVM Target 或创建 ORC；普通 JIT、PGO Tier-1/Tier-2 的 LLVM 初始化和编译均只发生在固定 worker 核。Sync、非共享 async、开放 owner 竞选不适用该优化。