### PR TITLE
[EJIT] Batch and report Tier-2 layout by code address

### DIFF
--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -40,16 +40,17 @@
 
 `EJIT_CODE_POOL_BATCHED_PUBLISH` 只改变 4K 封固模式下的发布时机和纯代码布局。普通
 EJIT 请求先由共享 worker 搬出有界 MPSC 队列，收到显式发布请求后按维度字典序排列
-（第一维 cell、第二维 TRP，最后按函数编号），再依次编译。JITLink allocation 以 16B
-对齐连续写入近端 RW/NX 页面，批量调用 `enable_ex`，随后才把对应函数指针从共享缓存的
-Pending 状态切换为 Ready。未封页的地址不会返回给业务核。
+（第一维 cell、第二维 TRP），同一完整维度组内保持业务触发顺序，再依次编译。
+JITLink allocation 以 16B 对齐连续写入近端 RW/NX 页面，批量调用 `enable_ex`，随后才把
+对应函数指针从共享缓存的 Pending 状态切换为 Ready。未封页的地址不会返回给业务核。
 
 Online-PGO 使用分层发布：Tier-1 立即编译到远端临时池并自动封固、发布，以便马上开始
-采样；达到阈值后，Tier-2 立即编译和 JITLink 到近端池，但保持 RW/NX 且仅保存在 owner
-私有队列中。此时共享 cache 仍保留可执行的 Tier-1 及其 counters，但采样达到阈值后的
-业务调用临时回退 AOT，不再继续承担整模块原子插桩开销；inline cache 仍不填 Tier-1。
-worker 观察到共享编译队列排空后，自动封固整批 Tier-2 页面，并在封固成功后将 cache 和
-inline cache 原子替换为 Tier-2。封固或 cache 发布失败时保留 Tier-1；可调用
+采样；达到阈值后，Tier-2 请求先保存在 owner 私有布局队列中。此时共享 cache 仍保留
+可执行的 Tier-1 及其 counters，但采样达到阈值后的业务调用临时回退 AOT，不再继续承担
+整模块原子插桩开销；inline cache 仍不填 Tier-1。worker 观察到共享编译队列排空后，按
+cell、TRP 和其余维度排列 Tier-2，同一完整维度组内保持业务触发顺序，再依次编译和
+JITLink 到近端池，自动封固整批 Tier-2 页面，并在封固成功后将 cache 和 inline cache
+原子替换为 Tier-2。封固或 cache 发布失败时保留 Tier-1；可调用
 `ejit_publish_pending_code()` 显式重试，不会把不可执行的 Tier-2 地址暴露给业务核。
 批次封固前会把 bump cursor 推到下一页，因此已经 RX 的尾页不会再被写入；含 GOT、数据
 段或要求超过 16B 对齐的 allocation 自动保持原来的 4K 独占布局。
@@ -57,9 +58,9 @@ inline cache 原子替换为 Tier-2。封固或 cache 发布失败时保留 Tier
 普通 EJIT 的发布由业务侧显式调用 `ejit_publish_pending_code()` 触发；Online-PGO Tier-2
 则在编译队列排空时自动触发。接口仍可用于强制发布或失败重试；返回 `EJIT_OK` 时，近端
 pending code 的 `enable_ex`、共享 cache 发布和 inline-cache 回填均已完成。该模式用于
-验证紧凑布局对 I-cache/L3 冲突的影响，默认关闭。普通 EJIT 请求仍按 cell/TRP 排序后才
-分配真实地址；Tier-2 为缩短采样完成后的等待时间而提前 JITLink，其地址顺序由 profile
-完成顺序决定，队列排空发布只批量封固和回填，不会重新排列已写入的 Tier-2 代码。
+验证紧凑布局对 I-cache/L3 冲突的影响，默认关闭。普通 EJIT 和 Tier-2 均在分配真实地址
+前按 cell/TRP 排序；Tier-2 由队列排空自动触发，不要求业务再次调用显式发布接口。Tier-1
+继续使用远端立即池且不参与排序，避免延迟 profile 采集。
 
 显式发布在排空调用前已有请求及执行排序后的 ORC 编译时，仍逐项执行共享 worker 的
 `EJIT_SRE_TASKPOOL_WORKER_THROTTLE_*` 延时。批量发布只改变代码布局和封页时机，不绕过
@@ -625,3 +626,44 @@ peer 准备任一步失败（缺 `enable_rw` callback、`enable_rw`/`enable_ex` 
 `requiresPeerEnableRw`、`writableRanges[]`），Tier-2 覆盖 Tier-1 时不会继承旧可写范围；
 `initSharedStorage`（owner 选举/reinit）把所有 slot 的 writable 元数据与 prepared bit
 清零，generation 不匹配的发布在 commit gate 被拒——stale writable range 不会被新 slot 继承。
+
+## 15. 板端验证 Tier-2 物理排布
+
+`EJIT_CODE_POOL_BATCHED_PUBLISH` 的排序目标是最终常驻 Tier-2 的 **executable
+allocation**，不能只用编译日志中的先后顺序推断。待本轮 Tier-2 全部发布并进入稳定期后，
+在任意已初始化 EJIT 的核调用：
+
+```c
+ejit_set_log_level(EJIT_LOG_VERBOSE);
+ejit_taskpool_print_compiled();
+ejit_set_log_level(EJIT_LOG_INFO);
+```
+
+输出只保留一份 `compiled layout` 列表，按精确的 JIT 入口 `fn` 地址升序排列；
+VERBOSE 额外显示 allocation end、gap/overlap、版本号和 generation：
+
+```text
+compiled layout: 6 entries sorted by fn address
+layout[0] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=n/a pool=near:0 name=FuncA tier=tier2 dims=[0:0]
+layout[1] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=...   pool=near:0 name=FuncB tier=tier2 dims=[0:0]
+layout[2] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=...   pool=near:0 name=FuncC tier=tier2 dims=[0:0]
+layout[3] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=...   pool=near:0 name=FuncA tier=tier2 dims=[0:1]
+```
+
+验证判据：
+
+- 只比较同一个 `pool=near:<id>` 内的条目；跨 pool 地址没有连续性要求。
+- `fn` 全局单调递增；同一个 pool 内 allocation 不得出现 `OVERLAP=`。
+- Tier-2 的 dimensions 应按 `cell -> TRP -> 其余维度` 聚集。
+- 完整 dimensions 相同的条目应保持业务首次触发顺序，例如 `FuncA -> FuncB -> FuncC`。
+- `gap` 允许非零（JITLink 对齐、stub、常量或其他 executable 内容），但异常的大 gap
+  应结合 `ejit_print_code_pool_stats()` 的 `used/wasted/finalized ranges` 继续检查。
+- `fn` 是精确入口符号地址，应位于 `[alloc_start, alloc_end)` 内；`alloc_size` 是整个
+  特化模块的 executable allocation 大小，可能包含 helper、stub 或多个 entry，不是入口
+  函数 symbol 的精确机器码大小。列表顺序用于观察实际入口地址，allocation 范围用于检查
+  code-pool 占用与重叠。
+- 同一 allocation 内有多个入口时显示 `gap=shared_alloc`，不视为重叠错误；
+  `fn_in_alloc=no` 才表示入口地址与 allocation 元数据不一致。
+
+为避免调测本身污染性能数据，只在稳定期采样结束后调用一次，并立即把日志等级恢复为
+`EJIT_LOG_INFO`。

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -48,10 +48,10 @@
 #define EJIT_PERIOD_CONST __attribute__((ejit_period_const))
 #define EJIT_IN_PERIOD(x) __attribute__((ejit_in_period(#x)))
 #define EJIT_IN_PERIOD_ARRAY(x) __attribute__((ejit_in_period_array(#x)))
-#define EJIT_DIM(x)             __attribute__((ejit_dim(#x)))
+#define EJIT_DIM(x) __attribute__((ejit_dim(#x)))
 #define EJIT_BOUND_PTR(x) __attribute__((ejit_bound_ptr(#x)))
-#define EJIT_ENTRY              __attribute__((ejit_entry))
-#define EJIT_PERIOD_GUARD(x)    __attribute__((ejit_period_guard(#x)))
+#define EJIT_ENTRY __attribute__((ejit_entry))
+#define EJIT_PERIOD_GUARD(x) __attribute__((ejit_period_guard(#x)))
 // Old names (aliases — use new macros to avoid double expansion)
 #define ejit_may_const EJIT_PERIOD_CONST
 #define ejit_period(x) EJIT_IN_PERIOD(x)
@@ -360,6 +360,9 @@ void ejit_taskpool_print_stats();
 /// Print every published shared-cache version and its dimensions. Stats builds
 /// also report whether a later taskpool lookup reused each published version;
 /// wrapper inline-cache calls after that first reuse remain intentionally free.
+/// Entries are sorted by the exact JIT function address and include the owning
+/// executable allocation start/end/size. The allocation size may cover helper
+/// code, stubs, or multiple entry symbols; it is not an exact symbol size.
 void ejit_taskpool_print_compiled();
 uint32_t ejit_taskpool_get_worker_core();
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -1319,7 +1319,7 @@ private:
   /// §4.9).
   void runCompile(const EJitCompileRequest &req,
                   bool hasBatchRequestMarker = false);
-  void compilePendingBatchRequests();
+  void compilePendingBatchRequests(bool tier2Only = false);
   bool flushPendingPublishes(bool compileBatchRequests = true);
   bool serviceCodeBatchRequest();
   bool serviceAutoTier2Publish();
@@ -1392,8 +1392,9 @@ private:
   };
   std::vector<PendingBatchCompile> pendingBatchCompiles_;
   std::vector<PendingPublish> pendingPublishes_;
-  /// Armed when Tier-2 links into the near RW/NX pool. Consumed only after the
-  /// owner worker observes the shared compile queue empty.
+  /// Armed when a Tier-2 request enters the owner-private layout batch.
+  /// Consumed only after the owner worker observes the shared compile queue
+  /// empty, sorts all queued Tier-2 requests, and publishes the linked batch.
   bool autoTier2PublishPending_ = false;
   // Inline-cache safety gate: true while the cache is safe to use (no releaser
   // wired - the production default). v2 does no HP-scan retire, so a wired

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -35,8 +35,10 @@
 #ifndef EJIT_SRE_DIAG
 #include <cstdio>
 #endif
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
+#include <vector>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -1804,8 +1806,8 @@ void ejit_taskpool_print_compiled() {
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Unknown)]);
 #ifdef EJIT_STATS_ENABLE
   constexpr bool ReuseTrackingEnabled = true;
-  const uint32_t FinalVersions = count.byTier[kEJitTierBaseline] +
-                                 count.byTier[kEJitTierPgoUse];
+  const uint32_t FinalVersions =
+      count.byTier[kEJitTierBaseline] + count.byTier[kEJitTierPgoUse];
   EJIT_DIAG_RAW("compiled final reuse: post_publish_seen=%u unseen=%u "
                 "(tier1_collecting_excluded=%u)",
                 count.finalPostPublishSeen,
@@ -1819,16 +1821,26 @@ void ejit_taskpool_print_compiled() {
 #endif
   // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
   // each printed line.
+  struct LayoutEntry {
+    uint32_t funcIndex;
+    uint32_t numDims;
+    EJitDimPair dims[kEJitSharedMaxDims];
+    uint32_t versions[kEJitSharedMaxDims];
+    uint8_t tier;
+    uintptr_t fn;
+    uintptr_t codeStart;
+    uint64_t codeSize;
+    uint32_t poolKind;
+    uint32_t poolId;
+    uint32_t generation;
+    uint8_t postPublishSeen;
+  };
   struct PrintCtx {
-    EJitModuleLoader &loader;
-    bool reuseTrackingEnabled;
-  } printCtx{loader, ReuseTrackingEnabled};
+    std::vector<LayoutEntry> layout;
+  } printCtx{{}};
   EJitSharedTaskPool::ForEachCompiledStats st2 = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         PrintCtx &ctx = *static_cast<PrintCtx *>(cbCtx);
-        EJitModuleLoader &ld = ctx.loader;
-        const std::string &name =
-            ld.getFuncNameByFuncIdx(slot.funcIndex);
         // Per the publish protocol: fnPtr is read with acquire only after
         // state==Ready was observed with acquire (forEachCompiled did).
         void *fn = reinterpret_cast<void *>(slot.fnPtr.loadAcquire());
@@ -1837,62 +1849,22 @@ void ejit_taskpool_print_compiled() {
         const uint32_t n = slot.numDims < kEJitSharedMaxDims
                                ? slot.numDims
                                : kEJitSharedMaxDims;
-        // dims=[d:i,...] for the n meaningful pairs, e.g. "1:5" / "1:5,2:7".
-        // Sized for the uint32 worst case: kEJitSharedMaxDims x
-        // ("4294967295:4294967295" = 21) + separators + NUL.
-        char dims[kEJitSharedMaxDims * 21 + (kEJitSharedMaxDims - 1) + 1];
-        char *p = dims;
-        char *end = dims + sizeof(dims);
-        for (uint32_t i = 0; i < n && p < end; ++i)
-          p += snprintf(p, (size_t)(end - p), "%s%u:%u", i ? "," : "",
-                        slot.dims[i].dimType, slot.dims[i].instanceId);
-        if (p >= end)
-          p = end - 1;
-        *p = '\0';
-        const char *PostPublishSeen =
-            !ctx.reuseTrackingEnabled
-                ? "disabled"
-                : (slot.postPublishSeen.loadRelaxed() != 0 ? "yes" : "no");
-        const uint8_t SlotTier = slot.tier.loadRelaxed();
-        const char *Tier = SlotTier == kEJitTierPgoUse ? "tier2"
-                           : SlotTier == kEJitTierInstrumented
-                               ? "tier1-collecting"
-                               : "baseline";
-        const char *PoolKind =
-            slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
-                ? "near"
-                : slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
-                      ? "far"
-                      : "unknown";
-        if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
-          // Same shape for the per-instance version snapshot (uint32 x
-          // kEJitSharedMaxDims + separators + NUL).
-          char ver[kEJitSharedMaxDims * 10 + (kEJitSharedMaxDims - 1) + 1];
-          p = ver;
-          end = ver + sizeof(ver);
-          for (uint32_t i = 0; i < n && p < end; ++i)
-            p += snprintf(p, (size_t)(end - p), "%s%u", i ? "," : "",
-                          slot.versions[i]);
-          if (p >= end)
-            p = end - 1;
-          *p = '\0';
-          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "post_publish_seen=%s ver=[%s] size=%llu "
-                        "pool=%s pool_id=%u "
-                        "gen=%u",
-                        slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PostPublishSeen, ver,
-                        static_cast<unsigned long long>(slot.codeSize),
-                        PoolKind, slot.poolId, slot.generation);
-        } else {
-          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "pool=%s post_publish_seen=%s",
-                        slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PoolKind, PostPublishSeen);
+        LayoutEntry Entry{};
+        Entry.funcIndex = slot.funcIndex;
+        Entry.numDims = n;
+        for (uint32_t i = 0; i < n; ++i) {
+          Entry.dims[i] = slot.dims[i];
+          Entry.versions[i] = slot.versions[i];
         }
-        ejitDiagPrintThrottle();
+        Entry.tier = slot.tier.loadRelaxed();
+        Entry.fn = reinterpret_cast<uintptr_t>(fn);
+        Entry.codeStart = slot.codeStart;
+        Entry.codeSize = slot.codeSize;
+        Entry.poolKind = slot.poolKind;
+        Entry.poolId = slot.poolId;
+        Entry.generation = slot.generation;
+        Entry.postPublishSeen = slot.postPublishSeen.loadRelaxed();
+        ctx.layout.push_back(Entry);
       },
       &printCtx);
   // The summary counted the first walk; if the entry walk itself skipped
@@ -1901,6 +1873,152 @@ void ejit_taskpool_print_compiled() {
   if (st2.skippedBuckets)
     EJIT_DIAG_RAW("compiled: %u buckets skipped during entry walk",
                   st2.skippedBuckets);
+  std::sort(printCtx.layout.begin(), printCtx.layout.end(),
+            [](const LayoutEntry &A, const LayoutEntry &B) {
+              // Ready slots should always have a non-null fnPtr. Keep a corrupt
+              // zero pointer last instead of presenting it as the lowest code
+              // address.
+              if ((A.fn == 0) != (B.fn == 0))
+                return A.fn != 0;
+              if (A.fn != B.fn)
+                return A.fn < B.fn;
+              if (A.codeStart != B.codeStart)
+                return A.codeStart < B.codeStart;
+              return A.funcIndex < B.funcIndex;
+            });
+  EJIT_DIAG_RAW("compiled layout: %zu entries sorted by fn address",
+                printCtx.layout.size());
+  {
+    uintptr_t PreviousStart = 0;
+    uintptr_t PreviousEnd = 0;
+    uint32_t PreviousPoolKind = ~0u;
+    uint32_t PreviousPoolId = ~0u;
+    bool PreviousRangeValid = false;
+    for (size_t Index = 0; Index < printCtx.layout.size(); ++Index) {
+      const LayoutEntry &Entry = printCtx.layout[Index];
+      const std::string &Name = loader.getFuncNameByFuncIdx(Entry.funcIndex);
+      char Dims[kEJitSharedMaxDims * 21 + (kEJitSharedMaxDims - 1) + 1];
+      char *DimPos = Dims;
+      char *DimEnd = Dims + sizeof(Dims);
+      for (uint32_t I = 0; I < Entry.numDims && DimPos < DimEnd; ++I)
+        DimPos += snprintf(DimPos, static_cast<size_t>(DimEnd - DimPos),
+                           "%s%u:%u", I ? "," : "", Entry.dims[I].dimType,
+                           Entry.dims[I].instanceId);
+      if (DimPos >= DimEnd)
+        DimPos = DimEnd - 1;
+      *DimPos = '\0';
+      char Versions[kEJitSharedMaxDims * 10 + (kEJitSharedMaxDims - 1) + 1];
+      char *VersionPos = Versions;
+      char *VersionEnd = Versions + sizeof(Versions);
+      for (uint32_t I = 0; I < Entry.numDims && VersionPos < VersionEnd; ++I)
+        VersionPos +=
+            snprintf(VersionPos, static_cast<size_t>(VersionEnd - VersionPos),
+                     "%s%u", I ? "," : "", Entry.versions[I]);
+      if (VersionPos >= VersionEnd)
+        VersionPos = VersionEnd - 1;
+      *VersionPos = '\0';
+      const char *Tier = Entry.tier == kEJitTierPgoUse ? "tier2"
+                         : Entry.tier == kEJitTierInstrumented
+                             ? "tier1-collecting"
+                             : "baseline";
+      const char *PoolKind =
+          Entry.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
+              ? "near"
+          : Entry.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
+              ? "far"
+              : "unknown";
+      const uintptr_t CodeEnd =
+          Entry.codeStart + static_cast<uintptr_t>(Entry.codeSize);
+      const bool RangeValid = Entry.codeStart != 0 && Entry.codeSize != 0 &&
+                              CodeEnd >= Entry.codeStart;
+      const bool SamePool = PreviousRangeValid &&
+                            PreviousPoolKind == Entry.poolKind &&
+                            PreviousPoolId == Entry.poolId;
+      const bool SameAllocation = SamePool && RangeValid &&
+                                  Entry.codeStart == PreviousStart &&
+                                  CodeEnd == PreviousEnd;
+      const char *FnInAllocation =
+          !RangeValid
+              ? "unknown"
+              : (Entry.fn >= Entry.codeStart && Entry.fn < CodeEnd ? "yes"
+                                                                   : "no");
+      const char *PostPublishSeen =
+          !ReuseTrackingEnabled ? "disabled"
+                                : (Entry.postPublishSeen != 0 ? "yes" : "no");
+      if (gEJitDiagLevel < EJIT_LOG_LVL_VERBOSE) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_size=%llu "
+            "pool=%s:%u funcIdx=%u name=%s tier=%s dims=[%s] "
+            "fn_in_alloc=%s post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(Entry.codeSize), PoolKind,
+            Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims,
+            FnInAllocation, PostPublishSeen);
+      } else if (!SamePool || !RangeValid) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu gap=n/a pool=%s:%u funcIdx=%u name=%s tier=%s "
+            "dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize), PoolKind,
+            Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      } else if (SameAllocation) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu gap=shared_alloc pool=%s:%u funcIdx=%u name=%s "
+            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize), PoolKind,
+            Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      } else if (Entry.codeStart >= PreviousEnd) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu gap=%llu pool=%s:%u funcIdx=%u name=%s tier=%s "
+            "dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize),
+            static_cast<unsigned long long>(Entry.codeStart - PreviousEnd),
+            PoolKind, Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      } else {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu OVERLAP=%llu pool=%s:%u funcIdx=%u name=%s "
+            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize),
+            static_cast<unsigned long long>(PreviousEnd - Entry.codeStart),
+            PoolKind, Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      }
+      PreviousStart = Entry.codeStart;
+      PreviousEnd = CodeEnd;
+      PreviousPoolKind = Entry.poolKind;
+      PreviousPoolId = Entry.poolId;
+      PreviousRangeValid = RangeValid;
+      ejitDiagPrintThrottle();
+    }
+  }
 #else
   EJIT_DIAG_RAW("print_compiled: shared taskpool not enabled");
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -3458,12 +3458,30 @@ void EJitSharedTaskPool::publishCodePoolStats() {
   PublishDetail(state_->codePoolStats.far, s.far);
 }
 
-void EJitSharedTaskPool::compilePendingBatchRequests() {
+void EJitSharedTaskPool::compilePendingBatchRequests(bool tier2Only) {
   if (pendingBatchCompiles_.empty())
     return;
 
+  std::vector<PendingBatchCompile> Batch;
+  if (tier2Only) {
+    std::vector<PendingBatchCompile> Deferred;
+    Batch.reserve(pendingBatchCompiles_.size());
+    Deferred.reserve(pendingBatchCompiles_.size());
+    for (PendingBatchCompile &P : pendingBatchCompiles_) {
+      if (decodeReqTier(P.req.funcIndex) == kEJitTierPgoUse)
+        Batch.push_back(P);
+      else
+        Deferred.push_back(P);
+    }
+    pendingBatchCompiles_.swap(Deferred);
+  } else {
+    Batch.swap(pendingBatchCompiles_);
+  }
+  if (Batch.empty())
+    return;
+
   std::stable_sort(
-      pendingBatchCompiles_.begin(), pendingBatchCompiles_.end(),
+      Batch.begin(), Batch.end(),
       [](const PendingBatchCompile &A, const PendingBatchCompile &B) {
         // Layout specializations lexicographically by dimensions. In the
         // product mapping this is cell first and TRP second; the same rule
@@ -3480,18 +3498,16 @@ void EJitSharedTaskPool::compilePendingBatchRequests() {
           if (A.req.dims[I].instanceId != B.req.dims[I].instanceId)
             return A.req.dims[I].instanceId < B.req.dims[I].instanceId;
         }
-        const uint32_t AFunc = stripReqTier(A.req.funcIndex);
-        const uint32_t BFunc = stripReqTier(B.req.funcIndex);
-        if (AFunc != BFunc)
-          return AFunc < BFunc;
-        return decodeReqTier(A.req.funcIndex) < decodeReqTier(B.req.funcIndex);
+        // stable_sort preserves business trigger order inside one complete
+        // dimension group. Do not reorder that hot call sequence by funcIndex.
+        return false;
       });
 
   [[maybe_unused]] size_t Dim0Groups = 0;
   bool HavePrevious = false;
   bool PreviousHasDim0 = false;
   EJitDimPair Previous{};
-  for (const PendingBatchCompile &P : pendingBatchCompiles_) {
+  for (const PendingBatchCompile &P : Batch) {
     const bool HasDim0 = P.req.numDims != 0;
     const bool Same =
         HavePrevious && HasDim0 == PreviousHasDim0 &&
@@ -3505,8 +3521,6 @@ void EJitSharedTaskPool::compilePendingBatchRequests() {
     PreviousHasDim0 = HasDim0;
   }
 
-  std::vector<PendingBatchCompile> Batch;
-  Batch.swap(pendingBatchCompiles_);
   EJIT_DIAG_DEBUG("shared worker batch layout: requests=%zu dim0Groups=%zu",
                   Batch.size(), Dim0Groups);
   for (const PendingBatchCompile &P : Batch) {
@@ -3632,14 +3646,18 @@ bool EJitSharedTaskPool::serviceAutoTier2Publish() {
   if (!autoTier2PublishPending_ || !state_)
     return false;
   // pollOne() has just observed the queue empty. Re-check both positions so a
-  // Tier-1 request that raced that observation is compiled from the far pool
-  // before the near-pool Tier-2 batch is sealed and published.
+  // Tier-1 request that raced that observation starts sampling before the
+  // near-pool Tier-2 batch is laid out, sealed, and published.
   if (state_->enqueuePos.loadAcquire() != state_->dequeuePos.loadAcquire())
     return false;
 
   autoTier2PublishPending_ = false;
-  EJIT_DIAG("PGO Tier-2 queue drained: auto-publishing %zu linked version(s)",
-            pendingPublishes_.size());
+  compilePendingBatchRequests(/*tier2Only=*/true);
+  EJIT_DIAG_DEBUG(
+      "PGO Tier-2 queue drained: auto-publishing %zu linked version(s)",
+      pendingPublishes_.size());
+  if (pendingPublishes_.empty())
+    return true;
   if (!flushPendingPublishes(/*compileBatchRequests=*/false))
     EJIT_DIAG("PGO Tier-2 auto-publish failed: pending=%zu; explicit publish "
               "may retry",
@@ -3834,7 +3852,6 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
       // compile queue empty and seals the batch. Keep only owner-private state
       // and retain the in-flight claim.
       pendingPublishes_.push_back({req, fn});
-      autoTier2PublishPending_ = true;
       EJIT_DIAG_DEBUG("PGO Tier-2 linked pending queue-drain publish func=%u "
                       "fn=%p pending=%zu",
                       realFuncIndex, fn, pendingPublishes_.size());
@@ -3930,27 +3947,40 @@ bool EJitSharedTaskPool::pollOne() {
     return false;
 
   // All tiers arrive on the same shared MPSC queue. Baseline requests defer
-  // compilation so explicit publication can sort their JITLink allocations.
-  // Tier-1 compiles immediately into the far pool and starts sampling. Tier-2
-  // also compiles immediately, but runCompile retains its near-pool result
-  // owner-private until queue-drain publication replaces the live Tier-1 slot.
+  // compilation until explicit publication. Tier-1 compiles immediately into
+  // the far pool and starts sampling. Tier-2 requests defer until the queue
+  // drains so their final near-pool JITLink allocations can be sorted by cell
+  // and TRP before one enable_ex/cache publication batch.
   EJitCompileRequest Req{};
   if (!queuePop(Req))
     return false;
+  const uint32_t Tier = decodeReqTier(Req.funcIndex);
   if (codeReadyFn_ && codeBatchFlushFn_ &&
-      decodeReqTier(Req.funcIndex) == kEJitTierBaseline) {
-    if (pendingBatchCompiles_.size() >= kEJitSharedQueueSlots) {
+      (Tier == kEJitTierBaseline || Tier == kEJitTierPgoUse)) {
+    // Baseline backlog is bounded by the shared queue capacity. Tier-2 has a
+    // separate hard bound from PGO admission (at most 16 active functions), so
+    // let final optimized code enter even when unpublished baseline work has
+    // consumed the normal layout budget.
+    if (Tier == kEJitTierBaseline &&
+        pendingBatchCompiles_.size() >= kEJitSharedQueueSlots) {
       dedupClear(Req.funcIndex, Req.generation);
       EJIT_STAT_INC(state_->counters.queueFull);
       EJIT_DIAG("shared worker batch backlog full func=%u capacity=%u",
                 stripReqTier(Req.funcIndex), kEJitSharedQueueSlots);
       return true;
     }
+    // Baseline has no live specialization to preserve, so a full-key Pending
+    // marker can release its coarse per-function claim and admit another cell.
+    // Tier-2 must leave the live Tier-1 slot untouched and retain its claim
+    // until the sorted replacement is published.
     const bool Marked =
+        Tier == kEJitTierBaseline &&
         cacheStageBatchRequest(Req) == EJitPublishStatus::Published;
     pendingBatchCompiles_.push_back({Req, Marked});
     if (Marked)
       dedupClear(Req.funcIndex, Req.generation);
+    if (Tier == kEJitTierPgoUse)
+      autoTier2PublishPending_ = true;
     EJIT_DIAG_VERBOSE(
         "shared worker batch queued func=%u dims=%u marker=%u requests=%zu",
         stripReqTier(Req.funcIndex), Req.numDims, static_cast<unsigned>(Marked),

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1071,8 +1071,8 @@ TEST_F(SharedTaskPoolTest, ExplicitBatchPublishDrainsPreexistingQueueFirst) {
 
   EXPECT_EQ(PublishResult.load(std::memory_order_acquire), 1);
   ASSERT_EQ(Batch.compileOrder.size(), 2u);
-  EXPECT_EQ(stripReqTier(Batch.compileOrder[0].funcIndex), 47u);
-  EXPECT_EQ(stripReqTier(Batch.compileOrder[1].funcIndex), 48u);
+  EXPECT_EQ(stripReqTier(Batch.compileOrder[0].funcIndex), 48u);
+  EXPECT_EQ(stripReqTier(Batch.compileOrder[1].funcIndex), 47u);
 #if EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT != 0u &&                            \
     EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS != 0u
   // One queue drain plus two sorted ORC compiles happen inside this publish
@@ -1139,15 +1139,15 @@ TEST_F(SharedTaskPoolTest, BatchPgoTier2AutoPublishesWhenQueueDrains) {
     Owner.releaseRead(Tier1.bucketIndex);
   ASSERT_EQ(Owner.pendingCount(), 1u);
 
-  // Tier-2 compiles and links immediately, but remains owner-private and RW/NX
-  // until the worker observes the compile queue empty. Tier-1 stays allocated
-  // for counter synthesis, but dispatch falls back to AOT once sampling is
-  // complete instead of continuing atomic instrumentation while waiting.
+  // Tier-2 remains owner-private and uncompiled until the worker observes the
+  // queue empty. Tier-1 stays allocated for profile synthesis, but dispatch
+  // falls back to AOT once sampling is complete instead of continuing atomic
+  // instrumentation while waiting.
   ASSERT_TRUE(Owner.pollOne());
   EXPECT_EQ(Batch.flushCalls, 0u);
-  ASSERT_EQ(Batch.compileOrder.size(), 2u);
-  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex), kEJitTierPgoUse);
-  EXPECT_EQ(Owner.pendingPublishCount(), 1u);
+  EXPECT_EQ(Batch.compileOrder.size(), 1u);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 1u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
   EXPECT_EQ(Owner.pendingCount(), 1u);
 
   auto StillTier1 = Owner.tryCacheHit0D(46);
@@ -1161,6 +1161,9 @@ TEST_F(SharedTaskPoolTest, BatchPgoTier2AutoPublishesWhenQueueDrains) {
   ASSERT_TRUE(Owner.flushCodeBatch());
 #endif
   EXPECT_EQ(Batch.flushCalls, 1u);
+  ASSERT_EQ(Batch.compileOrder.size(), 2u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex), kEJitTierPgoUse);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 0u);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
   EXPECT_EQ(Owner.pendingCount(), 0u);
 
@@ -1174,6 +1177,156 @@ TEST_F(SharedTaskPoolTest, BatchPgoTier2AutoPublishesWhenQueueDrains) {
   if (Tier2.hasReadToken)
     Owner.releaseRead(Tier2.bucketIndex);
 }
+
+#ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
+TEST_F(SharedTaskPoolTest, BatchPgoTier2SortsByCellBeforeJitLink) {
+  BatchPublishCtx Batch;
+  Batch.tier1ReadyImmediately = true;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockBatchCompile, &Batch);
+  Owner.setCodeRangeProvider(&mockBatchRange, &Batch);
+  Owner.setCodeBatchCallbacks(&mockBatchReady, &mockBatchFlush, &Batch);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setPgoEnabled(true, 1, /*maxConcurrentProfiles=*/4);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  constexpr uint32_t Funcs[] = {73, 71, 72, 70};
+  constexpr uint32_t Cells[] = {3, 1, 2, 0};
+  for (uint32_t Cell : Cells)
+    Owner.setInstanceEnabled(0, Cell, true);
+
+  for (unsigned I = 0; I != 4; ++I) {
+    EJitDimPair Dims[1] = {dim(0, Cells[I])};
+    ASSERT_EQ(Owner.compileOrGet(Funcs[I], Dims, 1, codeFor(Funcs[I])).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(Owner.pollOne());
+  }
+  ASSERT_EQ(Batch.compileOrder.size(), 4u);
+
+  // Complete profiling in deliberately non-lexicographic cell order.
+  for (unsigned I = 0; I != 4; ++I) {
+    EJitDimPair Dims[1] = {dim(0, Cells[I])};
+    auto Hit = Owner.tryCacheHit(Funcs[I], Dims, 1);
+    ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (Hit.hasReadToken)
+      Owner.releaseRead(Hit.bucketIndex);
+  }
+  ASSERT_EQ(Owner.pendingCount(), 4u);
+
+  for (unsigned I = 0; I != 4; ++I)
+    ASSERT_TRUE(Owner.pollOne());
+  EXPECT_EQ(Batch.compileOrder.size(), 4u)
+      << "Tier-2 must not allocate code before the layout batch is sorted";
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 4u);
+
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  ASSERT_EQ(Batch.compileOrder.size(), 8u);
+  for (unsigned I = 0; I != 4; ++I) {
+    const EJitCompileRequest &Req = Batch.compileOrder[4u + I];
+    EXPECT_EQ(decodeReqTier(Req.funcIndex), kEJitTierPgoUse);
+    ASSERT_EQ(Req.numDims, 1u);
+    EXPECT_EQ(Req.dims[0].instanceId, I);
+  }
+  EXPECT_EQ(Batch.flushCalls, 1u);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 0u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
+}
+
+TEST_F(SharedTaskPoolTest, BatchPgoTier2PreservesCallOrderWithinCell) {
+  BatchPublishCtx Batch;
+  Batch.tier1ReadyImmediately = true;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockBatchCompile, &Batch);
+  Owner.setCodeRangeProvider(&mockBatchRange, &Batch);
+  Owner.setCodeBatchCallbacks(&mockBatchReady, &mockBatchFlush, &Batch);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setPgoEnabled(true, 1, /*maxConcurrentProfiles=*/3);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  Owner.setInstanceEnabled(0, 0, true);
+
+  // Descending funcIndex makes a funcIndex tie-break produce C,B,A. The
+  // expected layout must instead retain the observed A,B,C business order.
+  constexpr uint32_t Funcs[] = {82, 81, 80};
+  EJitDimPair Cell0[1] = {dim(0, 0)};
+  for (uint32_t Func : Funcs) {
+    ASSERT_EQ(Owner.compileOrGet(Func, Cell0, 1, codeFor(Func)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(Owner.pollOne());
+  }
+  ASSERT_EQ(Batch.compileOrder.size(), 3u);
+
+  for (uint32_t Func : Funcs) {
+    auto Hit = Owner.tryCacheHit(Func, Cell0, 1);
+    ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (Hit.hasReadToken)
+      Owner.releaseRead(Hit.bucketIndex);
+  }
+  for (unsigned I = 0; I != 3; ++I)
+    ASSERT_TRUE(Owner.pollOne());
+  ASSERT_EQ(Batch.compileOrder.size(), 3u);
+
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  ASSERT_EQ(Batch.compileOrder.size(), 6u);
+  for (unsigned I = 0; I != 3; ++I) {
+    const EJitCompileRequest &Req = Batch.compileOrder[3u + I];
+    EXPECT_EQ(decodeReqTier(Req.funcIndex), kEJitTierPgoUse);
+    EXPECT_EQ(stripReqTier(Req.funcIndex), Funcs[I]);
+  }
+  EXPECT_EQ(Batch.flushCalls, 1u);
+}
+
+TEST_F(SharedTaskPoolTest, BatchPgoTier2BypassesFullBaselineLayoutBacklog) {
+  BatchPublishCtx Batch;
+  Batch.tier1ReadyImmediately = true;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockBatchCompile, &Batch);
+  Owner.setCodeRangeProvider(&mockBatchRange, &Batch);
+  Owner.setCodeBatchCallbacks(&mockBatchReady, &mockBatchFlush, &Batch);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  uint32_t BaselineCount = 0;
+  for (uint32_t Func = 1000; BaselineCount != kEJitSharedQueueSlots; ++Func) {
+    // Keep bucket zero available for the PGO identity below. The baseline
+    // layout vector still reaches its hard bound even after its other cache
+    // buckets fill and requests fall back to owner-private coarse claims.
+    if (Func % kEJitSharedCacheBuckets == 0)
+      continue;
+    ASSERT_EQ(Owner.compileOrGet(Func, nullptr, 0, codeFor(Func)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(Owner.pollOne());
+    ++BaselineCount;
+  }
+  ASSERT_EQ(Owner.pendingBatchCompileCount(), kEJitSharedQueueSlots);
+  EXPECT_TRUE(Batch.compileOrder.empty());
+
+  Owner.setPgoEnabled(true, 1);
+  constexpr uint32_t PgoFunc = 3008; // hashIdentity(0D) -> bucket zero.
+  ASSERT_EQ(Owner.compileOrGet(PgoFunc, nullptr, 0, codeFor(PgoFunc)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+  ASSERT_EQ(Batch.compileOrder.size(), 1u);
+  auto Hit = Owner.tryCacheHit0D(PgoFunc);
+  ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+  if (Hit.hasReadToken)
+    Owner.releaseRead(Hit.bucketIndex);
+
+  ASSERT_TRUE(Owner.pollOne());
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), kEJitSharedQueueSlots + 1u);
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  ASSERT_EQ(Batch.compileOrder.size(), 2u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder.back().funcIndex),
+            kEJitTierPgoUse);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), kEJitSharedQueueSlots);
+  EXPECT_EQ(Batch.flushCalls, 1u);
+}
+#endif
 
 #ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
 TEST_F(SharedTaskPoolTest, BatchPgoAutoPublishWaitsForQueuedTier1) {
@@ -1204,18 +1357,20 @@ TEST_F(SharedTaskPoolTest, BatchPgoAutoPublishWaitsForQueuedTier1) {
             EJitCompileOrGetStatus::EnqueuedPending);
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
   EXPECT_EQ(Batch.flushCalls, 0u);
-  ASSERT_EQ(Batch.compileOrder.size(), 2u);
-  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex), kEJitTierPgoUse);
+  ASSERT_EQ(Batch.compileOrder.size(), 1u);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 1u);
 
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
   EXPECT_EQ(Batch.flushCalls, 0u);
-  ASSERT_EQ(Batch.compileOrder.size(), 3u);
-  EXPECT_EQ(stripReqTier(Batch.compileOrder[2].funcIndex), 53u);
-  EXPECT_EQ(decodeReqTier(Batch.compileOrder[2].funcIndex),
+  ASSERT_EQ(Batch.compileOrder.size(), 2u);
+  EXPECT_EQ(stripReqTier(Batch.compileOrder[1].funcIndex), 53u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex),
             kEJitTierInstrumented);
 
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
   EXPECT_EQ(Batch.flushCalls, 1u);
+  ASSERT_EQ(Batch.compileOrder.size(), 3u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder[2].funcIndex), kEJitTierPgoUse);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
 }
 
@@ -1255,9 +1410,9 @@ TEST_F(SharedTaskPoolTest, BatchPgoFourTier2CompilesRetainWorkerThrottle) {
   Owner.setWorkerIdleHook(&mockBatchTimelineIdle, &Idle);
   Owner.runWorkerLoop();
 
-  // C=compile, D=worker throttle, F=enable_ex/cache publication. There must be
-  // a scheduling gap between every Tier-2 compile and after publication.
-  EXPECT_EQ(Batch.timeline, "CDCDCDCDFD");
+  // C=compile, D=worker throttle, F=enable_ex/cache publication. Queue staging
+  // retains its scheduling gaps, then every sorted Tier-2 compile does too.
+  EXPECT_EQ(Batch.timeline, "DDDDCDCDCDCDFD");
   EXPECT_EQ(Batch.maxActiveCompiles, 1u);
   EXPECT_EQ(Batch.flushCalls, 1u);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
@@ -1308,7 +1463,7 @@ TEST_F(SharedTaskPoolTest, ExplicitPublishFourTier2CompilesRetainThrottle) {
   Caller.join();
 
   EXPECT_EQ(PublishResult.load(std::memory_order_acquire), 1);
-  EXPECT_EQ(Batch.timeline, "CDCDCDCDF");
+  EXPECT_EQ(Batch.timeline, "DDDDCDCDCDCDF");
   EXPECT_EQ(Batch.maxActiveCompiles, 1u);
   EXPECT_EQ(Batch.flushCalls, 1u);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
@@ -1340,7 +1495,10 @@ TEST_F(SharedTaskPoolTest, BatchPgoTwentyFunctionsRunInFiveThrottledWaves) {
 
   std::string Expected;
   for (unsigned Wave = 0; Wave != 5; ++Wave) {
-    for (unsigned Compile = 0; Compile != 8; ++Compile)
+    for (unsigned Compile = 0; Compile != 4; ++Compile)
+      Expected += "CD";
+    Expected += "DDDD";
+    for (unsigned Compile = 0; Compile != 4; ++Compile)
       Expected += "CD";
     Expected += "FD";
   }
@@ -1373,7 +1531,8 @@ TEST_F(SharedTaskPoolTest, BatchPgoAutoPublishFailureWaitsForExplicitRetry) {
   if (Tier1.hasReadToken)
     Owner.releaseRead(Tier1.bucketIndex);
   ASSERT_TRUE(Owner.pollOne());
-  ASSERT_EQ(Owner.pendingPublishCount(), 1u);
+  ASSERT_EQ(Owner.pendingBatchCompileCount(), 1u);
+  ASSERT_EQ(Owner.pendingPublishCount(), 0u);
 
   Batch.failFlush = true;
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
@@ -1429,7 +1588,10 @@ TEST_F(SharedTaskPoolTest, BatchCompileLayoutSortsFirstThenSecondDimension) {
 
   ASSERT_TRUE(Owner.flushCodeBatch());
   ASSERT_EQ(Batch.compileOrder.size(), 5u);
-  const uint32_t ExpectedFunc[] = {9, 13, 11, 10, 12};
+  // Func 13 reached the identical cell0/trp1 group before func 9. Stable
+  // dimension sorting must retain that business order instead of sorting by
+  // funcIndex.
+  const uint32_t ExpectedFunc[] = {13, 9, 11, 10, 12};
   const uint32_t ExpectedCell[] = {0, 0, 0, 1, 2};
   const uint32_t ExpectedTrp[] = {1, 1, 3, UINT32_MAX, 1};
   for (size_t I = 0; I != Batch.compileOrder.size(); ++I) {


### PR DESCRIPTION
## 中文

### 修改
- Tier-1 继续立即编译到 far pool，不延迟 profiling。
- Tier-2 等共享编译队列排空后，按 `cell -> TRP -> 其余维度` 稳定排序，再在 near pool 中依次 JITLink、批量 `enable_ex` 和发布。
- 相同 dimensions 保持业务触发顺序；baseline backlog 不会饿死 Tier-2，发布失败可显式重试。
- `ejit_taskpool_print_compiled()` 现在只打印一份版本列表，所有日志等级均按精确 JIT 入口 `fn` 地址升序。
- 每项打印 `fn`、`alloc_start`、`alloc_size`、pool、tier、dimensions；VERBOSE 额外打印 `alloc_end`、gap/overlap、versions、generation。
- 同一 allocation 的多个入口标记 `gap=shared_alloc`，不会误报 overlap；`fn_in_alloc` 校验入口是否位于 allocation 范围。

`alloc_size` 是整个 executable allocation 的大小，可能包含 helper、stub 或多个 entry，不是精确 symbol size。

### 验证
- 基于最新 `ejit_dev_spec4` (`a6cbc831b2ec`) 重建 `LLVMEJIT` 成功。
- `EJITSharedTaskPoolTests`: 165/165 passed。
- LLVM 22 clang-format 与 `git diff --check` 通过。
- `EJITCodePoolTests` 源码编译完成，但现有 Windows build 目录因缺失生成的 `windows_version_resource.rc.res` 无法链接；与本次诊断改动无关。

## English

### Changes
- Keep Tier-1 immediate in the far pool so profiling starts without delay.
- Defer Tier-2 until the shared queue drains, stable-sort by `cell -> TRP -> remaining dimensions`, then JITLink and batch-publish into the near pool.
- Preserve business trigger order for identical dimensions; avoid Tier-2 starvation behind baseline backlog and retain explicit retry after publish failure.
- `ejit_taskpool_print_compiled()` now emits one list at every visible log level, sorted by the exact JIT entry `fn` address.
- Print `fn`, `alloc_start`, `alloc_size`, pool, tier, and dimensions; VERBOSE adds `alloc_end`, gap/overlap, versions, and generation.
- Mark multiple entries sharing one allocation as `gap=shared_alloc`; report `fn_in_alloc` to validate range metadata.

`alloc_size` covers the executable allocation and may include helpers, stubs, or multiple entries; it is not an exact symbol size.

### Validation
- Rebuilt `LLVMEJIT` on current `ejit_dev_spec4` (`a6cbc831b2ec`).
- `EJITSharedTaskPoolTests`: 165/165 passed.
- LLVM 22 clang-format and `git diff --check` passed.
- `EJITCodePoolTests` sources compiled, but the existing Windows build tree could not link because its generated `windows_version_resource.rc.res` is missing; unrelated to this diagnostic-only follow-up.