### PR TITLE
[EJIT] Add safe multi-pointer bound snapshots

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -9514,16 +9514,28 @@ may be marked with this attribute.
 def EjitBoundPtrDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{
-EmbeddedJIT: binds a pointer parameter's pointee to a specialization dimension.
+EmbeddedJIT: binds one or more pointer parameters' pointees to specialization
+dimensions.
 
 On a JIT cache miss, the runtime snapshots the complete pointee before the
 call returns. Loads of ``ejit_may_const`` fields through the parameter may then
 be specialized from that snapshot. The function must also have exactly one
 ``ejit_period_arr_ind`` parameter with the same period name.
 
-Only a pointer to a complete object type is accepted. The first implementation
-supports one bound pointer per function and performs a shallow object copy;
-pointers contained inside the object are not followed.
+Only a pointer to a complete object type is accepted. Every bound pointer is
+copied independently into an owned, shallow snapshot; pointers contained
+inside an object are not followed. The snapshot is allocated only on a real
+compile miss and is released after the compile attempt, so the caller may use
+stack storage, but it must not mutate the object concurrently with the entry
+call's copy. A null pointer with a non-zero object size, allocation failure, or
+an invalid lifecycle binding keeps execution on the AOT path. The specialization
+cache is keyed by the dimension tuple, not by object bytes: each object must
+remain stable for its associated lifecycle instance and should be updated only
+through the normal deactivate/update/reactivate sequence.
+
+At most 8 pointer parameters may be bound on one entry. This bounds only the
+small descriptor table emitted in the wrapper; there is no fixed byte-size cap
+on an individual snapshot.
 
 .. code-block:: c
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13505,7 +13505,7 @@ def err_ejit_bound_ptr_missing_dim : Error<
   "ejit_bound_ptr(%0) requires exactly one matching "
   "ejit_period_arr_ind(%0) parameter">;
 def err_ejit_bound_ptr_too_many : Error<
-  "function %0 has %1 ejit_bound_ptr parameters; at most one is supported">;
+  "function %0 has %1 ejit_bound_ptr parameters; at most 8 are supported">;
 def err_ejit_entry_recursive : Error<
   "ejit_entry function %0 cannot be recursive">;
 def err_ejit_period_lc_no_index : Error<

--- a/clang/lib/Sema/SemaEJIT.cpp
+++ b/clang/lib/Sema/SemaEJIT.cpp
@@ -24,6 +24,7 @@
 
 using llvm::ejit::MAX_PERIOD_ARR_IND_PARAMS;
 using llvm::ejit::MAX_PERIOD_ARR_SIZE;
+using llvm::ejit::MAX_BOUND_PTR_PARAMS;
 
 using namespace clang;
 
@@ -323,30 +324,29 @@ void checkEjitBoundPtrIndex(Sema &S, const FunctionDecl *FD) {
   if (!FD)
     return;
 
-  unsigned BoundCount = 0;
-  const EjitBoundPtrAttr *LastBound = nullptr;
-  for (const ParmVarDecl *P : FD->parameters())
-    if (const auto *A = P->getAttr<EjitBoundPtrAttr>()) {
-      ++BoundCount;
-      LastBound = A;
-    }
-
-  if (BoundCount > 1 && LastBound) {
-    S.Diag(LastBound->getLocation(), diag::err_ejit_bound_ptr_too_many)
-        << FD << BoundCount;
-    return;
+  unsigned Count = 0;
+  const ParmVarDecl *OverflowPVD = nullptr;
+  for (const ParmVarDecl *BoundParam : FD->parameters()) {
+    const auto *Bound = BoundParam->getAttr<EjitBoundPtrAttr>();
+    if (!Bound)
+      continue;
+    ++Count;
+    if (Count > MAX_BOUND_PTR_PARAMS)
+      OverflowPVD = BoundParam;
+    unsigned MatchingDims = 0;
+    for (const ParmVarDecl *P : FD->parameters())
+      if (const auto *D = P->getAttr<EjitPeriodArrIndAttr>())
+        if (D->getPeriodName() == Bound->getPeriodName())
+          ++MatchingDims;
+    if (MatchingDims != 1)
+      S.Diag(Bound->getLocation(), diag::err_ejit_bound_ptr_missing_dim)
+          << Bound->getPeriodName();
   }
-
-  if (!LastBound)
-    return;
-  unsigned MatchingDims = 0;
-  for (const ParmVarDecl *P : FD->parameters())
-    if (const auto *D = P->getAttr<EjitPeriodArrIndAttr>())
-      if (D->getPeriodName() == LastBound->getPeriodName())
-        ++MatchingDims;
-  if (MatchingDims != 1)
-    S.Diag(LastBound->getLocation(), diag::err_ejit_bound_ptr_missing_dim)
-        << LastBound->getPeriodName();
+  if (Count > MAX_BOUND_PTR_PARAMS && OverflowPVD) {
+    if (auto *A = OverflowPVD->getAttr<EjitBoundPtrAttr>())
+      S.Diag(A->getLocation(), diag::err_ejit_bound_ptr_too_many)
+          << FD << Count;
+  }
 }
 
 /// checkEjitEntryLcConflict - ejit_entry and ejit_period_lc are mutually

--- a/clang/test/CodeGen/ejit_metadata.c
+++ b/clang/test/CodeGen/ejit_metadata.c
@@ -35,6 +35,16 @@ int bound_entry(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx,
   return cfg->cellType + cfg->xx;
 }
 
+// CHECK: define {{.*}}i32 @bound_entry_two({{.*}} !ejit.metadata ![[BOUND_META_TWO:[0-9]+]]
+__attribute__((ejit_entry))
+int bound_entry_two(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx,
+                    __attribute__((ejit_bound_ptr("cell")))
+                    const struct CellConfig *a,
+                    __attribute__((ejit_bound_ptr("cell")))
+                    const struct CellConfig *b) {
+  return a->cellType + b->cellType;
+}
+
 // CHECK-DAG: ![[MAYCONST_FIELD:[0-9]+]] = !{!"ejit_may_const_field", i32 0}
 // CHECK-DAG: ![[PERIOD_META]] = distinct !{![[PERIOD:[0-9]+]], ![[MAYCONST_FIELD]]}
 // CHECK-DAG: ![[PERIOD]] = !{!"ejit_period", !"static"}
@@ -49,3 +59,10 @@ int bound_entry(__attribute__((ejit_period_arr_ind("cell"))) int cellIdx,
 // CHECK-DAG: ![[BOUND_META]] = distinct !{![[ENTRY]], ![[IND]], ![[BOUND:[0-9]+]]}
 // CHECK-DAG: ![[BOUND]] = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, ![[BOUND_FIELD:[0-9]+]]}
 // CHECK-DAG: ![[BOUND_FIELD]] = !{i64 0, i64 4}
+// CHECK-DAG: ![[BOUND_META_TWO]] = distinct !{![[ENTRY_TWO:[0-9]+]], ![[IND_TWO:[0-9]+]], ![[BOUND_A:[0-9]+]], ![[BOUND_B:[0-9]+]]}
+// CHECK-DAG: ![[ENTRY_TWO]] = !{!"ejit_entry"}
+// CHECK-DAG: ![[IND_TWO]] = !{!"ejit_period_arr_ind", !"cell", i32 0}
+// CHECK-DAG: ![[BOUND_A]] = !{!"ejit_bound_ptr", !"cell", i32 1, i64 8, ![[BOUND_FIELD_A:[0-9]+]]}
+// CHECK-DAG: ![[BOUND_B]] = !{!"ejit_bound_ptr", !"cell", i32 2, i64 8, ![[BOUND_FIELD_B:[0-9]+]]}
+// CHECK-DAG: ![[BOUND_FIELD_A]] = !{i64 0, i64 4}
+// CHECK-DAG: ![[BOUND_FIELD_B]] = !{i64 0, i64 4}

--- a/clang/test/Sema/ejit_bound_ptr.c
+++ b/clang/test/Sema/ejit_bound_ptr.c
@@ -26,4 +26,17 @@ __attribute__((ejit_entry))
 void two_bound(__attribute__((ejit_period_arr_ind("cell"))) int cell,
                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *a,
                __attribute__((ejit_bound_ptr("cell"))) struct Cfg *b);
-// expected-error@-1 {{function 'two_bound' has 2 ejit_bound_ptr parameters; at most one is supported}}
+
+__attribute__((ejit_entry))
+void too_many_bound(
+    __attribute__((ejit_period_arr_ind("cell"))) int cell,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p0,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p1,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p2,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p3,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p4,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p5,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p6,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p7,
+    __attribute__((ejit_bound_ptr("cell"))) struct Cfg *p8);
+// expected-error@-1 {{function 'too_many_bound' has 9 ejit_bound_ptr parameters; at most 8 are supported}}

--- a/jit_design_doc/EJIT_BOUND_PTR.md
+++ b/jit_design_doc/EJIT_BOUND_PTR.md
@@ -1,6 +1,6 @@
 # EJIT dimension-bound pointer snapshots
 
-`EJIT_BOUND_PTR(period)` associates one pointer parameter with an existing
+`EJIT_BOUND_PTR(period)` associates one or more pointer parameters with existing
 `EJIT_DIM(period)` parameter. It lets EJIT specialize fields whose values are
 stable for that period instance without requiring a global array name.
 
@@ -19,8 +19,8 @@ EJIT_ENTRY uint32_t process(
 }
 ```
 
-On a real JIT cache miss, the wrapper copies the complete `CellConfig` object
-into the compile request before returning. The asynchronous worker therefore
+On a real JIT cache miss, the wrapper copies each complete pointee into one
+runtime-owned snapshot before returning. The asynchronous worker therefore
 never retains or dereferences the caller's pointer. Stack-local objects are
 safe to destroy immediately after the entry call.
 
@@ -36,8 +36,11 @@ repeated `EJIT_BOUND_PTR` annotation.
 
 ## Contract and limits
 
-- The function must have exactly one matching `EJIT_DIM(period)` parameter.
-- The first implementation supports one `EJIT_BOUND_PTR` parameter per entry.
+- Every bound pointer must have exactly one matching `EJIT_DIM(period)` parameter.
+- An entry may have multiple `EJIT_BOUND_PTR` parameters. They are represented by
+  independent descriptors and byte ranges, even when they use the same period.
+- An entry may bind at most 8 pointer parameters. This is a bound on the small
+  wrapper descriptor table only; it does not limit the size of any snapshot.
 - Helper propagation accepts pointer casts and constant-offset GEPs. It stops
   conservatively at indirect calls, address-taken helpers, or a helper argument
   that receives different pointer sources at different call sites.
@@ -45,13 +48,47 @@ repeated `EJIT_BOUND_PTR` annotation.
 - An `ejit_may_const` field must remain stable while its period instance is
   active. Change it only as part of the normal deactivate/update/reactivate
   lifecycle so the period version invalidates old specialized code.
-- The default snapshot cap is 256 bytes. Configure
-  `EJIT_BOUND_PTR_MAX_BYTES` to a positive multiple of 8 when a larger object
-  is required. An oversize request falls back to AOT without queuing work.
+- There is no fixed snapshot byte cap. The queue carries a pointer to a
+  runtime-owned allocation containing a descriptor table and the copied bytes;
+  the queue slot size is independent of the pointee size. Arithmetic overflow,
+  invalid input, or allocation failure falls back to AOT without queuing work.
+- Snapshot allocation is platform-configurable. Hosted builds use `malloc` /
+  `free` by default. Freestanding/SRE builds intentionally have no default
+  allocator. On SRE, every producer core that may execute an entry wrapper
+  must call `ejit_set_bound_snapshot_allocator()` before that core's own
+  `ejit_init()`; configuring only the fixed worker core is insufficient. Each
+  producer must use the same paired allocator/free contract: the returned
+  storage, the `freeFn` code, and `ctx` must all be accessible and callable at
+  the same virtual address from the owner worker. The callbacks, context, and
+  allocator backing storage must remain valid until all queued snapshots have
+  drained. If no valid pair is installed, bound-pointer requests fail cleanly
+  and use AOT; an incomplete pair passed to the setter is rejected and leaves
+  the previous configuration unchanged.
+  The runtime does not assume that an SRE code-pool allocator can release
+  arbitrary snapshot storage.
+- The cache key remains the function index plus dimension tuple rather than
+  the snapshot bytes. This avoids one version per observed object value, but
+  requires all bound objects for a lifecycle instance to be stable and
+  consistent with that key.
 - Volatile, atomic, bit-field, union, dynamically indexed, and unmarked field
   loads are never folded from the snapshot.
 
-The snapshot is carried inline in `EJitCompileRequest`. This increases shared
-queue storage by `EJIT_BOUND_PTR_MAX_BYTES * queue capacity`, but avoids heap
-allocation, ownership handoff, cleanup races, and dangling-pointer failure
-paths on the worker side.
+The `EJitCompileRequest` carries only a same-address-space owned-snapshot handle.
+The producer transfers ownership after a successful queue enqueue; the worker
+releases it on every compile, drop, and publish path. Pending shared batch
+metadata is sanitized before the snapshot is released. This keeps shared queue
+storage bounded and avoids both unbounded stack copies and dangling caller
+pointers. The copy is shallow and is not an atomic multi-object transaction:
+callers must synchronize writers, and overlapping/aliased input pointers are
+copied in descriptor order into independent ranges.
+
+The snapshot allocation itself is one contiguous block and is not silently
+truncated. Dynamic allocation happens on the first cache-miss path that queues
+the specialization, not on steady-state cache hits. A very large or
+unavailable allocation is a normal AOT fallback; platform integrations should
+budget allocator capacity and allocation latency for this miss path rather
+than adding a hidden byte threshold here.
+
+The current branch keeps the shared taskpool ABI at v18. When rebasing onto a
+combined line that has advanced the shared ABI, coordinate the required bump
+to v19 or later together with the corresponding producer/worker images.

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -840,8 +840,6 @@ set(EJIT_SRE_TASKPOOL_BUCKETS "32" CACHE STRING
 # Async work-queue capacity (rounded up to a power of two).
 set(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY "1024" CACHE STRING
   "EmbeddedJIT SRE taskpool async queue capacity (power of two)")
-set(EJIT_BOUND_PTR_MAX_BYTES "256" CACHE STRING
-  "Maximum shallow pointee snapshot carried by one EJIT compile request")
 # Flat dedup table capacity = max dense funcIndex (spec §3.5 inFlight_[]).
 set(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX "4096" CACHE STRING
   "EmbeddedJIT SRE taskpool flat dedup capacity (max dense funcIndex)")
@@ -849,7 +847,6 @@ set(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX "4096" CACHE STRING
 # value fails at `cmake` time with a clear message instead of mid-build.
 ejit_require_numeric(EJIT_SRE_TASKPOOL_BUCKETS)
 ejit_require_numeric(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY)
-ejit_require_numeric(EJIT_BOUND_PTR_MAX_BYTES)
 ejit_require_numeric(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX)
 if(EJIT_SRE_TASKPOOL_BUCKETS LESS 1 OR EJIT_SRE_TASKPOOL_BUCKETS GREATER 254)
   message(FATAL_ERROR
@@ -863,18 +860,6 @@ if(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY LESS 2 OR NOT _ejit_queue_pow2 EQUAL 0)
     "EJIT_SRE_TASKPOOL_QUEUE_CAPACITY (${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}) "
     "must be a power of two >= 2 (the ring queue indexes with a mask).")
 endif()
-if(EJIT_BOUND_PTR_MAX_BYTES LESS 1 OR EJIT_BOUND_PTR_MAX_BYTES GREATER 65536)
-  message(FATAL_ERROR
-    "EJIT_BOUND_PTR_MAX_BYTES must be in [1, 65536], got ${EJIT_BOUND_PTR_MAX_BYTES}")
-endif()
-math(EXPR _ejit_bound_ptr_rem "${EJIT_BOUND_PTR_MAX_BYTES} % 8")
-if(NOT _ejit_bound_ptr_rem EQUAL 0)
-  message(FATAL_ERROR
-    "EJIT_BOUND_PTR_MAX_BYTES must be a multiple of 8, got ${EJIT_BOUND_PTR_MAX_BYTES}")
-endif()
-unset(_ejit_bound_ptr_rem)
-add_definitions(-DEJIT_BOUND_PTR_MAX_BYTES=${EJIT_BOUND_PTR_MAX_BYTES})
-message(STATUS "EmbeddedJIT: bound-pointer snapshot cap=${EJIT_BOUND_PTR_MAX_BYTES} bytes")
 unset(_ejit_queue_pow2)
 if(EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX LESS 1)
   message(FATAL_ERROR

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitBoundSnapshot.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitBoundSnapshot.h
@@ -1,0 +1,222 @@
+//===-- EJitBoundSnapshot.h - Owned bound-pointer snapshots --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITBOUNDSNAPSHOT_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITBOUNDSNAPSHOT_H
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#ifndef EJIT_FREESTANDING
+#include <cstdlib>
+#endif
+
+namespace llvm {
+namespace ejit {
+
+/// A caller-owned input used only while building an owned snapshot.
+struct EJitBoundPtrInput {
+  const void *data = nullptr;
+  uint32_t size = 0;
+  uint32_t argIndex = 0;
+};
+
+/// A non-owning view used by the compiler and specialization pass. The view is
+/// valid only while the compile callback is running.
+struct EJitBoundPointerView {
+  const uint8_t *data = nullptr;
+  uint32_t size = 0;
+  uint32_t argIndex = 0;
+};
+
+/// Fixed header of an owned snapshot. Entries and bytes follow in one
+/// allocation. Offsets are relative to the byte area, never raw caller
+/// pointers, so each entry has an independent copy and lifetime.
+struct EJitBoundSnapshotEntry {
+  uint32_t argIndex;
+  uint32_t size;
+  uint64_t offset;
+};
+
+using EJitBoundSnapshotAllocFn = void *(*)(void *ctx, size_t size);
+using EJitBoundSnapshotFreeFn = void (*)(void *ctx, void *ptr);
+
+/// Allocation hooks for snapshots that cross the producer/worker boundary.
+/// The pair must come from an allocator that is valid in the process address
+/// space, returns suitably aligned storage, and may be freed by the worker
+/// core. The callbacks and ctx must remain valid until all queued snapshots
+/// have been drained. Freestanding builds have no default allocator; the
+/// platform must inject both callbacks before use.
+struct EJitBoundSnapshotAllocator {
+  EJitBoundSnapshotAllocFn alloc = nullptr;
+  EJitBoundSnapshotFreeFn free = nullptr;
+  void *ctx = nullptr;
+};
+
+#ifndef EJIT_FREESTANDING
+inline void *ejitDefaultBoundSnapshotAlloc(void *, size_t size) {
+  return std::malloc(size);
+}
+
+inline void ejitDefaultBoundSnapshotFree(void *, void *ptr) { std::free(ptr); }
+#endif
+
+inline EJitBoundSnapshotAllocator getDefaultEJitBoundSnapshotAllocator() {
+#ifndef EJIT_FREESTANDING
+  return {&ejitDefaultBoundSnapshotAlloc, &ejitDefaultBoundSnapshotFree,
+          nullptr};
+#else
+  return {};
+#endif
+}
+
+struct EJitBoundSnapshot {
+  uint32_t entryCount;
+  uint32_t reserved;
+  uint64_t totalBytes;
+  EJitBoundSnapshotFreeFn freeFn;
+  void *freeCtx;
+};
+
+constexpr uint32_t kEJitBoundSnapshotMagic = 0x42534E50u; // "BSNP"
+constexpr uint32_t kEJitMaxBoundPointers = 8;
+
+inline bool ejitBoundSnapshotLayout(uint32_t entryCount, uint64_t totalBytes,
+                                    size_t &entriesOffset, size_t &dataOffset,
+                                    size_t &allocationSize) {
+  constexpr size_t HeaderSize = sizeof(EJitBoundSnapshot);
+  if constexpr (sizeof(size_t) < sizeof(uint64_t)) {
+    const uint64_t maxEntries =
+        (std::numeric_limits<size_t>::max() - HeaderSize) /
+        sizeof(EJitBoundSnapshotEntry);
+    if (static_cast<uint64_t>(entryCount) > maxEntries)
+      return false;
+  }
+  entriesOffset = HeaderSize;
+  dataOffset = entriesOffset +
+               static_cast<size_t>(entryCount) * sizeof(EJitBoundSnapshotEntry);
+  if (totalBytes > std::numeric_limits<size_t>::max() - dataOffset)
+    return false;
+  allocationSize = dataOffset + static_cast<size_t>(totalBytes);
+  return true;
+}
+
+/// Allocate one owned snapshot and copy every input exactly once. A null
+/// pointer with a non-zero size, arithmetic overflow, or allocation failure is
+/// rejected without truncation.
+inline EJitBoundSnapshot *
+createEJitBoundSnapshot(const EJitBoundPtrInput *inputs, uint32_t inputCount,
+                        EJitBoundSnapshotAllocator allocator =
+                            getDefaultEJitBoundSnapshotAllocator()) {
+  if (inputCount == 0 || inputCount > kEJitMaxBoundPointers || !inputs)
+    return nullptr;
+  if (!allocator.alloc || !allocator.free)
+    return nullptr;
+
+  uint64_t totalBytes = 0;
+  for (uint32_t i = 0; i < inputCount; ++i) {
+    // One formal argument must map to one snapshot. Rejecting duplicates keeps
+    // malformed metadata/API input from making propagation order-dependent.
+    for (uint32_t j = 0; j < i; ++j)
+      if (inputs[j].argIndex == inputs[i].argIndex)
+        return nullptr;
+    if (inputs[i].size != 0 && !inputs[i].data)
+      return nullptr;
+    if (inputs[i].size > std::numeric_limits<uint64_t>::max() - totalBytes)
+      return nullptr;
+    totalBytes += inputs[i].size;
+  }
+
+  size_t entriesOffset = 0;
+  size_t dataOffset = 0;
+  size_t allocationSize = 0;
+  if (!ejitBoundSnapshotLayout(inputCount, totalBytes, entriesOffset,
+                               dataOffset, allocationSize))
+    return nullptr;
+
+  auto *snapshot = static_cast<EJitBoundSnapshot *>(
+      allocator.alloc(allocator.ctx, allocationSize));
+  if (!snapshot)
+    return nullptr;
+  snapshot->entryCount = inputCount;
+  snapshot->reserved = kEJitBoundSnapshotMagic;
+  snapshot->totalBytes = totalBytes;
+  snapshot->freeFn = allocator.free;
+  snapshot->freeCtx = allocator.ctx;
+
+  auto *entries = reinterpret_cast<EJitBoundSnapshotEntry *>(
+      reinterpret_cast<uint8_t *>(snapshot) + entriesOffset);
+  auto *bytes = reinterpret_cast<uint8_t *>(snapshot) + dataOffset;
+  uint64_t offset = 0;
+  for (uint32_t i = 0; i < inputCount; ++i) {
+    entries[i] = {inputs[i].argIndex, inputs[i].size, offset};
+    if (inputs[i].size)
+      std::memcpy(bytes + static_cast<size_t>(offset), inputs[i].data,
+                  inputs[i].size);
+    offset += inputs[i].size;
+  }
+  return snapshot;
+}
+
+inline void destroyEJitBoundSnapshot(EJitBoundSnapshot *snapshot) {
+  if (!snapshot || snapshot->reserved != kEJitBoundSnapshotMagic ||
+      !snapshot->freeFn)
+    return;
+  snapshot->freeFn(snapshot->freeCtx, snapshot);
+}
+
+inline bool isValidEJitBoundSnapshot(const EJitBoundSnapshot *snapshot) {
+  if (!snapshot || snapshot->reserved != kEJitBoundSnapshotMagic ||
+      snapshot->entryCount == 0 || snapshot->entryCount > kEJitMaxBoundPointers)
+    return false;
+  size_t entriesOffset = 0;
+  size_t dataOffset = 0;
+  size_t allocationSize = 0;
+  if (!ejitBoundSnapshotLayout(snapshot->entryCount, snapshot->totalBytes,
+                               entriesOffset, dataOffset, allocationSize))
+    return false;
+  (void)dataOffset;
+  (void)allocationSize;
+  const auto *entries = reinterpret_cast<const EJitBoundSnapshotEntry *>(
+      reinterpret_cast<const uint8_t *>(snapshot) + entriesOffset);
+  uint64_t previousEnd = 0;
+  for (uint32_t i = 0; i < snapshot->entryCount; ++i) {
+    const auto &entry = entries[i];
+    if (entry.offset < previousEnd || entry.offset > snapshot->totalBytes ||
+        entry.size > snapshot->totalBytes - entry.offset)
+      return false;
+    previousEnd = entry.offset + entry.size;
+  }
+  return previousEnd <= snapshot->totalBytes;
+}
+
+inline const EJitBoundSnapshotEntry *
+getEJitBoundSnapshotEntries(const EJitBoundSnapshot *snapshot) {
+  return reinterpret_cast<const EJitBoundSnapshotEntry *>(
+      reinterpret_cast<const uint8_t *>(snapshot) + sizeof(EJitBoundSnapshot));
+}
+
+inline const uint8_t *
+getEJitBoundSnapshotBytes(const EJitBoundSnapshot *snapshot) {
+  return reinterpret_cast<const uint8_t *>(
+      getEJitBoundSnapshotEntries(snapshot) + snapshot->entryCount);
+}
+
+inline EJitBoundSnapshot *getEJitBoundSnapshot(uintptr_t pointer) {
+  return reinterpret_cast<EJitBoundSnapshot *>(pointer);
+}
+
+inline void destroyEJitBoundSnapshot(uintptr_t pointer) {
+  destroyEJitBoundSnapshot(getEJitBoundSnapshot(pointer));
+}
+
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITBOUNDSNAPSHOT_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCommon.h
@@ -15,6 +15,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITCOMMON_H
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundSnapshot.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -105,6 +106,8 @@ constexpr const char *FN_TASKPOOL_COMPILE_OR_GET =
     "ejit_taskpool_compile_or_get";
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_BOUND =
     "ejit_taskpool_compile_or_get_bound";
+constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_BOUND_V =
+    "ejit_taskpool_compile_or_get_bound_v";
 // Fixed-dimension fast-path C ABI entries (0-4 dims), emitted by the wrapper
 // when -ejit-wrapper-fixed-dim-entry is enabled and the entry has <= 4 dims.
 constexpr const char *FN_TASKPOOL_COMPILE_OR_GET_0D =
@@ -153,6 +156,10 @@ constexpr unsigned EJIT_CTOR_PRIORITY = 65535;
 // together with these values.
 constexpr unsigned MAX_PERIOD_ARR_IND_PARAMS = 4;
 constexpr unsigned MAX_PERIOD_ARR_SIZE = 100;
+// The wrapper materializes only this fixed-size descriptor table on its
+// stack. Payload bytes remain runtime-owned and dynamically allocated, so this
+// limit does not cap the size of any bound object.
+constexpr unsigned MAX_BOUND_PTR_PARAMS = kEJitMaxBoundPointers;
 
 //===----------------------------------------------------------------------===//
 // Metadata utility functions (shared across AOT passes)

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptions.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_EXECUTIONENGINE_EJIT_EJITOPTIONS_H
 #define LLVM_EXECUTIONENGINE_EJIT_EJITOPTIONS_H
 
+#include "llvm/ExecutionEngine/EJIT/EJitBoundSnapshot.h"
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -53,6 +54,12 @@ struct Config {
 #else
   bool enableProfileAudit = false;
 #endif
+  /// Allocator for bound-pointer snapshots crossing producer/worker cores.
+  /// Hosted builds default to malloc/free; freestanding builds default to an
+  /// invalid pair and therefore cleanly fall back to AOT until the platform
+  /// injects a cross-core-safe allocator.
+  EJitBoundSnapshotAllocator boundSnapshotAllocator =
+      getDefaultEJitBoundSnapshotAllocator();
 };
 
 } // namespace ejit

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -10,6 +10,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITORCENGINE_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundSnapshot.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/EJIT/EJitProfileMerge.h"
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT
@@ -100,8 +101,9 @@ struct SpecializationContext {
     uint8_t cellIdx;
   };
   SmallVector<DimInfo, 4> dimensions;
-  uint32_t boundArgIndex = 0;
-  SmallVector<uint8_t, 256> boundData;
+  /// Non-owning views into the request-owned snapshot. The taskpool keeps the
+  /// snapshot alive for the complete compile callback.
+  SmallVector<EJitBoundPointerView, 4> boundPointers;
   OptimizationLevel optLevel = OptimizationLevel::L2;
   /// PGO tier (Baseline when PGO is disabled or for the first compile).
   CompileTier tier = CompileTier::Baseline;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -154,6 +154,20 @@ typedef struct {
 } ejit_error_t;
 
 // Initialization
+typedef void *(*ejit_bound_snapshot_alloc_fn)(void *ctx, size_t size);
+typedef void (*ejit_bound_snapshot_free_fn)(void *ctx, void *ptr);
+
+/// Configure the allocator for bound-pointer snapshots. Must be called before
+/// ejit_init() when producer and worker may run on different cores. Pass both
+/// callbacks, or pass both NULL to restore the hosted default. Freestanding
+/// builds have no default allocator, so no injection causes bound-pointer
+/// compilation to fall back to AOT cleanly. An incomplete pair is rejected
+/// and leaves the previous configuration unchanged. The callbacks and ctx
+/// must remain valid until all queued snapshots have drained.
+void ejit_set_bound_snapshot_allocator(ejit_bound_snapshot_alloc_fn allocFn,
+                                       ejit_bound_snapshot_free_fn freeFn,
+                                       void *ctx);
+
 ejit_status_t ejit_init(const ejit_config_t *config);
 /// Initialize with online PGO enabled (Tier-1 instrumentation + lazy Tier-2
 /// PGOUse recompile). Additive, ABI-compatible entry point: `ejit_config_t`
@@ -224,18 +238,37 @@ typedef struct {
   uint32_t instanceId;
 } ejit_dim_pair_t;
 
+// One shallow object snapshot associated with a pointer parameter in an
+// ejit_entry function. The runtime copies data before returning, including for
+// asynchronous compilation; the caller may release or mutate data afterwards.
+// A non-zero size requires a non-null data pointer. Descriptors are processed
+// in array order and never share storage.
+typedef struct {
+  const void *data;
+  uint32_t size;
+  uint32_t argIndex;
+} ejit_bound_ptr_t;
+
 ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                                            const ejit_dim_pair_t *dims,
                                            uint32_t numDims, void **outFn,
                                            uint32_t *outBucket);
 
-// Slow-path variant used by wrappers with EJIT_BOUND_PTR. The runtime copies
+// Compatibility slow-path variant for one EJIT_BOUND_PTR. The runtime copies
 // snapshotData before returning; asynchronous compilation never retains the
-// caller's pointer. Oversize/null snapshots fail cleanly and execute AOT.
+// caller's pointer. There is no fixed snapshot-size cap.
 ejit_status_t ejit_taskpool_compile_or_get_bound(
     uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
     const void *snapshotData, uint32_t snapshotSize, uint32_t boundArgIndex,
     void **outFn, uint32_t *outBucket);
+
+// Multi-pointer slow path. Each descriptor is copied independently into an
+// owned snapshot. Invalid descriptors or allocation failure return a failure
+// status and leave the caller on its AOT path.
+ejit_status_t ejit_taskpool_compile_or_get_bound_v(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const ejit_bound_ptr_t *bounds, uint32_t numBounds, void **outFn,
+    uint32_t *outBucket);
 
 // Fixed-dimension fast paths (0-4 dims). Additive alternatives to
 // ejit_taskpool_compile_or_get that pass the dim identity as scalar arguments

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -98,14 +98,17 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// the shared blob also records completed-function and deferred-miss counts.
 /// v13: non-owner cores can post a may_const-ranking diagnostic request to the
 /// owner worker and wait for its completion without sharing optimizer objects.
-/// v14: EJitCompileRequest owns an inline bound-pointer snapshot.
+/// v14: EJitCompileRequest carried an inline bound-pointer snapshot.
 /// v15: each cache slot records whether its published JIT pointer was resolved
 /// by a later taskpool lookup, diagnosing compiled versions with no reuse.
 /// v16: code ranges identify near/far placement and the shared code-pool
 /// diagnostic mirror publishes aggregate plus placement-specific statistics.
 /// v17: cache slots can remain Pending while compact code waits for an explicit
 /// owner-worker batch publish request.
-constexpr uint32_t kEJitSharedAbiVersion = 17u;
+/// v18: bound-pointer snapshots moved out of queue cells into runtime-owned
+/// same-address-space allocations; the request now carries only an ownership
+/// handle, and one request can describe multiple independently copied pointers.
+constexpr uint32_t kEJitSharedAbiVersion = 18u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -513,6 +513,12 @@ public:
     publishFn_ = fn;
     publishCtx_ = ctx;
   }
+  /// Install the allocator used for snapshots copied on a producer core and
+  /// released by the owner worker. Call before submitting work; every
+  /// snapshot retains its own free hook.
+  void setBoundSnapshotAllocator(EJitBoundSnapshotAllocator allocator) {
+    boundSnapshotAllocator_ = allocator;
+  }
   void setMayConstRankingCallback(MayConstRankingCallback fn, void *ctx) {
     mayConstRankingFn_ = fn;
     mayConstRankingCtx_ = ctx;
@@ -874,6 +880,14 @@ public:
                                   const void *boundData = nullptr,
                                   uint32_t boundSize = 0,
                                   uint32_t boundArgIndex = 0);
+  /// Multi-pointer form. The producer owns a single dynamic snapshot until
+  /// the owner worker finishes compilation; no caller pointer crosses the
+  /// shared queue. Bound objects are keyed by the dimension tuple and must be
+  /// stable for that lifecycle instance.
+  CompileOrGetResult compileOrGetBound(
+      uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+      void *fallback, const EJitBoundPtrInput *boundPtrs,
+      uint32_t boundCount);
   /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
   /// terminal front half of compileOrGet(): the Ready check, the
   /// instance-enabled check, and the cache lookup, then classifies the outcome:
@@ -1341,6 +1355,8 @@ private:
   void *compileCtx_ = nullptr;
   PublishCallback publishFn_ = nullptr;
   void *publishCtx_ = nullptr;
+  EJitBoundSnapshotAllocator boundSnapshotAllocator_ =
+      getDefaultEJitBoundSnapshotAllocator();
   ReleaseCallback releaseFn_ = nullptr;
   void *releaseCtx_ = nullptr;
   PrepareCodeCallback prepareCodeFn_ = nullptr;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
@@ -33,12 +33,6 @@
 #ifndef EJIT_SRE_TASKPOOL_QUEUE_CAPACITY
 #define EJIT_SRE_TASKPOOL_QUEUE_CAPACITY 1024u
 #endif
-#ifndef EJIT_BOUND_PTR_MAX_BYTES
-#define EJIT_BOUND_PTR_MAX_BYTES 256u
-#endif
-static_assert(EJIT_BOUND_PTR_MAX_BYTES > 0 &&
-                  (EJIT_BOUND_PTR_MAX_BYTES % 8u) == 0,
-              "EJIT_BOUND_PTR_MAX_BYTES must be a positive multiple of 8");
 
 namespace llvm {
 namespace ejit {
@@ -70,21 +64,17 @@ struct EJitCompileRequest {
   // cache. Unused (left 0) by the non-shared taskpool. Endianness: a plain
   // fixed-width scalar accessed by value, never byte-parsed.
   uint32_t generation;
-  // Optional shallow pointee snapshot for ejit_bound_ptr. It is stored inline
-  // so an async request owns every byte it needs after the caller returns.
-  // boundSize == 0 means no bound pointer. No raw caller pointer crosses the
-  // queue boundary.
-  uint32_t boundArgIndex;
-  uint32_t boundSize;
-  alignas(uintptr_t) uint8_t boundData[EJIT_BOUND_PTR_MAX_BYTES];
+  // Optional owned shallow pointee snapshot for ejit_bound_ptr. The queue
+  // carries only a same-address-space handle; the producer allocates and copies
+  // the bytes before enqueue, and the worker destroys it after compilation.
+  // Zero means no bound pointer. See EJitBoundSnapshot.h.
+  uintptr_t boundSnapshotPtr;
 };
 
-// Size is stable per pointer width: on a 64-bit target the trailing uint32_t
-// generation forces 4 bytes of tail padding (alignof == 8) -> 72; on a 32-bit
-// target everything is 4-aligned with no padding -> 64.
+// Size is stable per pointer width. The queue remains compact regardless of
+// the pointee size: the bytes live in the separately-owned snapshot.
 static_assert(sizeof(EJitCompileRequest) ==
-                  (sizeof(uintptr_t) == 8 ? 80u + EJIT_BOUND_PTR_MAX_BYTES
-                                          : 72u + EJIT_BOUND_PTR_MAX_BYTES),
+                  (sizeof(uintptr_t) == 8 ? 80u : 68u),
               "EJitCompileRequest size must stay stable (incl. generation)");
 static_assert(alignof(EJitCompileRequest) <= 8,
               "EJitCompileRequest alignment must stay <= 8 bytes");

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitStructFieldPass.h
@@ -10,9 +10,11 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITSTRUCTFIELDPASS_H
 
 #include "llvm/ExecutionEngine/EJIT/EJitCommon.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundSnapshot.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT
@@ -40,12 +42,21 @@ using MayConstOffsetMap =
 class EJitStructFieldPass : public PassInfoMixin<EJitStructFieldPass> {
 public:
   EJitStructFieldPass(PeriodArrayRegistry &reg,
+                      ArrayRef<EJitBoundPointerView> boundPointers,
+                      StringRef boundRootFunction = {})
+      : registry_(reg), boundPointers_(boundPointers.begin(),
+                                       boundPointers.end()),
+        boundRootFunction_(boundRootFunction.str()) {}
+
+  /// Compatibility constructor for direct pass users and older tests.
+  EJitStructFieldPass(PeriodArrayRegistry &reg,
                       const uint8_t *boundData = nullptr,
                       uint32_t boundSize = 0, uint32_t boundArgIndex = 0,
                       StringRef boundRootFunction = {})
-      : registry_(reg), boundData_(boundData), boundSize_(boundSize),
-        boundArgIndex_(boundArgIndex),
-        boundRootFunction_(boundRootFunction.str()) {}
+      : registry_(reg), boundRootFunction_(boundRootFunction.str()) {
+    if (boundData && boundSize)
+      boundPointers_.push_back({boundData, boundSize, boundArgIndex});
+  }
 
   /// Pre-build GV metadata maps from the Module (call once before run()).
   void initFromModule(Module &M);
@@ -74,16 +85,18 @@ public:
 
 private:
   PeriodArrayRegistry &registry_;
-  const uint8_t *boundData_ = nullptr;
-  uint32_t boundSize_ = 0;
-  uint32_t boundArgIndex_ = 0;
+  SmallVector<EJitBoundPointerView, 4> boundPointers_;
   std::string boundRootFunction_;
 
-  // A specialization owns one pointee snapshot. Track which formal arguments
-  // are proven to receive that snapshot, and their byte offset into it, across
-  // direct calls from the entry. Ambiguous or indirect flows are omitted.
-  DenseMap<const Argument *, uint64_t> boundArguments_;
-  SmallVector<std::pair<uint64_t, uint64_t>, 4> boundMayConstFields_;
+  struct BoundSnapshotState {
+    EJitBoundPointerView view;
+    // A specialization owns one pointee snapshot. Track which formal
+    // arguments are proven to receive that snapshot, and their byte offset
+    // into it, across direct calls from the entry.
+    DenseMap<const Argument *, uint64_t> boundArguments;
+    SmallVector<std::pair<uint64_t, uint64_t>, 4> mayConstFields;
+  };
+  SmallVector<BoundSnapshotState, 4> boundSnapshots_;
   void initBoundArgumentPropagation(Module &M);
 
   // Cached metadata maps — built once per module, reused across functions.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitTaskPool.h
@@ -10,6 +10,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITTASKPOOL_H
 
 #include "llvm/ExecutionEngine/EJIT/EJitAtomic.h"
+#include "llvm/ExecutionEngine/EJIT/EJitBoundSnapshot.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRwLock.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h"
 #include "llvm/ExecutionEngine/EJIT/EJitWorker.h"
@@ -349,6 +350,11 @@ public:
     publishFn_ = fn;
     publishCtx_ = ctx;
   }
+  /// Install the allocator used for caller-owned bound-pointer snapshots.
+  /// Call before submitting work; each snapshot retains its own free hook.
+  void setBoundSnapshotAllocator(EJitBoundSnapshotAllocator allocator) {
+    boundSnapshotAllocator_ = allocator;
+  }
 
   /// Install the optional physical-code release callback used when publish
   /// overwrites an existing cache entry (see EJitTaskPoolCache::setReleaser).
@@ -371,6 +377,15 @@ public:
                                   const void *boundData = nullptr,
                                   uint32_t boundSize = 0,
                                   uint32_t boundArgIndex = 0);
+
+  /// Multi-pointer form. Each input is copied into one owned snapshot before
+  /// an asynchronous request is published; the worker never dereferences a
+  /// caller-owned pointer. The cache identity remains the dimension tuple, so
+  /// bound objects must be stable for that tuple's lifecycle instance.
+  CompileOrGetResult compileOrGetBound(
+      uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+      void *fallback, const EJitBoundPtrInput *boundPtrs,
+      uint32_t boundCount);
 
   /// Flattened fast cache-hit path (spec §5.2 steps 0-1). Performs ONLY the
   /// terminal front half of compileOrGet(): the instance-enabled check and the
@@ -436,6 +451,8 @@ private:
   EJitTaskQueue queue_;
   EJitTaskPoolCache cache_;
   bool pgoEnabled_ = false; // PGO (§6): gates the Tier-2 trigger
+  EJitBoundSnapshotAllocator boundSnapshotAllocator_ =
+      getDefaultEJitBoundSnapshotAllocator();
   CompileCallback compileFn_ = nullptr;
   void *compileCtx_ = nullptr;
   PublishCallback publishFn_ = nullptr;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -225,6 +225,7 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
   // calls startTaskPoolWorker() once everything is ready (spec §3.4).
   taskPool_ = std::make_unique<EJitTaskPool>(EJIT_SRE_TASKPOOL_QUEUE_CAPACITY,
                                              /*autoStartWorker=*/false);
+  taskPool_->setBoundSnapshotAllocator(config_.boundSnapshotAllocator);
   taskPool_->setCompiler(&taskpoolCompileThunk, this);
   taskPool_->setPublishCallback(&taskpoolPublishThunk, this);
   taskPool_->switchController().setMode(
@@ -239,6 +240,7 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
   // ORC engine is installed). Cross-core fnPtr sharing is OFF by default until
   // a platform asserts same-VA, sealed, I/D-coherent code (spec §11).
   sharedPool_.bind(&gEJitSharedTaskPoolState);
+  sharedPool_.setBoundSnapshotAllocator(config_.boundSnapshotAllocator);
   sharedPool_.setCompiler(&taskpoolCompileThunk, this);
   sharedPool_.setPublishCallback(&taskpoolPublishThunk, this);
   sharedPool_.setMayConstRankingCallback(&sharedMayConstRankingThunk, this);
@@ -514,15 +516,23 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
   ctx.optLevel = config_.optLevel;
   for (unsigned i = 0; i < dimCount; ++i)
     ctx.dimensions.push_back({periodNames[i], dims[i]});
-  if (request && request->boundSize) {
-    if (request->boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
-      EJIT_DIAG("compile FAIL key=0x%016lx func=%s: bound snapshot too large",
+  if (request && request->boundSnapshotPtr) {
+    const auto *snapshot =
+        getEJitBoundSnapshot(request->boundSnapshotPtr);
+    if (!isValidEJitBoundSnapshot(snapshot)) {
+      EJIT_DIAG("compile FAIL key=0x%016lx func=%s: invalid bound snapshot",
                 cacheKey, funcName.c_str());
       return nullptr;
     }
-    ctx.boundArgIndex = request->boundArgIndex;
-    ctx.boundData.append(request->boundData,
-                         request->boundData + request->boundSize);
+    const uint8_t *bytes = getEJitBoundSnapshotBytes(snapshot);
+    const EJitBoundSnapshotEntry *entries =
+        getEJitBoundSnapshotEntries(snapshot);
+    for (uint32_t i = 0; i < snapshot->entryCount; ++i) {
+      const auto &entry = entries[i];
+      ctx.boundPointers.push_back(
+          {bytes + static_cast<size_t>(entry.offset), entry.size,
+           entry.argIndex});
+    }
   }
 
   // PGO tier (EJIT_ONLINE_PGO.md §4). Gated by Config::enablePgo: off => the

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -764,10 +764,7 @@ void EJitOptimizer::runInterproceduralPropagation(Module &M) {
 
 void EJitOptimizer::runStructFieldPass(Module &M,
                                        const SpecializationContext &ctx) {
-  EJitStructFieldPass structField(
-      registry_, ctx.boundData.empty() ? nullptr : ctx.boundData.data(),
-      static_cast<uint32_t>(ctx.boundData.size()), ctx.boundArgIndex,
-      ctx.fnName);
+  EJitStructFieldPass structField(registry_, ctx.boundPointers, ctx.fnName);
   structField.initFromModule(M);
   for (Function &F : M.functions())
     if (!F.isDeclaration())

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -145,6 +145,8 @@ static_assert(kEJitMaxFuncIndex == kEJitSharedMaxFuncIndex,
 #endif // EJIT_SRE_SHARED_TASKPOOL
 
 static EJit *gEJIT = nullptr;
+static EJitBoundSnapshotAllocator gEJitBoundSnapshotAllocator =
+    getDefaultEJitBoundSnapshotAllocator();
 
 #ifdef EJIT_DIAG_ENABLE
 EJitAtomicU64 gIcacheNullFillSkips;
@@ -367,6 +369,7 @@ static ejit_status_t ejitInitImpl(const ejit_config_t *config, bool forcePgo) {
 
   Config cfg;
   parseConfig(config, cfg);
+  cfg.boundSnapshotAllocator = gEJitBoundSnapshotAllocator;
   if (forcePgo)
     cfg.enablePgo = true;
 
@@ -400,6 +403,25 @@ static ejit_status_t ejitInitImpl(const ejit_config_t *config, bool forcePgo) {
 }
 
 extern "C" {
+
+void ejit_set_bound_snapshot_allocator(ejit_bound_snapshot_alloc_fn allocFn,
+                                       ejit_bound_snapshot_free_fn freeFn,
+                                       void *ctx) {
+  if (gEJIT) {
+    EJIT_DIAG("bound snapshot allocator rejected: runtime already initialized");
+    return;
+  }
+  if ((allocFn == nullptr) != (freeFn == nullptr)) {
+    EJIT_DIAG("bound snapshot allocator rejected: alloc/free must be paired");
+    return;
+  }
+  if (!allocFn) {
+    gEJitBoundSnapshotAllocator =
+        getDefaultEJitBoundSnapshotAllocator();
+    return;
+  }
+  gEJitBoundSnapshotAllocator = {allocFn, freeFn, ctx};
+}
 
 ejit_status_t ejit_init(const ejit_config_t *config) {
   return ejitInitImpl(config, /*forcePgo=*/false);
@@ -903,8 +925,8 @@ inline void ejitIcacheFillOnSuccess(uint32_t funcIndex, void *fnPtr,
 
 static ejit_status_t
 taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
-                         uint32_t numDims, const void *snapshotData,
-                         uint32_t snapshotSize, uint32_t boundArgIndex,
+                         uint32_t numDims, const EJitBoundPtrInput *boundPtrs,
+                         uint32_t boundCount,
                          void **outFn, uint32_t *outBucket) {
   if (outFn)
     *outFn = nullptr;
@@ -984,9 +1006,8 @@ taskpoolCompileOrGetImpl(uint32_t funcIndex, const ejit_dim_pair_t *dims,
     return taskpoolStatus(fast.status);
   }
 
-  auto r = tp->compileOrGet(funcIndex, dimsCast, numDims,
-                            /*fallback=*/nullptr, snapshotData, snapshotSize,
-                            boundArgIndex);
+  auto r = tp->compileOrGetBound(funcIndex, dimsCast, numDims,
+                                 /*fallback=*/nullptr, boundPtrs, boundCount);
   if (outFn)
     *outFn = r.fnPtr;
   if (outBucket)
@@ -1003,17 +1024,41 @@ ejit_status_t ejit_taskpool_compile_or_get(uint32_t funcIndex,
                                            const ejit_dim_pair_t *dims,
                                            uint32_t numDims, void **outFn,
                                            uint32_t *outBucket) {
-  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, nullptr, 0, 0,
-                                  outFn, outBucket);
+  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, nullptr, 0, outFn,
+                                  outBucket);
 }
 
 ejit_status_t ejit_taskpool_compile_or_get_bound(
     uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
     const void *snapshotData, uint32_t snapshotSize, uint32_t boundArgIndex,
     void **outFn, uint32_t *outBucket) {
-  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, snapshotData,
-                                  snapshotSize, boundArgIndex, outFn,
+  EJitBoundPtrInput Bound{snapshotData, snapshotSize, boundArgIndex};
+  return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, &Bound, 1, outFn,
                                   outBucket);
+}
+
+ejit_status_t ejit_taskpool_compile_or_get_bound_v(
+    uint32_t funcIndex, const ejit_dim_pair_t *dims, uint32_t numDims,
+    const ejit_bound_ptr_t *bounds, uint32_t numBounds, void **outFn,
+    uint32_t *outBucket) {
+  if (numBounds == 0)
+    return taskpoolCompileOrGetImpl(funcIndex, dims, numDims, nullptr, 0,
+                                    outFn, outBucket);
+  static_assert(sizeof(ejit_bound_ptr_t) == sizeof(EJitBoundPtrInput),
+                "C and C++ bound-pointer descriptors must have one layout");
+  static_assert(offsetof(ejit_bound_ptr_t, data) ==
+                    offsetof(EJitBoundPtrInput, data),
+                "bound-pointer data offset drift");
+  static_assert(offsetof(ejit_bound_ptr_t, size) ==
+                    offsetof(EJitBoundPtrInput, size),
+                "bound-pointer size offset drift");
+  static_assert(offsetof(ejit_bound_ptr_t, argIndex) ==
+                    offsetof(EJitBoundPtrInput, argIndex),
+                "bound-pointer argument offset drift");
+  return taskpoolCompileOrGetImpl(
+      funcIndex, dims, numDims,
+      reinterpret_cast<const EJitBoundPtrInput *>(bounds), numBounds, outFn,
+      outBucket);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -56,6 +56,22 @@ static_assert(EJIT_ICACHE_MAX_DIMS == llvm::ejit::kEJitSharedMaxDims,
 using namespace llvm;
 using namespace llvm::ejit;
 
+namespace {
+struct BoundSnapshotGuard {
+  llvm::ejit::EJitBoundSnapshot *snapshot = nullptr;
+  ~BoundSnapshotGuard() {
+    if (snapshot)
+      llvm::ejit::destroyEJitBoundSnapshot(snapshot);
+  }
+  void release() { snapshot = nullptr; }
+};
+
+static EJitCompileRequest requestWithoutBoundSnapshot(EJitCompileRequest req) {
+  req.boundSnapshotPtr = 0;
+  return req;
+}
+} // namespace
+
 #ifndef EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT
 #define EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT 1u
 #endif
@@ -2812,6 +2828,13 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       uint32_t self = EJitCoreId::current();
       uint32_t nextGen = state_->generation.loadRelaxed() + 1;
       // Owner-private batch state must never cross a generation boundary.
+      for (PendingBatchCompile &P : pendingBatchCompiles_)
+        destroyEJitBoundSnapshot(P.req.boundSnapshotPtr);
+      for (PendingPublish &P : pendingPublishes_)
+        destroyEJitBoundSnapshot(P.req.boundSnapshotPtr);
+      EJitCompileRequest StaleRequest{};
+      while (queuePop(StaleRequest))
+        destroyEJitBoundSnapshot(StaleRequest.boundSnapshotPtr);
       pendingBatchCompiles_.clear();
       pendingPublishes_.clear();
       autoTier2PublishPending_ = false;
@@ -2968,9 +2991,16 @@ void EJitSharedTaskPool::ownerShutdown() {
   // A failed enable_ex may leave linked, non-executable objects queued after
   // the worker's final flush attempt. Drop their owner-private metadata before
   // destroying the engine; shared Pending slots were already drained above.
-  for (PendingPublish &P : pendingPublishes_)
+  for (PendingPublish &P : pendingPublishes_) {
+    destroyEJitBoundSnapshot(P.req.boundSnapshotPtr);
     if (releaseFn_)
       releaseFn_(releaseCtx_, P.fn);
+  }
+  for (PendingBatchCompile &P : pendingBatchCompiles_)
+    destroyEJitBoundSnapshot(P.req.boundSnapshotPtr);
+  EJitCompileRequest StaleRequest{};
+  while (queuePop(StaleRequest))
+    destroyEJitBoundSnapshot(StaleRequest.boundSnapshotPtr);
   pendingBatchCompiles_.clear();
   pendingPublishes_.clear();
   autoTier2PublishPending_ = false;
@@ -3207,6 +3237,16 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                                  uint32_t numDims, void *fallback,
                                  const void *boundData, uint32_t boundSize,
                                  uint32_t boundArgIndex) {
+  if (boundSize == 0)
+    return compileOrGetBound(funcIndex, dims, numDims, fallback, nullptr, 0);
+  EJitBoundPtrInput Bound{boundData, boundSize, boundArgIndex};
+  return compileOrGetBound(funcIndex, dims, numDims, fallback, &Bound, 1);
+}
+
+EJitSharedTaskPool::CompileOrGetResult
+EJitSharedTaskPool::compileOrGetBound(
+    uint32_t funcIndex, const EJitDimPair *dims, uint32_t numDims,
+    void *fallback, const EJitBoundPtrInput *boundPtrs, uint32_t boundCount) {
   EJIT_DIAG_VERBOSE("shared taskpool request func=%u dims=%u fallback=%p",
                     funcIndex, numDims, fallback);
   // Parameter check already done by the C API layer.
@@ -3223,6 +3263,11 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   }
   // True miss: continue the slow path with the caller's fallback.
   R.fnPtr = fallback;
+  if (boundCount != 0 &&
+      (boundCount > kEJitMaxBoundPointers || !boundPtrs)) {
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    return R;
+  }
   // Batched baseline compilation releases the coarse per-function in-flight
   // claim after installing an exact-identity Pending marker. Coalesce only an
   // identical request here so another cell/TRP version of the same function
@@ -3230,13 +3275,6 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (cacheHasPending(funcIndex, dims, numDims)) {
     EJIT_STAT_INC(state_->counters.alreadyPending);
     R.status = EJitCompileOrGetStatus::AlreadyPending;
-    return R;
-  }
-  if ((boundSize != 0 && !boundData) || boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
-    EJIT_DIAG("shared taskpool bound snapshot reject func=%u size=%u max=%u",
-              funcIndex, boundSize,
-              static_cast<unsigned>(EJIT_BOUND_PTR_MAX_BYTES));
-    R.status = EJitCompileOrGetStatus::InvalidParam;
     return R;
   }
   // Off mode (§5.2 step 2).
@@ -3258,6 +3296,15 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       R.status = EJitCompileOrGetStatus::OffMode;
       return R;
     }
+    BoundSnapshotGuard SnapshotGuard{
+        createEJitBoundSnapshot(boundPtrs, boundCount,
+                                boundSnapshotAllocator_)};
+    if (boundCount != 0 && !SnapshotGuard.snapshot) {
+      EJIT_DIAG("shared taskpool sync bound snapshot reject func=%u count=%u",
+                funcIndex, boundCount);
+      R.status = EJitCompileOrGetStatus::InvalidParam;
+      return R;
+    }
     // Build request with current instance versions, then compile inline.
     EJitCompileRequest ReqLocal{};
     ReqLocal.funcIndex = funcIndex;
@@ -3267,10 +3314,8 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       ReqLocal.versions[i] =
           instanceVersion(dims[i].dimType, dims[i].instanceId);
     }
-    ReqLocal.boundArgIndex = boundArgIndex;
-    ReqLocal.boundSize = boundSize;
-    if (boundSize)
-      std::memcpy(ReqLocal.boundData, boundData, boundSize);
+    ReqLocal.boundSnapshotPtr =
+        reinterpret_cast<uintptr_t>(SnapshotGuard.snapshot);
     if (!versionsCurrent(ReqLocal)) {
       EJIT_DIAG("shared taskpool sync snapshot drop func=%u: version changed",
                 funcIndex);
@@ -3384,6 +3429,18 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   if (pgoForRequest && pgoAdmissionTestHook_)
     pgoAdmissionTestHook_(pgoAdmissionTestHookCtx_);
 #endif
+  BoundSnapshotGuard SnapshotGuard{
+      createEJitBoundSnapshot(boundPtrs, boundCount, boundSnapshotAllocator_)};
+  if (boundCount != 0 && !SnapshotGuard.snapshot) {
+    dedupClear(funcIndex, gen);
+    if (newlyAdmitted)
+      finishPgoFunction(funcIndex, /*completed=*/false,
+                        "bound-snapshot-allocation-failed");
+    EJIT_DIAG("shared taskpool async bound snapshot reject func=%u count=%u",
+              funcIndex, boundCount);
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    return R;
+  }
   EJitCompileRequest Req{};
   Req.funcIndex = pgoForRequest
                       ? encodeReqTier(funcIndex, kEJitTierInstrumented)
@@ -3395,10 +3452,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     Req.dims[i] = dims[i];
     Req.versions[i] = instanceVersion(dims[i].dimType, dims[i].instanceId);
   }
-  Req.boundArgIndex = boundArgIndex;
-  Req.boundSize = boundSize;
-  if (boundSize)
-    std::memcpy(Req.boundData, boundData, boundSize);
+  Req.boundSnapshotPtr = reinterpret_cast<uintptr_t>(SnapshotGuard.snapshot);
   if (!versionsCurrent(Req) || state_->generation.loadAcquire() != gen) {
     dedupClear(funcIndex, gen);
     if (newlyAdmitted)
@@ -3418,6 +3472,7 @@ EJitSharedTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     R.status = EJitCompileOrGetStatus::QueueFullFallback;
     return R;
   }
+  SnapshotGuard.release(); // ownership moved into the shared queue
   EJIT_STAT_INC(state_->counters.asyncEnqueues);
   EJIT_DIAG_VERBOSE("shared taskpool enqueued func=%u gen=%u", funcIndex, gen);
   R.status = EJitCompileOrGetStatus::EnqueuedPending;
@@ -3737,6 +3792,7 @@ bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
 
 void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
                                     bool hasBatchRequestMarker) {
+  BoundSnapshotGuard SnapshotGuard{getEJitBoundSnapshot(req.boundSnapshotPtr)};
   // PGO (§4.9): the aarch64 exclusive-monitor workaround is a property of the
   // Tier-2 publish, not a caller flag. A Tier-2 (PGOUse) request always follows
   // an arming hit whose hitCount.fetchAdd primed the monitor on this bucket, so
@@ -3833,7 +3889,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
       // must not replace the live Tier-1 slot until the worker observes the
       // compile queue empty and seals the batch. Keep only owner-private state
       // and retain the in-flight claim.
-      pendingPublishes_.push_back({req, fn});
+      pendingPublishes_.push_back({requestWithoutBoundSnapshot(req), fn});
       autoTier2PublishPending_ = true;
       EJIT_DIAG_DEBUG("PGO Tier-2 linked pending queue-drain publish func=%u "
                       "fn=%p pending=%zu",
@@ -3857,7 +3913,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
     }
     EJitPublishStatus Staged = cacheStagePending(req, fn);
     if (Staged == EJitPublishStatus::Published) {
-      pendingPublishes_.push_back({req, fn});
+      pendingPublishes_.push_back({requestWithoutBoundSnapshot(req), fn});
       dedupClear(req.funcIndex, req.generation);
       EJIT_DIAG_DEBUG("shared worker batch staged func=%u fn=%p pending=%zu",
                       req.funcIndex, fn, pendingPublishes_.size());
@@ -3869,7 +3925,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
     // A bucket containing only other Pending identities has no safe eviction
     // victim. Keep the result owner-private with its coarse in-flight claim;
     // the explicit publish call seals all code and then inserts this identity.
-    pendingPublishes_.push_back({req, fn});
+    pendingPublishes_.push_back({requestWithoutBoundSnapshot(req), fn});
     EJIT_DIAG_VERBOSE(
         "shared worker batch retained unstaged func=%u pending=%zu",
         req.funcIndex, pendingPublishes_.size());
@@ -3941,6 +3997,7 @@ bool EJitSharedTaskPool::pollOne() {
       decodeReqTier(Req.funcIndex) == kEJitTierBaseline) {
     if (pendingBatchCompiles_.size() >= kEJitSharedQueueSlots) {
       dedupClear(Req.funcIndex, Req.generation);
+      destroyEJitBoundSnapshot(Req.boundSnapshotPtr);
       EJIT_STAT_INC(state_->counters.queueFull);
       EJIT_DIAG("shared worker batch backlog full func=%u capacity=%u",
                 stripReqTier(Req.funcIndex), kEJitSharedQueueSlots);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitStructFieldPass.cpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cstring>
 #include <limits>
+#include <utility>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -231,48 +232,9 @@ static Function *getDirectCallee(CallBase &CB) {
 }
 
 void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
-  boundArguments_.clear();
-  boundMayConstFields_.clear();
-  if (!boundData_ || !boundSize_)
+  boundSnapshots_.clear();
+  if (boundPointers_.empty())
     return;
-
-  Function *Root = nullptr;
-  if (!boundRootFunction_.empty()) {
-    Root = M.getFunction(boundRootFunction_);
-  } else {
-    // Direct pass users may omit the root name. Infer it only when the module
-    // contains a unique matching bound parameter.
-    for (Function &F : M) {
-      if (!functionBindsArgument(F, boundArgIndex_))
-        continue;
-      if (Root) {
-        Root = nullptr;
-        break;
-      }
-      Root = &F;
-    }
-  }
-  if (!Root || Root->isDeclaration() || boundArgIndex_ >= Root->arg_size() ||
-      !functionBindsArgument(*Root, boundArgIndex_))
-    return;
-
-  Argument *RootArgument = Root->getArg(boundArgIndex_);
-  if (!RootArgument->getType()->isPointerTy())
-    return;
-  boundArguments_[RootArgument] = 0;
-
-  if (MDNode *BoundMD = getBoundArgumentMetadata(*Root, boundArgIndex_)) {
-    for (unsigned I = 4; I < BoundMD->getNumOperands(); ++I) {
-      auto *Field = dyn_cast<MDNode>(BoundMD->getOperand(I));
-      if (!Field || Field->getNumOperands() != 2)
-        continue;
-      auto *Offset = mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
-      auto *Size = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
-      if (Offset && Size)
-        boundMayConstFields_.push_back(
-            {Offset->getZExtValue(), Size->getZExtValue()});
-    }
-  }
 
   const DataLayout &DL = M.getDataLayout();
   SmallVector<CallBase *, 32> DirectCalls;
@@ -294,64 +256,111 @@ void EJitStructFieldPass::initBoundArgumentPropagation(Module &M) {
     }
   }
 
-  bool Changed;
-  do {
-    Changed = false;
-    for (CallBase *CB : DirectCalls) {
-      Function *Callee = getDirectCallee(*CB);
-      unsigned Count =
-          std::min<unsigned>(CB->arg_size(), Callee->arg_size());
-      for (unsigned ArgIndex = 0; ArgIndex < Count; ++ArgIndex) {
-        Argument *Formal = Callee->getArg(ArgIndex);
-        if (!Formal->getType()->isPointerTy())
+  for (const EJitBoundPointerView &View : boundPointers_) {
+    if (!View.data || !View.size)
+      continue;
+
+    BoundSnapshotState State;
+    State.view = View;
+    Function *Root = nullptr;
+    if (!boundRootFunction_.empty()) {
+      Root = M.getFunction(boundRootFunction_);
+    } else {
+      // Direct pass users may omit the root name. Infer it only when the
+      // module contains a unique matching bound parameter.
+      for (Function &F : M) {
+        if (!functionBindsArgument(F, View.argIndex))
           continue;
-        auto Offset = getBoundSnapshotOffset(CB->getArgOperand(ArgIndex),
-                                             boundArguments_, DL);
-        if (!Offset || *Offset >= boundSize_)
-          continue;
-        Changed |= boundArguments_.try_emplace(Formal, *Offset).second;
+        if (Root) {
+          Root = nullptr;
+          break;
+        }
+        Root = &F;
       }
     }
-  } while (Changed);
+    if (!Root || Root->isDeclaration() || View.argIndex >= Root->arg_size() ||
+        !functionBindsArgument(*Root, View.argIndex))
+      continue;
 
-  // A callee is safe only if every call represented in this specialization
-  // module passes the same snapshot-derived pointer to that formal argument.
-  // Prune to a fixed point so ambiguity in an upper helper also removes all
-  // mappings derived through it further down the chain.
-  do {
-    Changed = false;
-    SmallVector<const Argument *, 8> Invalid;
-    for (const auto &[Formal, ExpectedOffset] : boundArguments_) {
-      if (Formal == RootArgument)
-        continue;
-      const Function *Callee = Formal->getParent();
-      if (Callee->hasAddressTaken()) {
-        Invalid.push_back(Formal);
-        continue;
+    Argument *RootArgument = Root->getArg(View.argIndex);
+    if (!RootArgument->getType()->isPointerTy())
+      continue;
+    State.boundArguments[RootArgument] = 0;
+
+    if (MDNode *BoundMD = getBoundArgumentMetadata(*Root, View.argIndex)) {
+      for (unsigned I = 4; I < BoundMD->getNumOperands(); ++I) {
+        auto *Field = dyn_cast<MDNode>(BoundMD->getOperand(I));
+        if (!Field || Field->getNumOperands() != 2)
+          continue;
+        auto *Offset =
+            mdconst::dyn_extract<ConstantInt>(Field->getOperand(0));
+        auto *Size = mdconst::dyn_extract<ConstantInt>(Field->getOperand(1));
+        if (Offset && Size)
+          State.mayConstFields.push_back(
+              {Offset->getZExtValue(), Size->getZExtValue()});
       }
-      bool SawCall = false;
-      bool AllMatch = true;
-      auto CallsIt = CallsByCallee.find(Callee);
-      if (CallsIt != CallsByCallee.end()) {
-        for (CallBase *CB : CallsIt->second) {
-          SawCall = true;
-          unsigned ArgIndex = Formal->getArgNo();
-          if (ArgIndex >= CB->arg_size()) {
-            AllMatch = false;
+    }
+
+    bool Changed;
+    do {
+      Changed = false;
+      for (CallBase *CB : DirectCalls) {
+        Function *Callee = getDirectCallee(*CB);
+        unsigned Count =
+            std::min<unsigned>(CB->arg_size(), Callee->arg_size());
+        for (unsigned ArgIndex = 0; ArgIndex < Count; ++ArgIndex) {
+          Argument *Formal = Callee->getArg(ArgIndex);
+          if (!Formal->getType()->isPointerTy())
             continue;
-          }
-          auto ActualOffset = getBoundSnapshotOffset(
-              CB->getArgOperand(ArgIndex), boundArguments_, DL);
-          if (!ActualOffset || *ActualOffset != ExpectedOffset)
-            AllMatch = false;
+          auto Offset = getBoundSnapshotOffset(
+              CB->getArgOperand(ArgIndex), State.boundArguments, DL);
+          if (!Offset || *Offset >= View.size)
+            continue;
+          Changed |=
+              State.boundArguments.try_emplace(Formal, *Offset).second;
         }
       }
-      if (!SawCall || !AllMatch)
-        Invalid.push_back(Formal);
-    }
-    for (const Argument *Formal : Invalid)
-      Changed |= boundArguments_.erase(Formal);
-  } while (Changed);
+    } while (Changed);
+
+    // A callee is safe only if every call represented in this specialization
+    // module passes the same snapshot-derived pointer to that formal argument.
+    do {
+      Changed = false;
+      SmallVector<const Argument *, 8> Invalid;
+      for (const auto &[Formal, ExpectedOffset] : State.boundArguments) {
+        if (Formal == RootArgument)
+          continue;
+        const Function *Callee = Formal->getParent();
+        if (Callee->hasAddressTaken()) {
+          Invalid.push_back(Formal);
+          continue;
+        }
+        bool SawCall = false;
+        bool AllMatch = true;
+        auto CallsIt = CallsByCallee.find(Callee);
+        if (CallsIt != CallsByCallee.end()) {
+          for (CallBase *CB : CallsIt->second) {
+            SawCall = true;
+            unsigned ArgIndex = Formal->getArgNo();
+            if (ArgIndex >= CB->arg_size()) {
+              AllMatch = false;
+              continue;
+            }
+            auto ActualOffset = getBoundSnapshotOffset(
+                CB->getArgOperand(ArgIndex), State.boundArguments, DL);
+            if (!ActualOffset || *ActualOffset != ExpectedOffset)
+              AllMatch = false;
+          }
+        }
+        if (!SawCall || !AllMatch)
+          Invalid.push_back(Formal);
+      }
+      for (const Argument *Formal : Invalid)
+        Changed |= State.boundArguments.erase(Formal);
+    } while (Changed);
+
+    boundSnapshots_.push_back(std::move(State));
+  }
 }
 
 static bool isBoundMayConstLoad(
@@ -884,8 +893,10 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
         continue;
       }
 
-      bool BoundMayConst = isBoundMayConstLoad(
-          LI, boundArguments_, boundMayConstFields_, DL);
+      bool BoundMayConst = false;
+      for (const BoundSnapshotState &Snapshot : boundSnapshots_)
+        BoundMayConst |= isBoundMayConstLoad(
+            LI, Snapshot.boundArguments, Snapshot.mayConstFields, DL);
       if (!BoundMayConst && !isMayConstLoad(LI, mayConstFieldMap_, DL))
         continue;
 #ifdef EJIT_DIAG_ENABLE
@@ -901,9 +912,14 @@ EJitStructFieldPass::run(Function &F, FunctionAnalysisManager &AM) {
       // Pattern 0: an ejit_bound_ptr parameter. Only the marked load is read
       // from the owned snapshot; the pointer argument and all dynamic fields
       // remain live inputs to the specialization.
-      if (!C)
-        C = tryReplaceBoundPointer(LI, boundData_, boundSize_, boundArguments_,
-                                   DL);
+      if (!C) {
+        for (const BoundSnapshotState &Snapshot : boundSnapshots_) {
+          C = tryReplaceBoundPointer(LI, Snapshot.view.data, Snapshot.view.size,
+                                     Snapshot.boundArguments, DL);
+          if (C)
+            break;
+        }
+      }
 
       // Pattern 1: direct GlobalVariable load (scalar static variable).
       if (!C) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitTaskPool.cpp
@@ -10,6 +10,17 @@
 using namespace llvm;
 using namespace llvm::ejit;
 
+namespace {
+struct BoundSnapshotGuard {
+  llvm::ejit::EJitBoundSnapshot *snapshot = nullptr;
+  ~BoundSnapshotGuard() {
+    if (snapshot)
+      llvm::ejit::destroyEJitBoundSnapshot(snapshot);
+  }
+  void release() { snapshot = nullptr; }
+};
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // EJitSwitchController (§5.1)
 //
@@ -360,6 +371,9 @@ EJitTaskPool::~EJitTaskPool() {
   // cache down, then drain each bucket (write lock waits readers → 0) and
   // clear.
   stopWorker();
+  EJitCompileRequest Pending{};
+  while (queue_.tryDequeue(Pending))
+    destroyEJitBoundSnapshot(Pending.boundSnapshotPtr);
   cache_.shutdown();
 }
 
@@ -491,6 +505,17 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
                            uint32_t numDims, void *fallback,
                            const void *boundData, uint32_t boundSize,
                            uint32_t boundArgIndex) {
+  if (boundSize == 0)
+    return compileOrGetBound(funcIndex, dims, numDims, fallback, nullptr, 0);
+  EJitBoundPtrInput Bound{boundData, boundSize, boundArgIndex};
+  return compileOrGetBound(funcIndex, dims, numDims, fallback, &Bound, 1);
+}
+
+EJitTaskPool::CompileOrGetResult
+EJitTaskPool::compileOrGetBound(uint32_t funcIndex, const EJitDimPair *dims,
+                                uint32_t numDims, void *fallback,
+                                const EJitBoundPtrInput *boundPtrs,
+                                uint32_t boundCount) {
   EJIT_DIAG_VERBOSE("taskpool request func=%u dims=%u fallback=%p", funcIndex,
                     numDims, fallback);
 
@@ -528,10 +553,8 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   // True miss: continue the slow path with the caller's fallback.
   R.fnPtr = fallback;
 
-  if ((boundSize != 0 && !boundData) || boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
-    EJIT_DIAG("taskpool bound snapshot reject func=%u size=%u max=%u",
-              funcIndex, boundSize,
-              static_cast<unsigned>(EJIT_BOUND_PTR_MAX_BYTES));
+  if (boundCount != 0 &&
+      (boundCount > kEJitMaxBoundPointers || !boundPtrs)) {
     R.status = EJitCompileOrGetStatus::InvalidParam;
     return R;
   }
@@ -551,6 +574,14 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       R.status = EJitCompileOrGetStatus::CompileFailed;
       return R;
     }
+    BoundSnapshotGuard SnapshotGuard{createEJitBoundSnapshot(
+        boundPtrs, boundCount, boundSnapshotAllocator_)};
+    if (boundCount != 0 && !SnapshotGuard.snapshot) {
+      EJIT_DIAG("taskpool sync bound snapshot reject func=%u count=%u",
+                funcIndex, boundCount);
+      R.status = EJitCompileOrGetStatus::InvalidParam;
+      return R;
+    }
     EJitCompileRequest Req{};
     Req.funcIndex = funcIndex;
     Req.numDims = numDims;
@@ -560,10 +591,7 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
       Req.versions[i] =
           switch_.getInstanceVersion(dims[i].dimType, dims[i].instanceId);
     }
-    Req.boundArgIndex = boundArgIndex;
-    Req.boundSize = boundSize;
-    if (boundSize)
-      std::memcpy(Req.boundData, boundData, boundSize);
+    Req.boundSnapshotPtr = reinterpret_cast<uintptr_t>(SnapshotGuard.snapshot);
     if (!versionsMatch(Req)) {
       EJIT_DIAG("taskpool sync snapshot drop func=%u: version changed",
                 funcIndex);
@@ -615,6 +643,14 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
   }
 
   // 5. Dedup + enqueue (§5.2 step 3) — Async path.
+  BoundSnapshotGuard SnapshotGuard{
+      createEJitBoundSnapshot(boundPtrs, boundCount, boundSnapshotAllocator_)};
+  if (boundCount != 0 && !SnapshotGuard.snapshot) {
+    EJIT_DIAG("taskpool async bound snapshot reject func=%u count=%u",
+              funcIndex, boundCount);
+    R.status = EJitCompileOrGetStatus::InvalidParam;
+    return R;
+  }
   EJitCompileRequest Req{};
   Req.funcIndex = funcIndex;
   Req.numDims = numDims;
@@ -624,10 +660,7 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
     Req.versions[i] =
         switch_.getInstanceVersion(dims[i].dimType, dims[i].instanceId);
   }
-  Req.boundArgIndex = boundArgIndex;
-  Req.boundSize = boundSize;
-  if (boundSize)
-    std::memcpy(Req.boundData, boundData, boundSize);
+  Req.boundSnapshotPtr = reinterpret_cast<uintptr_t>(SnapshotGuard.snapshot);
   if (!versionsMatch(Req)) {
     EJIT_DIAG("taskpool async snapshot drop func=%u: version changed",
               funcIndex);
@@ -637,6 +670,7 @@ EJitTaskPool::compileOrGet(uint32_t funcIndex, const EJitDimPair *dims,
 
   EJitTaskQueue::EnqueueResult EQ = queue_.tryEnqueue(Req);
   if (EQ == EJitTaskQueue::EnqueueResult::Enqueued) {
+    SnapshotGuard.release(); // ownership moved into the queue request
     EJIT_STAT_INC(counters_.asyncEnqueues);
     EJIT_DIAG_VERBOSE("taskpool enqueued func=%u", funcIndex);
     R.status = EJitCompileOrGetStatus::EnqueuedPending;
@@ -671,6 +705,7 @@ bool EJitTaskPool::versionsMatch(const EJitCompileRequest &req) const {
 }
 
 void EJitTaskPool::runCompile(const EJitCompileRequest &req) {
+  BoundSnapshotGuard SnapshotGuard{getEJitBoundSnapshot(req.boundSnapshotPtr)};
   EJIT_DIAG_VERBOSE("worker compile begin func=%u dims=%u", req.funcIndex,
                     req.numDims);
   // Checkpoint 1 (§5.3): drop a request invalidated before compilation started.

--- a/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitWrapperGen.cpp
@@ -153,10 +153,11 @@ struct BoundPtrInfo {
   uint64_t PointeeSize;
 };
 
-static std::optional<BoundPtrInfo> getBoundPtrInfo(const Function &F) {
+static SmallVector<BoundPtrInfo, 4> getBoundPtrInfo(const Function &F) {
+  SmallVector<BoundPtrInfo, 4> Result;
   MDNode *MD = F.getMetadata(MD_EJIT_METADATA);
   if (!MD)
-    return std::nullopt;
+    return Result;
   for (const MDOperand &Op : MD->operands()) {
     auto *Sub = dyn_cast<MDNode>(Op.get());
     if (!Sub || Sub->getNumOperands() < 4)
@@ -166,11 +167,11 @@ static std::optional<BoundPtrInfo> getBoundPtrInfo(const Function &F) {
     auto *Idx = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(2));
     auto *Size = mdconst::dyn_extract<ConstantInt>(Sub->getOperand(3));
     if (Tag && Tag->getString() == TAG_EJIT_BOUND_PTR && PN && Idx && Size)
-      return BoundPtrInfo{PN->getString().str(),
-                          static_cast<unsigned>(Idx->getZExtValue()),
-                          Size->getZExtValue()};
+      Result.push_back(BoundPtrInfo{PN->getString().str(),
+                                    static_cast<unsigned>(Idx->getZExtValue()),
+                                    Size->getZExtValue()});
   }
-  return std::nullopt;
+  return Result;
 }
 
 static SmallVector<PeriodArrIndInfo, 4> getPeriodArrIndInfo(const Function &F) {
@@ -586,7 +587,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       FN_TASKPOOL_COMPILE_OR_GET,
       FunctionType::get(I32Ty, {I32Ty, PtrTy, I32Ty, PtrTy, PtrTy}, false));
   bool HasBoundPtr = llvm::any_of(EntryFuncs, [](const Function *F) {
-    return getBoundPtrInfo(*F).has_value();
+    return !getBoundPtrInfo(*F).empty();
   });
   if (HasBoundPtr)
     M.getOrInsertFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND,
@@ -594,6 +595,12 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
                                             {I32Ty, PtrTy, I32Ty, PtrTy, I32Ty,
                                              I32Ty, PtrTy, PtrTy},
                                             false));
+  if (HasBoundPtr)
+    M.getOrInsertFunction(
+        FN_TASKPOOL_COMPILE_OR_GET_BOUND_V,
+        FunctionType::get(I32Ty,
+                          {I32Ty, PtrTy, I32Ty, PtrTy, I32Ty, PtrTy, PtrTy},
+                          false));
   M.getOrInsertFunction(
       FN_TASKPOOL_RELEASE_READ,
       FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false));
@@ -720,7 +727,7 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       F->addFnAttr(Attribute::NoInline);
 
     auto PeriodInds = getPeriodArrIndInfo(*F);
-    auto BoundPtr = getBoundPtrInfo(*F);
+    auto BoundPtrs = getBoundPtrInfo(*F);
     unsigned DimCount = PeriodInds.size();
 
     if (DimCount > EJIT_ICACHE_MAX_DIMS) {
@@ -775,20 +782,41 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
     if (Invalid)
       continue;
 
-    if (BoundPtr) {
+    for (const BoundPtrInfo &BoundPtr : BoundPtrs) {
       unsigned MatchingDims =
           llvm::count_if(PeriodInds, [&](const PeriodArrIndInfo &I) {
-            return I.PeriodName == BoundPtr->PeriodName;
+            return I.PeriodName == BoundPtr.PeriodName;
           });
-      if (BoundPtr->ArgIndex >= ArgCount ||
-          !F->getArg(BoundPtr->ArgIndex)->getType()->isPointerTy() ||
-          BoundPtr->PointeeSize == 0 ||
-          BoundPtr->PointeeSize > std::numeric_limits<uint32_t>::max() ||
+      if (BoundPtr.ArgIndex >= ArgCount ||
+          !F->getArg(BoundPtr.ArgIndex)->getType()->isPointerTy() ||
+          BoundPtr.PointeeSize == 0 ||
+          BoundPtr.PointeeSize > std::numeric_limits<uint32_t>::max() ||
           MatchingDims != 1) {
         F->getContext().emitError(
             "ejit-wrapper-gen: invalid ejit_bound_ptr metadata");
-        continue;
+        Invalid = true;
+        break;
       }
+    }
+    if (Invalid)
+      continue;
+
+    for (unsigned I = 0; I < BoundPtrs.size() && !Invalid; ++I)
+      for (unsigned J = 0; J < I; ++J)
+        if (BoundPtrs[I].ArgIndex == BoundPtrs[J].ArgIndex) {
+          F->getContext().emitError(
+              "ejit-wrapper-gen: duplicate ejit_bound_ptr argument");
+          Invalid = true;
+          break;
+        }
+    if (Invalid)
+      continue;
+
+    if (BoundPtrs.size() > MAX_BOUND_PTR_PARAMS) {
+      F->getContext().emitError(
+          "ejit-wrapper-gen: too many ejit_bound_ptr parameters; at most " +
+          Twine(MAX_BOUND_PTR_PARAMS) + " are supported");
+      continue;
     }
 
     // Save original entry block
@@ -801,8 +829,10 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         EJitInlineCache && IcacheIt != IcacheFnGlobals.end();
 
     auto *DimPairTy = StructType::get(I32Ty, I32Ty);
+    auto *BoundDescTy = StructType::get(PtrTy, I32Ty, I32Ty);
     auto *I64Ty = Type::getInt64Ty(Ctx);
-    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2 && !BoundPtr;
+    bool UseFixed = EJitWrapperFixedDimEntry && DimCount <= 2 &&
+                    BoundPtrs.empty();
 
     SmallVector<ReturnInst *, 8> OriginalReturns;
     for (BasicBlock &BB : *F)
@@ -912,10 +942,18 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
       // Allocas live in the entry block so they dominate the call/dispatch
       // blocks (and match the original layout: allocas precede the funcidx
       // guard).
-      Value *DimsAlloca = UseFixed
-                              ? nullptr
-                              : B.CreateAlloca(ArrayType::get(DimPairTy, 4),
-                                               nullptr, "ejit_dims");
+      Value *DimsAlloca =
+          UseFixed ? nullptr
+                   : B.CreateAlloca(ArrayType::get(DimPairTy, 4), nullptr,
+                                    "ejit_dims");
+      // Keep the compatibility single-pointer path as small as before. Only
+      // the multi-pointer ABI needs a stack descriptor table, whose size is
+      // bounded by MAX_BOUND_PTR_PARAMS and contains no payload bytes.
+      Value *BoundDescsAlloca =
+          BoundPtrs.size() > 1
+              ? B.CreateAlloca(ArrayType::get(BoundDescTy, BoundPtrs.size()),
+                               nullptr, "ejit_bound_ptrs")
+              : nullptr;
       Value *OutFnAlloca = B.CreateAlloca(PtrTy, nullptr, "ejit_out_fn");
       Value *OutBucketAlloca =
           B.CreateAlloca(I32Ty, nullptr, "ejit_out_bucket");
@@ -985,14 +1023,41 @@ PreservedAnalyses EJitWrapperGenPass::run(Module &M,
         }
         Value *DimsPtr = DimCount > 0 ? B.CreatePointerCast(DimsAlloca, PtrTy)
                                       : ConstantPointerNull::get(PtrTy);
-        if (BoundPtr) {
-          Value *Snapshot = Fn.getArg(BoundPtr->ArgIndex);
-          Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND),
-                                {FuncIdx, DimsPtr,
-                                 ConstantInt::get(I32Ty, DimCount), Snapshot,
-                                 ConstantInt::get(I32Ty, BoundPtr->PointeeSize),
-                                 ConstantInt::get(I32Ty, BoundPtr->ArgIndex),
-                                 OutFnArg, OutBucketArg});
+        if (!BoundPtrs.empty()) {
+          if (BoundPtrs.size() == 1) {
+            const BoundPtrInfo &BoundPtr = BoundPtrs.front();
+            Value *Snapshot = Fn.getArg(BoundPtr.ArgIndex);
+            Status = B.CreateCall(
+                M.getFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND),
+                {FuncIdx, DimsPtr, ConstantInt::get(I32Ty, DimCount),
+                 Snapshot, ConstantInt::get(I32Ty, BoundPtr.PointeeSize),
+                 ConstantInt::get(I32Ty, BoundPtr.ArgIndex), OutFnArg,
+                 OutBucketArg});
+          } else {
+            for (unsigned I = 0; I < BoundPtrs.size(); ++I) {
+              Value *Idxs[] = {ConstantInt::get(I32Ty, 0),
+                               ConstantInt::get(I32Ty, I)};
+              Value *DescPtr = B.CreateInBoundsGEP(
+                  ArrayType::get(BoundDescTy, BoundPtrs.size()),
+                  BoundDescsAlloca, Idxs);
+              B.CreateStore(Fn.getArg(BoundPtrs[I].ArgIndex),
+                            B.CreateStructGEP(BoundDescTy, DescPtr, 0,
+                                              "bound_data_ptr"));
+              B.CreateStore(
+                  ConstantInt::get(I32Ty, BoundPtrs[I].PointeeSize),
+                  B.CreateStructGEP(BoundDescTy, DescPtr, 1, "bound_size"));
+              B.CreateStore(
+                  ConstantInt::get(I32Ty, BoundPtrs[I].ArgIndex),
+                  B.CreateStructGEP(BoundDescTy, DescPtr, 2, "bound_arg"));
+            }
+            Value *BoundsPtr = B.CreatePointerCast(BoundDescsAlloca, PtrTy);
+            Status = B.CreateCall(
+                M.getFunction(FN_TASKPOOL_COMPILE_OR_GET_BOUND_V),
+                {FuncIdx, DimsPtr, ConstantInt::get(I32Ty, DimCount),
+                 BoundsPtr,
+                 ConstantInt::get(I32Ty, BoundPtrs.size()), OutFnArg,
+                 OutBucketArg});
+          }
         } else {
           Status = B.CreateCall(M.getFunction(FN_TASKPOOL_COMPILE_OR_GET),
                                 {FuncIdx, DimsPtr,

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -1734,6 +1734,55 @@ TEST(EJitStructFieldPass, BoundPointerUsesOwnedSnapshot) {
   EXPECT_TRUE(SawSnapshotConstant);
 }
 
+TEST(EJitStructFieldPass, MultipleBoundPointersRemainIndependent) {
+  LLVMContext Ctx;
+  SMDiagnostic Err;
+  auto M = parseAssemblyString(R"(
+    define i32 @bound_multi(i32 %cell, ptr %a, ptr %b) !ejit.metadata !0 {
+    entry:
+      %ap = getelementptr i32, ptr %a, i32 0
+      %av = load i32, ptr %ap, !ejit.may_const !4
+      %bp = getelementptr i32, ptr %b, i32 0
+      %bv = load i32, ptr %bp, !ejit.may_const !4
+      %sum = add i32 %av, %bv
+      ret i32 %sum
+    }
+    !0 = distinct !{!1, !2, !3, !5}
+    !1 = !{!"ejit_entry"}
+    !2 = !{!"ejit_period_arr_ind", !"cell", i32 0}
+    !3 = !{!"ejit_bound_ptr", !"cell", i32 1, i64 4, !6}
+    !4 = !{!"ejit"}
+    !5 = !{!"ejit_bound_ptr", !"cell", i32 2, i64 4, !7}
+    !6 = !{i64 0, i64 4}
+    !7 = !{i64 0, i64 4}
+  )",
+                               Err, Ctx);
+  ASSERT_TRUE(M) << Err.getMessage().str();
+  M->setDataLayout("e-p:64:64-i64:64-n8:16:32:64-S128");
+
+  uint32_t A = 7;
+  uint32_t B = 11;
+  EJitBoundPointerView Views[] = {
+      {reinterpret_cast<const uint8_t *>(&A), sizeof(A), 1},
+      {reinterpret_cast<const uint8_t *>(&B), sizeof(B), 2}};
+  PeriodArrayRegistry Registry;
+  EJitStructFieldPass Pass(Registry, Views, "bound_multi");
+  Pass.initFromModule(*M);
+  FunctionAnalysisManager FAM;
+  Pass.run(*M->getFunction("bound_multi"), FAM);
+
+  Function *F = M->getFunction("bound_multi");
+  ASSERT_NE(F, nullptr);
+  EXPECT_EQ(std::count_if(inst_begin(F), inst_end(F),
+                          [](Instruction &I) { return isa<LoadInst>(I); }),
+            0);
+  auto *Ret = dyn_cast<ReturnInst>(F->getEntryBlock().getTerminator());
+  ASSERT_NE(Ret, nullptr);
+  auto *Value = dyn_cast<ConstantInt>(Ret->getReturnValue());
+  ASSERT_NE(Value, nullptr);
+  EXPECT_EQ(Value->getZExtValue(), 18u);
+}
+
 TEST(EJitStructFieldPass, BoundPointerPropagatesThroughDirectHelpers) {
   LLVMContext Ctx;
   SMDiagnostic Err;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <thread>
@@ -60,17 +61,51 @@ struct BoundSnapshotLog {
   uint32_t argIndex = 0;
   uint32_t size = 0;
   uint32_t value = 0;
+  uint32_t entryCount = 0;
+  uint32_t secondArgIndex = 0;
+  uint32_t secondValue = 0;
 };
 bool mockCompileBoundSnapshot(void *ctx, const EJitCompileRequest &req,
                               void **outFn) {
   auto *log = static_cast<BoundSnapshotLog *>(ctx);
-  log->argIndex = req.boundArgIndex;
-  log->size = req.boundSize;
-  if (req.boundSize >= sizeof(log->value))
-    std::memcpy(&log->value, req.boundData, sizeof(log->value));
+  const auto *snapshot = getEJitBoundSnapshot(req.boundSnapshotPtr);
+  if (isValidEJitBoundSnapshot(snapshot)) {
+    log->entryCount = snapshot->entryCount;
+    const auto *entries = getEJitBoundSnapshotEntries(snapshot);
+    const auto *bytes = getEJitBoundSnapshotBytes(snapshot);
+    log->argIndex = entries[0].argIndex;
+    log->size = entries[0].size;
+    if (entries[0].size >= sizeof(log->value))
+      std::memcpy(&log->value, bytes + entries[0].offset, sizeof(log->value));
+    if (snapshot->entryCount > 1) {
+      log->secondArgIndex = entries[1].argIndex;
+      if (entries[1].size >= sizeof(log->secondValue))
+        std::memcpy(&log->secondValue, bytes + entries[1].offset,
+                    sizeof(log->secondValue));
+    }
+  }
   *outFn = codeFor(req.funcIndex);
   return true;
 }
+
+struct SnapshotAllocatorProbe {
+  uint32_t allocations = 0;
+  uint32_t frees = 0;
+  bool fail = false;
+
+  static void *allocate(void *ctx, size_t size) {
+    auto *probe = static_cast<SnapshotAllocatorProbe *>(ctx);
+    ++probe->allocations;
+    if (probe->fail)
+      return nullptr;
+    return std::malloc(size);
+  }
+  static void deallocate(void *ctx, void *ptr) {
+    auto *probe = static_cast<SnapshotAllocatorProbe *>(ctx);
+    ++probe->frees;
+    std::free(ptr);
+  }
+};
 
 // Compiler that toggles an instance mid-compile to model a deactivate landing
 // during compilation (ctx = the pool).
@@ -927,6 +962,76 @@ TEST_F(SharedTaskPoolTest, BoundSnapshotOwnedAcrossCores) {
   EXPECT_EQ(log.argIndex, 3u);
   EXPECT_EQ(log.size, sizeof(callerValue));
   EXPECT_EQ(log.value, 0x12345678u);
+}
+
+TEST_F(SharedTaskPoolTest, MultipleLargeBoundSnapshotsSurviveQueueHandoff) {
+  SnapshotAllocatorProbe allocator;
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  owner.setBoundSnapshotAllocator({&SnapshotAllocatorProbe::allocate,
+                                   &SnapshotAllocatorProbe::deallocate,
+                                   &allocator});
+  BoundSnapshotLog log;
+  owner.setCompiler(&mockCompileBoundSnapshot, &log);
+
+  std::vector<uint8_t> first(2048, 0);
+  std::vector<uint8_t> second(3072, 0);
+  uint32_t firstValue = 0x11112222u;
+  uint32_t secondValue = 0x33334444u;
+  std::memcpy(first.data(), &firstValue, sizeof(firstValue));
+  std::memcpy(second.data(), &secondValue, sizeof(secondValue));
+  EJitBoundPtrInput bounds[] = {
+      {first.data(), static_cast<uint32_t>(first.size()), 1},
+      {second.data(), static_cast<uint32_t>(second.size()), 4}};
+  // This test isolates snapshot ownership; using a dimension would add an
+  // unrelated instance-enable precondition to the shared-pool fixture.
+  const EJitDimPair *dims = nullptr;
+  EJitCoreId::setCurrentForTest(2);
+  // Keep this key isolated from the older cross-core tests in the same
+  // process; a stale pending claim must not turn this regression into a
+  // dedup assertion.
+  auto r = owner.compileOrGetBound(3001, dims, 0, codeFor(3001), bounds, 2);
+  ASSERT_EQ(r.status, EJitCompileOrGetStatus::EnqueuedPending);
+  first[0] = 0;
+  second[0] = 0;
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_TRUE(owner.pollOne());
+  EXPECT_EQ(log.entryCount, 2u);
+  EXPECT_EQ(log.size, first.size());
+  EXPECT_EQ(log.argIndex, 1u);
+  EXPECT_EQ(log.value, firstValue);
+  EXPECT_EQ(log.secondArgIndex, 4u);
+  EXPECT_EQ(log.secondValue, secondValue);
+  EXPECT_EQ(allocator.allocations, 1u);
+  EXPECT_EQ(allocator.frees, 1u);
+}
+
+TEST_F(SharedTaskPoolTest, BoundSnapshotFailureRollsBackDedupAndPgoAdmission) {
+  SnapshotAllocatorProbe allocator;
+  allocator.fail = true;
+  EJitSharedTaskPool owner;
+  bringUpOwner(owner);
+  owner.setPgoEnabled(true, 8);
+  owner.setBoundSnapshotAllocator({&SnapshotAllocatorProbe::allocate,
+                                   &SnapshotAllocatorProbe::deallocate,
+                                   &allocator});
+
+  uint32_t first = 0x11111111u;
+  EJitBoundPtrInput valid[] = {{&first, sizeof(first), 2}};
+  // A deterministic allocator failure is reported after the async path has
+  // claimed dedup and PGO admission. This covers the same rollback window as
+  // duplicate-argument validation without depending on host memory pressure.
+  const uint32_t activeBefore = state_->pgoActiveFunctionCount.loadAcquire();
+  auto bad = owner.compileOrGetBound(3002, nullptr, 0, codeFor(3002), valid, 1);
+  EXPECT_EQ(bad.status, EJitCompileOrGetStatus::InvalidParam);
+  EXPECT_EQ(owner.pendingCount(), 0u);
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), activeBefore);
+
+  allocator.fail = false;
+  auto good =
+      owner.compileOrGetBound(3002, nullptr, 0, codeFor(3002), valid, 1);
+  EXPECT_EQ(good.status, EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), activeBefore + 1);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3032,8 +3137,9 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // v10-v13 add PGO controls, writable ranges, staged admission, and audit
   // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
   // per-version post-publish reuse tracking; v16 adds near/far placement.
-  // v17 adds explicit batch publish state.
-  EXPECT_EQ(kEJitSharedAbiVersion, 17u);
+  // v17 adds explicit batch publish state; v18 moves bound snapshots out of
+  // the fixed queue cell into an owned same-address-space allocation.
+  EXPECT_EQ(kEJitSharedAbiVersion, 18u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <vector>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -88,16 +89,39 @@ struct PublishObserver {
 struct SnapshotCompiler {
   uint32_t first = 0;
   uint32_t second = 0;
+  uint32_t middle = 0;
   uint32_t argIndex = 0;
+  uint32_t entryCount = 0;
+  uint32_t secondArgIndex = 0;
 
   static bool compile(void *ctx, const EJitCompileRequest &req, void **outFn) {
     auto *self = static_cast<SnapshotCompiler *>(ctx);
-    if (req.boundSize >= 2 * sizeof(uint32_t)) {
-      std::memcpy(&self->first, req.boundData, sizeof(uint32_t));
-      std::memcpy(&self->second, req.boundData + sizeof(uint32_t),
-                  sizeof(uint32_t));
+    const auto *snapshot = getEJitBoundSnapshot(req.boundSnapshotPtr);
+    if (isValidEJitBoundSnapshot(snapshot)) {
+      self->entryCount = snapshot->entryCount;
+      const auto *entries = getEJitBoundSnapshotEntries(snapshot);
+      const auto *bytes = getEJitBoundSnapshotBytes(snapshot);
+      if (entries[0].size >= sizeof(uint32_t))
+        std::memcpy(&self->first, bytes + entries[0].offset,
+                    sizeof(uint32_t));
+      // Preserve the legacy single-buffer check while also checking that a
+      // large payload was copied beyond its initial bytes.
+      if (snapshot->entryCount == 1 &&
+          entries[0].size >= 2 * sizeof(uint32_t))
+        std::memcpy(&self->second, bytes + entries[0].offset + sizeof(uint32_t),
+                    sizeof(uint32_t));
+      if (snapshot->entryCount == 1 &&
+          entries[0].size >= 2048 + sizeof(uint32_t))
+        std::memcpy(&self->middle, bytes + entries[0].offset + 2048,
+                    sizeof(uint32_t));
+      self->argIndex = entries[0].argIndex;
+      if (snapshot->entryCount > 1) {
+        self->secondArgIndex = entries[1].argIndex;
+        if (entries[1].size >= sizeof(uint32_t))
+          std::memcpy(&self->second, bytes + entries[1].offset,
+                      sizeof(uint32_t));
+      }
     }
-    self->argIndex = req.boundArgIndex;
     *outFn = reinterpret_cast<void *>(&DummyFn0);
     return true;
   }
@@ -125,11 +149,11 @@ TEST(EJitTaskPoolLayout, RequestIsFlatPod) {
   static_assert(std::is_standard_layout<EJitCompileRequest>::value,
                 "EJitCompileRequest must be standard layout");
   EXPECT_LE(alignof(EJitCompileRequest), 8u);
-  // The fixed request owns its optional bound-pointer bytes inline. See the
+  // The request owns only a pointer-sized snapshot handle. See the
   // cross-pointer-width layout assertion in EJitSreQueue.h.
   EXPECT_EQ(sizeof(EJitCompileRequest), sizeof(uintptr_t) == 8
-                                            ? 80u + EJIT_BOUND_PTR_MAX_BYTES
-                                            : 72u + EJIT_BOUND_PTR_MAX_BYTES);
+                                            ? 80u
+                                            : 68u);
 }
 
 //===----------------------------------------------------------------------===//
@@ -981,11 +1005,85 @@ TEST(EJitTaskPoolTest, BoundSnapshotOutlivesCallerObject) {
 TEST(EJitTaskPoolTest, OversizeBoundSnapshotFallsBack) {
   EJitTaskPool P(8, false);
   P.switchController().setMode(EJitCompileMode::Async);
-  uint8_t Data[EJIT_BOUND_PTR_MAX_BYTES + 1] = {};
+  SnapshotCompiler C;
+  P.setCompiler(&SnapshotCompiler::compile, &C);
+  std::vector<uint8_t> Data(4096, 0);
+  uint32_t Expected = 0xA5A5A5A5u;
+  std::memcpy(Data.data() + 2048, &Expected, sizeof(Expected));
   EJitDimPair D[1] = {{0, 3}};
-  auto R = P.compileOrGet(18, D, 1, nullptr, Data, sizeof(Data), 1);
+  auto R = P.compileOrGet(18, D, 1, nullptr, Data.data(),
+                          static_cast<uint32_t>(Data.size()), 1);
+  ASSERT_EQ(R.status, EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(P.pollOne());
+  EXPECT_EQ(C.first, 0u);
+  EXPECT_EQ(C.entryCount, 1u);
+  EXPECT_EQ(C.middle, Expected);
+
+  // A malformed input fails without leaving an owned allocation or a pending
+  // dedup claim, and a later valid request still works.
+  auto Bad = P.compileOrGet(19, D, 1, nullptr, nullptr, 4096, 1);
+  EXPECT_EQ(Bad.status, EJitCompileOrGetStatus::InvalidParam);
+  EXPECT_EQ(P.pendingCount(), 0u);
+  auto Good = P.compileOrGet(19, D, 1, nullptr, Data.data(),
+                             static_cast<uint32_t>(Data.size()), 1);
+  EXPECT_EQ(Good.status, EJitCompileOrGetStatus::EnqueuedPending);
+}
+
+TEST(EJitTaskPoolTest, MultipleBoundSnapshotsAreIndependent) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  SnapshotCompiler C;
+  P.setCompiler(&SnapshotCompiler::compile, &C);
+  uint32_t First = 17;
+  uint32_t Second = 29;
+  EJitBoundPtrInput Bounds[] = {{&First, sizeof(First), 1},
+                                {&Second, sizeof(Second), 3}};
+  EJitDimPair D[1] = {{0, 4}};
+  auto R = P.compileOrGetBound(20, D, 1, nullptr, Bounds, 2);
+  ASSERT_EQ(R.status, EJitCompileOrGetStatus::EnqueuedPending);
+  First = 100;
+  Second = 200;
+  ASSERT_TRUE(P.pollOne());
+  EXPECT_EQ(C.entryCount, 2u);
+  EXPECT_EQ(C.first, 17u);
+  EXPECT_EQ(C.second, 29u);
+  EXPECT_EQ(C.argIndex, 1u);
+  EXPECT_EQ(C.secondArgIndex, 3u);
+}
+
+TEST(EJitTaskPoolTest, TooManyBoundPointersRejected) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  SnapshotCompiler C;
+  P.setCompiler(&SnapshotCompiler::compile, &C);
+  uint32_t Values[kEJitMaxBoundPointers + 1] = {};
+  EJitBoundPtrInput Bounds[kEJitMaxBoundPointers + 1] = {};
+  for (uint32_t I = 0; I < kEJitMaxBoundPointers + 1; ++I)
+    Bounds[I] = {&Values[I], sizeof(Values[I]), I};
+  EJitDimPair D[1] = {{0, 5}};
+
+  auto R = P.compileOrGetBound(21, D, 1, nullptr, Bounds,
+                               kEJitMaxBoundPointers + 1);
   EXPECT_EQ(R.status, EJitCompileOrGetStatus::InvalidParam);
   EXPECT_EQ(P.pendingCount(), 0u);
+  EXPECT_EQ(C.entryCount, 0u);
+}
+
+TEST(EJitTaskPoolTest, DuplicateBoundPointerArgumentRejected) {
+  EJitTaskPool P(8, false);
+  P.switchController().setMode(EJitCompileMode::Async);
+  SnapshotCompiler C;
+  P.setCompiler(&SnapshotCompiler::compile, &C);
+  uint32_t First = 1;
+  uint32_t Second = 2;
+  EJitBoundPtrInput Bounds[] = {{&First, sizeof(First), 4},
+                                {&Second, sizeof(Second), 4}};
+  EJitDimPair D[1] = {{0, 6}};
+
+  auto R = P.compileOrGetBound(22, D, 1, nullptr, Bounds, 2);
+  EXPECT_EQ(R.status, EJitCompileOrGetStatus::InvalidParam);
+  EXPECT_EQ(P.pendingCount(), 0u);
+  EXPECT_EQ(C.entryCount, 0u);
 }
 
 TEST(EJitTaskPoolTest, OutOfRangeFuncIndexRejected) {


### PR DESCRIPTION
Depends on #177

## 中文摘要

- 移除 bound-pointer snapshot 约 1500B 的固定硬限制；快照按实际大小一次性复制，不静默截断，分配失败时干净回退 AOT。
- 同一个 ejit_entry 支持最多 8 个独立结构体指针，分别维护 snapshot、生命周期、specialization key 和 wrapper 回填。
- 增加 snapshot allocator/free hooks。Host 默认使用 malloc/free；SRE/freestanding 集成必须在每个可能执行 entry wrapper 的 producer 核自己的 ejit_init() 前注入跨核、同 VA、线程安全且生命周期稳定的 allocator。未配置时回退 AOT。
- 修复异步 snapshot 创建失败后的 dedup 和 staged-PGO admission 状态泄漏。

## English Summary

- Removes the historical approximately 1500-byte bound-pointer snapshot cap. Snapshots are copied exactly once without silent truncation; allocation failure cleanly falls back to AOT.
- Supports up to 8 independent bound struct pointers per ejit_entry, with independent snapshot lifetime, specialization identity, and wrapper write-back.
- Adds injectable snapshot allocation/free hooks. Hosted builds use malloc/free by default; SRE/freestanding integrations must install a cross-core, same-VA, thread-safe allocator before ejit_init() on every producer core that may execute an entry wrapper. Missing hooks fall back to AOT.
- Rolls back dedup and staged-PGO admission when snapshot creation fails.

## Risk / Integration

- Snapshot allocation happens only on the first cache-miss enqueue path, but platform allocators must budget capacity and latency for large snapshots.
- The returned storage, freeFn code, and ctx must be accessible and callable at the same VA from the owner worker, and must remain valid until queued snapshots drain.
- This branch is based directly on the PR #177 head branch, not the pre-#177 history. The shared ABI is currently v18; coordinate the v19+ ABI bump when rebasing onto the combined line.

## Tests

- EJITTaskPoolTests: 92/92 passed.
- Shared bound snapshot focused tests: 3/3 passed.
- LLVMEJIT build passed.
- Freestanding object check: no malloc/free symbols.
- clang-format check and git diff --check passed.
- The full shared suite was 140/162 locally; the 22 failures are existing local code-sharing/4K-seal configuration failures and are unchanged by this branch.