### PR TITLE
[EJIT] Fix unused-dim warning false positives on value-use and bound_ptr dims

### DIFF
--- a/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitPassOptions.cpp
@@ -31,8 +31,9 @@ cl::opt<bool> EJitWarnNoSpecialization(
 cl::opt<bool> EJitWarnUnusedDim(
     "ejit-warn-unused-dim", cl::init(true), cl::Hidden,
     cl::desc("Warn when an ejit_entry declares ejit_period_arr_ind(P) but its "
-             "specialization closure never indexes an ejit_period_arr(P) "
-             "(unused specialization dimension)."));
+             "specialization closure neither reads that parameter nor "
+             "indexes an ejit_period_arr(P), and no ejit_bound_ptr is bound "
+             "to P (unused specialization dimension)."));
 
 // Optional info-level report (not a warning): per ejit_entry, count the
 // ejit_may_const reads in its specialization closure and how many sit inside

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -408,7 +408,12 @@ struct EjitFuncDiagInfo {
 /// metadata survived clone + preOptimize).
 struct EjitEntryDiag {
   std::string Name;
-  SmallVector<std::string, 4> DeclaredDims;
+  // (period name, parameter index) per ejit_period_arr_ind declaration.
+  SmallVector<std::pair<std::string, unsigned>, 4> DeclaredDims;
+  // Period names an ejit_bound_ptr parameter is bound to. EJitWrapperGen
+  // requires exactly one matching ejit_period_arr_ind for each, so the
+  // dimension cannot be removed - #2 must not advise removing it.
+  SmallVector<std::string, 4> BoundPtrPeriods;
 };
 
 } // namespace
@@ -490,8 +495,9 @@ computeEjitFuncDiagInfo(Function &F, EjitFuncDiagInfo &Info, unsigned MayConstKi
 /// AOT specialization diagnostics on the extracted bitcode (post-preOptimize),
 /// which is exactly what the JIT will specialize.
 ///   #1: ejit_entry whose specialization closure reads no ejit_may_const field.
-///   #2: ejit_entry that declares ejit_period_arr_ind(P) but its closure never
-///       indexes an ejit_period_arr(P).
+///   #2: ejit_entry that declares ejit_period_arr_ind(P) but whose closure
+///       neither reads that parameter nor indexes an ejit_period_arr(P), and
+///       has no ejit_bound_ptr bound to P.
 /// The closure is the direct-call reachability within the extracted module.
 /// External calls (declarations) and indirect calls (function pointers) do NOT
 /// count: the JIT cannot inline them, so their may_const reads never enter this
@@ -513,10 +519,21 @@ runSpecializationDiagnostic(Module &Extracted,
         if (!Sub || Sub->getNumOperands() < 2)
           continue;
         auto *Tag = dyn_cast<MDString>(Sub->getOperand(0));
-        if (!Tag || Tag->getString() != TAG_EJIT_PERIOD_ARR_IND)
+        if (!Tag)
           continue;
-        if (auto *PN = dyn_cast<MDString>(Sub->getOperand(1)))
-          ED.DeclaredDims.push_back(PN->getString().str());
+        if (Tag->getString() == TAG_EJIT_PERIOD_ARR_IND) {
+          if (Sub->getNumOperands() < 3)
+            continue;
+          auto *PN = dyn_cast<MDString>(Sub->getOperand(1));
+          auto *IdxC = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
+          if (PN && IdxC)
+            ED.DeclaredDims.push_back(
+                {PN->getString().str(),
+                 static_cast<unsigned>(IdxC->getZExtValue())});
+        } else if (Tag->getString() == TAG_EJIT_BOUND_PTR) {
+          if (auto *PN = dyn_cast<MDString>(Sub->getOperand(1)))
+            ED.BoundPtrPeriods.push_back(PN->getString().str());
+        }
       }
     Entries.push_back(std::move(ED));
   }
@@ -583,16 +600,32 @@ runSpecializationDiagnostic(Module &Extracted,
                 "closure; no JIT specialization value, consider removing "
                 "ejit_entry\n";
 
-    // #2: declared dimension never referenced by the closure.
+    // #2: declared dimension neither consumed by the JIT nor required by
+    // another mechanism. The runtime substitutes the index parameter with
+    // the current period value and folds EVERY use
+    // (EJitOptimizer::preReplacePeriodIndices), so a parameter read anywhere
+    // in the closure - plain arithmetic, not just period-array indexing - is
+    // a real specialization use. The dimension is also used when the closure
+    // references the period array: its folded may_const values are refreshed
+    // by recompiling when the dimension's period advances. And a dimension
+    // bound to an ejit_bound_ptr parameter must stay declared: EJitWrapperGen
+    // rejects a bound pointer without exactly one matching dimension. Warn
+    // only when none of these hold.
     if (EJitWarnUnusedDim)
-      for (const std::string &P : ED.DeclaredDims)
-        if (RefIt->second.count(P) == 0)
-          errs() << "EJit warning: ejit_entry function '" << EF->getName()
-                 << "' declares ejit_period_arr_ind('" << P
-                 << "') but its specialization closure never indexes an "
-                    "ejit_period_arr('"
-                 << P << "'); unused specialization dimension, consider "
-                        "removing it\n";
+      for (const auto &[P, ArgIdx] : ED.DeclaredDims) {
+        if (is_contained(ED.BoundPtrPeriods, P))
+          continue;
+        if (RefIt->second.count(P) != 0)
+          continue;
+        if (ArgIdx < EF->arg_size() && !EF->getArg(ArgIdx)->use_empty())
+          continue;
+        errs() << "EJit warning: ejit_entry function '" << EF->getName()
+               << "' declares ejit_period_arr_ind('" << P
+               << "') but its specialization closure neither reads that "
+                  "parameter nor indexes an ejit_period_arr('"
+               << P << "'); unused specialization dimension, consider "
+                          "removing it\n";
+      }
   }
 
   // Per-entry may_const read counts over the specialization closure (BFS).

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-diag-unused-dim.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-diag-unused-dim.ll
@@ -1,15 +1,25 @@
 ; RUN: opt -passes=ejit-register-bitcode -S %s 2>&1 | FileCheck %s
 ; RUN: opt -passes=ejit-register-bitcode -ejit-warn-unused-dim=false -S %s 2>&1 | FileCheck %s --check-prefix=OFF
 
-; #2: an ejit_entry that declares ejit_period_arr_ind(P) but whose closure
-; never indexes an ejit_period_arr(P) has an unused specialization dimension.
+; #2: an ejit_entry that declares ejit_period_arr_ind(P) but whose
+; specialization closure neither reads that parameter nor indexes an
+; ejit_period_arr(P), and has no ejit_bound_ptr bound to P, has an unused
+; specialization dimension.
 
-; CHECK: EJit warning: ejit_entry function 'entry_unused_cell' declares ejit_period_arr_ind('cell') but its specialization closure never indexes an ejit_period_arr('cell')
+; The classic shape: the cell dimension's parameter is dead and no closure
+; function touches cell_data (only trp_data, the other dimension).
+; CHECK: EJit warning: ejit_entry function 'entry_unused_cell' declares ejit_period_arr_ind('cell') but its specialization closure neither reads that parameter nor indexes an ejit_period_arr('cell')
 
-; The used dim (trp) on the same function must NOT warn, and an entry that does
-; index its declared dim must NOT warn.
+; A dimension that is used in ANY form must NOT warn: parameter read (even as
+; a plain value - the runtime substitutes the index parameter with a constant
+; and folds every use), period array referenced, or bound to an
+; ejit_bound_ptr parameter (EJitWrapperGen hard-requires a matching
+; dimension, so removing it is a compile error).
 ; CHECK-NOT: declares ejit_period_arr_ind('trp')
 ; CHECK-NOT: ejit_entry function 'entry_used' declares ejit_period_arr_ind
+; CHECK-NOT: ejit_entry function 'entry_value_use' declares ejit_period_arr_ind
+; CHECK-NOT: ejit_entry function 'entry_bound_ptr' declares ejit_period_arr_ind
+; CHECK-NOT: ejit_entry function 'entry_const_index' declares ejit_period_arr_ind
 
 ; With the flag off, no #2 warning at all.
 ; OFF-NOT: declares ejit_period_arr_ind
@@ -17,17 +27,48 @@
 @cell_data = global [16 x i32] zeroinitializer, !ejit.metadata !10
 @trp_data = global [8 x i32] zeroinitializer, !ejit.metadata !11
 
-; Declares cell + trp, but only indexes trp_data -> the cell dim is unused.
-; (Still has specialization value via trp, so #1 does not fire either.)
+; Declares cell + trp, but only indexes trp_data and never reads %c -> the
+; cell dim is unused. (Still has specialization value via trp, so #1 does not
+; fire either.)
 define i32 @entry_unused_cell(i32 %c, i32 %t) !ejit.metadata !21 {
   %p = getelementptr [8 x i32], ptr @trp_data, i32 0, i32 %t
   %v = load i32, ptr %p, !ejit.may_const !{}
   ret i32 %v
 }
 
-; Declares cell and indexes cell_data -> dim used, no warning.
+; Declares cell and indexes cell_data with %c -> dim used, no warning.
 define i32 @entry_used(i32 %c) !ejit.metadata !20 {
   %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 %c
+  %v = load i32, ptr %p, !ejit.may_const !{}
+  ret i32 %v
+}
+
+; Both dims' parameters are read as plain values; neither period array is
+; referenced. The runtime folds the substituted index constants into the
+; arithmetic, so both dims are used -> no warning (regression test for the
+; false positive this warning used to emit on value-only uses).
+define i32 @entry_value_use(i32 %c, i32 %t) !ejit.metadata !21 {
+  %p = getelementptr [8 x i32], ptr @trp_data, i32 0, i32 1
+  %m = load i32, ptr %p, !ejit.may_const !{}
+  %x = add i32 %c, %t
+  %s = add i32 %x, %m
+  ret i32 %s
+}
+
+; The cell dim's parameter is dead and cell_data is never referenced, but an
+; ejit_bound_ptr parameter is bound to cell: EJitWrapperGen requires exactly
+; one matching ejit_period_arr_ind, so the dim cannot be removed -> no
+; warning.
+define i32 @entry_bound_ptr(i32 %c, ptr %p) !ejit.metadata !22 {
+  %v = load i32, ptr %p, !ejit.may_const !{}
+  ret i32 %v
+}
+
+; The cell dim's parameter is dead, but the closure still reads cell_data at
+; a constant index: the folded may_const values are refreshed by recompiling
+; when the cell period advances, so the dim stays load-bearing -> no warning.
+define i32 @entry_const_index(i32 %c) !ejit.metadata !20 {
+  %p = getelementptr [16 x i32], ptr @cell_data, i32 0, i32 2
   %v = load i32, ptr %p, !ejit.may_const !{}
   ret i32 %v
 }
@@ -36,3 +77,4 @@ define i32 @entry_used(i32 %c) !ejit.metadata !20 {
 !11 = distinct !{!{!"ejit_period_arr", !"trp", i32 8}, !{!"ejit_may_const_field", i32 0}}
 !20 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}}
 !21 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_period_arr_ind", !"trp", i32 1}}
+!22 = distinct !{!{!"ejit_entry"}, !{!"ejit_period_arr_ind", !"cell", i32 0}, !{!"ejit_bound_ptr", !"cell", i32 1, i64 4}}


### PR DESCRIPTION
## Problem

PASS1 diagnostic #2 (`-ejit-warn-unused-dim`) warned whenever an `ejit_entry` declared `ejit_period_arr_ind(P)` but its specialization closure never referenced the `ejit_period_arr(P)`` global:

```
EJit warning: ejit_entry function 'bound_cell_config' declares ejit_period_arr_ind('cell') but its specialization closure never indexes an ejit_period_arr('cell'); unused specialization dimension, consider removing it
```

Two legitimate uses never touch the array, so the warning misfired (e.g. `ejit_bound_ptr_test.c` and `ejit_bound_ptr_sre_multicore_test.c` each emitted 2 false warnings), and its advice was actively harmful in the bound_ptr case.

## Root cause

1. **Value-use dims**: the JIT runtime substitutes the index parameter with the current period value and folds *every* use (`EJitOptimizer::preReplacePeriodIndices`), so a parameter read as a plain value (`+ cellIndex + trpIndex`) is a genuine specialization input. The old criterion only recognized period-array GV references.
2. **bound_ptr-tethered dims**: `EJitWrapperGen` requires exactly one matching `ejit_period_arr_ind` for every `ejit_bound_ptr` parameter (`MatchingDims != 1` → `emitError`); following the warning's "consider removing it" advice is a hard compile error.

## Fix

New criterion — a **strict subset** of the old warning set (no new warnings anywhere):

warn only when the declared dim's parameter is **dead** (`use_empty()` on the post-preOptimize extracted module — the exact bitcode the JIT specializes) **AND** the closure's period-array reference fixpoint has no entry for P **AND** no `ejit_bound_ptr` names P.

Warning text now says the closure "neither reads that parameter nor indexes an ejit_period_arr(P)".

## Changes

- `EJitRegisterBitcode.cpp`: `EjitEntryDiag` tracks (period name, arg index) per declared dimension plus bound_ptr period names; #2 gated on the three-part criterion
- `EJitPassOptions.cpp`: flag description updated
- `ejit-diag-unused-dim.ll`: three new cases pin the suppression paths — `entry_value_use` (value-only use), `entry_bound_ptr` (dead param + bound_ptr tether), `entry_const_index` (dead param + const-index array ref)

## Testing

- EmbeddedJIT lit suite: 46 PASS + 4 pre-existing XFAIL (unchanged)
- Clang EJIT tests (CodeGen/Sema): 18/18 PASS
- Both false-positive repro C tests now compile with zero warnings; the true-positive case (`entry_unused_cell`) still warns
- New criterion verified as a strict subset by reverting the diff and re-building (old code emitted the 2 false warnings; new code does not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
