### PR TITLE
[EJIT] Force static registry on fixed-worker builds

### DIFF
--- a/jit_design_doc/EJIT_SRE_TASKPOOL.md
+++ b/jit_design_doc/EJIT_SRE_TASKPOOL.md
@@ -1332,11 +1332,14 @@ Uninitialized ──CAS成功──> Initializing ──(建好全部共享状�
 #### 11.4.1 worker-only LLVM runtime initialization
 
 固定 worker 核的 shared-async 部署允许 producer-only 核跳过 LLVM/EJIT
-专用 `.init_array`：每个核仍必须以 `forceStaticRegistry=true` 调用
-`ejit_init()`，通过静态 registry table 完成本核 wrapper 的 funcIndex、
-lifecycle 和 inline-cache slot 回填；只有指定 worker 核需要在调用
-`ejit_init()` 前完成 LLVM 运行库的 init-array 准备。业务及其它库需要的
-构造函数不属于该豁免范围。
+专用 `.init_array`。固定 worker 构建会在 `ejit_init()` 和
+`ejit_init_pgo()` 内部强制 `forceStaticRegistry=true`；业务可继续调用
+`ejit_init(NULL)`，每个核都会通过静态 registry table 完成本核 wrapper 的
+funcIndex、lifecycle 和 inline-cache slot 回填。调用方传入的
+`forceStaticRegistry=false` 在该构建模式下也会被覆盖，避免 worker 的
+constructor 路径与 producer 的静态路径产生不同 registration fingerprint。
+只有指定 worker 核需要在调用 `ejit_init()` 前完成 LLVM 运行库的
+init-array 准备。业务及其它库需要的构造函数不属于该豁免范围。
 
 Target 注册位于 `EJitOrcEngine::Create()`，而不是 `EJit::EJit()`。因此：
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -367,6 +367,14 @@ static ejit_status_t ejitInitImpl(const ejit_config_t *config, bool forcePgo) {
 
   Config cfg;
   parseConfig(config, cfg);
+#if defined(EJIT_SRE_SHARED_TASKPOOL) &&                                  \
+    defined(EJIT_SRE_SHARED_TASKPOOL_WORKER_CORE)
+  // Fixed-worker deployments may skip EJIT constructors on producer cores.
+  // Force every core through the linker-backed registry so funcIndex and
+  // lifecycle fingerprints remain identical even when callers use
+  // ejit_init(nullptr) and only the worker runs the LLVM init array.
+  cfg.forceStaticRegistry = true;
+#endif
   if (forcePgo)
     cfg.enablePgo = true;
 
@@ -393,9 +401,11 @@ static ejit_status_t ejitInitImpl(const ejit_config_t *config, bool forcePgo) {
 #ifdef EJIT_SRE_SHARED_TASKPOOL
   bindDumpSharedStateFromRuntime();
 #endif
-  EJIT_DIAG("initialized: mode=%d opt=%d cache=%zu entries=%u pgo=%d",
+  EJIT_DIAG("initialized: mode=%d opt=%d cache=%zu entries=%u pgo=%d "
+            "static_registry=%d",
             (int)cfg.compileMode, (int)cfg.optLevel, cfg.maxCacheSize,
-            (unsigned)cfg.maxCacheEntries, (int)cfg.enablePgo);
+            (unsigned)cfg.maxCacheEntries, (int)cfg.enablePgo,
+            (int)cfg.forceStaticRegistry);
   return EJIT_OK;
 }
 


### PR DESCRIPTION
## Summary

- force `Config::forceStaticRegistry = true` inside the shared `ejit_init` / `ejit_init_pgo` path when the runtime is built with both `EJIT_SRE_SHARED_TASKPOOL` and `EJIT_SRE_SHARED_TASKPOOL_WORKER_CORE`
- keep the public `ejit_config_t` default and ABI unchanged, so production callers may continue using `ejit_init(NULL)`
- report `static_registry` in the successful initialization log
- update the fixed-worker deployment documentation

## Problem

With worker-only LLVM init-array execution, the fixed worker can retain constructor registration while producer cores fall back to the linker-backed static registry. Those paths may assign different funcIndex/lifecycle mappings, causing every producer attach to fail with `registration fingerprint mismatch` even though the worker successfully created LLJIT and reached Ready.

The production AArch64 BE preset already fixes the worker to core 6. In that build, all cores must use one canonical registration source, so the runtime now enforces the static registry internally rather than requiring every business caller to populate a config field.

## Behavior

- `ejit_init(NULL)` and `ejit_init_pgo(NULL)` use static registration on fixed-worker shared builds.
- An explicit caller value of `forceStaticRegistry=false` is overridden in that build mode.
- Non-shared, open-election, and ordinary host builds keep the existing configuration semantics.
- Only the fixed worker still needs LLVM runtime init-array preparation before `ejit_init`; producer cores do not.

## Verification

- `EJitRuntime.cpp` compiles with the existing shared-taskpool/PGO build flags.
- `EJitRuntime.cpp` also compiles with `EJIT_SRE_SHARED_TASKPOOL_WORKER_CORE=6` enabled.
- `git diff --check` passes.

## 中文说明

固定 worker 的 shared SRE 构建中，运行时现在会内部写死 `forceStaticRegistry=true`。业务侧继续使用 `ejit_init(NULL)` 即可，普通 EJIT 和 PGO 初始化都会统一从静态 registry 回填 funcIndex/lifecycle，避免 core 6 走 constructor、其它业务核走静态表而产生 registration fingerprint mismatch。只有固定 worker 核需要在 `ejit_init` 前执行 LLVM init-array。