### PR TITLE
[EJIT] Add may-const benefit density metric

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
@@ -55,6 +55,8 @@ struct EJitMayConstBenefitSample {
   uint64_t removedHitSites = 0;
   uint64_t sampledEntries = 0;
   uint64_t sampleCycles = 0;
+  /// Finalized executable bytes published for this JIT version.
+  uint64_t publishedHotCodeBytes = 0;
 };
 
 struct EJitMayConstBenefitSummary {
@@ -75,6 +77,9 @@ struct EJitMayConstBenefitSummary {
   uint64_t removedHitSites = 0;
   uint64_t sampledEntries = 0;
   uint64_t sampleCycles = 0;
+  uint64_t publishedHotCodeBytes = 0;
+  /// Sum of per-version ceil(publishedHotCodeBytes / 64).
+  uint64_t publishedHotICacheLines = 0;
   /// Average dynamically-reached may_const sites per unique JIT version,
   /// scaled by 1000 so freestanding diagnostics need no floating point.
   uint64_t averageActiveSitesPermille = 0;
@@ -83,6 +88,9 @@ struct EJitMayConstBenefitSummary {
   /// Removed dynamic load executions per million platform timestamp units,
   /// scaled by 1000 for three decimal places.
   uint64_t benefitPerMillionCyclesMilli = 0;
+  /// benefitPerMillionCycles divided by published hot I-cache lines, scaled
+  /// by 1000 for three decimal places.
+  uint64_t entryBenefitDensityMilli = 0;
 };
 
 /// Summarize the branch weights attached by PGOInstrumentationUse. This is a

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
@@ -57,6 +57,9 @@ struct EJitMayConstBenefitSample {
   uint64_t sampleCycles = 0;
   /// Finalized executable bytes published for this JIT version.
   uint64_t publishedHotCodeBytes = 0;
+  /// Fingerprints of non-zero 64-byte executable lines. Used only by the
+  /// diagnostic cross-version Partial JIT audit.
+  std::vector<uint64_t> publishedHotLineFingerprints;
 };
 
 struct EJitMayConstBenefitSummary {
@@ -80,6 +83,14 @@ struct EJitMayConstBenefitSummary {
   uint64_t publishedHotCodeBytes = 0;
   /// Sum of per-version ceil(publishedHotCodeBytes / 64).
   uint64_t publishedHotICacheLines = 0;
+  /// Non-zero executable lines included in the cross-version audit.
+  uint64_t fingerprintedHotICacheLines = 0;
+  /// Line instances whose fingerprint occurs in at least two JIT versions.
+  uint64_t crossVersionMatchingICacheLines = 0;
+  /// Matching line instances beyond one retained copy per fingerprint.
+  uint64_t partialJitCandidateICacheLines = 0;
+  /// partialJitCandidateICacheLines / publishedHotICacheLines, permille.
+  uint64_t partialJitCandidatePermille = 0;
   /// Average dynamically-reached may_const sites per unique JIT version,
   /// scaled by 1000 so freestanding diagnostics need no floating point.
   uint64_t averageActiveSitesPermille = 0;
@@ -101,6 +112,10 @@ analyzeBranchProfiles(const Module &M, const std::string &rootName);
 /// Aggregate unique specialization samples for one EJIT entry.
 EJitMayConstBenefitSummary
 summarizeMayConstBenefits(ArrayRef<EJitMayConstBenefitSample> Samples);
+
+/// Fingerprint non-zero 64-byte executable lines for the Partial JIT audit.
+std::vector<uint64_t>
+fingerprintPublishedHotICacheLines(ArrayRef<uint8_t> CodeBytes);
 
 } // namespace ejit
 } // namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -203,6 +203,17 @@ private:
   /// can use this key to timestamp the Tier-1 sample window exactly at publish.
   uint64_t pendingTier1MayConstKey_ = 0;
   bool hasPendingTier1MayConstKey_ = false;
+  struct PendingMayConstCodeAudit {
+    EJitCompileRequest request{};
+    std::string entry;
+    uint64_t cacheKey = 0;
+    uintptr_t codeStart = 0;
+    uint64_t codeSize = 0;
+  };
+  /// Batch mode may link several Tier-2 versions before publishing them. Keep
+  /// their readable ranges private until the matching publish callback says
+  /// the code is dispatch-visible.
+  std::vector<PendingMayConstCodeAudit> pendingMayConstCodeAudits_;
 #endif
 #ifdef EJIT_SRE_PGO_VALUE_PROFILE
   /// Value-profile capture per cacheKey (EJIT_VALUE_PROFILE.md §5.1): the

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -100,6 +100,11 @@ public:
   /// Returns false when no completed specialization sample is available.
   bool printMayConstRanking() const;
 
+  /// Attach the finalized executable footprint to a completed specialization
+  /// sample. Returns false when the sample is unavailable or audit is off.
+  bool recordMayConstPublishedCodeSize(StringRef Entry, uint64_t CacheKey,
+                                       uint64_t CodeBytes);
+
 private:
   /// Replace ejit_period_arr_ind parameters with their runtime constants.
   void preReplacePeriodIndices(Module &M, const SpecializationContext &ctx);

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -102,8 +102,8 @@ public:
 
   /// Attach the finalized executable footprint to a completed specialization
   /// sample. Returns false when the sample is unavailable or audit is off.
-  bool recordMayConstPublishedCodeSize(StringRef Entry, uint64_t CacheKey,
-                                       uint64_t CodeBytes);
+  bool recordMayConstPublishedCode(StringRef Entry, uint64_t CacheKey,
+                                   const void *CodeStart, uint64_t CodeBytes);
 
 private:
   /// Replace ejit_period_arr_ind parameters with their runtime constants.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -172,6 +172,11 @@ public:
   /// runtime-active sites per specialization.
   bool printMayConstRanking() const;
 
+  /// Attach finalized executable bytes to a completed may_const sample.
+  bool recordMayConstPublishedCodeSize(const std::string &Entry,
+                                       uint64_t CacheKey,
+                                       uint64_t CodeBytes);
+
   /// Register a user-defined external symbol (function or global) that the
   /// JIT can resolve when compiling bitcode modules. Required for bare-metal
   /// environments where dynamic symbol lookup is unavailable.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -173,9 +173,8 @@ public:
   bool printMayConstRanking() const;
 
   /// Attach finalized executable bytes to a completed may_const sample.
-  bool recordMayConstPublishedCodeSize(const std::string &Entry,
-                                       uint64_t CacheKey,
-                                       uint64_t CodeBytes);
+  bool recordMayConstPublishedCode(const std::string &Entry, uint64_t CacheKey,
+                                   const void *CodeStart, uint64_t CodeBytes);
 
   /// Register a user-defined external symbol (function or global) that the
   /// JIT can resolve when compiling bitcode modules. Required for bare-metal

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -463,6 +463,10 @@ void ejit_print_code_pool_stats(void);
 /// Call this explicitly after the audit sampling windows have completed. In a
 /// shared-taskpool build, a non-owner core forwards the request to the
 /// compile-owner worker and waits for printing to finish.
+/// The same rows include a Partial JIT audit based on matching non-zero
+/// 64-byte code fingerprints across different versions. Candidate lines are
+/// diagnostic evidence, not guaranteed extractable savings; relocations and
+/// shifted code may cause the audit to undercount similar regions.
 void ejit_print_mayconst_ranking(void);
 
 /// Print the currently-active time-window instances through the platform log:

--- a/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
@@ -2,11 +2,14 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitBranchProfile.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/ProfDataUtils.h"
+#include "llvm/Support/xxhash.h"
 
 #include <algorithm>
 #include <limits>
@@ -63,6 +66,27 @@ uint64_t scaledRatioWithProductDenominator(uint64_t Numerator,
 
 } // namespace
 
+std::vector<uint64_t> llvm::ejit::fingerprintPublishedHotICacheLines(
+    ArrayRef<uint8_t> CodeBytes) {
+  std::vector<uint64_t> Fingerprints;
+  Fingerprints.reserve(CodeBytes.size() / EJitICacheLineBytes +
+                       (CodeBytes.size() % EJitICacheLineBytes != 0));
+  for (size_t Offset = 0; Offset < CodeBytes.size();
+       Offset += EJitICacheLineBytes) {
+    const size_t LineSize =
+        std::min<size_t>(EJitICacheLineBytes, CodeBytes.size() - Offset);
+    ArrayRef<uint8_t> Line = CodeBytes.slice(Offset, LineSize);
+    if (std::all_of(Line.begin(), Line.end(),
+                    [](uint8_t Byte) { return Byte == 0; }))
+      continue;
+    uint64_t Fingerprint = xxHash64(Line);
+    // Keep a short tail distinct from an equal prefix of a full cache line.
+    Fingerprint ^= static_cast<uint64_t>(LineSize) * 0x9e3779b97f4a7c15ULL;
+    Fingerprints.push_back(Fingerprint);
+  }
+  return Fingerprints;
+}
+
 EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
     ArrayRef<EJitMayConstBenefitSample> Samples) {
   EJitMayConstBenefitSummary Summary;
@@ -71,6 +95,11 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
     return Summary;
 
   bool First = true;
+  struct FingerprintCounts {
+    uint64_t occurrences = 0;
+    uint64_t versions = 0;
+  };
+  DenseMap<uint64_t, FingerprintCounts> Fingerprints;
   for (const EJitMayConstBenefitSample &Sample : Samples) {
     Summary.inputMayConstLoads =
         saturatingAdd(Summary.inputMayConstLoads, Sample.inputMayConstLoads);
@@ -95,6 +124,15 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
         (Sample.publishedHotCodeBytes % EJitICacheLineBytes != 0);
     Summary.publishedHotICacheLines = saturatingAdd(
         Summary.publishedHotICacheLines, VersionICacheLines);
+    DenseSet<uint64_t> SeenInVersion;
+    for (uint64_t Fingerprint : Sample.publishedHotLineFingerprints) {
+      Summary.fingerprintedHotICacheLines =
+          saturatingAdd(Summary.fingerprintedHotICacheLines, 1);
+      FingerprintCounts &Counts = Fingerprints[Fingerprint];
+      Counts.occurrences = saturatingAdd(Counts.occurrences, 1);
+      if (SeenInVersion.insert(Fingerprint).second)
+        Counts.versions = saturatingAdd(Counts.versions, 1);
+    }
     const int64_t Removed = static_cast<int64_t>(Sample.inputMayConstLoads) -
                             static_cast<int64_t>(Sample.finalMayConstLoads);
     if (First) {
@@ -126,6 +164,18 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
   Summary.entryBenefitDensityMilli = scaledRatioWithProductDenominator(
       Summary.removedRuntimeHits, Summary.sampleCycles,
       Summary.publishedHotICacheLines, 1000000000);
+  for (const auto &Entry : Fingerprints) {
+    const FingerprintCounts &Counts = Entry.second;
+    if (Counts.versions < 2)
+      continue;
+    Summary.crossVersionMatchingICacheLines = saturatingAdd(
+        Summary.crossVersionMatchingICacheLines, Counts.occurrences);
+    Summary.partialJitCandidateICacheLines = saturatingAdd(
+        Summary.partialJitCandidateICacheLines, Counts.occurrences - 1);
+  }
+  Summary.partialJitCandidatePermille =
+      scaledRatio(Summary.partialJitCandidateICacheLines,
+                  Summary.publishedHotICacheLines, 1000);
   if (Summary.inputMayConstLoads != 0)
     Summary.weightedRemovedPermille =
         Summary.totalRemoved * 1000 /

--- a/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
@@ -16,6 +16,8 @@ using namespace llvm::ejit;
 
 namespace {
 
+constexpr uint64_t EJitICacheLineBytes = 64;
+
 uint64_t ceilPercent(uint64_t Total, uint32_t Percent) {
   return (Total / 100) * Percent + ((Total % 100) * Percent + 99) / 100;
 }
@@ -37,6 +39,23 @@ uint64_t scaledRatio(uint64_t Numerator, uint64_t Denominator,
   Wide *= APInt(129, Scale);
   Wide += APInt(129, Denominator / 2);
   Wide = Wide.udiv(APInt(129, Denominator));
+  if (Wide.getActiveBits() > 64)
+    return std::numeric_limits<uint64_t>::max();
+  return Wide.getZExtValue();
+}
+
+uint64_t scaledRatioWithProductDenominator(uint64_t Numerator,
+                                           uint64_t DenominatorL,
+                                           uint64_t DenominatorR,
+                                           uint64_t Scale) {
+  if (DenominatorL == 0 || DenominatorR == 0)
+    return 0;
+  APInt Denominator(192, DenominatorL);
+  Denominator *= APInt(192, DenominatorR);
+  APInt Wide(192, Numerator);
+  Wide *= APInt(192, Scale);
+  Wide += Denominator.lshr(1);
+  Wide = Wide.udiv(Denominator);
   if (Wide.getActiveBits() > 64)
     return std::numeric_limits<uint64_t>::max();
   return Wide.getZExtValue();
@@ -69,6 +88,13 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
         saturatingAdd(Summary.sampledEntries, Sample.sampledEntries);
     Summary.sampleCycles =
         saturatingAdd(Summary.sampleCycles, Sample.sampleCycles);
+    Summary.publishedHotCodeBytes = saturatingAdd(
+        Summary.publishedHotCodeBytes, Sample.publishedHotCodeBytes);
+    const uint64_t VersionICacheLines =
+        Sample.publishedHotCodeBytes / EJitICacheLineBytes +
+        (Sample.publishedHotCodeBytes % EJitICacheLineBytes != 0);
+    Summary.publishedHotICacheLines = saturatingAdd(
+        Summary.publishedHotICacheLines, VersionICacheLines);
     const int64_t Removed = static_cast<int64_t>(Sample.inputMayConstLoads) -
                             static_cast<int64_t>(Sample.finalMayConstLoads);
     if (First) {
@@ -97,6 +123,9 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
       scaledRatio(Summary.removedRuntimeHits, Summary.sampledEntries, 1000);
   Summary.benefitPerMillionCyclesMilli = scaledRatio(
       Summary.removedRuntimeHits, Summary.sampleCycles, 1000000000);
+  Summary.entryBenefitDensityMilli = scaledRatioWithProductDenominator(
+      Summary.removedRuntimeHits, Summary.sampleCycles,
+      Summary.publishedHotICacheLines, 1000000000);
   if (Summary.inputMayConstLoads != 0)
     Summary.weightedRemovedPermille =
         Summary.totalRemoved * 1000 /

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -8,6 +8,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include <cassert>
+#include <cstring>
 #ifndef EJIT_FREESTANDING
 #include "llvm/ExecutionEngine/EJIT/EJitLogger.h"
 #endif
@@ -31,6 +32,24 @@ using namespace llvm::ejit;
 
 #ifdef EJIT_SRE_TASKPOOL
 namespace {
+#if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
+bool sameAuditRequest(const EJitCompileRequest &L,
+                      const EJitCompileRequest &R) {
+  if (L.funcIndex != R.funcIndex || L.numDims != R.numDims ||
+      L.fallbackPtr != R.fallbackPtr || L.generation != R.generation ||
+      L.boundArgIndex != R.boundArgIndex || L.boundSize != R.boundSize ||
+      L.boundSize > EJIT_BOUND_PTR_MAX_BYTES)
+    return false;
+  for (uint32_t I = 0; I < 4; ++I)
+    if (L.dims[I].dimType != R.dims[I].dimType ||
+        L.dims[I].instanceId != R.dims[I].instanceId ||
+        L.versions[I] != R.versions[I])
+      return false;
+  return L.boundSize == 0 ||
+         std::memcmp(L.boundData, R.boundData, L.boundSize) == 0;
+}
+#endif
+
 /// Adapter so the taskpool can call back into the driver's cold compile path
 /// through a plain function pointer (never std::function). The produced JIT
 /// pointer still comes from the OrcJIT engine (SRE code pool when enabled).
@@ -805,12 +824,22 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
 
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE) &&         \
     defined(EJIT_SRE_CODE_POOL)
-  // Mainline publishes one executable range without a separate cold section,
-  // so its finalized code footprint is the current hot-code approximation.
+  // The current pipeline emits one executable range without a separate cold
+  // section, so its finalized footprint is the hot-code approximation.
   EJitCompiledCodeInfo CodeInfo;
-  if (jitEngine_->findCodeRange(funcPtr, CodeInfo))
-    (void)jitEngine_->recordMayConstPublishedCodeSize(
-        funcName, cacheKey, CodeInfo.codeSize);
+  if (ctx.tier != CompileTier::Instrumented &&
+      jitEngine_->findCodeRange(funcPtr, CodeInfo)) {
+    if (request) {
+      pendingMayConstCodeAudits_.push_back(
+          {*request, funcName, cacheKey, CodeInfo.codeStart,
+           CodeInfo.codeSize});
+    } else {
+      (void)jitEngine_->recordMayConstPublishedCode(
+          funcName, cacheKey,
+          reinterpret_cast<const void *>(CodeInfo.codeStart),
+          CodeInfo.codeSize);
+    }
+  }
 #endif
 
   EJIT_DIAG("compile OK key=0x%016lx func=%s → pfn=%p", cacheKey,
@@ -900,6 +929,19 @@ void *EJitCompileDriver::compileNow(const EJitCompileRequest &req) {
 void EJitCompileDriver::notifyTaskpoolPublished(const EJitCompileRequest &req,
                                                 bool published) {
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
+  auto CodeAudit = llvm::find_if(
+      pendingMayConstCodeAudits_, [&](const PendingMayConstCodeAudit &Pending) {
+        return sameAuditRequest(Pending.request, req);
+      });
+  if (CodeAudit != pendingMayConstCodeAudits_.end()) {
+    if (published && jitEngine_)
+      (void)jitEngine_->recordMayConstPublishedCode(
+          CodeAudit->entry, CodeAudit->cacheKey,
+          reinterpret_cast<const void *>(CodeAudit->codeStart),
+          CodeAudit->codeSize);
+    pendingMayConstCodeAudits_.erase(CodeAudit);
+  }
+
   const uint32_t AuditTier = decodeReqTier(req.funcIndex);
   if (AuditTier == kEJitTierInstrumented) {
     if (published && hasPendingTier1MayConstKey_) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -803,6 +803,16 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
   if (ctx.tier == CompileTier::PGOUse)
     tier1Counters_.erase(cacheKey);
 
+#if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE) &&         \
+    defined(EJIT_SRE_CODE_POOL)
+  // Mainline publishes one executable range without a separate cold section,
+  // so its finalized code footprint is the current hot-code approximation.
+  EJitCompiledCodeInfo CodeInfo;
+  if (jitEngine_->findCodeRange(funcPtr, CodeInfo))
+    (void)jitEngine_->recordMayConstPublishedCodeSize(
+        funcName, cacheKey, CodeInfo.codeSize);
+#endif
+
   EJIT_DIAG("compile OK key=0x%016lx func=%s → pfn=%p", cacheKey,
             funcName.c_str(), funcPtr);
   return funcPtr;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -542,6 +542,34 @@ void EJitOptimizer::recordMayConstBenefit(
 }
 #endif
 
+bool EJitOptimizer::recordMayConstPublishedCodeSize(StringRef Entry,
+                                                    uint64_t CacheKey,
+                                                    uint64_t CodeBytes) {
+#if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
+  uint32_t Expected = 0;
+  while (!mayConstBenefitLock_.compareExchange(Expected, 1))
+    Expected = 0;
+  auto EntryIt = mayConstBenefitSamples_.find(Entry);
+  if (EntryIt == mayConstBenefitSamples_.end()) {
+    mayConstBenefitLock_.storeRelease(0);
+    return false;
+  }
+  auto VersionIt = EntryIt->second.find(CacheKey);
+  if (VersionIt == EntryIt->second.end()) {
+    mayConstBenefitLock_.storeRelease(0);
+    return false;
+  }
+  VersionIt->second.publishedHotCodeBytes = CodeBytes;
+  mayConstBenefitLock_.storeRelease(0);
+  return true;
+#else
+  (void)Entry;
+  (void)CacheKey;
+  (void)CodeBytes;
+  return false;
+#endif
+}
+
 bool EJitOptimizer::printMayConstRanking() const {
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
   struct RankingRow {
@@ -596,8 +624,11 @@ bool EJitOptimizer::printMayConstRanking() const {
     const uint64_t RemovedPerEntry =
         Row.summary.removedHitsPerEntryPermille;
     const uint64_t Benefit = Row.summary.benefitPerMillionCyclesMilli;
+    const uint64_t Density = Row.summary.entryBenefitDensityMilli;
     EJIT_DIAG_RAW(
         "rank=%u entry=%s versions=%llu benefit_per_mcycle=%llu.%03llu "
+        "entry_benefit_density=%llu.%03llu hot_code_bytes=%llu "
+        "hot_icache_lines=%llu "
         "removed_per_entry=%llu.%03llu removed_runtime_hits=%llu "
         "sampled_entries=%llu sample_cycles=%llu avg_active_sites=%llu.%03llu "
         "hit_sites=%llu runtime_hits=%llu avg_removed=%lld "
@@ -606,6 +637,10 @@ bool EJitOptimizer::printMayConstRanking() const {
         static_cast<unsigned long long>(Row.summary.versions),
         static_cast<unsigned long long>(Benefit / 1000),
         static_cast<unsigned long long>(Benefit % 1000),
+        static_cast<unsigned long long>(Density / 1000),
+        static_cast<unsigned long long>(Density % 1000),
+        static_cast<unsigned long long>(Row.summary.publishedHotCodeBytes),
+        static_cast<unsigned long long>(Row.summary.publishedHotICacheLines),
         static_cast<unsigned long long>(RemovedPerEntry / 1000),
         static_cast<unsigned long long>(RemovedPerEntry % 1000),
         static_cast<unsigned long long>(Row.summary.removedRuntimeHits),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -542,10 +542,17 @@ void EJitOptimizer::recordMayConstBenefit(
 }
 #endif
 
-bool EJitOptimizer::recordMayConstPublishedCodeSize(StringRef Entry,
-                                                    uint64_t CacheKey,
-                                                    uint64_t CodeBytes) {
+bool EJitOptimizer::recordMayConstPublishedCode(StringRef Entry,
+                                                uint64_t CacheKey,
+                                                const void *CodeStart,
+                                                uint64_t CodeBytes) {
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
+  const auto *Bytes = static_cast<const uint8_t *>(CodeStart);
+  std::vector<uint64_t> Fingerprints;
+  if (Bytes && CodeBytes <= std::numeric_limits<size_t>::max())
+    Fingerprints = fingerprintPublishedHotICacheLines(
+        ArrayRef<uint8_t>(Bytes, static_cast<size_t>(CodeBytes)));
+
   uint32_t Expected = 0;
   while (!mayConstBenefitLock_.compareExchange(Expected, 1))
     Expected = 0;
@@ -560,11 +567,14 @@ bool EJitOptimizer::recordMayConstPublishedCodeSize(StringRef Entry,
     return false;
   }
   VersionIt->second.publishedHotCodeBytes = CodeBytes;
+  VersionIt->second.publishedHotLineFingerprints.assign(Fingerprints.begin(),
+                                                        Fingerprints.end());
   mayConstBenefitLock_.storeRelease(0);
   return true;
 #else
   (void)Entry;
   (void)CacheKey;
+  (void)CodeStart;
   (void)CodeBytes;
   return false;
 #endif
@@ -625,10 +635,14 @@ bool EJitOptimizer::printMayConstRanking() const {
         Row.summary.removedHitsPerEntryPermille;
     const uint64_t Benefit = Row.summary.benefitPerMillionCyclesMilli;
     const uint64_t Density = Row.summary.entryBenefitDensityMilli;
+    const uint64_t PartialJitRatio =
+        Row.summary.partialJitCandidatePermille;
     EJIT_DIAG_RAW(
         "rank=%u entry=%s versions=%llu benefit_per_mcycle=%llu.%03llu "
         "entry_benefit_density=%llu.%03llu hot_code_bytes=%llu "
-        "hot_icache_lines=%llu "
+        "hot_icache_lines=%llu fingerprinted_lines=%llu "
+        "cross_version_matching_lines=%llu partial_jit_candidate_lines=%llu "
+        "partial_jit_candidate_ratio=%llu.%01llu%% "
         "removed_per_entry=%llu.%03llu removed_runtime_hits=%llu "
         "sampled_entries=%llu sample_cycles=%llu avg_active_sites=%llu.%03llu "
         "hit_sites=%llu runtime_hits=%llu avg_removed=%lld "
@@ -641,6 +655,14 @@ bool EJitOptimizer::printMayConstRanking() const {
         static_cast<unsigned long long>(Density % 1000),
         static_cast<unsigned long long>(Row.summary.publishedHotCodeBytes),
         static_cast<unsigned long long>(Row.summary.publishedHotICacheLines),
+        static_cast<unsigned long long>(
+            Row.summary.fingerprintedHotICacheLines),
+        static_cast<unsigned long long>(
+            Row.summary.crossVersionMatchingICacheLines),
+        static_cast<unsigned long long>(
+            Row.summary.partialJitCandidateICacheLines),
+        static_cast<unsigned long long>(PartialJitRatio / 10),
+        static_cast<unsigned long long>(PartialJitRatio % 10),
         static_cast<unsigned long long>(RemovedPerEntry / 1000),
         static_cast<unsigned long long>(RemovedPerEntry % 1000),
         static_cast<unsigned long long>(Row.summary.removedRuntimeHits),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -1259,11 +1259,12 @@ bool EJitOrcEngine::printMayConstRanking() const {
   return P->optimizer && P->optimizer->printMayConstRanking();
 }
 
-bool EJitOrcEngine::recordMayConstPublishedCodeSize(const std::string &Entry,
-                                                    uint64_t CacheKey,
-                                                    uint64_t CodeBytes) {
-  return P->optimizer && P->optimizer->recordMayConstPublishedCodeSize(
-                             Entry, CacheKey, CodeBytes);
+bool EJitOrcEngine::recordMayConstPublishedCode(const std::string &Entry,
+                                                uint64_t CacheKey,
+                                                const void *CodeStart,
+                                                uint64_t CodeBytes) {
+  return P->optimizer && P->optimizer->recordMayConstPublishedCode(
+                             Entry, CacheKey, CodeStart, CodeBytes);
 }
 
 void EJitOrcEngine::addUserSymbol(const std::string &name, void *addr) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -1259,6 +1259,13 @@ bool EJitOrcEngine::printMayConstRanking() const {
   return P->optimizer && P->optimizer->printMayConstRanking();
 }
 
+bool EJitOrcEngine::recordMayConstPublishedCodeSize(const std::string &Entry,
+                                                    uint64_t CacheKey,
+                                                    uint64_t CodeBytes) {
+  return P->optimizer && P->optimizer->recordMayConstPublishedCodeSize(
+                             Entry, CacheKey, CodeBytes);
+}
+
 void EJitOrcEngine::addUserSymbol(const std::string &name, void *addr) {
   P->userSymbols[name] = addr;
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
@@ -131,4 +131,31 @@ TEST(EJitBranchProfile, BenefitScalingRoundsToNearestFixedPoint) {
   EXPECT_EQ(Summary.removedHitsPerEntryPermille, 667u);
 }
 
+TEST(EJitBranchProfile, ComputesBenefitDensityFromPerVersionCacheLines) {
+  EJitMayConstBenefitSample First;
+  First.removedRuntimeHits = 200;
+  First.sampleCycles = 500;
+  First.publishedHotCodeBytes = 65;
+  EJitMayConstBenefitSample Second;
+  Second.removedRuntimeHits = 100;
+  Second.sampleCycles = 500;
+  Second.publishedHotCodeBytes = 64;
+
+  EJitMayConstBenefitSummary Summary =
+      summarizeMayConstBenefits({First, Second});
+  EXPECT_EQ(Summary.publishedHotCodeBytes, 129u);
+  EXPECT_EQ(Summary.publishedHotICacheLines, 3u);
+  EXPECT_EQ(Summary.benefitPerMillionCyclesMilli, 300000000u);
+  EXPECT_EQ(Summary.entryBenefitDensityMilli, 100000000u);
+}
+
+TEST(EJitBranchProfile, ZeroCodeFootprintHasZeroBenefitDensity) {
+  EJitMayConstBenefitSample Sample;
+  Sample.removedRuntimeHits = 100;
+  Sample.sampleCycles = 100;
+  EJitMayConstBenefitSummary Summary = summarizeMayConstBenefits({Sample});
+  EXPECT_EQ(Summary.publishedHotICacheLines, 0u);
+  EXPECT_EQ(Summary.entryBenefitDensityMilli, 0u);
+}
+
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
@@ -158,4 +158,36 @@ TEST(EJitBranchProfile, ZeroCodeFootprintHasZeroBenefitDensity) {
   EXPECT_EQ(Summary.entryBenefitDensityMilli, 0u);
 }
 
+TEST(EJitBranchProfile, AuditsCrossVersionPartialJitCandidates) {
+  EJitMayConstBenefitSample First;
+  First.publishedHotCodeBytes = 5 * 64;
+  First.publishedHotLineFingerprints = {1, 2, 3, 9, 9};
+  EJitMayConstBenefitSample Second;
+  Second.publishedHotCodeBytes = 3 * 64;
+  Second.publishedHotLineFingerprints = {2, 3, 4};
+  EJitMayConstBenefitSample Third;
+  Third.publishedHotCodeBytes = 2 * 64;
+  Third.publishedHotLineFingerprints = {2, 5};
+
+  EJitMayConstBenefitSummary Summary =
+      summarizeMayConstBenefits({First, Second, Third});
+  EXPECT_EQ(Summary.fingerprintedHotICacheLines, 10u);
+  EXPECT_EQ(Summary.crossVersionMatchingICacheLines, 5u);
+  EXPECT_EQ(Summary.partialJitCandidateICacheLines, 3u);
+  EXPECT_EQ(Summary.partialJitCandidatePermille, 300u);
+}
+
+TEST(EJitBranchProfile, FingerprintsPublishedCodeLinesAndSkipsZeroPadding) {
+  std::vector<uint8_t> Code(64 * 3 + 8, 0);
+  std::fill(Code.begin(), Code.begin() + 64, 0x5a);
+  std::fill(Code.begin() + 128, Code.begin() + 192, 0x5a);
+  std::fill(Code.begin() + 192, Code.end(), 0x5a);
+
+  std::vector<uint64_t> Fingerprints =
+      fingerprintPublishedHotICacheLines(Code);
+  ASSERT_EQ(Fingerprints.size(), 3u);
+  EXPECT_EQ(Fingerprints[0], Fingerprints[1]);
+  EXPECT_NE(Fingerprints[0], Fingerprints[2]);
+}
+
 } // namespace


### PR DESCRIPTION
## Summary

- record finalized executable bytes for each completed `entry + cacheKey` may-const sample
- aggregate per-version 64-byte I-cache lines and report `entry_benefit_density`
- compute benefit density with wide integer arithmetic to avoid overflow and intermediate rounding
- audit raw cross-version code duplication as evidence for a future Partial JIT split
- defer audit capture until the taskpool confirms that code is actually published; linked RW/NX Tier-2 code and failed publishes are excluded

Benefit-density formula:

```text
entry_benefit_density =
  (sum(removed_runtime_hits) / sum(sample_cycles) * 1,000,000)
  / sum(published_hot_icache_lines)
```

`ejit_print_mayconst_ranking()` now also reports:

```text
fingerprinted_lines=<non-zero 64B code chunks>
cross_version_matching_lines=<instances present in >=2 versions>
partial_jit_candidate_lines=<matching instances beyond one retained copy>
partial_jit_candidate_ratio=<candidate lines / all published hot I-cache lines>
```

The Partial JIT result is an audit, not a guaranteed saving estimate. It excludes all-zero padding and same-version-only repetition. Relocations and shifted code can make equivalent regions hash differently, so the metric may undercount similarity; extraction control flow and ABI costs can make some reported candidates impractical to share.

The current pipeline has no separate cold executable section, so the finalized executable allocation is used as the hot-code footprint approximation.

## Validation

- `EJitBranchProfileAuditTests`: 8/8 passed, including cross-version aggregation, same-version exclusion, zero-padding exclusion, and short-tail fingerprinting
- syntax-compiled `EJitBranchProfile.cpp`, `EJitOptimizer.cpp`, `EJitOrcEngine.cpp`, and `EJitCompileDriver.cpp` with branch-audit, code-pool, taskpool, and shared-taskpool defines
- executable audit smoke output: `10` fingerprinted lines, `3` candidate lines, `30.0%`
- LLVM 22.1.8 `git-clang-format --diff`: clean
- `git diff --check`