### PR TITLE
[EJIT] Add code-pool accounting diagnostics

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -367,6 +367,7 @@ def doit_gc_merge(args):
         "ejit_set_log_level", "ejit_get_log_level",
         "ejit_print_registry", "ejit_print_func_meta",
         "ejit_get_code_pool_stats", "ejit_get_code_pool_stats_v2",
+        "ejit_get_code_pool_stats_v3",
         "ejit_print_code_pool_stats",
         "ejit_print_active",
         # Build identity (LLVM version + git commit). Called from user app

--- a/jit_design_doc/EJIT_DIAGNOSTICS.md
+++ b/jit_design_doc/EJIT_DIAGNOSTICS.md
@@ -128,7 +128,9 @@ unsigned      ejit_taskpool_pending_count(void); // 在途数量
 
 > 若 `cacheHits` 等逐调用计数全为零，说明运行库未启用逐调用统计（这些计数有热点路径开销，默认关闭）；`print_compiled()`、`get_worker_core()`、`pending_count()` 不受此影响，始终可用。
 
-`ejit_taskpool_print_compiled()` 的摘要中，`entries` 是本次尽力遍历到的 Ready 特化数，`slots` 是 cache 占用，`buckets skipped` 表示遍历时因并发竞争而跳过的 bucket；因此它不是强一致快照。摘要分别统计 `baseline/tier1_collecting/tier2`、主代码池落点和带 MFS 冷区的版本数。明细中的 `dims=[d:i,...]` 表示 `dimType:instanceId`，`pool=near|far` 表示入口代码实际落点，`mfs_cold=yes` 表示同一版本还有 `.text.ejit_cold` companion range。VERBOSE 级额外显示各维度版本 `ver`、热代码大小 `size`、`cold_size`、池内编号 `pool_id` 和发布代数 `gen`。
+`ejit_taskpool_print_compiled()` 的摘要中，`entries` 是本次尽力遍历到的 Ready 特化数，`slots` 是 cache 占用，`buckets skipped` 表示遍历时因并发竞争而跳过的 bucket；因此它不是强一致快照。摘要分别统计 `baseline/tier1_collecting/tier2`、主代码池落点和带 MFS 冷区的版本数。明细中的 `dims=[d:i,...]` 表示 `dimType:instanceId`，`pool=near-hot|near-cold|far-tier1` 表示入口代码实际落点，`extra_ranges=[...]` 保留同一 slot 的全部 companion executable ranges（包括 `.text.ejit_cold`）。
+
+汇总行还会输出 `ready_entry_exec_bytes`（每个 Ready slot 的主 range 与全部 companion range 逐 entry 相加）、`ready_unique_exec_bytes` / `ready_unique_exec_ranges`（在 `(poolKind,poolId)` 域内做区间 union）、`shared_slot_exec_bytes`（entry 总量减去 union 后的重复覆盖量）以及 `invalid_exec_ranges`。`near_hot_unique_exec_bytes`、`near_cold_unique_exec_bytes`、`far_unique_exec_bytes` 分别给出三类池的 union 字节数；非法 range 不进入任何字节总量，只进入 invalid 计数。明细的 `entry_exec_bytes` 同样包含该 slot 的主 range 和全部合法 companion，`extra_ranges` 则保留每个 companion 的独立地址、池和大小。这样共享 allocation、cold range overlap 不会被重复算入 unique 值。
 
 ### 2.3 代码池统计
 
@@ -169,6 +171,10 @@ void          ejit_print_code_pool_stats(void);
 | `sealInvocations` | 成功切换为可执行状态的次数；4K 模式按页计，不能直接当成编译函数数。 |
 | `splitInvocations` | 成功将 2 MiB 映射拆成 4K 页的次数，仅 4K 模式有意义。 |
 | `finalizedRangeCount` | 已记录的可执行代码区间数，通常比 pool 数更接近已完成的代码分配批次数。 |
+| `finalizedExecBytes` / `pendingExecBytes` | owner 侧已封固 / 已 staging 的可执行区间 union 字节数；只统计真实 range，不包含页对齐、padding 或池尾空洞。 |
+| `pendingRangeCount` / `pendingAllocationCount` | 当前尚未 flush 的去重 range 数与 allocation 数；owner 在批量编译边界合并刷新，诊断 reader 发现 dirty 时请求 owner 刷新，flush 后归零。 |
+
+`usedBytes` 与 `finalizedExecBytes` 是有意不同的口径：前者是所有 pool 的 bump cursor，可能包含 4K 对齐、GOT/data、放弃的尾部和尚未发布的空间；后者是已记录 executable range 的 union。`ejit_print_code_pool_stats()` 会在原有池容量行之外打印这些详细字段。shared taskpool 的 owner mirror 使用 `snapshotSeq` 做带完整屏障的 seqcount：owner 在 odd 序号之后执行 full write barrier，在 relaxed payload 写入后、even 序号发布前再执行 full write barrier；peer 在两次序号读取之间也执行 full barrier，只有前后序号相同且为偶数时才接受整组字段。该顺序通过 `__atomic_thread_fence(__ATOMIC_SEQ_CST)` 映射到 AArch64/SRE 的系统级屏障，不依赖 x86 的隐含顺序。dirty/pending 变化在批次或 flush 边界合并发布；peer 的诊断读取会主动请求 owner 刷新，因此不需要每个 staging 函数都重算全量 range union。peer 刷新请求会先校验 `generation`、`initState`、owner 与 worker 可用性，并在等待期间重复校验；代际切换、worker 停止或超时会快速返回 `false`。owner 即使 provider 刷新失败也会发布失败结果并确认该 ticket，后续 worker 轮询不会重复重算，只有新的诊断请求才会重试。
 
 > **固定代码段模式**：若你的运行库使用固定代码段模式（代码池位于链接脚本固定的 `.text.ejit` 区域，给 JIT 稳定地址），每次页状态转换会在 **INFO 级**打印 `enableRwRange` 系列日志（`begin` / `OK` / `FAIL`（未归属 / 跨池 / `enable_rw` 失败）/ `rollback`（部分失败时回退 RW->RX）），用于诊断 W^X 页状态转换。封固粒度（4K 页 vs 整 2MiB 池）影响 `sealInvocations` / `splitInvocations` 的计数粒度。
 

--- a/jit_design_doc/EJIT_DIAGNOSTICS.md
+++ b/jit_design_doc/EJIT_DIAGNOSTICS.md
@@ -128,7 +128,7 @@ unsigned      ejit_taskpool_pending_count(void); // 在途数量
 
 > 若 `cacheHits` 等逐调用计数全为零，说明运行库未启用逐调用统计（这些计数有热点路径开销，默认关闭）；`print_compiled()`、`get_worker_core()`、`pending_count()` 不受此影响，始终可用。
 
-`ejit_taskpool_print_compiled()` 的摘要中，`entries` 是本次尽力遍历到的 Ready 特化数，`slots` 是 cache 占用，`buckets skipped` 表示遍历时因并发竞争而跳过的 bucket；因此它不是强一致快照。摘要分别统计 `baseline/tier1_collecting/tier2` 和 `near/far/unknown`。明细中的 `dims=[d:i,...]` 表示 `dimType:instanceId`，`pool=near|far` 表示代码实际落点。VERBOSE 级额外显示各维度版本 `ver`、代码大小 `size`、池内编号 `pool_id` 和发布代数 `gen`。
+`ejit_taskpool_print_compiled()` 的摘要中，`entries` 是本次尽力遍历到的 Ready 特化数，`slots` 是 cache 占用，`buckets skipped` 表示遍历时因并发竞争而跳过的 bucket；因此它不是强一致快照。摘要分别统计 `baseline/tier1_collecting/tier2`、主代码池落点和带 MFS 冷区的版本数。明细中的 `dims=[d:i,...]` 表示 `dimType:instanceId`，`pool=near|far` 表示入口代码实际落点，`mfs_cold=yes` 表示同一版本还有 `.text.ejit_cold` companion range。VERBOSE 级额外显示各维度版本 `ver`、热代码大小 `size`、`cold_size`、池内编号 `pool_id` 和发布代数 `gen`。
 
 ### 2.3 代码池统计
 
@@ -156,7 +156,7 @@ ejit_status_t ejit_get_code_pool_stats_v2(ejit_code_pool_stats_v2_t *out);
 void          ejit_print_code_pool_stats(void);
 ```
 
-**作用**：监控 JIT 代码内存占用与是否趋近耗尽（`usedBytes` vs `reservedBytes`）。旧接口保持 ABI 不变并返回两池合计；v2 接口进一步区分 near/far。`ejit_print_code_pool_stats()` 同时打印 `total`、`near(final)` 和 `far(tier1)`。返回值：`EJIT_OK` 成功；`EJIT_ERR_NOT_ACTIVE` 运行时未初始化；`EJIT_ERR_INVALID_PARAM` 入参为空；`EJIT_ERR_DISABLED` 运行库未含代码池支持。
+**作用**：监控 JIT 代码内存占用与是否趋近耗尽（`usedBytes` vs `reservedBytes`）。旧接口保持 ABI 不变并返回全部池合计；v2 的 `near` 合并 hot/cold 固定池以保持 ABI，v3 进一步拆分 `nearHot/nearCold/farTier1`。`ejit_print_code_pool_stats()` 同时打印 `total`、`near-hot(final)`、`near-cold(mfs)` 和 `far(tier1)`。返回值：`EJIT_OK` 成功；`EJIT_ERR_NOT_ACTIVE` 运行时未初始化；`EJIT_ERR_INVALID_PARAM` 入参为空；`EJIT_ERR_DISABLED` 运行库未含代码池支持。
 
 **结构体解读**：
 

--- a/jit_design_doc/EJIT_MFS_COLD_CODE_POOL.md
+++ b/jit_design_doc/EJIT_MFS_COLD_CODE_POOL.md
@@ -1,0 +1,90 @@
+# EJIT Tier-2 MFS Cold Code Pool
+
+## Purpose
+
+`EJIT_MFS_COLD_CODE_POOL` enables LLVM MachineFunctionSplitter for profiled
+JIT code. Final online-PGO Tier-2 machine functions keep hot blocks in the
+fixed `.text.ejit` pool and place MFS-generated `.text.split.<function>` blocks
+in a second fixed RX region, `.text.ejit_cold`.
+
+Tier-1 instrumented code remains in the dynamic far pool. Baseline and Tier-1
+functions without profile data are not split by MFS.
+
+## Build
+
+The feature requires all three options:
+
+```text
+EJIT_SRE_CODE_POOL=ON
+EJIT_FIXED_CODE_POOL=ON
+EJIT_MFS_COLD_CODE_POOL=ON
+```
+
+The `ejit-minimal-aarch64_be` preset enables the feature. The trimmed backend
+restores only MachineFunctionSplitter; the other AutoFDO and generic basic
+block section machinery remains trimmed.
+
+## Linker-script contract
+
+The final product link must define both fixed regions. Keep both within direct
+AArch64 branch reach of AOT `.text` and each other.
+
+```ld
+.text.ejit : ALIGN(4096) {
+  __ejit_code_start = .;
+  . += 16M;
+  __ejit_code_end = .;
+} > CODE
+
+.text.ejit_cold : ALIGN(4096) {
+  __ejit_cold_code_start = .;
+  . += 8M;
+  __ejit_cold_code_end = .;
+} > CODE
+```
+
+The runtime aligns each region start up to 2 MiB. Budget at least one complete
+2 MiB pool after that alignment. In a freestanding feature build the cold
+symbols are strong: omitting them is an intentional link error.
+
+## Runtime layout and cross-core safety
+
+JITLink normally merges all RX sections into one allocation segment. EJIT
+intercepts `.text.split.*` blocks before `BasicLayout`, assigns them working
+memory and target addresses from the cold manager, and leaves the remaining
+graph to the normal hot/far layout.
+
+A split Tier-2 publication carries two real executable extents: the hot range
+containing the entry and one cold companion range. A peer core splits and seals
+both pools before receiving the JIT pointer. Shared taskpool ABI v17 carries
+this companion range.
+
+## Diagnostics
+
+`ejit_print_code_pool_stats()` reports:
+
+```text
+code pool total: ...
+code pool near-hot(final): ...
+code pool near-cold(mfs): ...
+code pool far(tier1): ...
+```
+
+`ejit_get_code_pool_stats_v2()` remains ABI compatible: `near` is the sum of
+hot and cold fixed pools. `ejit_get_code_pool_stats_v3()` exposes
+`nearHot`, `nearCold`, and `farTier1` separately.
+
+`ejit_taskpool_print_compiled()` reports `mfs_cold=yes/no`; VERBOSE output also
+includes `cold_ranges` and `cold_size`.
+
+## Board validation
+
+1. Rebuild the full runtime and business image because shared ABI changed to
+   v17 and the linker script gained strong symbols.
+2. Run the existing multi-core `test_ejit_period` flow until Tier-2 publishes.
+3. Confirm `near-cold(mfs)` has non-zero `used` and at least one finalized
+   range for a function with a sufficiently cold branch.
+4. Trigger both hot and cold paths from a non-owner core. Neither path may
+   produce an execute-permission abort.
+5. Compare `L1I miss`, hot-pool used bytes, end-to-end cycles, and the number
+   of cross hot/cold branches against the unsplit build.

--- a/jit_design_doc/EJIT_SRE_CODE_POOL.md
+++ b/jit_design_doc/EJIT_SRE_CODE_POOL.md
@@ -40,16 +40,17 @@
 
 `EJIT_CODE_POOL_BATCHED_PUBLISH` 只改变 4K 封固模式下的发布时机和纯代码布局。普通
 EJIT 请求先由共享 worker 搬出有界 MPSC 队列，收到显式发布请求后按维度字典序排列
-（第一维 cell、第二维 TRP，最后按函数编号），再依次编译。JITLink allocation 以 16B
-对齐连续写入近端 RW/NX 页面，批量调用 `enable_ex`，随后才把对应函数指针从共享缓存的
-Pending 状态切换为 Ready。未封页的地址不会返回给业务核。
+（第一维 cell、第二维 TRP），同一完整维度组内保持业务触发顺序，再依次编译。
+JITLink allocation 以 16B 对齐连续写入近端 RW/NX 页面，批量调用 `enable_ex`，随后才把
+对应函数指针从共享缓存的 Pending 状态切换为 Ready。未封页的地址不会返回给业务核。
 
 Online-PGO 使用分层发布：Tier-1 立即编译到远端临时池并自动封固、发布，以便马上开始
-采样；达到阈值后，Tier-2 立即编译和 JITLink 到近端池，但保持 RW/NX 且仅保存在 owner
-私有队列中。此时共享 cache 仍保留可执行的 Tier-1 及其 counters，但采样达到阈值后的
-业务调用临时回退 AOT，不再继续承担整模块原子插桩开销；inline cache 仍不填 Tier-1。
-worker 观察到共享编译队列排空后，自动封固整批 Tier-2 页面，并在封固成功后将 cache 和
-inline cache 原子替换为 Tier-2。封固或 cache 发布失败时保留 Tier-1；可调用
+采样；达到阈值后，Tier-2 请求先保存在 owner 私有布局队列中。此时共享 cache 仍保留
+可执行的 Tier-1 及其 counters，但采样达到阈值后的业务调用临时回退 AOT，不再继续承担
+整模块原子插桩开销；inline cache 仍不填 Tier-1。worker 观察到共享编译队列排空后，按
+cell、TRP 和其余维度排列 Tier-2，同一完整维度组内保持业务触发顺序，再依次编译和
+JITLink 到近端池，自动封固整批 Tier-2 页面，并在封固成功后将 cache 和 inline cache
+原子替换为 Tier-2。封固或 cache 发布失败时保留 Tier-1；可调用
 `ejit_publish_pending_code()` 显式重试，不会把不可执行的 Tier-2 地址暴露给业务核。
 批次封固前会把 bump cursor 推到下一页，因此已经 RX 的尾页不会再被写入；含 GOT、数据
 段或要求超过 16B 对齐的 allocation 自动保持原来的 4K 独占布局。
@@ -57,9 +58,9 @@ inline cache 原子替换为 Tier-2。封固或 cache 发布失败时保留 Tier
 普通 EJIT 的发布由业务侧显式调用 `ejit_publish_pending_code()` 触发；Online-PGO Tier-2
 则在编译队列排空时自动触发。接口仍可用于强制发布或失败重试；返回 `EJIT_OK` 时，近端
 pending code 的 `enable_ex`、共享 cache 发布和 inline-cache 回填均已完成。该模式用于
-验证紧凑布局对 I-cache/L3 冲突的影响，默认关闭。普通 EJIT 请求仍按 cell/TRP 排序后才
-分配真实地址；Tier-2 为缩短采样完成后的等待时间而提前 JITLink，其地址顺序由 profile
-完成顺序决定，队列排空发布只批量封固和回填，不会重新排列已写入的 Tier-2 代码。
+验证紧凑布局对 I-cache/L3 冲突的影响，默认关闭。普通 EJIT 和 Tier-2 均在分配真实地址
+前按 cell/TRP 排序；Tier-2 由队列排空自动触发，不要求业务再次调用显式发布接口。Tier-1
+继续使用远端立即池且不参与排序，避免延迟 profile 采集。
 
 显式发布在排空调用前已有请求及执行排序后的 ORC 编译时，仍逐项执行共享 worker 的
 `EJIT_SRE_TASKPOOL_WORKER_THROTTLE_*` 延时。批量发布只改变代码布局和封页时机，不绕过
@@ -625,3 +626,44 @@ peer 准备任一步失败（缺 `enable_rw` callback、`enable_rw`/`enable_ex` 
 `requiresPeerEnableRw`、`writableRanges[]`），Tier-2 覆盖 Tier-1 时不会继承旧可写范围；
 `initSharedStorage`（owner 选举/reinit）把所有 slot 的 writable 元数据与 prepared bit
 清零，generation 不匹配的发布在 commit gate 被拒——stale writable range 不会被新 slot 继承。
+
+## 15. 板端验证 Tier-2 物理排布
+
+`EJIT_CODE_POOL_BATCHED_PUBLISH` 的排序目标是最终常驻 Tier-2 的 **executable
+allocation**，不能只用编译日志中的先后顺序推断。待本轮 Tier-2 全部发布并进入稳定期后，
+在任意已初始化 EJIT 的核调用：
+
+```c
+ejit_set_log_level(EJIT_LOG_VERBOSE);
+ejit_taskpool_print_compiled();
+ejit_set_log_level(EJIT_LOG_INFO);
+```
+
+输出只保留一份 `compiled layout` 列表，按精确的 JIT 入口 `fn` 地址升序排列；
+VERBOSE 额外显示 allocation end、gap/overlap、版本号和 generation：
+
+```text
+compiled layout: 6 entries sorted by fn address
+layout[0] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=n/a pool=near:0 name=FuncA tier=tier2 dims=[0:0]
+layout[1] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=...   pool=near:0 name=FuncB tier=tier2 dims=[0:0]
+layout[2] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=...   pool=near:0 name=FuncC tier=tier2 dims=[0:0]
+layout[3] fn=0x... alloc_start=0x... alloc_end=0x... alloc_size=... gap=...   pool=near:0 name=FuncA tier=tier2 dims=[0:1]
+```
+
+验证判据：
+
+- 只比较同一个 `pool=near:<id>` 内的条目；跨 pool 地址没有连续性要求。
+- `fn` 全局单调递增；同一个 pool 内 allocation 不得出现 `OVERLAP=`。
+- Tier-2 的 dimensions 应按 `cell -> TRP -> 其余维度` 聚集。
+- 完整 dimensions 相同的条目应保持业务首次触发顺序，例如 `FuncA -> FuncB -> FuncC`。
+- `gap` 允许非零（JITLink 对齐、stub、常量或其他 executable 内容），但异常的大 gap
+  应结合 `ejit_print_code_pool_stats()` 的 `used/wasted/finalized ranges` 继续检查。
+- `fn` 是精确入口符号地址，应位于 `[alloc_start, alloc_end)` 内；`alloc_size` 是整个
+  特化模块的 executable allocation 大小，可能包含 helper、stub 或多个 entry，不是入口
+  函数 symbol 的精确机器码大小。列表顺序用于观察实际入口地址，allocation 范围用于检查
+  code-pool 占用与重叠。
+- 同一 allocation 内有多个入口时显示 `gap=shared_alloc`，不视为重叠错误；
+  `fn_in_alloc=no` 才表示入口地址与 allocation 元数据不一致。
+
+为避免调测本身污染性能数据，只在稳定期采样结束后调用一次，并立即把日志等级恢复为
+`EJIT_LOG_INFO`。

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -736,6 +736,22 @@ if(EJIT_SRE_CODE_POOL AND EJIT_FIXED_CODE_POOL)
                  "(size is __ejit_code_end - __ejit_code_start from the linker script's .text.ejit block)")
 endif()
 
+# Split profile-cold machine basic blocks out of final Tier-2 code and place
+# them in a second fixed RX linker-script region. This is opt-in because an
+# enabled freestanding build requires the product linker script to provide
+# __ejit_cold_code_start/__ejit_cold_code_end around .text.ejit_cold.
+option(EJIT_MFS_COLD_CODE_POOL
+  "Enable MachineFunctionSplitter for profiled JIT code and place cold blocks in .text.ejit_cold" OFF)
+if(EJIT_MFS_COLD_CODE_POOL)
+  if(NOT EJIT_SRE_CODE_POOL OR NOT EJIT_FIXED_CODE_POOL)
+    message(FATAL_ERROR
+      "EJIT_MFS_COLD_CODE_POOL requires EJIT_SRE_CODE_POOL=ON and EJIT_FIXED_CODE_POOL=ON")
+  endif()
+  add_definitions(-DEJIT_MFS_COLD_CODE_POOL)
+  message(STATUS "EmbeddedJIT: MFS cold code pool enabled "
+                 "(.text.ejit_cold, __ejit_cold_code_start/end)")
+endif()
+
 #===-- EmbeddedJIT per-function inline cache (multi-version) -------------===#
 # EJIT_ICACHE_DIM_SIZE: the per-dimension bound D of the per-function
 # @__ejit_icache_fn_<name> [D]^numDims inline-cache array. MUST be a power of 2

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -79,6 +79,7 @@
         "EJIT_SRE_CODE_POOL": "ON",
         "EJIT_SRE_CODE_POOL_PTNO": "8",
         "EJIT_FIXED_CODE_POOL": "ON",
+        "EJIT_MFS_COLD_CODE_POOL": "ON",
         "EJIT_SRE_TASKPOOL": "ON",
         "EJIT_SRE_SHARED_TASKPOOL": "ON",
         "EJIT_SRE_TASKPOOL_NO_RECLAIM": "ON",

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJit.h
@@ -22,6 +22,7 @@
 extern "C" {
 struct ejit_code_pool_stats_t;
 struct ejit_code_pool_stats_v2_t;
+struct ejit_code_pool_stats_v3_t;
 }
 
 namespace llvm {
@@ -159,8 +160,11 @@ public:
   /// or built without EJIT_SRE_CODE_POOL. For ejit_get_code_pool_stats().
   bool getCodePoolStats(ejit_code_pool_stats_t *out) const;
 
-  /// Fill aggregate plus near/far placement-specific code-pool statistics.
+  /// Fill aggregate plus ABI-compatible near/far statistics. near includes
+  /// both hot and MFS-cold fixed pools.
   bool getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const;
+  /// Fill aggregate plus near-hot/near-cold/far-Tier-1 statistics.
+  bool getCodePoolStatsV3(ejit_code_pool_stats_v3_t *out) const;
 
   /// Print code pool usage stats through EJIT_DIAG. For
   /// ejit_print_code_pool_stats().

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -171,6 +171,13 @@ public:
                                     ///< (per 4K page, code-segment mode only)
     size_t finalizedRangeCount = 0; ///< distinct executable ranges recorded
                                     ///< (duplicates are not double-counted)
+    /// Union of the executable extents in finalized/pending range records.
+    /// This is code bytes, not pool bump usage (which includes alignment and
+    /// abandoned tails).
+    size_t finalizedExecBytes = 0;
+    size_t pendingExecBytes = 0;
+    size_t pendingRangeCount = 0;
+    size_t pendingAllocationCount = 0;
   };
 
   EJitCodePoolManager(Options Opts, RawAllocFn Alloc, SealFn Seal,

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
@@ -38,6 +38,10 @@ public:
   EJitCodePoolMemoryManager(EJitCodePoolManager &Pool, size_t PageSize);
   EJitCodePoolMemoryManager(EJitCodePoolManager &NearPool,
                             EJitCodePoolManager &FarPool, size_t PageSize);
+  EJitCodePoolMemoryManager(EJitCodePoolManager &NearPool,
+                            EJitCodePoolManager &ColdPool,
+                            EJitCodePoolManager &FarPool, size_t PageSize);
+  ~EJitCodePoolMemoryManager() override;
 
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;
@@ -51,15 +55,23 @@ public:
 
   EJitCodePoolManager &getPool() { return NearPool_; }
 
+  /// Resolve an entry pointer to every executable extent in its finalized
+  /// allocation. A split Tier-2 allocation has a hot primary range and one
+  /// cold companion range that peers must also make executable.
+  bool findAllocation(const void *Ptr, EJitCompiledCodeInfo &Out) const;
+
 private:
   class InFlightAllocImpl;
   struct FinalizedInfo;
+  struct State;
 
   EJitCodePoolManager &selectPool(const jitlink::JITLinkDylib *JD) const;
 
   EJitCodePoolManager &NearPool_;
+  EJitCodePoolManager *ColdPool_ = nullptr;
   EJitCodePoolManager *FarPool_ = nullptr;
   size_t PageSize_;
+  std::unique_ptr<State> State_;
 };
 
 } // namespace ejit

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
@@ -34,8 +34,20 @@ namespace ejit {
 
 enum class EJitCodePoolKind : uint32_t {
   Unknown = 0,
-  Near = 1,
+  Near = 1, // Hot fixed .text.ejit pool (kept for ABI compatibility).
   Far = 2,
+  Cold = 3,
+};
+
+constexpr uint32_t kEJitMaxExtraCodeRanges = 1u;
+
+struct EJitExecutableRange {
+  uintptr_t codeStart = 0;
+  uint64_t codeSize = 0;
+  uintptr_t poolBase = 0;
+  uint64_t poolSize = 0;
+  uint32_t poolId = 0;
+  EJitCodePoolKind poolKind = EJitCodePoolKind::Unknown;
 };
 
 /// Maximum number of runtime-writable ranges carried with one finalized
@@ -97,6 +109,10 @@ struct EJitCompiledCodeInfo {
   /// Placement class of the owning pool. Near is the fixed .text.ejit region;
   /// Far is the dynamic SRE_MemDbgAlloc region used by temporary Tier-1 code.
   EJitCodePoolKind poolKind = EJitCodePoolKind::Unknown;
+  /// Additional executable extent belonging to the same compilation. MFS
+  /// currently produces at most one cold RX extent in .text.ejit_cold.
+  uint32_t extraCodeCount = 0;
+  EJitExecutableRange extraCodeRanges[kEJitMaxExtraCodeRanges] = {};
 };
 
 } // namespace ejit

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -34,6 +34,7 @@ namespace ejit {
 struct EJitTieredCodePoolStats {
   EJitCodePoolManager::Stats total;
   EJitCodePoolManager::Stats near;
+  EJitCodePoolManager::Stats cold;
   EJitCodePoolManager::Stats far;
 };
 #endif

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -48,10 +48,10 @@
 #define EJIT_PERIOD_CONST __attribute__((ejit_period_const))
 #define EJIT_IN_PERIOD(x) __attribute__((ejit_in_period(#x)))
 #define EJIT_IN_PERIOD_ARRAY(x) __attribute__((ejit_in_period_array(#x)))
-#define EJIT_DIM(x)             __attribute__((ejit_dim(#x)))
+#define EJIT_DIM(x) __attribute__((ejit_dim(#x)))
 #define EJIT_BOUND_PTR(x) __attribute__((ejit_bound_ptr(#x)))
-#define EJIT_ENTRY              __attribute__((ejit_entry))
-#define EJIT_PERIOD_GUARD(x)    __attribute__((ejit_period_guard(#x)))
+#define EJIT_ENTRY __attribute__((ejit_entry))
+#define EJIT_PERIOD_GUARD(x) __attribute__((ejit_period_guard(#x)))
 // Old names (aliases — use new macros to avoid double expansion)
 #define ejit_may_const EJIT_PERIOD_CONST
 #define ejit_period(x) EJIT_IN_PERIOD(x)
@@ -360,6 +360,9 @@ void ejit_taskpool_print_stats();
 /// Print every published shared-cache version and its dimensions. Stats builds
 /// also report whether a later taskpool lookup reused each published version;
 /// wrapper inline-cache calls after that first reuse remain intentionally free.
+/// Entries are sorted by the exact JIT function address and include the owning
+/// executable allocation start/end/size. The allocation size may cover helper
+/// code, stubs, or multiple entry symbols; it is not an exact symbol size.
 void ejit_taskpool_print_compiled();
 uint32_t ejit_taskpool_get_worker_core();
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -146,6 +146,13 @@ typedef struct ejit_code_pool_stats_v2_t {
   ejit_code_pool_stats_t far;
 } ejit_code_pool_stats_v2_t;
 
+typedef struct ejit_code_pool_stats_v3_t {
+  ejit_code_pool_stats_t total;
+  ejit_code_pool_stats_t nearHot;
+  ejit_code_pool_stats_t nearCold;
+  ejit_code_pool_stats_t farTier1;
+} ejit_code_pool_stats_v3_t;
+
 typedef struct {
   int code;
   char message[256];
@@ -440,8 +447,10 @@ void ejit_print_func_meta(const char *funcName);
 /// embedded code-memory exhaustion. Mirrors EJitCodePoolManager::Stats.
 ejit_status_t ejit_get_code_pool_stats(ejit_code_pool_stats_t *out);
 
-/// Placement-aware counterpart of ejit_get_code_pool_stats().
+/// Placement-aware counterpart; near includes hot and MFS-cold fixed pools.
 ejit_status_t ejit_get_code_pool_stats_v2(ejit_code_pool_stats_v2_t *out);
+/// Three-way placement breakdown for hot final, MFS cold, and Tier-1 code.
+ejit_status_t ejit_get_code_pool_stats_v3(ejit_code_pool_stats_v3_t *out);
 
 /// Print code pool usage statistics through the platform log. Paired with
 /// ejit_get_code_pool_stats() (human-readable form).

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntimeDiagnostics.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntimeDiagnostics.h
@@ -1,0 +1,132 @@
+//===-- EJitRuntimeDiagnostics.h - print_compiled accounting --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_EXECUTIONENGINE_EJIT_EJITRUNTIMEDIAGNOSTICS_H
+#define LLVM_EXECUTIONENGINE_EJIT_EJITRUNTIMEDIAGNOSTICS_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace llvm {
+namespace ejit {
+namespace detail {
+
+/// One executable extent reported by a Ready shared-cache slot. A slot's
+/// primary range and every extraCodeRanges entry use the same representation.
+/// poolKind/poolId are part of the identity: two pools may have overlapping
+/// virtual-address intervals only if they are distinct allocation domains.
+struct EJitCompiledExecRange {
+  uint32_t poolKind = 0;
+  uint32_t poolId = 0;
+  uintptr_t start = 0;
+  uint64_t size = 0;
+};
+
+/// Summary used by ejit_taskpool_print_compiled. Entry bytes include every
+/// valid primary and companion range. Unique bytes are the union within each
+/// (poolKind, poolId) domain, so shared allocations and overlapping cold
+/// companions are counted once. Invalid ranges are excluded from all byte
+/// totals and counted separately.
+struct EJitCompiledExecSummary {
+  uint64_t readyEntryExecBytes = 0;
+  uint64_t readyUniqueExecBytes = 0;
+  uint64_t readyUniqueExecRanges = 0;
+  uint64_t sharedSlotExecBytes = 0;
+  uint64_t invalidExecRanges = 0;
+  uint64_t nearHotUniqueExecBytes = 0;
+  uint64_t nearColdUniqueExecBytes = 0;
+  uint64_t farUniqueExecBytes = 0;
+  uint64_t unknownUniqueExecBytes = 0;
+};
+
+inline EJitCompiledExecSummary
+summarizeCompiledExecRanges(ArrayRef<EJitCompiledExecRange> Ranges) {
+  struct Interval {
+    uint32_t Kind;
+    uint32_t PoolId;
+    uintptr_t Start;
+    uintptr_t End;
+  };
+  std::vector<Interval> Valid;
+  EJitCompiledExecSummary Summary;
+  Valid.reserve(Ranges.size());
+  for (const EJitCompiledExecRange &R : Ranges) {
+    if (R.start == 0 || R.size == 0 ||
+        R.size > std::numeric_limits<uintptr_t>::max() - R.start) {
+      ++Summary.invalidExecRanges;
+      continue;
+    }
+    Summary.readyEntryExecBytes += R.size;
+    Valid.push_back({R.poolKind, R.poolId, R.start,
+                     R.start + static_cast<uintptr_t>(R.size)});
+  }
+  std::sort(Valid.begin(), Valid.end(), [](const Interval &A, const Interval &B) {
+    if (A.Kind != B.Kind)
+      return A.Kind < B.Kind;
+    if (A.PoolId != B.PoolId)
+      return A.PoolId < B.PoolId;
+    if (A.Start != B.Start)
+      return A.Start < B.Start;
+    return A.End < B.End;
+  });
+
+  uint32_t CurrentKind = 0;
+  uint32_t CurrentPoolId = 0;
+  uintptr_t CurrentStart = 0;
+  uintptr_t CurrentEnd = 0;
+  bool HaveCurrent = false;
+  auto Account = [&](uint32_t Kind, uintptr_t Start, uintptr_t End) {
+    const uint64_t Bytes = static_cast<uint64_t>(End - Start);
+    Summary.readyUniqueExecBytes += Bytes;
+    ++Summary.readyUniqueExecRanges;
+    switch (Kind) {
+    case 1: // EJitCodePoolKind::Near
+      Summary.nearHotUniqueExecBytes += Bytes;
+      break;
+    case 2: // EJitCodePoolKind::Far
+      Summary.farUniqueExecBytes += Bytes;
+      break;
+    case 3: // EJitCodePoolKind::Cold
+      Summary.nearColdUniqueExecBytes += Bytes;
+      break;
+    default:
+      Summary.unknownUniqueExecBytes += Bytes;
+      break;
+    }
+  };
+  for (const Interval &I : Valid) {
+    if (!HaveCurrent || I.Kind != CurrentKind || I.PoolId != CurrentPoolId ||
+        I.Start > CurrentEnd) {
+      if (HaveCurrent)
+        Account(CurrentKind, CurrentStart, CurrentEnd);
+      CurrentKind = I.Kind;
+      CurrentPoolId = I.PoolId;
+      CurrentStart = I.Start;
+      CurrentEnd = I.End;
+      HaveCurrent = true;
+    } else {
+      CurrentEnd = std::max(CurrentEnd, I.End);
+    }
+  }
+  if (HaveCurrent)
+    Account(CurrentKind, CurrentStart, CurrentEnd);
+  Summary.sharedSlotExecBytes =
+      Summary.readyEntryExecBytes >= Summary.readyUniqueExecBytes
+          ? Summary.readyEntryExecBytes - Summary.readyUniqueExecBytes
+          : 0;
+  return Summary;
+}
+
+} // namespace detail
+} // namespace ejit
+} // namespace llvm
+
+#endif // LLVM_EXECUTIONENGINE_EJIT_EJITRUNTIMEDIAGNOSTICS_H

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -103,11 +103,12 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// by a later taskpool lookup, diagnosing compiled versions with no reuse.
 /// v16: code ranges identify near/far placement and the shared code-pool
 /// diagnostic mirror publishes aggregate plus placement-specific statistics.
-/// v17: cache slots can remain Pending while compact code waits for an explicit
-/// owner-worker batch publish request.
-/// v17: one published compilation may carry a companion MFS cold-code range.
-/// v18 combines both layouts: pending batch publication and MFS cold ranges.
-constexpr uint32_t kEJitSharedAbiVersion = 18u;
+/// v17 was used independently by the batched-publish and MFS-cold branches.
+/// v18 combines both layouts: cache slots may remain Pending for explicit batch
+/// publication and one compilation may carry a companion cold-code range.
+/// v19 adds detailed executable/pending byte counters and a sequence-checked
+/// stats mirror snapshot.
+constexpr uint32_t kEJitSharedAbiVersion = 19u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -103,7 +103,8 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// by a later taskpool lookup, diagnosing compiled versions with no reuse.
 /// v16: code ranges identify near/far placement and the shared code-pool
 /// diagnostic mirror publishes aggregate plus placement-specific statistics.
-constexpr uint32_t kEJitSharedAbiVersion = 16u;
+/// v17: one published compilation may carry a companion MFS cold-code range.
+constexpr uint32_t kEJitSharedAbiVersion = 17u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -1319,7 +1319,7 @@ private:
   /// §4.9).
   void runCompile(const EJitCompileRequest &req,
                   bool hasBatchRequestMarker = false);
-  void compilePendingBatchRequests();
+  void compilePendingBatchRequests(bool tier2Only = false);
   bool flushPendingPublishes(bool compileBatchRequests = true);
   bool serviceCodeBatchRequest();
   bool serviceAutoTier2Publish();
@@ -1392,8 +1392,9 @@ private:
   };
   std::vector<PendingBatchCompile> pendingBatchCompiles_;
   std::vector<PendingPublish> pendingPublishes_;
-  /// Armed when Tier-2 links into the near RW/NX pool. Consumed only after the
-  /// owner worker observes the shared compile queue empty.
+  /// Armed when a Tier-2 request enters the owner-private layout batch.
+  /// Consumed only after the owner worker observes the shared compile queue
+  /// empty, sorts all queued Tier-2 requests, and publishes the linked batch.
   bool autoTier2PublishPending_ = false;
   // Inline-cache safety gate: true while the cache is safe to use (no releaser
   // wired - the production default). v2 does no HP-scan retire, so a wired

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -1214,6 +1214,8 @@ private:
     uint64_t codeSize = 0;
     uintptr_t poolBase = 0;
     uint64_t poolSize = 0;
+    uint32_t extraCodeCount = 0;
+    EJitSharedExecutableRange extraCodeRanges[kEJitMaxExtraCodeRanges] = {};
     /// Runtime-writable extents (e.g. __profc_) this core must enable_rw before
     /// it may execute the code. Snapshotted with the range so the per-core
     /// enable_rw runs with NO bucket lock held. writableCount 0 => none.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -347,11 +347,12 @@ public:
   using CodeRangeCallback = bool (*)(void *ctx, const void *fnPtr,
                                      EJitCompiledCodeInfo *outInfo);
   /// Owner-private provider that snapshots the owner-core code-pool manager
-  /// stats. The owner publishes this into the shared mirror after every
-  /// successful compile so every core's ejit_print_code_pool_stats is
-  /// consistent (the real pools are owner-private). Returns false when no code
-  /// pool exists (clean fallback). Optional: when unset, the shared mirror
-  /// stays zero and readers fall back to their per-core (empty) view.
+  /// stats. Pending changes mark the mirror dirty and are published at a
+  /// compile-batch/flush boundary; a diagnostic read can request an owner
+  /// refresh. This avoids sorting/unioning all ranges once per function while
+  /// keeping a peer read current. Returns false when no code pool exists
+  /// (clean fallback). Optional: when unset, the shared mirror stays zero and
+  /// readers fall back to their per-core (empty) view.
   using CodePoolStatsCallback = bool (*)(void *ctx, EJitCodePoolStatsOut *out);
   /// Batched code-pool hooks. isReady is false while a linked address remains
   /// RW/NX; flush seals the current owner-private batch and makes every staged
@@ -412,6 +413,10 @@ public:
   using MayConstRankingCallback = bool (*)(void *ctx);
 #ifdef EJIT_SRE_TASKPOOL_TESTING
   using TestHookFn = void (*)(void *ctx);
+  /// Test-only hook fired at the two writer-side seqcount interruption points:
+  /// phase 1 is after the odd marker and full write barrier; phase 2 is after
+  /// the payload and full write barrier, immediately before the even marker.
+  using CodePoolStatsPublishHook = void (*)(void *ctx, uint32_t phase);
 #endif
 
   enum class InitResult : uint32_t {
@@ -621,9 +626,11 @@ public:
     codeBatchFlushFn_ = flush;
     codeBatchCtx_ = ctx;
   }
-  /// Read the shared code-pool stats mirror (last owner-published snapshot).
-  /// Returns false if the shared state is not bound. Every core sees the same
-  /// values. Use this for ejit_get/print_code_pool_stats in shared builds.
+  /// Read the shared code-pool stats mirror. A peer requests the owner to
+  /// refresh a dirty snapshot before reading, so this diagnostic-only call may
+  /// yield/wait; it returns false if the owner cannot refresh or the seqcount
+  /// remains unstable. Every core sees the same values. Use this for
+  /// ejit_get/print_code_pool_stats in shared builds.
   bool readCodePoolStats(EJitCodePoolStatsOut *out) const;
   /// Select the execute-permission seal granularity for non-owner preparation:
   /// true = 4KiB page seal (split the pool once per core, then enable_ex every
@@ -758,6 +765,11 @@ public:
   void setPgoAdmissionTestHook(TestHookFn fn, void *ctx) {
     pgoAdmissionTestHook_ = fn;
     pgoAdmissionTestHookCtx_ = ctx;
+  }
+
+  void setCodePoolStatsPublishHook(CodePoolStatsPublishHook fn, void *ctx) {
+    codePoolStatsPublishHook_ = fn;
+    codePoolStatsPublishHookCtx_ = ctx;
   }
 #endif
 
@@ -1138,6 +1150,7 @@ private:
   /// operations because they execute more than one operation per worker step.
   void workerThrottle();
   bool serviceMayConstRankingRequest();
+  bool serviceCodePoolStatsRequest();
 
   /// Result of a shared-cache lookup, including the cross-core fnPtr gate.
   struct SharedLookup {
@@ -1333,10 +1346,13 @@ private:
                          const char *reason = nullptr);
 
   /// Owner-only: snapshot the owner-core code-pool stats via the registered
-  /// provider and storeRelaxed them into the shared mirror. Called after every
-  /// successful compile (sync + async publish) so the mirror stays fresh for
-  /// cross-core readers. No-op when no provider is registered.
+  /// provider and publish them into the shared mirror. The mirror uses a
+  /// full-barrier odd/even seqcount around its relaxed data fields, so peers
+  /// read a self-consistent provider snapshot. No-op when no provider is
+  /// registered or the provider fails.
   void publishCodePoolStats();
+  void markCodePoolStatsDirty();
+  void publishCodePoolStatsIfDirty();
 
   EJitSharedTaskPoolState *state_ = nullptr;
   CompileCallback compileFn_ = nullptr;
@@ -1371,6 +1387,8 @@ private:
 #ifdef EJIT_SRE_TASKPOOL_TESTING
   TestHookFn pgoAdmissionTestHook_ = nullptr;
   void *pgoAdmissionTestHookCtx_ = nullptr;
+  CodePoolStatsPublishHook codePoolStatsPublishHook_ = nullptr;
+  void *codePoolStatsPublishHookCtx_ = nullptr;
 #endif
   OwnerElectedFn ownerElected_ = nullptr;
   void *ownerElectedCtx_ = nullptr;
@@ -1394,6 +1412,10 @@ private:
   };
   std::vector<PendingBatchCompile> pendingBatchCompiles_;
   std::vector<PendingPublish> pendingPublishes_;
+  /// Set by pending staging and cleared by the next successful stats publish.
+  /// It coalesces the provider's O(ranges log ranges) snapshot work across a
+  /// whole compile batch instead of paying it once per function.
+  bool codePoolStatsDirty_ = false;
   /// Armed when a Tier-2 request enters the owner-private layout batch.
   /// Consumed only after the owner worker observes the shared compile queue
   /// empty, sorts all queued Tier-2 requests, and publishes the linked batch.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -169,6 +169,15 @@ struct EJitSharedWritableRange {
   uint64_t size;  ///< size in bytes of that extent (0 = unused entry)
 };
 
+struct EJitSharedExecutableRange {
+  uintptr_t codeStart;
+  uint64_t codeSize;
+  uintptr_t poolBase;
+  uint64_t poolSize;
+  uint32_t poolId;
+  uint32_t poolKind;
+};
+
 //===----------------------------------------------------------------------===//
 // EJitSharedCacheSlot: one POD result-cache entry.
 //===----------------------------------------------------------------------===//
@@ -196,8 +205,10 @@ struct EJitSharedCacheSlot {
   uint64_t codeSize;      ///< size in bytes of that allocation (0 = none)
   uintptr_t poolBase;     ///< 2MiB pool base (split_2m_to_4k granule)
   uint64_t poolSize;      ///< usable pool size
-  uint32_t poolId;   ///< stable pool index within its near/far manager
-  uint32_t poolKind; ///< EJitCodePoolKind: unknown=0, near=1, far=2
+  uint32_t poolId;        ///< stable pool index within its hot/cold/far manager
+  uint32_t poolKind; ///< EJitCodePoolKind: unknown=0, near=1, far=2, cold=3
+  uint32_t extraCodeCount;
+  EJitSharedExecutableRange extraCodeRanges[kEJitMaxExtraCodeRanges];
   /// Runtime-writable extents of the published code (v9): the pages the JIT
   /// body writes at runtime (e.g. Tier-1 __profc_ counters). A non-owner core
   /// in 4K-seal mode MUST enable_rw exactly these in its own translation
@@ -369,7 +380,7 @@ struct EJitSharedCodePoolStats {
     EJitAtomicU64 sealInvocations;
     EJitAtomicU64 splitInvocations;
     EJitAtomicU64 finalizedRangeCount;
-  } near, far;
+  } near, cold, far;
 };
 
 /// Plain (non-atomic) snapshot of code-pool stats, used as the callback
@@ -398,6 +409,7 @@ struct EJitCodePoolStatsOut {
   uint64_t splitInvocations = 0;
   uint64_t finalizedRangeCount = 0;
   Detail near;
+  Detail cold;
   Detail far;
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -365,12 +365,29 @@ struct EJitSharedCounters {
 // EJitSharedCodePoolStats: owner-published mirror of the owner-core
 // EJitCodePoolManager stats. The code pool itself is owner-private (only the
 // worker core allocates/seals), so a non-owner core reading its own per-core
-// manager sees pools=0. The owner publishes a fresh snapshot here after every
-// successful compile (runCompile / sync publish), and every core reads this for
-// ejit_print_code_pool_stats / ejit_get_code_pool_stats — so the diagnostic is
-// consistent cross-core. Relaxed loads/stores: diagnostic only, monotone-ish.
+// manager sees pools=0. The owner publishes a fresh snapshot here at compile
+// batch / flush boundaries, and a diagnostic read can request a dirty owner
+// snapshot; every core reads this for ejit_print_code_pool_stats /
+// ejit_get_code_pool_stats. The mirror uses a seqcount with full barriers: the
+// owner publishes an odd sequence, executes a full write barrier, copies the
+// relaxed fields, executes another full write barrier, and publishes an even
+// sequence. Readers execute full barriers between the sequence and payload
+// reads and accept only an unchanged even sequence. This is intentional: a
+// release store alone is not a complete seqlock on weakly ordered AArch64.
 //===----------------------------------------------------------------------===//
 struct EJitSharedCodePoolStats {
+  /// Even means stable, odd means the owner is copying a new snapshot.
+  EJitAtomicU32 snapshotSeq;
+  /// ABI v19 diagnostic refresh controls. A peer increments this when a read
+  /// observes dirty owner data; the owner acknowledges the latest request
+  /// after attempting a refresh. refreshResult is 1 for success and 0 for
+  /// failure, and is published before refreshComplete.
+  EJitAtomicU32 refreshRequest;
+  EJitAtomicU32 refreshResult;
+  EJitAtomicU32 refreshComplete;
+  /// Non-zero means owner-private stats changed since the last published
+  /// snapshot. This is a control flag, not part of the copied stats payload.
+  EJitAtomicU32 dirty;
   EJitAtomicU64 poolCount;
   EJitAtomicU64 sealedCount;
   EJitAtomicU64 activeCount;
@@ -390,7 +407,15 @@ struct EJitSharedCodePoolStats {
     EJitAtomicU64 sealInvocations;
     EJitAtomicU64 splitInvocations;
     EJitAtomicU64 finalizedRangeCount;
+    EJitAtomicU64 finalizedExecBytes;
+    EJitAtomicU64 pendingExecBytes;
+    EJitAtomicU64 pendingRangeCount;
+    EJitAtomicU64 pendingAllocationCount;
   } near, cold, far;
+  EJitAtomicU64 finalizedExecBytes;
+  EJitAtomicU64 pendingExecBytes;
+  EJitAtomicU64 pendingRangeCount;
+  EJitAtomicU64 pendingAllocationCount;
 };
 
 /// Plain (non-atomic) snapshot of code-pool stats, used as the callback
@@ -408,6 +433,10 @@ struct EJitCodePoolStatsOut {
     uint64_t sealInvocations = 0;
     uint64_t splitInvocations = 0;
     uint64_t finalizedRangeCount = 0;
+    uint64_t finalizedExecBytes = 0;
+    uint64_t pendingExecBytes = 0;
+    uint64_t pendingRangeCount = 0;
+    uint64_t pendingAllocationCount = 0;
   };
   uint64_t poolCount = 0;
   uint64_t sealedCount = 0;
@@ -418,6 +447,10 @@ struct EJitCodePoolStatsOut {
   uint64_t sealInvocations = 0;
   uint64_t splitInvocations = 0;
   uint64_t finalizedRangeCount = 0;
+  uint64_t finalizedExecBytes = 0;
+  uint64_t pendingExecBytes = 0;
+  uint64_t pendingRangeCount = 0;
+  uint64_t pendingAllocationCount = 0;
   Detail near;
   Detail cold;
   Detail far;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
@@ -24,7 +24,7 @@
 namespace llvm {
 namespace ejit {
 
-enum class EJitCodePoolPlacement { NearFixed, FarDynamic };
+enum class EJitCodePoolPlacement { NearFixed, ColdFixed, FarDynamic };
 
 /// Construct an EJitCodePoolManager wired to the SRE platform: raw memory from
 /// SRE_MemDbgAlloc (partition EJIT_SRE_CODE_POOL_PTNO) and sealing via

--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -1301,6 +1301,16 @@ void TargetPassConfig::addMachinePasses() {
   }
 #endif
 
+#if defined(EJIT_MFS_COLD_CODE_POOL) &&                                        \
+    defined(EJIT_TRIM_LLVM_BACKEND_EXPERIMENTAL)
+  // The embedded backend trims the surrounding AutoFDO/BB-section machinery,
+  // but Tier-2 already carries an in-memory instrumentation profile. Restore
+  // only MFS: it consumes the IR profile through MBFI/PSI and emits the cold
+  // blocks as .text.split.<function> sections.
+  if (TM->Options.EnableMachineFunctionSplitter)
+    addPass(createMachineFunctionSplitterPass());
+#endif
+
   addPostBBSections();
 
   if (!DisableCFIFixup && TM->Options.EnableCFIFixup)

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -957,6 +957,29 @@ bool EJit::getCodePoolStats(ejit_code_pool_stats_t *out) const {
 bool EJit::getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const {
   if (!out)
     return false;
+  ejit_code_pool_stats_v3_t V3{};
+  if (!getCodePoolStatsV3(&V3))
+    return false;
+  out->total = V3.total;
+  out->near = V3.nearHot;
+#define EJIT_ADD_PUBLIC_STAT(Field) out->near.Field += V3.nearCold.Field
+  EJIT_ADD_PUBLIC_STAT(poolCount);
+  EJIT_ADD_PUBLIC_STAT(sealedCount);
+  EJIT_ADD_PUBLIC_STAT(activeCount);
+  EJIT_ADD_PUBLIC_STAT(usedBytes);
+  EJIT_ADD_PUBLIC_STAT(reservedBytes);
+  EJIT_ADD_PUBLIC_STAT(wastedBytes);
+  EJIT_ADD_PUBLIC_STAT(sealInvocations);
+  EJIT_ADD_PUBLIC_STAT(splitInvocations);
+  EJIT_ADD_PUBLIC_STAT(finalizedRangeCount);
+#undef EJIT_ADD_PUBLIC_STAT
+  out->far = V3.farTier1;
+  return true;
+}
+
+bool EJit::getCodePoolStatsV3(ejit_code_pool_stats_v3_t *out) const {
+  if (!out)
+    return false;
 #if defined(EJIT_SRE_SHARED_TASKPOOL) && defined(EJIT_SRE_CODE_POOL)
   auto CopyShared = [](ejit_code_pool_stats_t &Dst,
                        const EJitCodePoolStatsOut::Detail &Src) {
@@ -1004,8 +1027,9 @@ bool EJit::getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const {
       Total.splitInvocations = s.splitInvocations;
       Total.finalizedRangeCount = s.finalizedRangeCount;
       CopyShared(out->total, Total);
-      CopyShared(out->near, s.near);
-      CopyShared(out->far, s.far);
+      CopyShared(out->nearHot, s.near);
+      CopyShared(out->nearCold, s.cold);
+      CopyShared(out->farTier1, s.far);
       return true;
     }
   }
@@ -1018,8 +1042,9 @@ bool EJit::getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const {
     return false;
   EJitTieredCodePoolStats s = engine->getTieredCodePoolStats();
   CopyManager(out->total, s.total);
-  CopyManager(out->near, s.near);
-  CopyManager(out->far, s.far);
+  CopyManager(out->nearHot, s.near);
+  CopyManager(out->nearCold, s.cold);
+  CopyManager(out->farTier1, s.far);
   return true;
 #else
   return false;
@@ -1028,8 +1053,8 @@ bool EJit::getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const {
 
 void EJit::printCodePoolStats() const {
 #ifdef EJIT_SRE_CODE_POOL
-  ejit_code_pool_stats_v2_t s{};
-  if (!getCodePoolStatsV2(&s)) {
+  ejit_code_pool_stats_v3_t s{};
+  if (!getCodePoolStatsV3(&s)) {
     EJIT_DIAG_RAW("code pool: not available (no engine)");
     return;
   }
@@ -1053,8 +1078,9 @@ void EJit::printCodePoolStats() const {
     (void)Permille;
   };
   PrintOne("total", s.total);
-  PrintOne("near(final)", s.near);
-  PrintOne("far(tier1)", s.far);
+  PrintOne("near-hot(final)", s.nearHot);
+  PrintOne("near-cold(mfs)", s.nearCold);
+  PrintOne("far(tier1)", s.farTier1);
 #else
   EJIT_DIAG_RAW("code pool: EJIT_SRE_CODE_POOL not enabled");
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -1003,34 +1003,94 @@ bool EJit::getCodePoolStatsV3(ejit_code_pool_stats_v3_t *out) const {
 
 void EJit::printCodePoolStats() const {
 #ifdef EJIT_SRE_CODE_POOL
-  ejit_code_pool_stats_v3_t s{};
-  if (!getCodePoolStatsV3(&s)) {
+  auto PrintOne = [](const char *Kind, uint64_t PoolCount,
+                     uint64_t SealedCount, uint64_t ActiveCount,
+                     uint64_t UsedBytes, uint64_t ReservedBytes,
+                     uint64_t WastedBytes, uint64_t SealInvocations,
+                     uint64_t SplitInvocations, uint64_t FinalizedRanges,
+                     uint64_t FinalizedExecBytes, uint64_t PendingExecBytes,
+                     uint64_t PendingRangeCount,
+                     uint64_t PendingAllocationCount) {
+    const uint64_t Permille = ejitDiagPermille(UsedBytes, ReservedBytes);
+    EJIT_DIAG_RAW("code pool %s: pools=%llu sealed=%llu active=%llu "
+                  "used=%llu reserved=%llu wasted=%llu usage=%llu.%u%%",
+                  Kind, (unsigned long long)PoolCount,
+                  (unsigned long long)SealedCount,
+                  (unsigned long long)ActiveCount,
+                  (unsigned long long)UsedBytes,
+                  (unsigned long long)ReservedBytes,
+                  (unsigned long long)WastedBytes,
+                  (unsigned long long)(Permille / 10),
+                  (unsigned)(Permille % 10));
+    EJIT_DIAG_RAW(
+        "  %s sealInvocations=%llu splitInvocations=%llu "
+        "finalizedRanges=%llu finalizedExecBytes=%llu "
+        "pendingExecBytes=%llu pendingRangeCount=%llu "
+        "pendingAllocationCount=%llu",
+        Kind, (unsigned long long)SealInvocations,
+        (unsigned long long)SplitInvocations,
+        (unsigned long long)FinalizedRanges,
+        (unsigned long long)FinalizedExecBytes,
+        (unsigned long long)PendingExecBytes,
+        (unsigned long long)PendingRangeCount,
+        (unsigned long long)PendingAllocationCount);
+  };
+#if defined(EJIT_SRE_SHARED_TASKPOOL)
+  if (const EJitSharedTaskPool *sp = sharedTaskPool()) {
+    EJitCodePoolStatsOut S;
+    if (sp->readCodePoolStats(&S)) {
+      auto PrintDetail = [&](const char *Kind,
+                             const EJitCodePoolStatsOut::Detail &D) {
+        PrintOne(Kind, D.poolCount, D.sealedCount, D.activeCount, D.usedBytes,
+                 D.reservedBytes, D.wastedBytes, D.sealInvocations,
+                 D.splitInvocations, D.finalizedRangeCount,
+                 D.finalizedExecBytes, D.pendingExecBytes,
+                 D.pendingRangeCount, D.pendingAllocationCount);
+      };
+      EJitCodePoolStatsOut::Detail Total;
+      Total.poolCount = S.poolCount;
+      Total.sealedCount = S.sealedCount;
+      Total.activeCount = S.activeCount;
+      Total.usedBytes = S.usedBytes;
+      Total.reservedBytes = S.reservedBytes;
+      Total.wastedBytes = S.wastedBytes;
+      Total.sealInvocations = S.sealInvocations;
+      Total.splitInvocations = S.splitInvocations;
+      Total.finalizedRangeCount = S.finalizedRangeCount;
+      Total.finalizedExecBytes = S.finalizedExecBytes;
+      Total.pendingExecBytes = S.pendingExecBytes;
+      Total.pendingRangeCount = S.pendingRangeCount;
+      Total.pendingAllocationCount = S.pendingAllocationCount;
+      PrintDetail("total", Total);
+      PrintDetail("near-hot(final)", S.near);
+      PrintDetail("near-cold(mfs)", S.cold);
+      PrintDetail("far(tier1)", S.far);
+      return;
+    }
+  }
+#endif
+  if (!compileDriver_) {
     EJIT_DIAG_RAW("code pool: not available (no engine)");
     return;
   }
-  auto PrintOne = [](const char *Kind, const ejit_code_pool_stats_t &S) {
-    const uint64_t Permille = ejitDiagPermille(S.usedBytes, S.reservedBytes);
-    EJIT_DIAG_RAW("code pool %s: pools=%llu sealed=%llu active=%llu "
-                  "used=%llu reserved=%llu wasted=%llu usage=%llu.%u%%",
-                  Kind, (unsigned long long)S.poolCount,
-                  (unsigned long long)S.sealedCount,
-                  (unsigned long long)S.activeCount,
-                  (unsigned long long)S.usedBytes,
-                  (unsigned long long)S.reservedBytes,
-                  (unsigned long long)S.wastedBytes,
-                  (unsigned long long)(Permille / 10),
-                  (unsigned)(Permille % 10));
-    EJIT_DIAG_RAW("  %s sealInvocations=%llu splitInvocations=%llu "
-                  "finalizedRanges=%llu",
-                  Kind, (unsigned long long)S.sealInvocations,
-                  (unsigned long long)S.splitInvocations,
-                  (unsigned long long)S.finalizedRangeCount);
-    (void)Permille;
+  EJitOrcEngine *Engine = compileDriver_->getJitEngine();
+  if (!Engine) {
+    EJIT_DIAG_RAW("code pool: not available (no engine)");
+    return;
+  }
+  EJitTieredCodePoolStats S = Engine->getTieredCodePoolStats();
+  auto PrintManager = [&](const char *Kind,
+                          const EJitCodePoolManager::Stats &D) {
+    PrintOne(Kind, D.poolCount, D.sealedCount, D.activeCount, D.usedBytes,
+             D.reservedBytes, D.wastedBytes, D.sealInvocations,
+             D.splitInvocations, D.finalizedRangeCount, D.finalizedExecBytes,
+             D.pendingExecBytes, D.pendingRangeCount,
+             D.pendingAllocationCount);
   };
-  PrintOne("total", s.total);
-  PrintOne("near-hot(final)", s.nearHot);
-  PrintOne("near-cold(mfs)", s.nearCold);
-  PrintOne("far(tier1)", s.farTier1);
+  PrintManager("total", S.total);
+  PrintManager("near-hot(final)", S.near);
+  PrintManager("near-cold(mfs)", S.cold);
+  PrintManager("far(tier1)", S.far);
 #else
   EJIT_DIAG_RAW("code pool: EJIT_SRE_CODE_POOL not enabled");
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -10,6 +10,8 @@
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/Support/MathExtras.h"
 #include <algorithm>
+#include <limits>
+#include <utility>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -811,6 +813,41 @@ EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
   S.splitInvocations = SplitInvocations_;
   S.rwEnableInvocations = RwEnableInvocations_;
   S.finalizedRangeCount = FinalizedRanges_.size();
+  auto SumUnionBytes = [](const std::vector<EJitCodePoolManager::FinalizedRange> &Ranges) {
+    std::vector<std::pair<uintptr_t, uintptr_t>> Intervals;
+    Intervals.reserve(Ranges.size());
+    for (const auto &R : Ranges) {
+      if (R.start == 0 || R.size == 0 ||
+          R.size > std::numeric_limits<uintptr_t>::max() - R.start)
+        continue;
+      Intervals.push_back({R.start, R.start + static_cast<uintptr_t>(R.size)});
+    }
+    std::sort(Intervals.begin(), Intervals.end());
+    uintptr_t CurrentStart = 0;
+    uintptr_t CurrentEnd = 0;
+    size_t Total = 0;
+    for (const auto &I : Intervals) {
+      if (CurrentStart == 0) {
+        CurrentStart = I.first;
+        CurrentEnd = I.second;
+        continue;
+      }
+      if (I.first <= CurrentEnd) {
+        CurrentEnd = std::max(CurrentEnd, I.second);
+        continue;
+      }
+      Total += static_cast<size_t>(CurrentEnd - CurrentStart);
+      CurrentStart = I.first;
+      CurrentEnd = I.second;
+    }
+    if (CurrentStart != 0)
+      Total += static_cast<size_t>(CurrentEnd - CurrentStart);
+    return Total;
+  };
+  S.finalizedExecBytes = SumUnionBytes(FinalizedRanges_);
+  S.pendingExecBytes = SumUnionBytes(PendingRanges_);
+  S.pendingRangeCount = PendingRanges_.size();
+  S.pendingAllocationCount = PendingAllocations_;
   for (auto &P : Pools_) {
     S.reservedBytes += P->size;
     S.usedBytes += P->used;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -7,13 +7,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/JITLink/JITLink.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkDylib.h"
 #include "llvm/ExecutionEngine/Orc/Shared/AllocationActions.h"
 #include "llvm/ExecutionEngine/Orc/Shared/MemoryFlags.h"
 #include "llvm/Support/MathExtras.h"
+#include <algorithm>
 #include <cstring>
+#ifndef EJIT_FREESTANDING
+#include <mutex>
+#endif
 #include <vector>
 
 using namespace llvm;
@@ -29,8 +34,15 @@ namespace {
 /// (non-contiguous) executable segments and any number of non-executable
 /// (read-only / writable / GOT) segments, which are NEVER sealed RX.
 struct ExecSegRange {
+  EJitCodePoolManager *Pool = nullptr;
   uintptr_t Addr = 0;
   uint64_t Size = 0;
+};
+
+struct PoolAllocRange {
+  EJitCodePoolManager *Pool = nullptr;
+  void *Base = nullptr;
+  size_t Size = 0;
 };
 } // namespace
 
@@ -41,14 +53,24 @@ struct EJitCodePoolMemoryManager::FinalizedInfo {
   std::vector<WrapperFunctionCall> DeallocActions;
 };
 
+struct EJitCodePoolMemoryManager::State {
+  struct AllocationRecord {
+    std::vector<ExecSegRange> ExecRanges;
+  };
+  std::vector<AllocationRecord> Allocations;
+#ifndef EJIT_FREESTANDING
+  mutable std::mutex Mutex;
+#endif
+};
+
 class EJitCodePoolMemoryManager::InFlightAllocImpl
     : public JITLinkMemoryManager::InFlightAlloc {
 public:
-  InFlightAllocImpl(EJitCodePoolManager &Pool, LinkGraph &G, BasicLayout BL,
-                    void *Base, size_t Size,
+  InFlightAllocImpl(EJitCodePoolMemoryManager &Owner, LinkGraph &G,
+                    BasicLayout BL, std::vector<PoolAllocRange> Allocs,
                     std::vector<ExecSegRange> ExecRanges,
                     std::vector<EJitWritableRange> WritableRanges)
-      : Pool(&Pool), G(&G), BL(std::move(BL)), Base(Base), Size(Size),
+      : Owner(&Owner), G(&G), BL(std::move(BL)), Allocs(std::move(Allocs)),
         ExecRanges(std::move(ExecRanges)),
         WritableRanges(std::move(WritableRanges)) {}
 
@@ -65,26 +87,32 @@ public:
     // engine.) We do not invalidate the instruction cache here either \u2014
     // the SRE seal callback does it (sealAndSyncCache: make page executable +
     // sync caches).
-    if (Pool->usesPageSeal()) {
-      for (const ExecSegRange &R : ExecRanges)
-        if (auto Err = Pool->sealCodeRange(reinterpret_cast<void *>(R.Addr),
+    for (const ExecSegRange &R : ExecRanges) {
+      if (!R.Pool->usesPageSeal())
+        continue;
+      if (auto Err = R.Pool->sealCodeRange(reinterpret_cast<void *>(R.Addr),
                                            static_cast<size_t>(R.Size))) {
-          EJIT_DIAG("finalize FAIL: sealCodeRange addr=0x%llx size=%llu",
-                    static_cast<unsigned long long>(R.Addr),
-                    static_cast<unsigned long long>(R.Size));
-          OnFinalized(
-              joinErrors(std::move(Err), Pool->restoreRxRange(Base, Size)));
-          return;
-        }
+        EJIT_DIAG("finalize FAIL: sealCodeRange addr=0x%llx size=%llu",
+                  static_cast<unsigned long long>(R.Addr),
+                  static_cast<unsigned long long>(R.Size));
+        for (const PoolAllocRange &A : Allocs)
+          Err = joinErrors(std::move(Err),
+                           A.Pool->restoreRxRange(A.Base, A.Size));
+        OnFinalized(std::move(Err));
+        return;
+      }
     }
     runFinalizeActions(
         G->allocActions(),
         [this, OnFinalized = std::move(OnFinalized)](
             Expected<std::vector<WrapperFunctionCall>> DeallocActions) mutable {
           if (!DeallocActions) {
-            EJIT_DIAG("finalize FAIL: runFinalizeActions error base=%p", Base);
-            OnFinalized(joinErrors(DeallocActions.takeError(),
-                                   Pool->restoreRxRange(Base, Size)));
+            Error Err = DeallocActions.takeError();
+            for (const PoolAllocRange &A : Allocs)
+              Err = joinErrors(std::move(Err),
+                               A.Pool->restoreRxRange(A.Base, A.Size));
+            EJIT_DIAG("finalize FAIL: runFinalizeActions error");
+            OnFinalized(std::move(Err));
             return;
           }
           // Publish executable ranges only after every finalize action has
@@ -96,27 +124,40 @@ public:
           // malformed writable set rather than truncating it; that must fail
           // finalize (no callable pointer) so a peer is never handed code whose
           // counter pages it cannot fully prepare. Restore W^X and report.
-          for (const ExecSegRange &R : ExecRanges)
-            if (!Pool->recordFinalizedRange(
+          for (const ExecSegRange &R : ExecRanges) {
+            SmallVector<EJitWritableRange, kEJitMaxWritableRanges> LocalWrites;
+            for (const EJitWritableRange &W : WritableRanges)
+              if (R.Pool->contains(reinterpret_cast<void *>(W.addr)))
+                LocalWrites.push_back(W);
+            if (!R.Pool->recordFinalizedRange(
                     reinterpret_cast<void *>(R.Addr),
                     static_cast<size_t>(R.Size),
-                    WritableRanges.empty() ? nullptr : WritableRanges.data(),
-                    static_cast<uint32_t>(WritableRanges.size()))) {
+                    LocalWrites.empty() ? nullptr : LocalWrites.data(),
+                    static_cast<uint32_t>(LocalWrites.size()))) {
               EJIT_DIAG(
                   "finalize FAIL: recordFinalizedRange rejected addr=0x%llx"
                   " writable=%zu",
                   static_cast<unsigned long long>(R.Addr),
                   WritableRanges.size());
-              OnFinalized(joinErrors(
-                  make_error<StringError>(
-                      "EJitCodePool: finalized allocation has an over-bound or "
-                      "malformed runtime-writable range set",
-                      inconvertibleErrorCode()),
-                  Pool->restoreRxRange(Base, Size)));
+              Error Err = make_error<StringError>(
+                  "EJitCodePool: finalized allocation has an over-bound or "
+                  "malformed runtime-writable range set",
+                  inconvertibleErrorCode());
+              for (const PoolAllocRange &A : Allocs)
+                Err = joinErrors(std::move(Err),
+                                 A.Pool->restoreRxRange(A.Base, A.Size));
+              OnFinalized(std::move(Err));
               return;
             }
+          }
+          {
+#ifndef EJIT_FREESTANDING
+            std::lock_guard<std::mutex> Lock(Owner->State_->Mutex);
+#endif
+            Owner->State_->Allocations.push_back({ExecRanges});
+          }
           auto *Info = new FinalizedInfo();
-          Info->Base = Base;
+          Info->Base = Allocs.empty() ? nullptr : Allocs.front().Base;
           Info->DeallocActions = std::move(*DeallocActions);
 #ifndef NDEBUG
           G = nullptr; // mark finalized
@@ -131,27 +172,38 @@ public:
 #ifndef NDEBUG
     G = nullptr;
 #endif
-    OnAbandoned(Pool->restoreRxRange(Base, Size));
+    Error Err = Error::success();
+    for (const PoolAllocRange &A : Allocs)
+      Err = joinErrors(std::move(Err), A.Pool->restoreRxRange(A.Base, A.Size));
+    OnAbandoned(std::move(Err));
   }
 
 private:
-  EJitCodePoolManager *Pool;
+  EJitCodePoolMemoryManager *Owner;
   LinkGraph *G;
   BasicLayout BL;
-  void *Base;
-  size_t Size;
+  std::vector<PoolAllocRange> Allocs;
   std::vector<ExecSegRange> ExecRanges;
   std::vector<EJitWritableRange> WritableRanges;
 };
 
 EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(EJitCodePoolManager &Pool,
                                                      size_t PageSize)
-    : NearPool_(Pool), PageSize_(PageSize) {}
+    : NearPool_(Pool), PageSize_(PageSize), State_(std::make_unique<State>()) {}
 
 EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(
     EJitCodePoolManager &NearPool, EJitCodePoolManager &FarPool,
     size_t PageSize)
-    : NearPool_(NearPool), FarPool_(&FarPool), PageSize_(PageSize) {}
+    : NearPool_(NearPool), FarPool_(&FarPool), PageSize_(PageSize),
+      State_(std::make_unique<State>()) {}
+
+EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(
+    EJitCodePoolManager &NearPool, EJitCodePoolManager &ColdPool,
+    EJitCodePoolManager &FarPool, size_t PageSize)
+    : NearPool_(NearPool), ColdPool_(&ColdPool), FarPool_(&FarPool),
+      PageSize_(PageSize), State_(std::make_unique<State>()) {}
+
+EJitCodePoolMemoryManager::~EJitCodePoolMemoryManager() = default;
 
 EJitCodePoolManager &EJitCodePoolMemoryManager::selectPool(
     const JITLinkDylib *JD) const {
@@ -160,16 +212,133 @@ EJitCodePoolManager &EJitCodePoolMemoryManager::selectPool(
   return NearPool_;
 }
 
+bool EJitCodePoolMemoryManager::findAllocation(
+    const void *Ptr, EJitCompiledCodeInfo &Out) const {
+  const uintptr_t Addr = reinterpret_cast<uintptr_t>(Ptr);
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(State_->Mutex);
+#endif
+  for (const State::AllocationRecord &A : State_->Allocations) {
+    const ExecSegRange *Primary = nullptr;
+    for (const ExecSegRange &R : A.ExecRanges)
+      if (Addr >= R.Addr && Addr < R.Addr + R.Size) {
+        Primary = &R;
+        break;
+      }
+    if (!Primary)
+      continue;
+    EJitCompiledCodeInfo Result{};
+    if (!Primary->Pool->findRange(Ptr, Result))
+      return false;
+    for (const ExecSegRange &R : A.ExecRanges) {
+      if (&R == Primary)
+        continue;
+      if (Result.extraCodeCount >= kEJitMaxExtraCodeRanges)
+        return false;
+      EJitCompiledCodeInfo ExtraInfo{};
+      if (!R.Pool->findRange(reinterpret_cast<void *>(R.Addr), ExtraInfo))
+        return false;
+      EJitExecutableRange &Extra =
+          Result.extraCodeRanges[Result.extraCodeCount++];
+      Extra.codeStart = ExtraInfo.codeStart;
+      Extra.codeSize = ExtraInfo.codeSize;
+      Extra.poolBase = ExtraInfo.poolBase;
+      Extra.poolSize = ExtraInfo.poolSize;
+      Extra.poolId = ExtraInfo.poolId;
+      Extra.poolKind = ExtraInfo.poolKind;
+    }
+    Out = Result;
+    return true;
+  }
+  return false;
+}
+
 void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
                                          OnAllocatedFunction OnAllocated) {
   EJitCodePoolManager &Pool = selectPool(JD);
+  std::vector<PoolAllocRange> Allocs;
+  std::vector<ExecSegRange> ExecRanges;
+  auto RestoreAll = [&Allocs]() {
+    Error Err = Error::success();
+    for (const PoolAllocRange &A : Allocs)
+      Err = joinErrors(std::move(Err), A.Pool->restoreRxRange(A.Base, A.Size));
+    return Err;
+  };
+
+  // MFS emits profile-cold blocks as .text.split.<function>. Give those blocks
+  // addresses and working memory from the dedicated fixed cold pool, then mark
+  // the sections NoAlloc so BasicLayout lays out the remaining graph in the
+  // normal hot/far pool without merging both RX classes back together.
+  if (ColdPool_ && &Pool == &NearPool_) {
+    SmallVector<Section *, 4> ColdSections;
+    SmallVector<Block *, 16> ColdBlocks;
+    for (Section &Sec : G.sections()) {
+      if (!Sec.getName().starts_with(".text.split.") &&
+          !Sec.getName().starts_with(".text.ejit_cold"))
+        continue;
+      if ((Sec.getMemProt() & orc::MemProt::Exec) == orc::MemProt::None)
+        continue;
+      ColdSections.push_back(&Sec);
+      for (Block *B : Sec.blocks())
+        ColdBlocks.push_back(B);
+    }
+    if (!ColdBlocks.empty()) {
+      llvm::sort(ColdBlocks, [](const Block *L, const Block *R) {
+        if (L->getSection().getOrdinal() != R->getSection().getOrdinal())
+          return L->getSection().getOrdinal() < R->getSection().getOrdinal();
+        return L->getAddress() < R->getAddress();
+      });
+      uint64_t ColdSize = 0;
+      for (Block *B : ColdBlocks) {
+        ColdSize = alignToBlock(ColdSize, *B);
+        ColdSize += B->getSize();
+      }
+      ColdSize = alignTo(ColdSize, PageSize_);
+      auto ColdMemOrErr =
+          ColdPool_->allocateCode(static_cast<size_t>(ColdSize), PageSize_);
+      if (!ColdMemOrErr) {
+        OnAllocated(ColdMemOrErr.takeError());
+        return;
+      }
+      void *ColdBase = *ColdMemOrErr;
+      if (auto Err = ColdPool_->enableRwRange(ColdBase, ColdSize)) {
+        OnAllocated(joinErrors(std::move(Err),
+                               ColdPool_->restoreRxRange(ColdBase, ColdSize)));
+        return;
+      }
+      std::memset(ColdBase, 0, static_cast<size_t>(ColdSize));
+      uintptr_t ColdAddr = reinterpret_cast<uintptr_t>(ColdBase);
+      size_t WorkingOffset = 0;
+      for (Block *B : ColdBlocks) {
+        ColdAddr = alignToBlock(ColdAddr, *B);
+        WorkingOffset = static_cast<size_t>(
+            alignToBlock(static_cast<uint64_t>(WorkingOffset), *B));
+        B->setAddress(ExecutorAddr(ColdAddr));
+        if (!B->isZeroFill()) {
+          char *Dst = static_cast<char *>(ColdBase) + WorkingOffset;
+          std::memcpy(Dst, B->getContent().data(), B->getSize());
+          B->setMutableContent({Dst, B->getSize()});
+        }
+        ColdAddr += B->getSize();
+        WorkingOffset += B->getSize();
+      }
+      for (Section *Sec : ColdSections)
+        Sec->setMemLifetime(orc::MemLifetime::NoAlloc);
+      Allocs.push_back({ColdPool_, ColdBase, static_cast<size_t>(ColdSize)});
+      ExecRanges.push_back(
+          {ColdPool_, reinterpret_cast<uintptr_t>(ColdBase), ColdSize});
+      EJIT_DIAG("allocate: graph=%s cold=%llu bytes sections=%zu",
+                G.getName().c_str(), static_cast<unsigned long long>(ColdSize),
+                ColdSections.size());
+    }
+  }
   BasicLayout BL(G);
 
   auto SegsSizes = BL.getContiguousPageBasedLayoutSizes(PageSize_);
   if (!SegsSizes) {
     EJIT_DIAG("allocate FAIL: layout sizes error graph=%s",
               G.getName().c_str());
-    OnAllocated(SegsSizes.takeError());
+    OnAllocated(joinErrors(SegsSizes.takeError(), RestoreAll()));
     return;
   }
 
@@ -185,7 +354,7 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     if (!MemOrErr) {
       EJIT_DIAG("allocate FAIL: pool allocateCode total=%llu",
                 static_cast<unsigned long long>(Total));
-      OnAllocated(MemOrErr.takeError());
+      OnAllocated(joinErrors(MemOrErr.takeError(), RestoreAll()));
       return;
     }
     Slab = *MemOrErr;
@@ -196,7 +365,10 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     if (auto Err = Pool.enableRwRange(Slab, static_cast<size_t>(Total))) {
       EJIT_DIAG("allocate FAIL: enableRwRange total=%llu",
                 static_cast<unsigned long long>(Total));
-      OnAllocated(std::move(Err));
+      OnAllocated(joinErrors(
+          std::move(Err),
+          joinErrors(Pool.restoreRxRange(Slab, static_cast<size_t>(Total)),
+                     RestoreAll())));
       return;
     }
     // Zero-fill the whole slab up-front (covers zero-fill segments and any
@@ -222,7 +394,6 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   // because a peer reads it fine from an RX page. The same page-aligned layout
   // guarantees a writable segment never shares a 4KiB page with an executable
   // one, so making these RW on a peer never touches a code page (no RWX).
-  std::vector<ExecSegRange> ExecRanges;
   std::vector<EJitWritableRange> WritableRanges;
   for (auto &KV : BL.segments()) {
     auto &AG = KV.first;
@@ -242,7 +413,8 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     if (IsExec) {
       if (SegSize > 0)
         ExecRanges.push_back(
-            {reinterpret_cast<uintptr_t>(SegAddr.toPtr<char *>()), SegSize});
+            {&Pool, reinterpret_cast<uintptr_t>(SegAddr.toPtr<char *>()),
+             SegSize});
     } else if (IsWrite) {
       if (SegSize > 0)
         WritableRanges.push_back(
@@ -264,25 +436,41 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
             "EJitCodePool: allocation has more runtime-writable segments than "
             "the fixed cross-core bound",
             inconvertibleErrorCode()),
-        Pool.restoreRxRange(Slab, static_cast<size_t>(Total))));
+        joinErrors(Pool.restoreRxRange(Slab, static_cast<size_t>(Total)),
+                   RestoreAll())));
+    return;
+  }
+
+  if (ExecRanges.size() > 1 + kEJitMaxExtraCodeRanges) {
+    Error Err = make_error<StringError>(
+        "EJitCodePool: too many executable extents for cross-core metadata",
+        inconvertibleErrorCode());
+    Err = joinErrors(std::move(Err), RestoreAll());
+    if (Total > 0)
+      Err = joinErrors(std::move(Err),
+                       Pool.restoreRxRange(Slab, static_cast<size_t>(Total)));
+    OnAllocated(std::move(Err));
     return;
   }
 
   if (auto Err = BL.apply()) {
     EJIT_DIAG("allocate FAIL: BasicLayout apply error graph=%s",
               G.getName().c_str());
-    OnAllocated(
-        joinErrors(std::move(Err),
-                   Pool.restoreRxRange(Slab, static_cast<size_t>(Total))));
+    OnAllocated(joinErrors(
+        std::move(Err),
+        joinErrors(Pool.restoreRxRange(Slab, static_cast<size_t>(Total)),
+                   RestoreAll())));
     return;
   }
 
   EJIT_DIAG("allocate OK: slab=%p total=%llu execRanges=%zu writableRanges=%zu",
             Slab, static_cast<unsigned long long>(Total), ExecRanges.size(),
             WritableRanges.size());
+  if (Total > 0)
+    Allocs.push_back({&Pool, Slab, static_cast<size_t>(Total)});
   OnAllocated(std::make_unique<InFlightAllocImpl>(
-      Pool, G, std::move(BL), Slab, static_cast<size_t>(Total),
-      std::move(ExecRanges), std::move(WritableRanges)));
+      *this, G, std::move(BL), std::move(Allocs), std::move(ExecRanges),
+      std::move(WritableRanges)));
 }
 
 void EJitCodePoolMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -57,6 +57,9 @@ struct EJitCodePoolMemoryManager::State {
   struct AllocationRecord {
     std::vector<ExecSegRange> ExecRanges;
   };
+  // Code-pool v1 never reclaims executable storage, so allocation addresses
+  // remain valid for the manager lifetime. If reclamation is introduced,
+  // deallocate() must remove these records and this lookup should be indexed.
   std::vector<AllocationRecord> Allocations;
 #ifndef EJIT_FREESTANDING
   mutable std::mutex Mutex;
@@ -365,10 +368,9 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
     if (auto Err = Pool.enableRwRange(Slab, static_cast<size_t>(Total))) {
       EJIT_DIAG("allocate FAIL: enableRwRange total=%llu",
                 static_cast<unsigned long long>(Total));
-      OnAllocated(joinErrors(
-          std::move(Err),
-          joinErrors(Pool.restoreRxRange(Slab, static_cast<size_t>(Total)),
-                     RestoreAll())));
+      // enableRwRange seals every page it made writable before returning an
+      // error. Only the earlier companion cold allocation remains to restore.
+      OnAllocated(joinErrors(std::move(Err), RestoreAll()));
       return;
     }
     // Zero-fill the whole slab up-front (covers zero-fill segments and any

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -112,6 +112,7 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
       Dst.finalizedRangeCount = Src.finalizedRangeCount;
     };
     CopyDetail(out->near, tiered.near);
+    CopyDetail(out->cold, tiered.cold);
     CopyDetail(out->far, tiered.far);
     return true;
   }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -128,6 +128,10 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
     out->sealInvocations = s.sealInvocations;
     out->splitInvocations = s.splitInvocations;
     out->finalizedRangeCount = s.finalizedRangeCount;
+    out->finalizedExecBytes = s.finalizedExecBytes;
+    out->pendingExecBytes = s.pendingExecBytes;
+    out->pendingRangeCount = s.pendingRangeCount;
+    out->pendingAllocationCount = s.pendingAllocationCount;
     auto CopyDetail = [](EJitCodePoolStatsOut::Detail &Dst,
                          const EJitCodePoolManager::Stats &Src) {
       Dst.poolCount = Src.poolCount;
@@ -139,6 +143,10 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
       Dst.sealInvocations = Src.sealInvocations;
       Dst.splitInvocations = Src.splitInvocations;
       Dst.finalizedRangeCount = Src.finalizedRangeCount;
+      Dst.finalizedExecBytes = Src.finalizedExecBytes;
+      Dst.pendingExecBytes = Src.pendingExecBytes;
+      Dst.pendingRangeCount = Src.pendingRangeCount;
+      Dst.pendingAllocationCount = Src.pendingAllocationCount;
     };
     CopyDetail(out->near, tiered.near);
     CopyDetail(out->cold, tiered.cold);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -1352,6 +1352,10 @@ EJitTieredCodePoolStats EJitOrcEngine::getTieredCodePoolStats() const {
   EJIT_SUM_STAT(splitInvocations);
   EJIT_SUM_STAT(rwEnableInvocations);
   EJIT_SUM_STAT(finalizedRangeCount);
+  EJIT_SUM_STAT(finalizedExecBytes);
+  EJIT_SUM_STAT(pendingExecBytes);
+  EJIT_SUM_STAT(pendingRangeCount);
+  EJIT_SUM_STAT(pendingAllocationCount);
 #undef EJIT_SUM_STAT
   return Out;
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -92,7 +92,9 @@ struct EJitOrcEngine::Impl {
   /// Tier-1 code uses the previous dynamic SRE allocation path. Both outlive
   /// LLJIT and its routing memory manager.
   std::unique_ptr<EJitCodePoolManager> nearCodePool;
+  std::unique_ptr<EJitCodePoolManager> coldCodePool;
   std::unique_ptr<EJitCodePoolManager> farCodePool;
+  EJitCodePoolMemoryManager *codePoolMemoryManager = nullptr;
 #endif
   std::unique_ptr<orc::LLJIT> J;
   PeriodArrayRegistry *periodReg = nullptr;
@@ -639,6 +641,9 @@ EJitOrcEngine::Create(const Config &config,
   // the specialization savings (fewer BBs / folded branches). Small makes
   // the per-global cost match AOT (ADRP+LDR), so specialization gains show.
   JTMBOrErr->setCodeModel(CodeModel::Small);
+#ifdef EJIT_MFS_COLD_CODE_POOL
+  JTMBOrErr->getOptions().EnableMachineFunctionSplitter = true;
+#endif
 
   // Build a TargetMachine (same options the JIT compiles with) for the
   // name-filtered ASM diagnostic dump. Failure is non-fatal — the dump is
@@ -670,21 +675,33 @@ EJitOrcEngine::Create(const Config &config,
   // at lookup time, by the pool manager's enable_ex sealing.
   engine->P->nearCodePool =
       makeSreCodePoolManager(EJitCodePoolPlacement::NearFixed);
+#ifdef EJIT_MFS_COLD_CODE_POOL
+  engine->P->coldCodePool =
+      makeSreCodePoolManager(EJitCodePoolPlacement::ColdFixed);
+#endif
   engine->P->farCodePool =
       makeSreCodePoolManager(EJitCodePoolPlacement::FarDynamic);
   {
     EJitCodePoolManager *NearPool = engine->P->nearCodePool.get();
+    EJitCodePoolManager *ColdPool = engine->P->coldCodePool.get();
     EJitCodePoolManager *FarPool = engine->P->farCodePool.get();
+    Impl *EngineImpl = engine->P.get();
     Builder.setObjectLinkingLayerCreator(
-        [NearPool, FarPool](orc::ExecutionSession &ES)
+        [NearPool, ColdPool, FarPool, EngineImpl](orc::ExecutionSession &ES)
             -> Expected<std::unique_ptr<orc::ObjectLayer>> {
           // Page size only affects per-segment layout padding; we never apply
           // per-segment protections (sealing is done per 2MiB pool), so a
           // conservative 4KiB is sufficient and portable.
           constexpr size_t JitPageSize = 4096;
-          return std::make_unique<orc::ObjectLinkingLayer>(
-              ES, std::make_unique<EJitCodePoolMemoryManager>(
-                      *NearPool, *FarPool, JitPageSize));
+          std::unique_ptr<EJitCodePoolMemoryManager> MM;
+          if (ColdPool)
+            MM = std::make_unique<EJitCodePoolMemoryManager>(
+                *NearPool, *ColdPool, *FarPool, JitPageSize);
+          else
+            MM = std::make_unique<EJitCodePoolMemoryManager>(
+                *NearPool, *FarPool, JitPageSize);
+          EngineImpl->codePoolMemoryManager = MM.get();
+          return std::make_unique<orc::ObjectLinkingLayer>(ES, std::move(MM));
         });
   }
 #endif
@@ -1150,6 +1167,8 @@ Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
   EJitCodePoolManager *OwningPool = nullptr;
   if (P->nearCodePool && P->nearCodePool->contains(Ptr))
     OwningPool = P->nearCodePool.get();
+  else if (P->coldCodePool && P->coldCodePool->contains(Ptr))
+    OwningPool = P->coldCodePool.get();
   else if (P->farCodePool && P->farCodePool->contains(Ptr))
     OwningPool = P->farCodePool.get();
   if (OwningPool && !OwningPool->usesPageSeal()) {
@@ -1158,6 +1177,23 @@ Expected<void *> EJitOrcEngine::lookup(uint64_t cacheKey,
                 Ptr);
       return std::move(Err);
     }
+  }
+  // Legacy whole-pool mode must also seal MFS's companion cold extent before
+  // the entry pointer can be published. In 4K mode finalize already sealed it.
+  if (P->codePoolMemoryManager) {
+    EJitCompiledCodeInfo Info{};
+    if (P->codePoolMemoryManager->findAllocation(Ptr, Info))
+      for (uint32_t I = 0; I < Info.extraCodeCount; ++I) {
+        const EJitExecutableRange &R = Info.extraCodeRanges[I];
+        EJitCodePoolManager *ExtraPool =
+            R.poolKind == EJitCodePoolKind::Cold  ? P->coldCodePool.get()
+            : R.poolKind == EJitCodePoolKind::Far ? P->farCodePool.get()
+                                                  : P->nearCodePool.get();
+        if (ExtraPool && !ExtraPool->usesPageSeal())
+          if (auto Err = ExtraPool->sealPoolContaining(
+                  reinterpret_cast<void *>(R.codeStart)))
+            return std::move(Err);
+      }
   }
 #endif
 
@@ -1212,9 +1248,12 @@ EJitTieredCodePoolStats EJitOrcEngine::getTieredCodePoolStats() const {
   EJitTieredCodePoolStats Out;
   if (P->nearCodePool)
     Out.near = P->nearCodePool->getStats();
+  if (P->coldCodePool)
+    Out.cold = P->coldCodePool->getStats();
   if (P->farCodePool)
     Out.far = P->farCodePool->getStats();
-#define EJIT_SUM_STAT(Field) Out.total.Field = Out.near.Field + Out.far.Field
+#define EJIT_SUM_STAT(Field)                                                   \
+  Out.total.Field = Out.near.Field + Out.cold.Field + Out.far.Field
   EJIT_SUM_STAT(poolCount);
   EJIT_SUM_STAT(sealedCount);
   EJIT_SUM_STAT(activeCount);
@@ -1231,11 +1270,16 @@ EJitTieredCodePoolStats EJitOrcEngine::getTieredCodePoolStats() const {
 
 bool EJitOrcEngine::findCodeRange(const void *FnPtr,
                                   EJitCompiledCodeInfo &Out) const {
-  if (!P->nearCodePool && !P->farCodePool) {
+  if (!P->nearCodePool && !P->coldCodePool && !P->farCodePool) {
     EJIT_DIAG("findCodeRange FAIL: no code pool (fnPtr=%p)", FnPtr);
     return false;
   }
+  if (P->codePoolMemoryManager &&
+      P->codePoolMemoryManager->findAllocation(FnPtr, Out))
+    return true;
   if (P->nearCodePool && P->nearCodePool->findRange(FnPtr, Out))
+    return true;
+  if (P->coldCodePool && P->coldCodePool->findRange(FnPtr, Out))
     return true;
   return P->farCodePool && P->farCodePool->findRange(FnPtr, Out);
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -35,8 +35,10 @@
 #ifndef EJIT_SRE_DIAG
 #include <cstdio>
 #endif
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
+#include <vector>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -1804,8 +1806,8 @@ void ejit_taskpool_print_compiled() {
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Unknown)]);
 #ifdef EJIT_STATS_ENABLE
   constexpr bool ReuseTrackingEnabled = true;
-  const uint32_t FinalVersions = count.byTier[kEJitTierBaseline] +
-                                 count.byTier[kEJitTierPgoUse];
+  const uint32_t FinalVersions =
+      count.byTier[kEJitTierBaseline] + count.byTier[kEJitTierPgoUse];
   EJIT_DIAG_RAW("compiled final reuse: post_publish_seen=%u unseen=%u "
                 "(tier1_collecting_excluded=%u)",
                 count.finalPostPublishSeen,
@@ -1819,16 +1821,26 @@ void ejit_taskpool_print_compiled() {
 #endif
   // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
   // each printed line.
+  struct LayoutEntry {
+    uint32_t funcIndex;
+    uint32_t numDims;
+    EJitDimPair dims[kEJitSharedMaxDims];
+    uint32_t versions[kEJitSharedMaxDims];
+    uint8_t tier;
+    uintptr_t fn;
+    uintptr_t codeStart;
+    uint64_t codeSize;
+    uint32_t poolKind;
+    uint32_t poolId;
+    uint32_t generation;
+    uint8_t postPublishSeen;
+  };
   struct PrintCtx {
-    EJitModuleLoader &loader;
-    bool reuseTrackingEnabled;
-  } printCtx{loader, ReuseTrackingEnabled};
+    std::vector<LayoutEntry> layout;
+  } printCtx{{}};
   EJitSharedTaskPool::ForEachCompiledStats st2 = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         PrintCtx &ctx = *static_cast<PrintCtx *>(cbCtx);
-        EJitModuleLoader &ld = ctx.loader;
-        const std::string &name =
-            ld.getFuncNameByFuncIdx(slot.funcIndex);
         // Per the publish protocol: fnPtr is read with acquire only after
         // state==Ready was observed with acquire (forEachCompiled did).
         void *fn = reinterpret_cast<void *>(slot.fnPtr.loadAcquire());
@@ -1837,62 +1849,22 @@ void ejit_taskpool_print_compiled() {
         const uint32_t n = slot.numDims < kEJitSharedMaxDims
                                ? slot.numDims
                                : kEJitSharedMaxDims;
-        // dims=[d:i,...] for the n meaningful pairs, e.g. "1:5" / "1:5,2:7".
-        // Sized for the uint32 worst case: kEJitSharedMaxDims x
-        // ("4294967295:4294967295" = 21) + separators + NUL.
-        char dims[kEJitSharedMaxDims * 21 + (kEJitSharedMaxDims - 1) + 1];
-        char *p = dims;
-        char *end = dims + sizeof(dims);
-        for (uint32_t i = 0; i < n && p < end; ++i)
-          p += snprintf(p, (size_t)(end - p), "%s%u:%u", i ? "," : "",
-                        slot.dims[i].dimType, slot.dims[i].instanceId);
-        if (p >= end)
-          p = end - 1;
-        *p = '\0';
-        const char *PostPublishSeen =
-            !ctx.reuseTrackingEnabled
-                ? "disabled"
-                : (slot.postPublishSeen.loadRelaxed() != 0 ? "yes" : "no");
-        const uint8_t SlotTier = slot.tier.loadRelaxed();
-        const char *Tier = SlotTier == kEJitTierPgoUse ? "tier2"
-                           : SlotTier == kEJitTierInstrumented
-                               ? "tier1-collecting"
-                               : "baseline";
-        const char *PoolKind =
-            slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
-                ? "near"
-                : slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
-                      ? "far"
-                      : "unknown";
-        if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
-          // Same shape for the per-instance version snapshot (uint32 x
-          // kEJitSharedMaxDims + separators + NUL).
-          char ver[kEJitSharedMaxDims * 10 + (kEJitSharedMaxDims - 1) + 1];
-          p = ver;
-          end = ver + sizeof(ver);
-          for (uint32_t i = 0; i < n && p < end; ++i)
-            p += snprintf(p, (size_t)(end - p), "%s%u", i ? "," : "",
-                          slot.versions[i]);
-          if (p >= end)
-            p = end - 1;
-          *p = '\0';
-          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "post_publish_seen=%s ver=[%s] size=%llu "
-                        "pool=%s pool_id=%u "
-                        "gen=%u",
-                        slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PostPublishSeen, ver,
-                        static_cast<unsigned long long>(slot.codeSize),
-                        PoolKind, slot.poolId, slot.generation);
-        } else {
-          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "pool=%s post_publish_seen=%s",
-                        slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PoolKind, PostPublishSeen);
+        LayoutEntry Entry{};
+        Entry.funcIndex = slot.funcIndex;
+        Entry.numDims = n;
+        for (uint32_t i = 0; i < n; ++i) {
+          Entry.dims[i] = slot.dims[i];
+          Entry.versions[i] = slot.versions[i];
         }
-        ejitDiagPrintThrottle();
+        Entry.tier = slot.tier.loadRelaxed();
+        Entry.fn = reinterpret_cast<uintptr_t>(fn);
+        Entry.codeStart = slot.codeStart;
+        Entry.codeSize = slot.codeSize;
+        Entry.poolKind = slot.poolKind;
+        Entry.poolId = slot.poolId;
+        Entry.generation = slot.generation;
+        Entry.postPublishSeen = slot.postPublishSeen.loadRelaxed();
+        ctx.layout.push_back(Entry);
       },
       &printCtx);
   // The summary counted the first walk; if the entry walk itself skipped
@@ -1901,6 +1873,152 @@ void ejit_taskpool_print_compiled() {
   if (st2.skippedBuckets)
     EJIT_DIAG_RAW("compiled: %u buckets skipped during entry walk",
                   st2.skippedBuckets);
+  std::sort(printCtx.layout.begin(), printCtx.layout.end(),
+            [](const LayoutEntry &A, const LayoutEntry &B) {
+              // Ready slots should always have a non-null fnPtr. Keep a corrupt
+              // zero pointer last instead of presenting it as the lowest code
+              // address.
+              if ((A.fn == 0) != (B.fn == 0))
+                return A.fn != 0;
+              if (A.fn != B.fn)
+                return A.fn < B.fn;
+              if (A.codeStart != B.codeStart)
+                return A.codeStart < B.codeStart;
+              return A.funcIndex < B.funcIndex;
+            });
+  EJIT_DIAG_RAW("compiled layout: %zu entries sorted by fn address",
+                printCtx.layout.size());
+  {
+    uintptr_t PreviousStart = 0;
+    uintptr_t PreviousEnd = 0;
+    uint32_t PreviousPoolKind = ~0u;
+    uint32_t PreviousPoolId = ~0u;
+    bool PreviousRangeValid = false;
+    for (size_t Index = 0; Index < printCtx.layout.size(); ++Index) {
+      const LayoutEntry &Entry = printCtx.layout[Index];
+      const std::string &Name = loader.getFuncNameByFuncIdx(Entry.funcIndex);
+      char Dims[kEJitSharedMaxDims * 21 + (kEJitSharedMaxDims - 1) + 1];
+      char *DimPos = Dims;
+      char *DimEnd = Dims + sizeof(Dims);
+      for (uint32_t I = 0; I < Entry.numDims && DimPos < DimEnd; ++I)
+        DimPos += snprintf(DimPos, static_cast<size_t>(DimEnd - DimPos),
+                           "%s%u:%u", I ? "," : "", Entry.dims[I].dimType,
+                           Entry.dims[I].instanceId);
+      if (DimPos >= DimEnd)
+        DimPos = DimEnd - 1;
+      *DimPos = '\0';
+      char Versions[kEJitSharedMaxDims * 10 + (kEJitSharedMaxDims - 1) + 1];
+      char *VersionPos = Versions;
+      char *VersionEnd = Versions + sizeof(Versions);
+      for (uint32_t I = 0; I < Entry.numDims && VersionPos < VersionEnd; ++I)
+        VersionPos +=
+            snprintf(VersionPos, static_cast<size_t>(VersionEnd - VersionPos),
+                     "%s%u", I ? "," : "", Entry.versions[I]);
+      if (VersionPos >= VersionEnd)
+        VersionPos = VersionEnd - 1;
+      *VersionPos = '\0';
+      const char *Tier = Entry.tier == kEJitTierPgoUse ? "tier2"
+                         : Entry.tier == kEJitTierInstrumented
+                             ? "tier1-collecting"
+                             : "baseline";
+      const char *PoolKind =
+          Entry.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
+              ? "near"
+          : Entry.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
+              ? "far"
+              : "unknown";
+      const uintptr_t CodeEnd =
+          Entry.codeStart + static_cast<uintptr_t>(Entry.codeSize);
+      const bool RangeValid = Entry.codeStart != 0 && Entry.codeSize != 0 &&
+                              CodeEnd >= Entry.codeStart;
+      const bool SamePool = PreviousRangeValid &&
+                            PreviousPoolKind == Entry.poolKind &&
+                            PreviousPoolId == Entry.poolId;
+      const bool SameAllocation = SamePool && RangeValid &&
+                                  Entry.codeStart == PreviousStart &&
+                                  CodeEnd == PreviousEnd;
+      const char *FnInAllocation =
+          !RangeValid
+              ? "unknown"
+              : (Entry.fn >= Entry.codeStart && Entry.fn < CodeEnd ? "yes"
+                                                                   : "no");
+      const char *PostPublishSeen =
+          !ReuseTrackingEnabled ? "disabled"
+                                : (Entry.postPublishSeen != 0 ? "yes" : "no");
+      if (gEJitDiagLevel < EJIT_LOG_LVL_VERBOSE) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_size=%llu "
+            "pool=%s:%u funcIdx=%u name=%s tier=%s dims=[%s] "
+            "fn_in_alloc=%s post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(Entry.codeSize), PoolKind,
+            Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims,
+            FnInAllocation, PostPublishSeen);
+      } else if (!SamePool || !RangeValid) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu gap=n/a pool=%s:%u funcIdx=%u name=%s tier=%s "
+            "dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize), PoolKind,
+            Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      } else if (SameAllocation) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu gap=shared_alloc pool=%s:%u funcIdx=%u name=%s "
+            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize), PoolKind,
+            Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      } else if (Entry.codeStart >= PreviousEnd) {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu gap=%llu pool=%s:%u funcIdx=%u name=%s tier=%s "
+            "dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize),
+            static_cast<unsigned long long>(Entry.codeStart - PreviousEnd),
+            PoolKind, Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      } else {
+        EJIT_DIAG_RAW(
+            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
+            "alloc_size=%llu OVERLAP=%llu pool=%s:%u funcIdx=%u name=%s "
+            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "post_publish_seen=%s",
+            Index, static_cast<unsigned long long>(Entry.fn),
+            static_cast<unsigned long long>(Entry.codeStart),
+            static_cast<unsigned long long>(CodeEnd),
+            static_cast<unsigned long long>(Entry.codeSize),
+            static_cast<unsigned long long>(PreviousEnd - Entry.codeStart),
+            PoolKind, Entry.poolId, Entry.funcIndex,
+            Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
+            Entry.generation, FnInAllocation, PostPublishSeen);
+      }
+      PreviousStart = Entry.codeStart;
+      PreviousEnd = CodeEnd;
+      PreviousPoolKind = Entry.poolKind;
+      PreviousPoolId = Entry.poolId;
+      PreviousRangeValid = RangeValid;
+      ejitDiagPrintThrottle();
+    }
+  }
 #else
   EJIT_DIAG_RAW("print_compiled: shared taskpool not enabled");
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -1701,9 +1701,10 @@ void ejit_taskpool_print_compiled() {
   struct CountCtx {
     uint32_t byDims[kEJitSharedMaxDims + 1];
     uint32_t byTier[3];
-    uint32_t byPool[3];
+    uint32_t byPool[4];
+    uint32_t withColdRange;
     uint32_t finalPostPublishSeen;
-  } count = {{0}, {0}, {0}, 0};
+  } count = {{0}, {0}, {0}, 0, 0};
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
         // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
@@ -1714,8 +1715,10 @@ void ejit_taskpool_print_compiled() {
         uint8_t tier = slot.tier.loadRelaxed();
         if (tier <= kEJitTierPgoUse)
           ++static_cast<CountCtx *>(cbCtx)->byTier[tier];
-        if (slot.poolKind <= static_cast<uint32_t>(EJitCodePoolKind::Far))
+        if (slot.poolKind <= static_cast<uint32_t>(EJitCodePoolKind::Cold))
           ++static_cast<CountCtx *>(cbCtx)->byPool[slot.poolKind];
+        if (slot.extraCodeCount != 0)
+          ++static_cast<CountCtx *>(cbCtx)->withColdRange;
         if (tier != kEJitTierInstrumented &&
             slot.postPublishSeen.loadRelaxed() != 0)
           ++static_cast<CountCtx *>(cbCtx)->finalPostPublishSeen;
@@ -1745,10 +1748,12 @@ void ejit_taskpool_print_compiled() {
                 count.byTier[kEJitTierBaseline],
                 count.byTier[kEJitTierInstrumented],
                 count.byTier[kEJitTierPgoUse]);
-  EJIT_DIAG_RAW("compiled pools: near=%u far=%u unknown=%u",
+  EJIT_DIAG_RAW("compiled pools: near-hot=%u far-tier1=%u unknown=%u "
+                "with_mfs_cold=%u",
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Near)],
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Far)],
-                count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Unknown)]);
+                count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Unknown)],
+                count.withColdRange);
 #ifdef EJIT_STATS_ENABLE
   constexpr bool ReuseTrackingEnabled = true;
   const uint32_t FinalVersions = count.byTier[kEJitTierBaseline] +
@@ -1808,9 +1813,11 @@ void ejit_taskpool_print_compiled() {
         const char *PoolKind =
             slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
                 ? "near"
-                : slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
-                      ? "far"
-                      : "unknown";
+            : slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
+                ? "far"
+            : slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Cold)
+                ? "cold"
+                : "unknown";
         if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
           // Same shape for the per-instance version snapshot (uint32 x
           // kEJitSharedMaxDims + separators + NUL).
@@ -1823,21 +1830,26 @@ void ejit_taskpool_print_compiled() {
           if (p >= end)
             p = end - 1;
           *p = '\0';
-          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "post_publish_seen=%s ver=[%s] size=%llu "
-                        "pool=%s pool_id=%u "
-                        "gen=%u",
-                        slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PostPublishSeen, ver,
-                        static_cast<unsigned long long>(slot.codeSize),
-                        PoolKind, slot.poolId, slot.generation);
+          EJIT_DIAG_RAW(
+              "funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
+              "post_publish_seen=%s ver=[%s] size=%llu "
+              "pool=%s pool_id=%u cold_ranges=%u cold_size=%llu "
+              "gen=%u",
+              slot.funcIndex, name.empty() ? "<unknown>" : name.c_str(), Tier,
+              slot.numDims, dims, fn, PostPublishSeen, ver,
+              static_cast<unsigned long long>(slot.codeSize), PoolKind,
+              slot.poolId, slot.extraCodeCount,
+              slot.extraCodeCount ? static_cast<unsigned long long>(
+                                        slot.extraCodeRanges[0].codeSize)
+                                  : 0ull,
+              slot.generation);
         } else {
           EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "pool=%s post_publish_seen=%s",
+                        "pool=%s mfs_cold=%s post_publish_seen=%s",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PoolKind, PostPublishSeen);
+                        slot.numDims, dims, fn, PoolKind,
+                        slot.extraCodeCount ? "yes" : "no", PostPublishSeen);
         }
         ejitDiagPrintThrottle();
       },
@@ -1966,6 +1978,14 @@ ejit_status_t ejit_get_code_pool_stats_v2(ejit_code_pool_stats_v2_t *out) {
     return EJIT_ERR_DISABLED;
   }
   return EJIT_OK;
+}
+
+ejit_status_t ejit_get_code_pool_stats_v3(ejit_code_pool_stats_v3_t *out) {
+  if (!out)
+    return EJIT_ERR_INVALID_PARAM;
+  if (!gEJIT)
+    return EJIT_ERR_NOT_ACTIVE;
+  return gEJIT->getCodePoolStatsV3(out) ? EJIT_OK : EJIT_ERR_DISABLED;
 }
 
 void ejit_print_code_pool_stats(void) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitRegistrationStore.h"
 #include "llvm/ExecutionEngine/EJIT/EJitRegistryEntry.h" // ejit_reg_entry_t layout
 #include "llvm/ExecutionEngine/EJIT/EJitRuntimeState.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntimeDiagnostics.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSreQueue.h" // EJitDimPair layout
 // Build-time-generated: EJIT_GIT_COMMIT / EJIT_GIT_BRANCH (git HEAD of the
 // llvm-project source tree). Lives in the LLVMEJIT build directory.
@@ -1874,8 +1875,8 @@ void ejit_taskpool_print_compiled() {
         Entry.extraCodeCount = slot.extraCodeCount > kEJitMaxExtraCodeRanges
                                    ? kEJitMaxExtraCodeRanges
                                    : slot.extraCodeCount;
-        for (uint32_t i = 0; i < Entry.extraCodeCount; ++i)
-          Entry.extraCodeRanges[i] = slot.extraCodeRanges[i];
+        for (uint32_t I = 0; I < Entry.extraCodeCount; ++I)
+          Entry.extraCodeRanges[I] = slot.extraCodeRanges[I];
         ctx.layout.push_back(Entry);
       },
       &printCtx);
@@ -1898,6 +1899,32 @@ void ejit_taskpool_print_compiled() {
                 return A.codeStart < B.codeStart;
               return A.funcIndex < B.funcIndex;
             });
+  std::vector<ejit::detail::EJitCompiledExecRange> ExecRanges;
+  for (const LayoutEntry &Entry : printCtx.layout) {
+    ExecRanges.push_back({Entry.poolKind, Entry.poolId, Entry.codeStart,
+                          Entry.codeSize});
+    for (uint32_t I = 0; I < Entry.extraCodeCount; ++I) {
+      const EJitSharedExecutableRange &R = Entry.extraCodeRanges[I];
+      ExecRanges.push_back({R.poolKind, R.poolId, R.codeStart, R.codeSize});
+    }
+  }
+  const ejit::detail::EJitCompiledExecSummary ExecSummary =
+      ejit::detail::summarizeCompiledExecRanges(ExecRanges);
+  EJIT_DIAG_RAW(
+      "compiled exec summary: ready_entry_exec_bytes=%llu "
+      "ready_unique_exec_bytes=%llu ready_unique_exec_ranges=%llu "
+      "shared_slot_exec_bytes=%llu invalid_exec_ranges=%llu "
+      "near_hot_unique_exec_bytes=%llu near_cold_unique_exec_bytes=%llu "
+      "far_unique_exec_bytes=%llu unknown_unique_exec_bytes=%llu",
+      static_cast<unsigned long long>(ExecSummary.readyEntryExecBytes),
+      static_cast<unsigned long long>(ExecSummary.readyUniqueExecBytes),
+      static_cast<unsigned long long>(ExecSummary.readyUniqueExecRanges),
+      static_cast<unsigned long long>(ExecSummary.sharedSlotExecBytes),
+      static_cast<unsigned long long>(ExecSummary.invalidExecRanges),
+      static_cast<unsigned long long>(ExecSummary.nearHotUniqueExecBytes),
+      static_cast<unsigned long long>(ExecSummary.nearColdUniqueExecBytes),
+      static_cast<unsigned long long>(ExecSummary.farUniqueExecBytes),
+      static_cast<unsigned long long>(ExecSummary.unknownUniqueExecBytes));
   EJIT_DIAG_RAW("compiled layout: %zu entries sorted by fn address",
                 printCtx.layout.size());
   {
@@ -1933,12 +1960,16 @@ void ejit_taskpool_print_compiled() {
                          : Entry.tier == kEJitTierInstrumented
                              ? "tier1-collecting"
                              : "baseline";
-      const char *PoolKind =
-          Entry.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
-              ? "near"
-          : Entry.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
-              ? "far"
-              : "unknown";
+      auto PoolKindName = [](uint32_t Kind) {
+        return Kind == static_cast<uint32_t>(EJitCodePoolKind::Near)
+                   ? "near-hot"
+               : Kind == static_cast<uint32_t>(EJitCodePoolKind::Far)
+                   ? "far-tier1"
+               : Kind == static_cast<uint32_t>(EJitCodePoolKind::Cold)
+                   ? "near-cold"
+                   : "unknown";
+      };
+      const char *PoolKind = PoolKindName(Entry.poolKind);
       const uintptr_t CodeEnd =
           Entry.codeStart + static_cast<uintptr_t>(Entry.codeSize);
       const bool RangeValid = Entry.codeStart != 0 && Entry.codeSize != 0 &&
@@ -1954,25 +1985,62 @@ void ejit_taskpool_print_compiled() {
               ? "unknown"
               : (Entry.fn >= Entry.codeStart && Entry.fn < CodeEnd ? "yes"
                                                                    : "no");
+      uint64_t ExtraExecBytes = 0;
+      uint64_t EntryExecBytes = RangeValid ? Entry.codeSize : 0;
+      char ExtraRanges[kEJitMaxExtraCodeRanges * 80 + 1];
+      char *ExtraPos = ExtraRanges;
+      char *ExtraEnd = ExtraRanges + sizeof(ExtraRanges);
+      for (uint32_t I = 0; I < Entry.extraCodeCount && ExtraPos < ExtraEnd;
+           ++I) {
+        const EJitSharedExecutableRange &R = Entry.extraCodeRanges[I];
+        const uintptr_t REnd =
+            R.codeStart + static_cast<uintptr_t>(R.codeSize);
+        const bool Valid = R.codeStart != 0 && R.codeSize != 0 &&
+                           REnd >= R.codeStart;
+        if (Valid)
+          ExtraExecBytes += R.codeSize;
+        if (Valid)
+          EntryExecBytes += R.codeSize;
+        const int Written = snprintf(
+            ExtraPos, static_cast<size_t>(ExtraEnd - ExtraPos),
+            "%s%s:%u@0x%llx+%llu", ExtraPos == ExtraRanges ? "" : ";",
+            PoolKindName(R.poolKind), R.poolId,
+            static_cast<unsigned long long>(R.codeStart),
+            static_cast<unsigned long long>(R.codeSize));
+        if (Written > 0)
+          ExtraPos += std::min(static_cast<size_t>(Written),
+                               static_cast<size_t>(ExtraEnd - ExtraPos));
+      }
+      if (ExtraPos >= ExtraEnd)
+        ExtraPos = ExtraEnd - 1;
+      *ExtraPos = '\0';
       const char *PostPublishSeen =
           !ReuseTrackingEnabled ? "disabled"
                                 : (Entry.postPublishSeen != 0 ? "yes" : "no");
       if (gEJitDiagLevel < EJIT_LOG_LVL_VERBOSE) {
         EJIT_DIAG_RAW(
-            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_size=%llu "
+            "layout[%zu] fn=0x%llx exec_start=0x%llx exec_size=%llu "
             "pool=%s:%u funcIdx=%u name=%s tier=%s dims=[%s] "
-            "fn_in_alloc=%s post_publish_seen=%s",
+            "fn_in_exec=%s extra_count=%u entry_exec_bytes=%llu "
+            "extra_exec_bytes=%llu "
+            "extra_ranges=[%s] "
+            "post_publish_seen=%s",
             Index, static_cast<unsigned long long>(Entry.fn),
             static_cast<unsigned long long>(Entry.codeStart),
             static_cast<unsigned long long>(Entry.codeSize), PoolKind,
             Entry.poolId, Entry.funcIndex,
             Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims,
-            FnInAllocation, PostPublishSeen);
+            FnInAllocation, Entry.extraCodeCount,
+            static_cast<unsigned long long>(EntryExecBytes),
+            static_cast<unsigned long long>(ExtraExecBytes), ExtraRanges,
+            PostPublishSeen);
       } else if (!SamePool || !RangeValid) {
         EJIT_DIAG_RAW(
-            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
-            "alloc_size=%llu gap=n/a pool=%s:%u funcIdx=%u name=%s tier=%s "
-            "dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "layout[%zu] fn=0x%llx exec_start=0x%llx exec_end=0x%llx "
+            "exec_size=%llu gap=n/a pool=%s:%u funcIdx=%u name=%s tier=%s "
+            "dims=[%s] ver=[%s] gen=%u fn_in_exec=%s "
+            "extra_count=%u entry_exec_bytes=%llu extra_exec_bytes=%llu "
+            "extra_ranges=[%s] "
             "post_publish_seen=%s",
             Index, static_cast<unsigned long long>(Entry.fn),
             static_cast<unsigned long long>(Entry.codeStart),
@@ -1980,12 +2048,17 @@ void ejit_taskpool_print_compiled() {
             static_cast<unsigned long long>(Entry.codeSize), PoolKind,
             Entry.poolId, Entry.funcIndex,
             Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
-            Entry.generation, FnInAllocation, PostPublishSeen);
+            Entry.generation, FnInAllocation, Entry.extraCodeCount,
+            static_cast<unsigned long long>(EntryExecBytes),
+            static_cast<unsigned long long>(ExtraExecBytes), ExtraRanges,
+            PostPublishSeen);
       } else if (SameAllocation) {
         EJIT_DIAG_RAW(
-            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
-            "alloc_size=%llu gap=shared_alloc pool=%s:%u funcIdx=%u name=%s "
-            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "layout[%zu] fn=0x%llx exec_start=0x%llx exec_end=0x%llx "
+            "exec_size=%llu gap=shared_alloc pool=%s:%u funcIdx=%u name=%s "
+            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_exec=%s "
+            "extra_count=%u entry_exec_bytes=%llu extra_exec_bytes=%llu "
+            "extra_ranges=[%s] "
             "post_publish_seen=%s",
             Index, static_cast<unsigned long long>(Entry.fn),
             static_cast<unsigned long long>(Entry.codeStart),
@@ -1993,12 +2066,17 @@ void ejit_taskpool_print_compiled() {
             static_cast<unsigned long long>(Entry.codeSize), PoolKind,
             Entry.poolId, Entry.funcIndex,
             Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
-            Entry.generation, FnInAllocation, PostPublishSeen);
+            Entry.generation, FnInAllocation, Entry.extraCodeCount,
+            static_cast<unsigned long long>(EntryExecBytes),
+            static_cast<unsigned long long>(ExtraExecBytes), ExtraRanges,
+            PostPublishSeen);
       } else if (Entry.codeStart >= PreviousEnd) {
         EJIT_DIAG_RAW(
-            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
-            "alloc_size=%llu gap=%llu pool=%s:%u funcIdx=%u name=%s tier=%s "
-            "dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "layout[%zu] fn=0x%llx exec_start=0x%llx exec_end=0x%llx "
+            "exec_size=%llu gap=%llu pool=%s:%u funcIdx=%u name=%s tier=%s "
+            "dims=[%s] ver=[%s] gen=%u fn_in_exec=%s "
+            "extra_count=%u entry_exec_bytes=%llu extra_exec_bytes=%llu "
+            "extra_ranges=[%s] "
             "post_publish_seen=%s",
             Index, static_cast<unsigned long long>(Entry.fn),
             static_cast<unsigned long long>(Entry.codeStart),
@@ -2007,12 +2085,17 @@ void ejit_taskpool_print_compiled() {
             static_cast<unsigned long long>(Entry.codeStart - PreviousEnd),
             PoolKind, Entry.poolId, Entry.funcIndex,
             Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
-            Entry.generation, FnInAllocation, PostPublishSeen);
+            Entry.generation, FnInAllocation, Entry.extraCodeCount,
+            static_cast<unsigned long long>(EntryExecBytes),
+            static_cast<unsigned long long>(ExtraExecBytes), ExtraRanges,
+            PostPublishSeen);
       } else {
         EJIT_DIAG_RAW(
-            "layout[%zu] fn=0x%llx alloc_start=0x%llx alloc_end=0x%llx "
-            "alloc_size=%llu OVERLAP=%llu pool=%s:%u funcIdx=%u name=%s "
-            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_alloc=%s "
+            "layout[%zu] fn=0x%llx exec_start=0x%llx exec_end=0x%llx "
+            "exec_size=%llu OVERLAP=%llu pool=%s:%u funcIdx=%u name=%s "
+            "tier=%s dims=[%s] ver=[%s] gen=%u fn_in_exec=%s "
+            "extra_count=%u entry_exec_bytes=%llu extra_exec_bytes=%llu "
+            "extra_ranges=[%s] "
             "post_publish_seen=%s",
             Index, static_cast<unsigned long long>(Entry.fn),
             static_cast<unsigned long long>(Entry.codeStart),
@@ -2021,7 +2104,10 @@ void ejit_taskpool_print_compiled() {
             static_cast<unsigned long long>(PreviousEnd - Entry.codeStart),
             PoolKind, Entry.poolId, Entry.funcIndex,
             Name.empty() ? "<unknown>" : Name.c_str(), Tier, Dims, Versions,
-            Entry.generation, FnInAllocation, PostPublishSeen);
+            Entry.generation, FnInAllocation, Entry.extraCodeCount,
+            static_cast<unsigned long long>(EntryExecBytes),
+            static_cast<unsigned long long>(ExtraExecBytes), ExtraRanges,
+            PostPublishSeen);
       }
       PreviousStart = Entry.codeStart;
       PreviousEnd = CodeEnd;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -3458,12 +3458,30 @@ void EJitSharedTaskPool::publishCodePoolStats() {
   PublishDetail(state_->codePoolStats.far, s.far);
 }
 
-void EJitSharedTaskPool::compilePendingBatchRequests() {
+void EJitSharedTaskPool::compilePendingBatchRequests(bool tier2Only) {
   if (pendingBatchCompiles_.empty())
     return;
 
+  std::vector<PendingBatchCompile> Batch;
+  if (tier2Only) {
+    std::vector<PendingBatchCompile> Deferred;
+    Batch.reserve(pendingBatchCompiles_.size());
+    Deferred.reserve(pendingBatchCompiles_.size());
+    for (PendingBatchCompile &P : pendingBatchCompiles_) {
+      if (decodeReqTier(P.req.funcIndex) == kEJitTierPgoUse)
+        Batch.push_back(P);
+      else
+        Deferred.push_back(P);
+    }
+    pendingBatchCompiles_.swap(Deferred);
+  } else {
+    Batch.swap(pendingBatchCompiles_);
+  }
+  if (Batch.empty())
+    return;
+
   std::stable_sort(
-      pendingBatchCompiles_.begin(), pendingBatchCompiles_.end(),
+      Batch.begin(), Batch.end(),
       [](const PendingBatchCompile &A, const PendingBatchCompile &B) {
         // Layout specializations lexicographically by dimensions. In the
         // product mapping this is cell first and TRP second; the same rule
@@ -3480,18 +3498,16 @@ void EJitSharedTaskPool::compilePendingBatchRequests() {
           if (A.req.dims[I].instanceId != B.req.dims[I].instanceId)
             return A.req.dims[I].instanceId < B.req.dims[I].instanceId;
         }
-        const uint32_t AFunc = stripReqTier(A.req.funcIndex);
-        const uint32_t BFunc = stripReqTier(B.req.funcIndex);
-        if (AFunc != BFunc)
-          return AFunc < BFunc;
-        return decodeReqTier(A.req.funcIndex) < decodeReqTier(B.req.funcIndex);
+        // stable_sort preserves business trigger order inside one complete
+        // dimension group. Do not reorder that hot call sequence by funcIndex.
+        return false;
       });
 
   [[maybe_unused]] size_t Dim0Groups = 0;
   bool HavePrevious = false;
   bool PreviousHasDim0 = false;
   EJitDimPair Previous{};
-  for (const PendingBatchCompile &P : pendingBatchCompiles_) {
+  for (const PendingBatchCompile &P : Batch) {
     const bool HasDim0 = P.req.numDims != 0;
     const bool Same =
         HavePrevious && HasDim0 == PreviousHasDim0 &&
@@ -3505,8 +3521,6 @@ void EJitSharedTaskPool::compilePendingBatchRequests() {
     PreviousHasDim0 = HasDim0;
   }
 
-  std::vector<PendingBatchCompile> Batch;
-  Batch.swap(pendingBatchCompiles_);
   EJIT_DIAG_DEBUG("shared worker batch layout: requests=%zu dim0Groups=%zu",
                   Batch.size(), Dim0Groups);
   for (const PendingBatchCompile &P : Batch) {
@@ -3632,14 +3646,18 @@ bool EJitSharedTaskPool::serviceAutoTier2Publish() {
   if (!autoTier2PublishPending_ || !state_)
     return false;
   // pollOne() has just observed the queue empty. Re-check both positions so a
-  // Tier-1 request that raced that observation is compiled from the far pool
-  // before the near-pool Tier-2 batch is sealed and published.
+  // Tier-1 request that raced that observation starts sampling before the
+  // near-pool Tier-2 batch is laid out, sealed, and published.
   if (state_->enqueuePos.loadAcquire() != state_->dequeuePos.loadAcquire())
     return false;
 
   autoTier2PublishPending_ = false;
-  EJIT_DIAG("PGO Tier-2 queue drained: auto-publishing %zu linked version(s)",
-            pendingPublishes_.size());
+  compilePendingBatchRequests(/*tier2Only=*/true);
+  EJIT_DIAG_DEBUG(
+      "PGO Tier-2 queue drained: auto-publishing %zu linked version(s)",
+      pendingPublishes_.size());
+  if (pendingPublishes_.empty())
+    return true;
   if (!flushPendingPublishes(/*compileBatchRequests=*/false))
     EJIT_DIAG("PGO Tier-2 auto-publish failed: pending=%zu; explicit publish "
               "may retry",
@@ -3834,7 +3852,6 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
       // compile queue empty and seals the batch. Keep only owner-private state
       // and retain the in-flight claim.
       pendingPublishes_.push_back({req, fn});
-      autoTier2PublishPending_ = true;
       EJIT_DIAG_DEBUG("PGO Tier-2 linked pending queue-drain publish func=%u "
                       "fn=%p pending=%zu",
                       realFuncIndex, fn, pendingPublishes_.size());
@@ -3930,27 +3947,40 @@ bool EJitSharedTaskPool::pollOne() {
     return false;
 
   // All tiers arrive on the same shared MPSC queue. Baseline requests defer
-  // compilation so explicit publication can sort their JITLink allocations.
-  // Tier-1 compiles immediately into the far pool and starts sampling. Tier-2
-  // also compiles immediately, but runCompile retains its near-pool result
-  // owner-private until queue-drain publication replaces the live Tier-1 slot.
+  // compilation until explicit publication. Tier-1 compiles immediately into
+  // the far pool and starts sampling. Tier-2 requests defer until the queue
+  // drains so their final near-pool JITLink allocations can be sorted by cell
+  // and TRP before one enable_ex/cache publication batch.
   EJitCompileRequest Req{};
   if (!queuePop(Req))
     return false;
+  const uint32_t Tier = decodeReqTier(Req.funcIndex);
   if (codeReadyFn_ && codeBatchFlushFn_ &&
-      decodeReqTier(Req.funcIndex) == kEJitTierBaseline) {
-    if (pendingBatchCompiles_.size() >= kEJitSharedQueueSlots) {
+      (Tier == kEJitTierBaseline || Tier == kEJitTierPgoUse)) {
+    // Baseline backlog is bounded by the shared queue capacity. Tier-2 has a
+    // separate hard bound from PGO admission (at most 16 active functions), so
+    // let final optimized code enter even when unpublished baseline work has
+    // consumed the normal layout budget.
+    if (Tier == kEJitTierBaseline &&
+        pendingBatchCompiles_.size() >= kEJitSharedQueueSlots) {
       dedupClear(Req.funcIndex, Req.generation);
       EJIT_STAT_INC(state_->counters.queueFull);
       EJIT_DIAG("shared worker batch backlog full func=%u capacity=%u",
                 stripReqTier(Req.funcIndex), kEJitSharedQueueSlots);
       return true;
     }
+    // Baseline has no live specialization to preserve, so a full-key Pending
+    // marker can release its coarse per-function claim and admit another cell.
+    // Tier-2 must leave the live Tier-1 slot untouched and retain its claim
+    // until the sorted replacement is published.
     const bool Marked =
+        Tier == kEJitTierBaseline &&
         cacheStageBatchRequest(Req) == EJitPublishStatus::Published;
     pendingBatchCompiles_.push_back({Req, Marked});
     if (Marked)
       dedupClear(Req.funcIndex, Req.generation);
+    if (Tier == kEJitTierPgoUse)
+      autoTier2PublishPending_ = true;
     EJIT_DIAG_VERBOSE(
         "shared worker batch queued func=%u dims=%u marker=%u requests=%zu",
         stripReqTier(Req.funcIndex), Req.numDims, static_cast<unsigned>(Marked),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -1642,6 +1642,12 @@ EJitSharedTaskPool::peerPrepareSlot(EJitSharedCacheBucket &B, uint32_t bucket,
   Snap.codeSize = Slot.codeSize;
   Snap.poolBase = Slot.poolBase;
   Snap.poolSize = Slot.poolSize;
+  Snap.extraCodeCount = Slot.extraCodeCount;
+  uint32_t ExtraCopy = Slot.extraCodeCount > kEJitMaxExtraCodeRanges
+                           ? kEJitMaxExtraCodeRanges
+                           : Slot.extraCodeCount;
+  for (uint32_t I = 0; I < ExtraCopy; ++I)
+    Snap.extraCodeRanges[I] = Slot.extraCodeRanges[I];
   // Snapshot the runtime-writable extents too: the per-core enable_rw must run
   // with NO bucket lock held (like the split/seal below). Keep the raw count so
   // prepareExecForCurrentCore stays the single authority that rejects an
@@ -2043,13 +2049,19 @@ bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
     if (!ok)
       EJIT_DIAG("prepareExec FAIL: core=%u legacy prepareCode fn=%p", self,
                 R.fn);
-    return ok;
+    if (!ok || R.extraCodeCount > kEJitMaxExtraCodeRanges)
+      return false;
+    for (uint32_t I = 0; I < R.extraCodeCount; ++I)
+      if (!prepareCodeFn_(prepareCodeCtx_, reinterpret_cast<void *>(
+                                               R.extraCodeRanges[I].codeStart)))
+        return false;
+    return true;
   }
 
   // 4K page seal needs the real executable extent. A slot with no recorded
   // range (or a malformed one) is a clean fallback, never a guessed seal.
-  if (R.codeStart == 0 || R.codeSize == 0 || R.poolBase == 0 ||
-      R.poolSize == 0) {
+  if (R.extraCodeCount > kEJitMaxExtraCodeRanges || R.codeStart == 0 ||
+      R.codeSize == 0 || R.poolBase == 0 || R.poolSize == 0) {
     EJIT_DIAG_VERBOSE(
         "prepareExec fallback: core=%u fn=%p malformed range "
         "(codeStart=0x%llx codeSize=%llu poolBase=0x%llx poolSize=%llu)",
@@ -2163,6 +2175,26 @@ bool EJitSharedTaskPool::prepareExecForCurrentCore(const PeerCodeRange &R,
                 static_cast<unsigned long long>(VA));
       return false; // any page failure -> no callable pointer is returned.
     }
+
+  for (uint32_t I = 0; I < R.extraCodeCount; ++I) {
+    const EJitSharedExecutableRange &Extra = R.extraCodeRanges[I];
+    if (Extra.codeStart == 0 || Extra.codeSize == 0 || Extra.poolBase == 0 ||
+        Extra.poolSize == 0 ||
+        Extra.codeStart + Extra.codeSize < Extra.codeStart ||
+        Extra.poolBase + Extra.poolSize < Extra.poolBase ||
+        Extra.codeStart < Extra.poolBase ||
+        Extra.codeStart + Extra.codeSize > Extra.poolBase + Extra.poolSize)
+      return false;
+    if (!ensurePoolSplitForCurrentCore(self, Extra.poolBase, Extra.poolSize))
+      return false;
+    const uintptr_t ExtraPageStart = Extra.codeStart & ~(Page - 1);
+    const uintptr_t ExtraPageEnd =
+        (Extra.codeStart + static_cast<uintptr_t>(Extra.codeSize) + Page - 1) &
+        ~(Page - 1);
+    for (uintptr_t VA = ExtraPageStart; VA < ExtraPageEnd; VA += Page)
+      if (!sealPageFn_ || !sealPageFn_(sealPageCtx_, VA))
+        return false;
+  }
   EJIT_DIAG_VERBOSE("prepareExec OK: core=%u fn=%p pages=[0x%llx,0x%llx)", self,
                     R.fn, static_cast<unsigned long long>(CodePageStart),
                     static_cast<unsigned long long>(CodePageEnd));
@@ -2179,9 +2211,12 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   // slot). Clamping would drop counter pages a peer must enable_rw, so the peer
   // would under-prepare and fault. Rejecting here means no slot goes Ready, no
   // fnPtr is published, and no executableCoreMask bit is set for this identity.
-  if (info && info->writableCount > kEJitSharedMaxWritableRanges) {
-    EJIT_DIAG("cachePublish REJECT: writableCount=%u > max=%u",
-              info->writableCount, kEJitSharedMaxWritableRanges);
+  if (info && (info->writableCount > kEJitSharedMaxWritableRanges ||
+               info->extraCodeCount > kEJitMaxExtraCodeRanges)) {
+    EJIT_DIAG("cachePublish REJECT: writableCount=%u max=%u "
+              "extraCodeCount=%u max=%u",
+              info->writableCount, kEJitSharedMaxWritableRanges,
+              info->extraCodeCount, kEJitMaxExtraCodeRanges);
     return EJitPublishStatus::InvalidParam;
   }
   uint32_t tier = decodeReqTier(req.funcIndex);
@@ -2256,6 +2291,21 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
     target->poolSize = info->poolSize;
     target->poolId = info->poolId;
     target->poolKind = static_cast<uint32_t>(info->poolKind);
+    target->extraCodeCount = info->extraCodeCount;
+    for (uint32_t I = 0; I < kEJitMaxExtraCodeRanges; ++I) {
+      EJitSharedExecutableRange &Dst = target->extraCodeRanges[I];
+      if (I < info->extraCodeCount) {
+        const EJitExecutableRange &Src = info->extraCodeRanges[I];
+        Dst.codeStart = Src.codeStart;
+        Dst.codeSize = Src.codeSize;
+        Dst.poolBase = Src.poolBase;
+        Dst.poolSize = Src.poolSize;
+        Dst.poolId = Src.poolId;
+        Dst.poolKind = static_cast<uint32_t>(Src.poolKind);
+      } else {
+        Dst = {};
+      }
+    }
     // Runtime-writable extents (v9): copy the bounded set the peer may need to
     // enable_rw. The over-bound case was already rejected at entry, so this
     // never truncates. requiresPeerEnableRw records whether the peer must
@@ -2280,6 +2330,9 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
     target->poolSize = 0;
     target->poolId = 0;
     target->poolKind = static_cast<uint32_t>(EJitCodePoolKind::Unknown);
+    target->extraCodeCount = 0;
+    for (EJitSharedExecutableRange &R : target->extraCodeRanges)
+      R = {};
     target->writableCount = 0;
     target->requiresPeerEnableRw = 0;
     for (uint32_t i = 0; i < kEJitSharedMaxWritableRanges; ++i) {
@@ -2446,6 +2499,7 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
     D.finalizedRangeCount.storeRelaxed(0);
   };
   ClearPoolDetail(st->codePoolStats.near);
+  ClearPoolDetail(st->codePoolStats.cold);
   ClearPoolDetail(st->codePoolStats.far);
   // Per-core, per-pool 4K split readiness (ABI v5). MUST be cleared on every
   // (re)initialization: a stale splitDone bit from an earlier generation would
@@ -2499,6 +2553,9 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
       Slot.poolSize = 0;
       Slot.poolId = 0;
       Slot.poolKind = static_cast<uint32_t>(EJitCodePoolKind::Unknown);
+      Slot.extraCodeCount = 0;
+      for (EJitSharedExecutableRange &R : Slot.extraCodeRanges)
+        R = {};
       // Runtime-writable ranges (ABI v9): cleared so a re-init never leaves a
       // stale writable extent a peer could enable_rw for retired code.
       Slot.writableCount = 0;
@@ -3164,6 +3221,7 @@ void EJitSharedTaskPool::publishCodePoolStats() {
     Dst.finalizedRangeCount.storeRelaxed(Src.finalizedRangeCount);
   };
   PublishDetail(state_->codePoolStats.near, s.near);
+  PublishDetail(state_->codePoolStats.cold, s.cold);
   PublishDetail(state_->codePoolStats.far, s.far);
 }
 
@@ -3193,6 +3251,7 @@ bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
     Dst.finalizedRangeCount = Src.finalizedRangeCount.loadRelaxed();
   };
   ReadDetail(state_->codePoolStats.near, out->near);
+  ReadDetail(state_->codePoolStats.cold, out->cold);
   ReadDetail(state_->codePoolStats.far, out->far);
   return true;
 }

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -18,6 +18,7 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
+#include "llvm/ExecutionEngine/EJIT/EJitIpcLock.h"
 #include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h"
 #include "llvm/ExecutionEngine/EJIT/EJitStats.h"
@@ -2724,7 +2725,13 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
   st->counters.tier2Compiles.storeRelaxed(0);
   st->counters.profileMergeFails.storeRelaxed(0);
   // Code-pool stats mirror: zero until the owner publishes the first snapshot
-  // after a successful compile (the pools are owner-private and empty at init).
+  // at a compile/flush boundary (the pools are owner-private and empty at
+  // init).
+  st->codePoolStats.snapshotSeq.storeRelaxed(0);
+  st->codePoolStats.refreshRequest.storeRelaxed(0);
+  st->codePoolStats.refreshResult.storeRelaxed(0);
+  st->codePoolStats.refreshComplete.storeRelaxed(0);
+  st->codePoolStats.dirty.storeRelaxed(0);
   st->codePoolStats.poolCount.storeRelaxed(0);
   st->codePoolStats.sealedCount.storeRelaxed(0);
   st->codePoolStats.activeCount.storeRelaxed(0);
@@ -2734,6 +2741,10 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
   st->codePoolStats.sealInvocations.storeRelaxed(0);
   st->codePoolStats.splitInvocations.storeRelaxed(0);
   st->codePoolStats.finalizedRangeCount.storeRelaxed(0);
+  st->codePoolStats.finalizedExecBytes.storeRelaxed(0);
+  st->codePoolStats.pendingExecBytes.storeRelaxed(0);
+  st->codePoolStats.pendingRangeCount.storeRelaxed(0);
+  st->codePoolStats.pendingAllocationCount.storeRelaxed(0);
   auto ClearPoolDetail = [](EJitSharedCodePoolStats::Detail &D) {
     D.poolCount.storeRelaxed(0);
     D.sealedCount.storeRelaxed(0);
@@ -2744,6 +2755,10 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
     D.sealInvocations.storeRelaxed(0);
     D.splitInvocations.storeRelaxed(0);
     D.finalizedRangeCount.storeRelaxed(0);
+    D.finalizedExecBytes.storeRelaxed(0);
+    D.pendingExecBytes.storeRelaxed(0);
+    D.pendingRangeCount.storeRelaxed(0);
+    D.pendingAllocationCount.storeRelaxed(0);
   };
   ClearPoolDetail(st->codePoolStats.near);
   ClearPoolDetail(st->codePoolStats.cold);
@@ -2871,6 +2886,7 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       // Owner-private batch state must never cross a generation boundary.
       pendingBatchCompiles_.clear();
       pendingPublishes_.clear();
+      codePoolStatsDirty_ = false;
       autoTier2PublishPending_ = false;
       initSharedStorage(state_, static_cast<uint32_t>(configuredMode_),
                         pgoEnabled_.loadRelaxed(),
@@ -3490,6 +3506,20 @@ void EJitSharedTaskPool::publishCodePoolStats() {
   EJitCodePoolStatsOut s{};
   if (!codePoolStatsFn_(codePoolStatsCtx_, &s))
     return;
+  // Only the owner writes this mirror. This is a seqcount, not merely a pair
+  // of release/acquire operations: the full barriers make the odd marker
+  // visible before any relaxed payload store, and make every payload store
+  // visible before the even marker. That ordering is required on weakly
+  // ordered AArch64/SRE as well as on the host.
+  uint32_t Seq = state_->codePoolStats.snapshotSeq.loadRelaxed();
+  if (Seq & 1u)
+    ++Seq;
+  state_->codePoolStats.snapshotSeq.storeRelease(Seq + 1u);
+  EJitSharedBarrier::fenceFull();
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+  if (codePoolStatsPublishHook_)
+    codePoolStatsPublishHook_(codePoolStatsPublishHookCtx_, 1);
+#endif
   state_->codePoolStats.poolCount.storeRelaxed(s.poolCount);
   state_->codePoolStats.sealedCount.storeRelaxed(s.sealedCount);
   state_->codePoolStats.activeCount.storeRelaxed(s.activeCount);
@@ -3499,6 +3529,11 @@ void EJitSharedTaskPool::publishCodePoolStats() {
   state_->codePoolStats.sealInvocations.storeRelaxed(s.sealInvocations);
   state_->codePoolStats.splitInvocations.storeRelaxed(s.splitInvocations);
   state_->codePoolStats.finalizedRangeCount.storeRelaxed(s.finalizedRangeCount);
+  state_->codePoolStats.finalizedExecBytes.storeRelaxed(s.finalizedExecBytes);
+  state_->codePoolStats.pendingExecBytes.storeRelaxed(s.pendingExecBytes);
+  state_->codePoolStats.pendingRangeCount.storeRelaxed(s.pendingRangeCount);
+  state_->codePoolStats.pendingAllocationCount.storeRelaxed(
+      s.pendingAllocationCount);
   auto PublishDetail = [](EJitSharedCodePoolStats::Detail &Dst,
                           const EJitCodePoolStatsOut::Detail &Src) {
     Dst.poolCount.storeRelaxed(Src.poolCount);
@@ -3510,10 +3545,34 @@ void EJitSharedTaskPool::publishCodePoolStats() {
     Dst.sealInvocations.storeRelaxed(Src.sealInvocations);
     Dst.splitInvocations.storeRelaxed(Src.splitInvocations);
     Dst.finalizedRangeCount.storeRelaxed(Src.finalizedRangeCount);
+    Dst.finalizedExecBytes.storeRelaxed(Src.finalizedExecBytes);
+    Dst.pendingExecBytes.storeRelaxed(Src.pendingExecBytes);
+    Dst.pendingRangeCount.storeRelaxed(Src.pendingRangeCount);
+    Dst.pendingAllocationCount.storeRelaxed(Src.pendingAllocationCount);
   };
   PublishDetail(state_->codePoolStats.near, s.near);
   PublishDetail(state_->codePoolStats.cold, s.cold);
   PublishDetail(state_->codePoolStats.far, s.far);
+  EJitSharedBarrier::fenceFull();
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+  if (codePoolStatsPublishHook_)
+    codePoolStatsPublishHook_(codePoolStatsPublishHookCtx_, 2);
+#endif
+  state_->codePoolStats.snapshotSeq.storeRelease(Seq + 2u);
+  state_->codePoolStats.dirty.storeRelease(0);
+  codePoolStatsDirty_ = false;
+}
+
+void EJitSharedTaskPool::markCodePoolStatsDirty() {
+  if (!state_ || !codePoolStatsFn_)
+    return;
+  codePoolStatsDirty_ = true;
+  state_->codePoolStats.dirty.storeRelease(1);
+}
+
+void EJitSharedTaskPool::publishCodePoolStatsIfDirty() {
+  if (codePoolStatsDirty_)
+    publishCodePoolStats();
 }
 
 void EJitSharedTaskPool::compilePendingBatchRequests(bool tier2Only) {
@@ -3587,6 +3646,9 @@ void EJitSharedTaskPool::compilePendingBatchRequests(bool tier2Only) {
     // between expensive ORC compilations just as the normal queue loop does.
     workerThrottle();
   }
+  // The provider may union/sort every pending/finalized range. Refresh once
+  // after the whole compile batch, rather than once for every staged entry.
+  publishCodePoolStatsIfDirty();
 }
 
 bool EJitSharedTaskPool::flushPendingPublishes(bool compileBatchRequests) {
@@ -3784,16 +3846,69 @@ bool EJitSharedTaskPool::requestCodeBatchFlushAndWait() {
 bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
   if (!state_ || !out)
     return false;
-  out->poolCount = state_->codePoolStats.poolCount.loadRelaxed();
-  out->sealedCount = state_->codePoolStats.sealedCount.loadRelaxed();
-  out->activeCount = state_->codePoolStats.activeCount.loadRelaxed();
-  out->usedBytes = state_->codePoolStats.usedBytes.loadRelaxed();
-  out->reservedBytes = state_->codePoolStats.reservedBytes.loadRelaxed();
-  out->wastedBytes = state_->codePoolStats.wastedBytes.loadRelaxed();
-  out->sealInvocations = state_->codePoolStats.sealInvocations.loadRelaxed();
-  out->splitInvocations = state_->codePoolStats.splitInvocations.loadRelaxed();
-  out->finalizedRangeCount =
-      state_->codePoolStats.finalizedRangeCount.loadRelaxed();
+
+  const uint32_t Generation = state_->generation.loadAcquire();
+  if (state_->initState.loadAcquire() !=
+      static_cast<uint32_t>(EJitSharedInitState::Ready))
+    return false;
+
+  // A peer may ask for a diagnostic snapshot while the owner has staged code
+  // since its last batch boundary. The owner can refresh synchronously; a
+  // peer posts a monotonic request and yields until the owner acknowledges it.
+  // This path is diagnostic-only and therefore may wait, unlike the compile
+  // hot path. If the owner cannot produce a snapshot, leave the dirty bit set
+  // and report failure rather than returning stale data as current.
+  if (state_->codePoolStats.dirty.loadAcquire() != 0) {
+    if (isOwner_) {
+      auto *Self = const_cast<EJitSharedTaskPool *>(this);
+      if (Self->state_->generation.loadAcquire() != Generation ||
+          Self->state_->initState.loadAcquire() !=
+              static_cast<uint32_t>(EJitSharedInitState::Ready))
+        return false;
+      Self->publishCodePoolStatsIfDirty();
+      if (Self->codePoolStatsDirty_)
+        return false;
+    } else {
+      uint32_t ServiceGeneration = 0;
+      if (!asyncServiceAvailable(&ServiceGeneration) ||
+          ServiceGeneration != Generation)
+        return false;
+      const uint32_t Request =
+          state_->codePoolStats.refreshRequest.fetchAdd(1u) + 1u;
+      // A diagnostic call must not turn a stopped/missing worker into a
+      // million-tick delay on the product. This is deliberately bounded well
+      // below the compile request wait budget.
+      constexpr uint32_t MaxWaits = 1u << 12;
+      bool Complete = false;
+      for (uint32_t Wait = 0; Wait != MaxWaits; ++Wait) {
+        if (state_->generation.loadAcquire() != Generation ||
+            state_->initState.loadAcquire() !=
+                static_cast<uint32_t>(EJitSharedInitState::Ready))
+          return false;
+        if (state_->ownerCoreId.loadAcquire() == kEJitInvalidCoreId ||
+            state_->workerTaskId.loadAcquire() == 0)
+          return false;
+        const uint32_t Done =
+            state_->codePoolStats.refreshComplete.loadAcquire();
+        if (static_cast<int32_t>(Done - Request) >= 0) {
+          if (state_->codePoolStats.refreshResult.loadAcquire() == 0 ||
+              state_->codePoolStats.dirty.loadAcquire() != 0)
+            return false;
+          Complete = true;
+          break;
+        }
+        const_cast<EJitSharedTaskPool *>(this)->workerIdle(1);
+      }
+      if (!Complete)
+        return false;
+    }
+  }
+
+  if (state_->generation.loadAcquire() != Generation ||
+      state_->initState.loadAcquire() !=
+          static_cast<uint32_t>(EJitSharedInitState::Ready))
+    return false;
+
   auto ReadDetail = [](const EJitSharedCodePoolStats::Detail &Src,
                        EJitCodePoolStatsOut::Detail &Dst) {
     Dst.poolCount = Src.poolCount.loadRelaxed();
@@ -3805,11 +3920,53 @@ bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
     Dst.sealInvocations = Src.sealInvocations.loadRelaxed();
     Dst.splitInvocations = Src.splitInvocations.loadRelaxed();
     Dst.finalizedRangeCount = Src.finalizedRangeCount.loadRelaxed();
+    Dst.finalizedExecBytes = Src.finalizedExecBytes.loadRelaxed();
+    Dst.pendingExecBytes = Src.pendingExecBytes.loadRelaxed();
+    Dst.pendingRangeCount = Src.pendingRangeCount.loadRelaxed();
+    Dst.pendingAllocationCount = Src.pendingAllocationCount.loadRelaxed();
   };
-  ReadDetail(state_->codePoolStats.near, out->near);
-  ReadDetail(state_->codePoolStats.cold, out->cold);
-  ReadDetail(state_->codePoolStats.far, out->far);
-  return true;
+  for (unsigned Attempt = 0; Attempt != 32; ++Attempt) {
+    const uint32_t Begin = state_->codePoolStats.snapshotSeq.loadAcquire();
+    if (Begin & 1u)
+      continue;
+    // Pair with the writer-side full barrier after the odd marker. Without
+    // this barrier a weakly ordered reader could observe an old even marker
+    // around a partially copied relaxed payload.
+    EJitSharedBarrier::fenceFull();
+    EJitCodePoolStatsOut Candidate{};
+    Candidate.poolCount = state_->codePoolStats.poolCount.loadRelaxed();
+    Candidate.sealedCount = state_->codePoolStats.sealedCount.loadRelaxed();
+    Candidate.activeCount = state_->codePoolStats.activeCount.loadRelaxed();
+    Candidate.usedBytes = state_->codePoolStats.usedBytes.loadRelaxed();
+    Candidate.reservedBytes =
+        state_->codePoolStats.reservedBytes.loadRelaxed();
+    Candidate.wastedBytes = state_->codePoolStats.wastedBytes.loadRelaxed();
+    Candidate.sealInvocations =
+        state_->codePoolStats.sealInvocations.loadRelaxed();
+    Candidate.splitInvocations =
+        state_->codePoolStats.splitInvocations.loadRelaxed();
+    Candidate.finalizedRangeCount =
+        state_->codePoolStats.finalizedRangeCount.loadRelaxed();
+    Candidate.finalizedExecBytes =
+        state_->codePoolStats.finalizedExecBytes.loadRelaxed();
+    Candidate.pendingExecBytes =
+        state_->codePoolStats.pendingExecBytes.loadRelaxed();
+    Candidate.pendingRangeCount =
+        state_->codePoolStats.pendingRangeCount.loadRelaxed();
+    Candidate.pendingAllocationCount =
+        state_->codePoolStats.pendingAllocationCount.loadRelaxed();
+    ReadDetail(state_->codePoolStats.near, Candidate.near);
+    ReadDetail(state_->codePoolStats.cold, Candidate.cold);
+    ReadDetail(state_->codePoolStats.far, Candidate.far);
+    // Keep all relaxed payload loads before the validation sequence load.
+    EJitSharedBarrier::fenceFull();
+    const uint32_t End = state_->codePoolStats.snapshotSeq.loadAcquire();
+    if (Begin == End && !(End & 1u)) {
+      *out = Candidate;
+      return true;
+    }
+  }
+  return false;
 }
 
 void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
@@ -3911,6 +4068,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
       // compile queue empty and seals the batch. Keep only owner-private state
       // and retain the in-flight claim.
       pendingPublishes_.push_back({req, fn});
+      markCodePoolStatsDirty();
       EJIT_DIAG_DEBUG("PGO Tier-2 linked pending queue-drain publish func=%u "
                       "fn=%p pending=%zu",
                       realFuncIndex, fn, pendingPublishes_.size());
@@ -3935,6 +4093,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
     if (Staged == EJitPublishStatus::Published) {
       pendingPublishes_.push_back({req, fn});
       dedupClear(req.funcIndex, req.generation);
+      markCodePoolStatsDirty();
       EJIT_DIAG_DEBUG("shared worker batch staged func=%u fn=%p pending=%zu",
                       req.funcIndex, fn, pendingPublishes_.size());
       return;
@@ -3946,6 +4105,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
     // victim. Keep the result owner-private with its coarse in-flight claim;
     // the explicit publish call seals all code and then inserts this identity.
     pendingPublishes_.push_back({req, fn});
+    markCodePoolStatsDirty();
     EJIT_DIAG_VERBOSE(
         "shared worker batch retained unstaged func=%u pending=%zu",
         req.funcIndex, pendingPublishes_.size());
@@ -4063,6 +4223,23 @@ bool EJitSharedTaskPool::serviceMayConstRankingRequest() {
   return true;
 }
 
+bool EJitSharedTaskPool::serviceCodePoolStatsRequest() {
+  if (!state_ || !isOwner_)
+    return false;
+  const uint32_t Request = state_->codePoolStats.refreshRequest.loadAcquire();
+  if (Request == state_->codePoolStats.refreshComplete.loadAcquire())
+    return false;
+
+  // A request is a diagnostic consistency point, not a per-function hook. If
+  // a batch boundary already published the dirty snapshot, just acknowledge
+  // the request without invoking the O(ranges log ranges) provider again.
+  publishCodePoolStatsIfDirty();
+  const bool Success = !codePoolStatsDirty_;
+  state_->codePoolStats.refreshResult.storeRelease(Success ? 1u : 0u);
+  state_->codePoolStats.refreshComplete.storeRelease(Request);
+  return true;
+}
+
 unsigned EJitSharedTaskPool::pollBudget(unsigned maxItems) {
   unsigned n = 0;
   while (n < maxItems && pollOne())
@@ -4083,6 +4260,8 @@ EJitWorkerStep EJitSharedTaskPool::workerPollOnce() {
     if (serviceCodeBatchRequest())
       return EJitWorkerStep::Consumed;
     if (serviceMayConstRankingRequest())
+      return EJitWorkerStep::Consumed;
+    if (serviceCodePoolStatsRequest())
       return EJitWorkerStep::Consumed;
     if (pollOne())
       return EJitWorkerStep::Consumed;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -127,6 +127,15 @@ extern const unsigned char __ejit_code_end[] __attribute__((weak));
 extern const unsigned char __ejit_code_start[];
 extern const unsigned char __ejit_code_end[];
 #endif
+#ifdef EJIT_MFS_COLD_CODE_POOL
+#ifndef EJIT_FREESTANDING
+extern const unsigned char __ejit_cold_code_start[] __attribute__((weak));
+extern const unsigned char __ejit_cold_code_end[] __attribute__((weak));
+#else
+extern const unsigned char __ejit_cold_code_start[];
+extern const unsigned char __ejit_cold_code_end[];
+#endif
+#endif
 }
 #endif
 
@@ -185,15 +194,18 @@ unsigned sealAndSyncCache(uintptr_t Va, size_t Size) {
 std::unique_ptr<llvm::ejit::EJitCodePoolManager>
 llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement) {
   EJitCodePoolManager::Options Opts;
-  Opts.kind = Placement == EJitCodePoolPlacement::NearFixed
-                  ? EJitCodePoolKind::Near
-                  : EJitCodePoolKind::Far;
+  Opts.kind =
+      Placement == EJitCodePoolPlacement::NearFixed   ? EJitCodePoolKind::Near
+      : Placement == EJitCodePoolPlacement::ColdFixed ? EJitCodePoolKind::Cold
+                                                      : EJitCodePoolKind::Far;
   Opts.poolSize = static_cast<size_t>(kSrePoolSize);
   Opts.poolAlign = k2MiB; // large-page / split granularity
   Opts.minCodeAlign = 64;
   EJIT_DIAG_VERBOSE(
       "makeSreCodePoolManager: kind=%s poolSize=%llu poolAlign=%zu",
-      Placement == EJitCodePoolPlacement::NearFixed ? "near" : "far",
+      Placement == EJitCodePoolPlacement::NearFixed   ? "near-hot"
+      : Placement == EJitCodePoolPlacement::ColdFixed ? "near-cold"
+                                                      : "far-tier1",
       kSrePoolSize, k2MiB);
 #ifdef EJIT_CODE_POOL_4K_SEAL
   // Adapt to the platform's 4K execute-permission interface: the 2MiB pool is
@@ -213,36 +225,50 @@ llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement) {
   // fall back to SRE_MemDbgAlloc (a too-small fixed region would exhaust on
   // every compile). A fixed region gives a stable JIT address range and, when
   // placed within +-128MiB of .text, lets codegen use direct bl/adrp.
-  if (Placement == EJitCodePoolPlacement::NearFixed) {
-    uintptr_t FBase = reinterpret_cast<uintptr_t>(__ejit_code_start);
-    uintptr_t FEnd = reinterpret_cast<uintptr_t>(__ejit_code_end);
+  if (Placement != EJitCodePoolPlacement::FarDynamic) {
+    uintptr_t FBase = 0;
+    uintptr_t FEnd = 0;
+    const char *RegionName = ".text.ejit";
+    if (Placement == EJitCodePoolPlacement::NearFixed) {
+      FBase = reinterpret_cast<uintptr_t>(__ejit_code_start);
+      FEnd = reinterpret_cast<uintptr_t>(__ejit_code_end);
+    }
+#ifdef EJIT_MFS_COLD_CODE_POOL
+    else {
+      FBase = reinterpret_cast<uintptr_t>(__ejit_cold_code_start);
+      FEnd = reinterpret_cast<uintptr_t>(__ejit_cold_code_end);
+      RegionName = ".text.ejit_cold";
+    }
+#endif
     uintptr_t AlignedBase =
         (FBase + (static_cast<uintptr_t>(k2MiB) - 1)) &
         ~(static_cast<uintptr_t>(k2MiB) - 1);
     if (FEnd > AlignedBase && (FEnd - AlignedBase) >= kSrePoolSize) {
       Opts.fixedBase = AlignedBase;
       Opts.fixedSize = FEnd - AlignedBase;
-      EJIT_DIAG("makeSreCodePoolManager: FIXED region sym=[0x%llx,0x%llx) "
-                "alignedBase=0x%llx usable=%llu (~%llu pools of %lluB)",
-                static_cast<unsigned long long>(FBase),
-                static_cast<unsigned long long>(FEnd),
-                static_cast<unsigned long long>(AlignedBase),
-                static_cast<unsigned long long>(FEnd - AlignedBase),
-                static_cast<unsigned long long>((FEnd - AlignedBase) / kSrePoolSize),
-                static_cast<unsigned long long>(kSrePoolSize));
+      EJIT_DIAG(
+          "makeSreCodePoolManager: FIXED %s region "
+          "sym=[0x%llx,0x%llx) "
+          "alignedBase=0x%llx usable=%llu (~%llu pools of %lluB)",
+          RegionName, static_cast<unsigned long long>(FBase),
+          static_cast<unsigned long long>(FEnd),
+          static_cast<unsigned long long>(AlignedBase),
+          static_cast<unsigned long long>(FEnd - AlignedBase),
+          static_cast<unsigned long long>((FEnd - AlignedBase) / kSrePoolSize),
+          static_cast<unsigned long long>(kSrePoolSize));
     } else {
-      EJIT_DIAG("makeSreCodePoolManager: fixed region absent or too small after "
-                "2MiB alignment (sym=[0x%llx,0x%llx) alignedBase=0x%llx "
-                "usable=%llu < poolSize=%llu), falling back to SRE_MemDbgAlloc "
-                "ptNo=%u",
-                static_cast<unsigned long long>(FBase),
-                static_cast<unsigned long long>(FEnd),
-                static_cast<unsigned long long>(AlignedBase),
-                static_cast<unsigned long long>(FEnd > AlignedBase
-                                                    ? FEnd - AlignedBase
-                                                    : 0),
-                static_cast<unsigned long long>(kSrePoolSize),
-                static_cast<unsigned>(kSrePtNo));
+      EJIT_DIAG(
+          "makeSreCodePoolManager: fixed %s region absent or too small after "
+          "2MiB alignment (sym=[0x%llx,0x%llx) alignedBase=0x%llx "
+          "usable=%llu < poolSize=%llu), falling back to SRE_MemDbgAlloc "
+          "ptNo=%u",
+          RegionName, static_cast<unsigned long long>(FBase),
+          static_cast<unsigned long long>(FEnd),
+          static_cast<unsigned long long>(AlignedBase),
+          static_cast<unsigned long long>(
+              FEnd > AlignedBase ? FEnd - AlignedBase : 0),
+          static_cast<unsigned long long>(kSrePoolSize),
+          static_cast<unsigned>(kSrePtNo));
     }
   }
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
+++ b/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
@@ -125,6 +125,15 @@ SECTIONS
     __ejit_code_end = .;
   } > CODE       /* code segment, near .text (±128MiB bl/adrp reach to AOT) */
 
+  /* Optional EJIT_MFS_COLD_CODE_POOL region. Keep it within +-128MiB of both
+   * .text and .text.ejit so hot/cold machine-BB branches remain direct. */
+  .text.ejit_cold : ALIGN(4096)
+  {
+    __ejit_cold_code_start = .;
+    . = __ejit_cold_code_start + 8M;
+    __ejit_cold_code_end = .;
+  } > CODE
+
   /* ... your existing .bss / etc. ... */
 }
 

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -129,6 +129,7 @@ set(EJIT_SHARED_TASKPOOL_LINK_COMPONENTS_SAVED "${LLVM_LINK_COMPONENTS}")
 set(LLVM_LINK_COMPONENTS Support)
 add_llvm_unittest(EJITSharedTaskPoolTests
   EJitSharedTaskPoolTest.cpp
+  ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
   ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
   ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp
   # Defines gEJitDiagLevel (the level gate behind every EJIT_DIAG* call in the

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -122,6 +122,22 @@ TEST(EJitCodePoolMemMgr, CodeMemoryComesFromPool) {
   cantFail(MM.deallocate(std::move(FA)));
 }
 
+std::unique_ptr<LinkGraph> makeHotColdGraph() {
+  auto G = std::make_unique<LinkGraph>(
+      "hot-cold", std::make_shared<orc::SymbolStringPool>(),
+      Triple("x86_64-unknown-linux-gnu"), SubtargetFeatures(),
+      getGenericEdgeKindName);
+  auto &Hot =
+      G->createSection(".text.foo", orc::MemProt::Read | orc::MemProt::Exec);
+  auto &Cold = G->createSection(".text.split.foo",
+                                orc::MemProt::Read | orc::MemProt::Exec);
+  G->createContentBlock(Hot, ArrayRef<char>(CodeBytes, 32),
+                        orc::ExecutorAddr(0x1000), 16, 0);
+  G->createContentBlock(Cold, ArrayRef<char>(CodeBytes, 32),
+                        orc::ExecutorAddr(0x2000), 16, 0);
+  return G;
+}
+
 TEST(EJitCodePoolMemMgr, RoutesTemporaryTier1ToFarPool) {
   MockSre M;
   auto NearOpts = poolOpts(/*PoolSize=*/256 * 1024);
@@ -165,6 +181,49 @@ TEST(EJitCodePoolMemMgr, RoutesTemporaryTier1ToFarPool) {
 
   cantFail(MM.deallocate(std::move(FA1)));
   cantFail(MM.deallocate(std::move(FA2)));
+}
+
+TEST(EJitCodePoolMemMgr, RoutesMfsColdBlocksToCompanionPool) {
+  MockSre M;
+  auto HotOpts = poolOpts(256 * 1024);
+  HotOpts.kind = EJitCodePoolKind::Near;
+  auto ColdOpts = poolOpts(256 * 1024);
+  ColdOpts.kind = EJitCodePoolKind::Cold;
+  auto FarOpts = poolOpts(256 * 1024);
+  FarOpts.kind = EJitCodePoolKind::Far;
+  auto MakePool = [&](EJitCodePoolManager::Options Opts) {
+    return std::make_unique<EJitCodePoolManager>(
+        Opts, [&M](size_t N) { return M.rawAlloc(N); },
+        [&M](void *B) { return M.seal(B); });
+  };
+  auto Hot = MakePool(HotOpts);
+  auto Cold = MakePool(ColdOpts);
+  auto Far = MakePool(FarOpts);
+  EJitCodePoolMemoryManager MM(*Hot, *Cold, *Far, 4096);
+
+  JITLinkDylib Tier2("spec_t2_7");
+  auto G = makeHotColdGraph();
+  auto IFA = cantFail(MM.allocate(&Tier2, *G));
+  SmallVector<void *, 2> BlockAddrs;
+  for (Block *B : G->blocks())
+    BlockAddrs.push_back(B->getAddress().toPtr<void *>());
+  ASSERT_EQ(BlockAddrs.size(), 2u);
+  void *First = BlockAddrs[0];
+  void *Second = BlockAddrs[1];
+  void *HotAddr = Hot->contains(First) ? First : Second;
+  void *ColdAddr = Cold->contains(First) ? First : Second;
+  EXPECT_TRUE(Hot->contains(HotAddr));
+  EXPECT_TRUE(Cold->contains(ColdAddr));
+  auto FA = cantFail(IFA->finalize());
+
+  EJitCompiledCodeInfo Info{};
+  ASSERT_TRUE(MM.findAllocation(HotAddr, Info));
+  EXPECT_EQ(Info.poolKind, EJitCodePoolKind::Near);
+  ASSERT_EQ(Info.extraCodeCount, 1u);
+  EXPECT_EQ(Info.extraCodeRanges[0].poolKind, EJitCodePoolKind::Cold);
+  EXPECT_EQ(Info.extraCodeRanges[0].codeStart,
+            reinterpret_cast<uintptr_t>(ColdAddr));
+  cantFail(MM.deallocate(std::move(FA)));
 }
 
 // finalize() does NOT seal: the pool stays RW so JITLink can keep writing.

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -226,6 +226,40 @@ TEST(EJitCodePoolMemMgr, RoutesMfsColdBlocksToCompanionPool) {
   cantFail(MM.deallocate(std::move(FA)));
 }
 
+TEST(EJitCodePoolMemMgr, ThreePoolManagerKeepsPureHotGraphInNearPool) {
+  MockSre M;
+  auto HotOpts = poolOpts(256 * 1024);
+  HotOpts.kind = EJitCodePoolKind::Near;
+  auto ColdOpts = poolOpts(256 * 1024);
+  ColdOpts.kind = EJitCodePoolKind::Cold;
+  auto FarOpts = poolOpts(256 * 1024);
+  FarOpts.kind = EJitCodePoolKind::Far;
+  auto MakePool = [&](EJitCodePoolManager::Options Opts) {
+    return std::make_unique<EJitCodePoolManager>(
+        Opts, [&M](size_t N) { return M.rawAlloc(N); },
+        [&M](void *B) { return M.seal(B); });
+  };
+  auto Hot = MakePool(HotOpts);
+  auto Cold = MakePool(ColdOpts);
+  auto Far = MakePool(FarOpts);
+  EJitCodePoolMemoryManager MM(*Hot, *Cold, *Far, 4096);
+
+  JITLinkDylib Tier2("spec_t2_hot_only");
+  auto G = makeCodeGraph(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(&Tier2, *G));
+  void *HotAddr = firstBlockAddr(*G);
+  auto FA = cantFail(IFA->finalize());
+
+  EXPECT_TRUE(Hot->contains(HotAddr));
+  EXPECT_EQ(Cold->getStats().poolCount, 0u);
+  EXPECT_EQ(Far->getStats().poolCount, 0u);
+  EJitCompiledCodeInfo Info{};
+  ASSERT_TRUE(MM.findAllocation(HotAddr, Info));
+  EXPECT_EQ(Info.poolKind, EJitCodePoolKind::Near);
+  EXPECT_EQ(Info.extraCodeCount, 0u);
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
 // finalize() does NOT seal: the pool stays RW so JITLink can keep writing.
 // Sealing happens out-of-band (the engine does it at lookup).
 TEST(EJitCodePoolMemMgr, FinalizeKeepsPoolWritable) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolTest.cpp
@@ -13,11 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
+#include "llvm/ExecutionEngine/EJIT/EJitRuntimeDiagnostics.h"
 #include "llvm/Support/Error.h"
 #include "gtest/gtest.h"
 
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <vector>
 
 using namespace llvm;
@@ -95,6 +97,52 @@ EJitCodePoolManager::Options smallOpts(size_t PoolSize = 256) {
 uintptr_t A(const void *P) { return reinterpret_cast<uintptr_t>(P); }
 
 } // namespace
+
+TEST(EJitRuntimeDiagnostics, PrintCompiledIncludesHotAndColdCompanions) {
+  std::vector<llvm::ejit::detail::EJitCompiledExecRange> Ranges = {
+      {1, 4, 0x1000, 0x100}, // primary near-hot range
+      {3, 9, 0x8000, 0x40},  // MFS near-cold companion
+  };
+  const auto S = llvm::ejit::detail::summarizeCompiledExecRanges(Ranges);
+  EXPECT_EQ(S.readyEntryExecBytes, 0x140u);
+  EXPECT_EQ(S.readyUniqueExecBytes, 0x140u);
+  EXPECT_EQ(S.readyUniqueExecRanges, 2u);
+  EXPECT_EQ(S.sharedSlotExecBytes, 0u);
+  EXPECT_EQ(S.nearHotUniqueExecBytes, 0x100u);
+  EXPECT_EQ(S.nearColdUniqueExecBytes, 0x40u);
+  EXPECT_EQ(S.farUniqueExecBytes, 0u);
+  EXPECT_EQ(S.invalidExecRanges, 0u);
+}
+
+TEST(EJitRuntimeDiagnostics, PrintCompiledDeduplicatesSharedHotAndColdRanges) {
+  std::vector<llvm::ejit::detail::EJitCompiledExecRange> Ranges = {
+      {1, 4, 0x1000, 0x100}, {1, 4, 0x1000, 0x100},
+      {3, 9, 0x8000, 0x80},  {3, 9, 0x8000, 0x80},
+  };
+  const auto S = llvm::ejit::detail::summarizeCompiledExecRanges(Ranges);
+  EXPECT_EQ(S.readyEntryExecBytes, 0x300u);
+  EXPECT_EQ(S.readyUniqueExecBytes, 0x180u);
+  EXPECT_EQ(S.readyUniqueExecRanges, 2u);
+  EXPECT_EQ(S.sharedSlotExecBytes, 0x180u);
+  EXPECT_EQ(S.nearHotUniqueExecBytes, 0x100u);
+  EXPECT_EQ(S.nearColdUniqueExecBytes, 0x80u);
+}
+
+TEST(EJitRuntimeDiagnostics, PrintCompiledUnionsOverlappingAndReportsInvalidCold) {
+  std::vector<llvm::ejit::detail::EJitCompiledExecRange> Ranges = {
+      {3, 9, 0x4000, 0x100},
+      {3, 9, 0x4080, 0x100}, // overlaps the first cold range by 0x80
+      {3, 9, 0, 0x10},
+      {3, 9, 0x5000, 0},
+      {3, 9, std::numeric_limits<uintptr_t>::max() - 3, 8},
+  };
+  const auto S = llvm::ejit::detail::summarizeCompiledExecRanges(Ranges);
+  EXPECT_EQ(S.readyEntryExecBytes, 0x200u);
+  EXPECT_EQ(S.readyUniqueExecBytes, 0x180u);
+  EXPECT_EQ(S.readyUniqueExecRanges, 1u);
+  EXPECT_EQ(S.nearColdUniqueExecBytes, 0x180u);
+  EXPECT_EQ(S.invalidExecRanges, 3u);
+}
 
 // 1. The usable base of a pool is 2MiB aligned.
 TEST(EJitCodePool, BaseIs2MiBAligned) {
@@ -1004,12 +1052,22 @@ TEST(EJitCodePoolBatch, PacksRangesAndStartsFreshPageAfterFlush) {
   Mgr.notePendingAllocation();
   Mgr.recordPendingRange(A1, 2000);
   Mgr.notePendingAllocation();
+  auto Pending = Mgr.getStats();
+  EXPECT_EQ(Pending.finalizedExecBytes, 0u);
+  EXPECT_EQ(Pending.pendingExecBytes, 4000u);
+  EXPECT_EQ(Pending.pendingRangeCount, 2u);
+  EXPECT_EQ(Pending.pendingAllocationCount, 2u);
   EJitCompiledCodeInfo Info{};
   EXPECT_FALSE(Mgr.findRange(A0, Info));
   EXPECT_EQ(M.SealCalls, 0u);
 
   cantFail(Mgr.flushPendingRanges());
   EXPECT_EQ(M.SealCalls, 1u);
+  auto Finalized = Mgr.getStats();
+  EXPECT_EQ(Finalized.finalizedExecBytes, 4000u);
+  EXPECT_EQ(Finalized.pendingExecBytes, 0u);
+  EXPECT_EQ(Finalized.pendingRangeCount, 0u);
+  EXPECT_EQ(Finalized.pendingAllocationCount, 0u);
   EXPECT_TRUE(Mgr.findRange(A0, Info));
   EXPECT_TRUE(Mgr.findRange(A1, Info));
 

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitRuntimeTest.cpp
@@ -797,6 +797,7 @@ extern void ejit_print_func_meta(const char *funcName);
 // -2=NOT_ACTIVE, -9=DISABLED) so the test need not include the C API header.
 extern int ejit_get_code_pool_stats(void *out);
 extern int ejit_get_code_pool_stats_v2(void *out);
+extern int ejit_get_code_pool_stats_v3(void *out);
 extern void ejit_print_code_pool_stats(void);
 extern void ejit_print_mayconst_ranking(void);
 extern void ejit_print_active(void);
@@ -3514,6 +3515,7 @@ TEST(EJitDiagnostics, PrintFuncMetaMissingName) {
 TEST(EJitDiagnostics, CodePoolStatsNullOutRejected) {
   EXPECT_EQ(ejit_get_code_pool_stats(nullptr), -1);
   EXPECT_EQ(ejit_get_code_pool_stats_v2(nullptr), -1);
+  EXPECT_EQ(ejit_get_code_pool_stats_v3(nullptr), -1);
 }
 
 // With a valid out pointer the call either succeeds (0) or reports a clean

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1071,8 +1071,8 @@ TEST_F(SharedTaskPoolTest, ExplicitBatchPublishDrainsPreexistingQueueFirst) {
 
   EXPECT_EQ(PublishResult.load(std::memory_order_acquire), 1);
   ASSERT_EQ(Batch.compileOrder.size(), 2u);
-  EXPECT_EQ(stripReqTier(Batch.compileOrder[0].funcIndex), 47u);
-  EXPECT_EQ(stripReqTier(Batch.compileOrder[1].funcIndex), 48u);
+  EXPECT_EQ(stripReqTier(Batch.compileOrder[0].funcIndex), 48u);
+  EXPECT_EQ(stripReqTier(Batch.compileOrder[1].funcIndex), 47u);
 #if EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT != 0u &&                            \
     EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS != 0u
   // One queue drain plus two sorted ORC compiles happen inside this publish
@@ -1139,15 +1139,15 @@ TEST_F(SharedTaskPoolTest, BatchPgoTier2AutoPublishesWhenQueueDrains) {
     Owner.releaseRead(Tier1.bucketIndex);
   ASSERT_EQ(Owner.pendingCount(), 1u);
 
-  // Tier-2 compiles and links immediately, but remains owner-private and RW/NX
-  // until the worker observes the compile queue empty. Tier-1 stays allocated
-  // for counter synthesis, but dispatch falls back to AOT once sampling is
-  // complete instead of continuing atomic instrumentation while waiting.
+  // Tier-2 remains owner-private and uncompiled until the worker observes the
+  // queue empty. Tier-1 stays allocated for profile synthesis, but dispatch
+  // falls back to AOT once sampling is complete instead of continuing atomic
+  // instrumentation while waiting.
   ASSERT_TRUE(Owner.pollOne());
   EXPECT_EQ(Batch.flushCalls, 0u);
-  ASSERT_EQ(Batch.compileOrder.size(), 2u);
-  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex), kEJitTierPgoUse);
-  EXPECT_EQ(Owner.pendingPublishCount(), 1u);
+  EXPECT_EQ(Batch.compileOrder.size(), 1u);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 1u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
   EXPECT_EQ(Owner.pendingCount(), 1u);
 
   auto StillTier1 = Owner.tryCacheHit0D(46);
@@ -1161,6 +1161,9 @@ TEST_F(SharedTaskPoolTest, BatchPgoTier2AutoPublishesWhenQueueDrains) {
   ASSERT_TRUE(Owner.flushCodeBatch());
 #endif
   EXPECT_EQ(Batch.flushCalls, 1u);
+  ASSERT_EQ(Batch.compileOrder.size(), 2u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex), kEJitTierPgoUse);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 0u);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
   EXPECT_EQ(Owner.pendingCount(), 0u);
 
@@ -1174,6 +1177,156 @@ TEST_F(SharedTaskPoolTest, BatchPgoTier2AutoPublishesWhenQueueDrains) {
   if (Tier2.hasReadToken)
     Owner.releaseRead(Tier2.bucketIndex);
 }
+
+#ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
+TEST_F(SharedTaskPoolTest, BatchPgoTier2SortsByCellBeforeJitLink) {
+  BatchPublishCtx Batch;
+  Batch.tier1ReadyImmediately = true;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockBatchCompile, &Batch);
+  Owner.setCodeRangeProvider(&mockBatchRange, &Batch);
+  Owner.setCodeBatchCallbacks(&mockBatchReady, &mockBatchFlush, &Batch);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setPgoEnabled(true, 1, /*maxConcurrentProfiles=*/4);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  constexpr uint32_t Funcs[] = {73, 71, 72, 70};
+  constexpr uint32_t Cells[] = {3, 1, 2, 0};
+  for (uint32_t Cell : Cells)
+    Owner.setInstanceEnabled(0, Cell, true);
+
+  for (unsigned I = 0; I != 4; ++I) {
+    EJitDimPair Dims[1] = {dim(0, Cells[I])};
+    ASSERT_EQ(Owner.compileOrGet(Funcs[I], Dims, 1, codeFor(Funcs[I])).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(Owner.pollOne());
+  }
+  ASSERT_EQ(Batch.compileOrder.size(), 4u);
+
+  // Complete profiling in deliberately non-lexicographic cell order.
+  for (unsigned I = 0; I != 4; ++I) {
+    EJitDimPair Dims[1] = {dim(0, Cells[I])};
+    auto Hit = Owner.tryCacheHit(Funcs[I], Dims, 1);
+    ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (Hit.hasReadToken)
+      Owner.releaseRead(Hit.bucketIndex);
+  }
+  ASSERT_EQ(Owner.pendingCount(), 4u);
+
+  for (unsigned I = 0; I != 4; ++I)
+    ASSERT_TRUE(Owner.pollOne());
+  EXPECT_EQ(Batch.compileOrder.size(), 4u)
+      << "Tier-2 must not allocate code before the layout batch is sorted";
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 4u);
+
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  ASSERT_EQ(Batch.compileOrder.size(), 8u);
+  for (unsigned I = 0; I != 4; ++I) {
+    const EJitCompileRequest &Req = Batch.compileOrder[4u + I];
+    EXPECT_EQ(decodeReqTier(Req.funcIndex), kEJitTierPgoUse);
+    ASSERT_EQ(Req.numDims, 1u);
+    EXPECT_EQ(Req.dims[0].instanceId, I);
+  }
+  EXPECT_EQ(Batch.flushCalls, 1u);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 0u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
+}
+
+TEST_F(SharedTaskPoolTest, BatchPgoTier2PreservesCallOrderWithinCell) {
+  BatchPublishCtx Batch;
+  Batch.tier1ReadyImmediately = true;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockBatchCompile, &Batch);
+  Owner.setCodeRangeProvider(&mockBatchRange, &Batch);
+  Owner.setCodeBatchCallbacks(&mockBatchReady, &mockBatchFlush, &Batch);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setPgoEnabled(true, 1, /*maxConcurrentProfiles=*/3);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  Owner.setInstanceEnabled(0, 0, true);
+
+  // Descending funcIndex makes a funcIndex tie-break produce C,B,A. The
+  // expected layout must instead retain the observed A,B,C business order.
+  constexpr uint32_t Funcs[] = {82, 81, 80};
+  EJitDimPair Cell0[1] = {dim(0, 0)};
+  for (uint32_t Func : Funcs) {
+    ASSERT_EQ(Owner.compileOrGet(Func, Cell0, 1, codeFor(Func)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(Owner.pollOne());
+  }
+  ASSERT_EQ(Batch.compileOrder.size(), 3u);
+
+  for (uint32_t Func : Funcs) {
+    auto Hit = Owner.tryCacheHit(Func, Cell0, 1);
+    ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (Hit.hasReadToken)
+      Owner.releaseRead(Hit.bucketIndex);
+  }
+  for (unsigned I = 0; I != 3; ++I)
+    ASSERT_TRUE(Owner.pollOne());
+  ASSERT_EQ(Batch.compileOrder.size(), 3u);
+
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  ASSERT_EQ(Batch.compileOrder.size(), 6u);
+  for (unsigned I = 0; I != 3; ++I) {
+    const EJitCompileRequest &Req = Batch.compileOrder[3u + I];
+    EXPECT_EQ(decodeReqTier(Req.funcIndex), kEJitTierPgoUse);
+    EXPECT_EQ(stripReqTier(Req.funcIndex), Funcs[I]);
+  }
+  EXPECT_EQ(Batch.flushCalls, 1u);
+}
+
+TEST_F(SharedTaskPoolTest, BatchPgoTier2BypassesFullBaselineLayoutBacklog) {
+  BatchPublishCtx Batch;
+  Batch.tier1ReadyImmediately = true;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockBatchCompile, &Batch);
+  Owner.setCodeRangeProvider(&mockBatchRange, &Batch);
+  Owner.setCodeBatchCallbacks(&mockBatchReady, &mockBatchFlush, &Batch);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  uint32_t BaselineCount = 0;
+  for (uint32_t Func = 1000; BaselineCount != kEJitSharedQueueSlots; ++Func) {
+    // Keep bucket zero available for the PGO identity below. The baseline
+    // layout vector still reaches its hard bound even after its other cache
+    // buckets fill and requests fall back to owner-private coarse claims.
+    if (Func % kEJitSharedCacheBuckets == 0)
+      continue;
+    ASSERT_EQ(Owner.compileOrGet(Func, nullptr, 0, codeFor(Func)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(Owner.pollOne());
+    ++BaselineCount;
+  }
+  ASSERT_EQ(Owner.pendingBatchCompileCount(), kEJitSharedQueueSlots);
+  EXPECT_TRUE(Batch.compileOrder.empty());
+
+  Owner.setPgoEnabled(true, 1);
+  constexpr uint32_t PgoFunc = 3008; // hashIdentity(0D) -> bucket zero.
+  ASSERT_EQ(Owner.compileOrGet(PgoFunc, nullptr, 0, codeFor(PgoFunc)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+  ASSERT_EQ(Batch.compileOrder.size(), 1u);
+  auto Hit = Owner.tryCacheHit0D(PgoFunc);
+  ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+  if (Hit.hasReadToken)
+    Owner.releaseRead(Hit.bucketIndex);
+
+  ASSERT_TRUE(Owner.pollOne());
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), kEJitSharedQueueSlots + 1u);
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  ASSERT_EQ(Batch.compileOrder.size(), 2u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder.back().funcIndex),
+            kEJitTierPgoUse);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), kEJitSharedQueueSlots);
+  EXPECT_EQ(Batch.flushCalls, 1u);
+}
+#endif
 
 #ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
 TEST_F(SharedTaskPoolTest, BatchPgoAutoPublishWaitsForQueuedTier1) {
@@ -1204,18 +1357,20 @@ TEST_F(SharedTaskPoolTest, BatchPgoAutoPublishWaitsForQueuedTier1) {
             EJitCompileOrGetStatus::EnqueuedPending);
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
   EXPECT_EQ(Batch.flushCalls, 0u);
-  ASSERT_EQ(Batch.compileOrder.size(), 2u);
-  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex), kEJitTierPgoUse);
+  ASSERT_EQ(Batch.compileOrder.size(), 1u);
+  EXPECT_EQ(Owner.pendingBatchCompileCount(), 1u);
 
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
   EXPECT_EQ(Batch.flushCalls, 0u);
-  ASSERT_EQ(Batch.compileOrder.size(), 3u);
-  EXPECT_EQ(stripReqTier(Batch.compileOrder[2].funcIndex), 53u);
-  EXPECT_EQ(decodeReqTier(Batch.compileOrder[2].funcIndex),
+  ASSERT_EQ(Batch.compileOrder.size(), 2u);
+  EXPECT_EQ(stripReqTier(Batch.compileOrder[1].funcIndex), 53u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder[1].funcIndex),
             kEJitTierInstrumented);
 
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
   EXPECT_EQ(Batch.flushCalls, 1u);
+  ASSERT_EQ(Batch.compileOrder.size(), 3u);
+  EXPECT_EQ(decodeReqTier(Batch.compileOrder[2].funcIndex), kEJitTierPgoUse);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
 }
 
@@ -1255,9 +1410,9 @@ TEST_F(SharedTaskPoolTest, BatchPgoFourTier2CompilesRetainWorkerThrottle) {
   Owner.setWorkerIdleHook(&mockBatchTimelineIdle, &Idle);
   Owner.runWorkerLoop();
 
-  // C=compile, D=worker throttle, F=enable_ex/cache publication. There must be
-  // a scheduling gap between every Tier-2 compile and after publication.
-  EXPECT_EQ(Batch.timeline, "CDCDCDCDFD");
+  // C=compile, D=worker throttle, F=enable_ex/cache publication. Queue staging
+  // retains its scheduling gaps, then every sorted Tier-2 compile does too.
+  EXPECT_EQ(Batch.timeline, "DDDDCDCDCDCDFD");
   EXPECT_EQ(Batch.maxActiveCompiles, 1u);
   EXPECT_EQ(Batch.flushCalls, 1u);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
@@ -1308,7 +1463,7 @@ TEST_F(SharedTaskPoolTest, ExplicitPublishFourTier2CompilesRetainThrottle) {
   Caller.join();
 
   EXPECT_EQ(PublishResult.load(std::memory_order_acquire), 1);
-  EXPECT_EQ(Batch.timeline, "CDCDCDCDF");
+  EXPECT_EQ(Batch.timeline, "DDDDCDCDCDCDF");
   EXPECT_EQ(Batch.maxActiveCompiles, 1u);
   EXPECT_EQ(Batch.flushCalls, 1u);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
@@ -1340,7 +1495,10 @@ TEST_F(SharedTaskPoolTest, BatchPgoTwentyFunctionsRunInFiveThrottledWaves) {
 
   std::string Expected;
   for (unsigned Wave = 0; Wave != 5; ++Wave) {
-    for (unsigned Compile = 0; Compile != 8; ++Compile)
+    for (unsigned Compile = 0; Compile != 4; ++Compile)
+      Expected += "CD";
+    Expected += "DDDD";
+    for (unsigned Compile = 0; Compile != 4; ++Compile)
       Expected += "CD";
     Expected += "FD";
   }
@@ -1373,7 +1531,8 @@ TEST_F(SharedTaskPoolTest, BatchPgoAutoPublishFailureWaitsForExplicitRetry) {
   if (Tier1.hasReadToken)
     Owner.releaseRead(Tier1.bucketIndex);
   ASSERT_TRUE(Owner.pollOne());
-  ASSERT_EQ(Owner.pendingPublishCount(), 1u);
+  ASSERT_EQ(Owner.pendingBatchCompileCount(), 1u);
+  ASSERT_EQ(Owner.pendingPublishCount(), 0u);
 
   Batch.failFlush = true;
   EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
@@ -1429,7 +1588,10 @@ TEST_F(SharedTaskPoolTest, BatchCompileLayoutSortsFirstThenSecondDimension) {
 
   ASSERT_TRUE(Owner.flushCodeBatch());
   ASSERT_EQ(Batch.compileOrder.size(), 5u);
-  const uint32_t ExpectedFunc[] = {9, 13, 11, 10, 12};
+  // Func 13 reached the identical cell0/trp1 group before func 9. Stable
+  // dimension sorting must retain that business order instead of sorting by
+  // funcIndex.
+  const uint32_t ExpectedFunc[] = {13, 9, 11, 10, 12};
   const uint32_t ExpectedCell[] = {0, 0, 0, 1, 2};
   const uint32_t ExpectedTrp[] = {1, 1, 3, UINT32_MAX, 1};
   for (size_t I = 0; I != Batch.compileOrder.size(); ++I) {

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -168,6 +168,8 @@ struct RangeCtx {
   uint64_t codeSize = 64;
   uint32_t poolId = 0;
   EJitCodePoolKind poolKind = EJitCodePoolKind::Near;
+  uint32_t extraCodeCount = 0;
+  EJitExecutableRange extraCodeRanges[kEJitMaxExtraCodeRanges] = {};
   bool provide = true;
   // Runtime-writable ranges (v9): 0 => none (non-PGO / Tier-2). When set,
   // models the Tier-1 __profc_ counter pages a peer core must enable_rw.
@@ -190,6 +192,9 @@ bool mockCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
   out->poolSize = r->poolSize;
   out->poolId = r->poolId;
   out->poolKind = r->poolKind;
+  out->extraCodeCount = r->extraCodeCount;
+  for (uint32_t I = 0; I < kEJitMaxExtraCodeRanges; ++I)
+    out->extraCodeRanges[I] = r->extraCodeRanges[I];
   out->writableCount = r->writableCount;
   out->requiresPeerEnableRw = r->requiresPeerEnableRw;
   for (uint32_t i = 0; i < kEJitSharedMaxWritableRanges; ++i) {
@@ -1716,6 +1721,32 @@ TEST_F(SharedTaskPoolTest, FourKPeerSplitsOnceSealsSinglePage) {
   EXPECT_EQ(fourK.seals[0].second, 3u);
 }
 
+TEST_F(SharedTaskPoolTest, FourKPeerPreparesMfsColdCompanionRange) {
+  FourKLog fourK;
+  RangeCtx range;
+  range.extraCodeCount = 1;
+  range.extraCodeRanges[0].codeStart = 0x40401200ull;
+  range.extraCodeRanges[0].codeSize = 0x80;
+  range.extraCodeRanges[0].poolBase = 0x40400000ull;
+  range.extraCodeRanges[0].poolSize = 0x200000ull;
+  range.extraCodeRanges[0].poolKind = EJitCodePoolKind::Cold;
+  EJitSharedTaskPool owner;
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 1);
+
+  EJitCoreId::setCurrentForTest(4);
+  auto hit = owner.compileOrGet(1, nullptr, 0, codeFor(1));
+  ASSERT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  owner.releaseRead(hit.bucketIndex);
+
+  ASSERT_EQ(fourK.splits.size(), 2u);
+  EXPECT_EQ(fourK.splits[0].first, 0x40000000ull);
+  EXPECT_EQ(fourK.splits[1].first, 0x40400000ull);
+  ASSERT_EQ(fourK.seals.size(), 2u);
+  EXPECT_EQ(fourK.seals[0].first, 0x40000000ull);
+  EXPECT_EQ(fourK.seals[1].first, 0x40401000ull);
+}
+
 // 2/3 Range spanning two pages with an unaligned start/end: seal BOTH pages.
 TEST_F(SharedTaskPoolTest, FourKPeerSealsEveryCoveredPageUnaligned) {
   FourKLog fourK;
@@ -2374,8 +2405,9 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // a silent cross-core corruption.
   // v10-v13 add PGO controls, writable ranges, staged admission, and audit
   // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
-  // per-version post-publish reuse tracking; v16 adds near/far placement.
-  EXPECT_EQ(kEJitSharedAbiVersion, 16u);
+  // per-version post-publish reuse tracking; v16 adds near/far placement and
+  // v17 carries an MFS cold companion executable range.
+  EXPECT_EQ(kEJitSharedAbiVersion, 17u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -2391,6 +2423,13 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   range.poolBase = 0x40000000ull;
   range.poolSize = 0x200000ull;
   range.poolId = 7;
+  range.extraCodeCount = 1;
+  range.extraCodeRanges[0].codeStart = 0x40402000ull;
+  range.extraCodeRanges[0].codeSize = 0x321;
+  range.extraCodeRanges[0].poolBase = 0x40400000ull;
+  range.extraCodeRanges[0].poolSize = 0x200000ull;
+  range.extraCodeRanges[0].poolId = 2;
+  range.extraCodeRanges[0].poolKind = EJitCodePoolKind::Cold;
   range.writableCount = 1;
   range.writableAddr[0] = 0x40080000ull;
   range.writableSize[0] = 0x40;
@@ -2408,6 +2447,10 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   EXPECT_EQ(slot->poolId, 7u);
   EXPECT_EQ(slot->poolKind,
             static_cast<uint32_t>(EJitCodePoolKind::Near));
+  ASSERT_EQ(slot->extraCodeCount, 1u);
+  EXPECT_EQ(slot->extraCodeRanges[0].codeStart, 0x40402000ull);
+  EXPECT_EQ(slot->extraCodeRanges[0].poolKind,
+            static_cast<uint32_t>(EJitCodePoolKind::Cold));
   // Runtime-writable ranges (v9): published verbatim from the code-range info.
   EXPECT_EQ(slot->writableCount, 1u);
   EXPECT_EQ(slot->requiresPeerEnableRw, 1u); // RangeCtx default: fixed RX pool

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
 #include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
 #include "gtest/gtest.h"
 #include <algorithm>
@@ -126,6 +127,18 @@ void driveOwnerOnRequesterIdle(void *ctx, uint32_t /*ticks*/) {
   EJitCoreId::setCurrentForTest(0);
   (void)drive->owner->workerPollOnce();
   EJitCoreId::setCurrentForTest(drive->requesterCore);
+}
+
+struct BumpGenerationOnIdleCtx {
+  EJitSharedTaskPoolState *state = nullptr;
+  bool bumped = false;
+};
+void bumpGenerationOnIdle(void *ctx, uint32_t /*ticks*/) {
+  auto *B = static_cast<BumpGenerationOnIdleCtx *>(ctx);
+  if (!B->bumped) {
+    B->state->generation.fetchAdd(1u);
+    B->bumped = true;
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -275,6 +288,118 @@ struct BatchTimelineIdleCtx {
   BatchPublishCtx *batch = nullptr;
   EJitSharedTaskPoolState *state = nullptr;
 };
+
+// Real code-pool-backed callbacks for the mirror regression. Unlike the other
+// batch tests, this deliberately obtains pending/finalized counters from an
+// EJitCodePoolManager instead of filling an artificial stats struct.
+struct RealPendingPoolCtx {
+  std::vector<void *> raws;
+  EJitCodePoolManager *manager = nullptr;
+  EJitSharedTaskPool *peer = nullptr;
+  EJitCodePoolStatsOut beforeFlushStats{};
+  uint32_t statsCalls = 0;
+  bool failStatsOnce = false;
+  bool failStatsAlways = false;
+  bool failFlush = false;
+  bool capturedBeforeFlush = false;
+  bool flushed = false;
+
+  ~RealPendingPoolCtx() {
+    for (void *Raw : raws)
+      std::free(Raw);
+  }
+
+  void *allocate(size_t Bytes) {
+    void *Raw = std::malloc(Bytes);
+    if (Raw)
+      raws.push_back(Raw);
+    return Raw;
+  }
+};
+
+unsigned realPendingSeal(void * /*ctx*/, void * /*page*/) { return 0; }
+
+bool realPendingCompile(void *ctx, const EJitCompileRequest & /*req*/,
+                        void **outFn) {
+  auto *P = static_cast<RealPendingPoolCtx *>(ctx);
+  auto Code = P->manager->allocateCode(96, 16);
+  if (!Code)
+    return false;
+  *outFn = llvm::cantFail(std::move(Code));
+  if (!P->manager->recordPendingRange(*outFn, 96))
+    return false;
+  P->manager->notePendingAllocation();
+  return true;
+}
+
+bool realPendingReady(void *ctx, const void * /*fnPtr*/) {
+  return static_cast<RealPendingPoolCtx *>(ctx)->flushed;
+}
+
+bool realPendingFlush(void *ctx) {
+  auto *P = static_cast<RealPendingPoolCtx *>(ctx);
+  if (P->failFlush)
+    return false;
+  // Observe the shared mirror while the compiled range is still staged in the
+  // owner's pending-publish list. The manager is deliberately flushed only
+  // after this read, so the test covers the pre-flush peer-visible state.
+  if (P->peer)
+    P->capturedBeforeFlush = P->peer->readCodePoolStats(&P->beforeFlushStats);
+  if (auto Err = P->manager->flushPendingRanges()) {
+    llvm::consumeError(std::move(Err));
+    return false;
+  }
+  P->flushed = true;
+  return true;
+}
+
+bool realPendingRange(void *ctx, const void *fnPtr,
+                     EJitCompiledCodeInfo *outInfo) {
+  return static_cast<RealPendingPoolCtx *>(ctx)->manager->findRange(fnPtr,
+                                                                     *outInfo);
+}
+
+bool realPendingStats(void *ctx, EJitCodePoolStatsOut *out) {
+  auto *P = static_cast<RealPendingPoolCtx *>(ctx);
+  if (!out)
+    return false;
+  ++P->statsCalls;
+  if (P->failStatsAlways || P->failStatsOnce) {
+    P->failStatsOnce = false;
+    return false;
+  }
+  const auto S = P->manager->getStats();
+  out->poolCount = S.poolCount;
+  out->sealedCount = S.sealedCount;
+  out->activeCount = S.activeCount;
+  out->usedBytes = S.usedBytes;
+  out->reservedBytes = S.reservedBytes;
+  out->wastedBytes = S.wastedBytes;
+  out->sealInvocations = S.sealInvocations;
+  out->splitInvocations = S.splitInvocations;
+  out->finalizedRangeCount = S.finalizedRangeCount;
+  out->finalizedExecBytes = S.finalizedExecBytes;
+  out->pendingExecBytes = S.pendingExecBytes;
+  out->pendingRangeCount = S.pendingRangeCount;
+  out->pendingAllocationCount = S.pendingAllocationCount;
+  return true;
+}
+
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+struct StatsPublishPauseCtx {
+  std::atomic<uint32_t> entered{0};
+  std::atomic<uint32_t> release{0};
+};
+
+void pauseStatsPublishAfterOdd(void *ctx, uint32_t phase) {
+  auto *P = static_cast<StatsPublishPauseCtx *>(ctx);
+  if (phase != 1)
+    return;
+  P->entered.store(1, std::memory_order_release);
+  while (P->release.load(std::memory_order_acquire) == 0)
+    std::this_thread::yield();
+}
+#endif
 
 void mockBatchTimelineIdle(void *ctx, uint32_t ticks) {
   auto *T = static_cast<BatchTimelineIdleCtx *>(ctx);
@@ -3234,10 +3359,11 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // a silent cross-core corruption.
   // v10-v13 add PGO controls, writable ranges, staged admission, and audit
   // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
-  // per-version post-publish reuse tracking; v16 adds near/far placement and
-  // v17 carries an MFS cold companion executable range.
-  // v18 combines the MFS cold range with explicit batch publish state.
-  EXPECT_EQ(kEJitSharedAbiVersion, 18u);
+  // per-version post-publish reuse tracking; v16 adds near/far placement.
+  // The two source branches both used v17 for incompatible additions. This
+  // integration uses v18 for explicit batch state plus the MFS cold companion
+  // executable range.
+  EXPECT_EQ(kEJitSharedAbiVersion, 19u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -7100,5 +7226,381 @@ TEST_F(SharedTaskPoolTest, AsyncServiceUnavailableWithoutAWorker) {
             static_cast<uint32_t>(EJitSharedInitState::Ready));
   EXPECT_FALSE(owner.asyncServiceAvailable());
 }
+
+#ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
+TEST_F(SharedTaskPoolTest, CodePoolStatsMirrorTracksPendingThenFinalized) {
+  RealPendingPoolCtx Backing;
+  EJitCodePoolManager::Options Options;
+  Options.poolSize = 4096;
+  Options.poolAlign = 4096;
+  Options.minCodeAlign = 16;
+  Options.fourKSeal = true;
+  Options.batchedPageSeal = true;
+  Options.sealPageSize = 4096;
+  EJitCodePoolManager Manager(
+      Options, [&Backing](size_t Bytes) { return Backing.allocate(Bytes); },
+      [](void *Page) { return realPendingSeal(nullptr, Page); },
+      [](void *, size_t) { return 0u; });
+  Backing.manager = &Manager;
+
+  EJitSharedTaskPool Owner;
+  EJitSharedTaskPool Peer;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&realPendingCompile, &Backing);
+  Owner.setCodeRangeProvider(&realPendingRange, &Backing);
+  Owner.setCodePoolStatsProvider(&realPendingStats, &Backing);
+  Owner.setCodeBatchCallbacks(&realPendingReady, &realPendingFlush, &Backing);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setCodeSharingEnabled(true);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EJitCoreId::setCurrentForTest(1);
+  Peer.bind(state_.get());
+  Peer.setMode(EJitCompileMode::Async);
+  Peer.setCodeSharingEnabled(true);
+  ASSERT_EQ(Peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+  Backing.peer = &Peer;
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(Owner.compileOrGet(901, nullptr, 0, codeFor(901)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+  ASSERT_EQ(Owner.pendingBatchCompileCount(), 1u);
+
+  EJitCodePoolStatsOut Initial;
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_TRUE(Peer.readCodePoolStats(&Initial));
+  EXPECT_EQ(Initial.pendingExecBytes, 0u);
+  EXPECT_EQ(Initial.finalizedExecBytes, 0u);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_TRUE(Owner.flushCodeBatch());
+  EXPECT_EQ(Backing.statsCalls, 2u)
+      << "one merged refresh at batch completion and one at flush completion";
+  ASSERT_TRUE(Backing.capturedBeforeFlush);
+  EXPECT_EQ(Backing.beforeFlushStats.pendingExecBytes, 96u);
+  EXPECT_EQ(Backing.beforeFlushStats.pendingRangeCount, 1u);
+  EXPECT_EQ(Backing.beforeFlushStats.pendingAllocationCount, 1u);
+  EXPECT_EQ(Backing.beforeFlushStats.finalizedExecBytes, 0u);
+  EXPECT_TRUE(Backing.flushed);
+
+  EJitCodePoolStatsOut Final;
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_TRUE(Peer.readCodePoolStats(&Final));
+  EXPECT_EQ(Final.pendingExecBytes, 0u);
+  EXPECT_EQ(Final.pendingRangeCount, 0u);
+  EXPECT_EQ(Final.pendingAllocationCount, 0u);
+  EXPECT_EQ(Final.finalizedExecBytes, 96u);
+  EXPECT_EQ(Final.finalizedRangeCount, 1u);
+}
+
+TEST_F(SharedTaskPoolTest, CodePoolStatsMirrorBatchesProviderRefreshes) {
+  RealPendingPoolCtx Backing;
+  EJitCodePoolManager::Options Options;
+  Options.poolSize = 4096;
+  Options.poolAlign = 4096;
+  Options.minCodeAlign = 16;
+  Options.fourKSeal = true;
+  Options.batchedPageSeal = true;
+  Options.sealPageSize = 4096;
+  EJitCodePoolManager Manager(
+      Options, [&Backing](size_t Bytes) { return Backing.allocate(Bytes); },
+      [](void *Page) { return realPendingSeal(nullptr, Page); },
+      [](void *, size_t) { return 0u; });
+  Backing.manager = &Manager;
+
+  EJitSharedTaskPool Owner;
+  EJitSharedTaskPool Peer;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&realPendingCompile, &Backing);
+  Owner.setCodeRangeProvider(&realPendingRange, &Backing);
+  Owner.setCodePoolStatsProvider(&realPendingStats, &Backing);
+  Owner.setCodeBatchCallbacks(&realPendingReady, &realPendingFlush, &Backing);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setCodeSharingEnabled(true);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EJitCoreId::setCurrentForTest(1);
+  Peer.bind(state_.get());
+  Peer.setMode(EJitCompileMode::Async);
+  Peer.setCodeSharingEnabled(true);
+  ASSERT_EQ(Peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+  Backing.peer = &Peer;
+
+  constexpr uint32_t Count = 24;
+  EJitCoreId::setCurrentForTest(0);
+  for (uint32_t I = 0; I != Count; ++I) {
+    ASSERT_EQ(Owner.compileOrGet(1200 + I, nullptr, 0, codeFor(1200 + I))
+                  .status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+    ASSERT_TRUE(Owner.pollOne());
+  }
+  ASSERT_EQ(Owner.pendingBatchCompileCount(), Count);
+  EXPECT_EQ(Backing.statsCalls, 0u)
+      << "staging requests must not snapshot all code-pool ranges";
+
+  EJitCodePoolStatsOut Initial;
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_TRUE(Peer.readCodePoolStats(&Initial));
+  EXPECT_EQ(Initial.pendingExecBytes, 0u);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_TRUE(Owner.flushCodeBatch());
+  EXPECT_EQ(Backing.statsCalls, 2u)
+      << "provider work is coalesced to batch and flush boundaries";
+  ASSERT_TRUE(Backing.capturedBeforeFlush);
+  EXPECT_EQ(Backing.beforeFlushStats.pendingExecBytes,
+            static_cast<uint64_t>(Count) * 96u);
+  EXPECT_EQ(Backing.beforeFlushStats.pendingRangeCount, Count);
+  EXPECT_EQ(Backing.beforeFlushStats.pendingAllocationCount, Count);
+  EXPECT_EQ(Backing.beforeFlushStats.finalizedExecBytes, 0u);
+
+  EJitCodePoolStatsOut Final;
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_TRUE(Peer.readCodePoolStats(&Final));
+  EXPECT_EQ(Final.pendingExecBytes, 0u);
+  EXPECT_EQ(Final.pendingRangeCount, 0u);
+  EXPECT_EQ(Final.pendingAllocationCount, 0u);
+  EXPECT_EQ(Final.finalizedExecBytes, static_cast<uint64_t>(Count) * 96u);
+  EXPECT_EQ(Final.finalizedRangeCount, Count);
+}
+
+TEST_F(SharedTaskPoolTest, CodePoolStatsPeerReadRequestsDirtyOwnerRefresh) {
+  RealPendingPoolCtx Backing;
+  EJitCodePoolManager::Options Options;
+  Options.poolSize = 4096;
+  Options.poolAlign = 4096;
+  Options.minCodeAlign = 16;
+  Options.fourKSeal = true;
+  Options.batchedPageSeal = true;
+  Options.sealPageSize = 4096;
+  EJitCodePoolManager Manager(
+      Options, [&Backing](size_t Bytes) { return Backing.allocate(Bytes); },
+      [](void *Page) { return realPendingSeal(nullptr, Page); },
+      [](void *, size_t) { return 0u; });
+  Backing.manager = &Manager;
+  Backing.failStatsOnce = true;
+  Backing.failFlush = true;
+
+  WorkerHooks OwnerHooks;
+  EJitSharedTaskPool Owner;
+  EJitSharedTaskPool Peer;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&realPendingCompile, &Backing);
+  Owner.setCodeRangeProvider(&realPendingRange, &Backing);
+  Owner.setCodePoolStatsProvider(&realPendingStats, &Backing);
+  Owner.setCodeBatchCallbacks(&realPendingReady, &realPendingFlush, &Backing);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setCodeSharingEnabled(true);
+  Owner.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &OwnerHooks);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EJitCoreId::setCurrentForTest(1);
+  Peer.bind(state_.get());
+  Peer.setMode(EJitCompileMode::Async);
+  Peer.setCodeSharingEnabled(true);
+  ASSERT_EQ(Peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(Owner.compileOrGet(1300, nullptr, 0, codeFor(1300)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+  ASSERT_FALSE(Owner.flushCodeBatch());
+  ASSERT_EQ(Backing.statsCalls, 1u);
+  ASSERT_EQ(Owner.pendingPublishCount(), 1u);
+
+  // The failed first boundary leaves dirty=1. A peer diagnostic read asks the
+  // owner worker to retry the provider instead of returning stale zero stats.
+  DriveOwnerCtx Drive{&Owner, 1};
+  Peer.setWorkerIdleHook(&driveOwnerOnRequesterIdle, &Drive);
+  Backing.failFlush = false;
+  EJitCodePoolStatsOut Pending;
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_TRUE(Peer.readCodePoolStats(&Pending));
+  EXPECT_EQ(Backing.statsCalls, 2u);
+  EXPECT_EQ(Pending.pendingExecBytes, 96u);
+  EXPECT_EQ(Pending.pendingRangeCount, 1u);
+  EXPECT_EQ(Pending.finalizedExecBytes, 0u);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_TRUE(Owner.flushCodeBatch());
+  EXPECT_EQ(Backing.statsCalls, 3u);
+  EJitCodePoolStatsOut Final;
+  EJitCoreId::setCurrentForTest(1);
+  ASSERT_TRUE(Peer.readCodePoolStats(&Final));
+  EXPECT_EQ(Final.pendingExecBytes, 0u);
+  EXPECT_EQ(Final.finalizedExecBytes, 96u);
+}
+
+TEST_F(SharedTaskPoolTest, CodePoolStatsPeerReadFailsFastWithoutOwnerWorker) {
+  EJitSharedTaskPool Owner;
+  bringUpOwner(Owner);
+
+  EJitSharedTaskPool Peer;
+  EJitCoreId::setCurrentForTest(1);
+  Peer.bind(state_.get());
+  Peer.setMode(EJitCompileMode::Async);
+  Peer.setCodeSharingEnabled(true);
+  ASSERT_EQ(Peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+
+  // Model a staged owner update while no worker was ever started. The peer
+  // must reject before posting a request, rather than yielding 4096 rounds.
+  state_->codePoolStats.dirty.storeRelease(1);
+  EJitCodePoolStatsOut Stats;
+  EXPECT_FALSE(Peer.readCodePoolStats(&Stats));
+  EXPECT_EQ(state_->codePoolStats.refreshRequest.loadAcquire(), 0u);
+  EXPECT_EQ(Peer.workerIdleYields(), 0u);
+}
+
+TEST_F(SharedTaskPoolTest, CodePoolStatsPeerReadStopsOnGenerationChange) {
+  EJitSharedTaskPool Owner;
+  bringUpOwner(Owner);
+
+  EJitSharedTaskPool Peer;
+  EJitCoreId::setCurrentForTest(1);
+  Peer.bind(state_.get());
+  Peer.setMode(EJitCompileMode::Async);
+  Peer.setCodeSharingEnabled(true);
+  ASSERT_EQ(Peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+
+  // Install the minimum published worker identity so the request passes the
+  // preflight gate; then model a re-election during the first wait yield.
+  state_->workerTaskId.storeRelease(0xABCDu);
+  state_->codePoolStats.dirty.storeRelease(1);
+  BumpGenerationOnIdleCtx Bump{state_.get(), false};
+  Peer.setWorkerIdleHook(&bumpGenerationOnIdle, &Bump);
+
+  EJitCodePoolStatsOut Stats;
+  EXPECT_FALSE(Peer.readCodePoolStats(&Stats));
+  EXPECT_TRUE(Bump.bumped);
+  EXPECT_EQ(state_->codePoolStats.refreshRequest.loadAcquire(), 1u);
+}
+
+TEST_F(SharedTaskPoolTest, CodePoolStatsPermanentProviderFailureIsAcknowledged) {
+  RealPendingPoolCtx Backing;
+  EJitCodePoolManager::Options Options;
+  Options.poolSize = 4096;
+  Options.poolAlign = 4096;
+  Options.minCodeAlign = 16;
+  Options.fourKSeal = true;
+  Options.batchedPageSeal = true;
+  Options.sealPageSize = 4096;
+  EJitCodePoolManager Manager(
+      Options, [&Backing](size_t Bytes) { return Backing.allocate(Bytes); },
+      [](void *Page) { return realPendingSeal(nullptr, Page); },
+      [](void *, size_t) { return 0u; });
+  Backing.manager = &Manager;
+  Backing.failStatsAlways = true;
+  Backing.failFlush = true;
+
+  WorkerHooks Hooks;
+  EJitSharedTaskPool Owner;
+  EJitSharedTaskPool Peer;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&realPendingCompile, &Backing);
+  Owner.setCodeRangeProvider(&realPendingRange, &Backing);
+  Owner.setCodePoolStatsProvider(&realPendingStats, &Backing);
+  Owner.setCodeBatchCallbacks(&realPendingReady, &realPendingFlush, &Backing);
+  Owner.setWorkerHooks(&mockWorkerStart, &mockWorkerStop, &Hooks);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setCodeSharingEnabled(true);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EJitCoreId::setCurrentForTest(1);
+  Peer.bind(state_.get());
+  Peer.setMode(EJitCompileMode::Async);
+  Peer.setCodeSharingEnabled(true);
+  ASSERT_EQ(Peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(Owner.compileOrGet(1400, nullptr, 0, codeFor(1400)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+  ASSERT_FALSE(Owner.flushCodeBatch());
+  ASSERT_EQ(Backing.statsCalls, 1u)
+      << "the failed batch boundary leaves one dirty snapshot request";
+
+  const uint32_t CallsBeforePeerRequest = Backing.statsCalls;
+  DriveOwnerCtx Drive{&Owner, 1};
+  Peer.setWorkerIdleHook(&driveOwnerOnRequesterIdle, &Drive);
+  EJitCodePoolStatsOut Stats;
+  EJitCoreId::setCurrentForTest(1);
+  EXPECT_FALSE(Peer.readCodePoolStats(&Stats));
+  EXPECT_EQ(Backing.statsCalls, CallsBeforePeerRequest + 1u)
+      << "one provider attempt is made for one diagnostic ticket";
+  EXPECT_EQ(state_->codePoolStats.refreshComplete.loadAcquire(), 1u);
+  EXPECT_EQ(state_->codePoolStats.refreshResult.loadAcquire(), 0u);
+
+  // The failed ticket is acknowledged, so idle worker polls do not create a
+  // provider retry storm. A later diagnostic ticket is the explicit retry.
+  EJitCoreId::setCurrentForTest(0);
+  for (unsigned I = 0; I != 4; ++I)
+    EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Idle);
+  EXPECT_EQ(Backing.statsCalls, CallsBeforePeerRequest + 1u);
+}
+
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+TEST_F(SharedTaskPoolTest, CodePoolStatsSeqcountRejectsInterruptedWriter) {
+  RealPendingPoolCtx Backing;
+  EJitCodePoolManager::Options Options;
+  Options.poolSize = 4096;
+  Options.poolAlign = 4096;
+  Options.minCodeAlign = 16;
+  Options.fourKSeal = true;
+  Options.batchedPageSeal = true;
+  Options.sealPageSize = 4096;
+  EJitCodePoolManager Manager(
+      Options, [&Backing](size_t Bytes) { return Backing.allocate(Bytes); },
+      [](void *Page) { return realPendingSeal(nullptr, Page); },
+      [](void *, size_t) { return 0u; });
+  Backing.manager = &Manager;
+
+  EJitSharedTaskPool Owner;
+  EJitSharedTaskPool Peer;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&realPendingCompile, &Backing);
+  Owner.setCodeRangeProvider(&realPendingRange, &Backing);
+  Owner.setCodePoolStatsProvider(&realPendingStats, &Backing);
+  Owner.setCodeBatchCallbacks(&realPendingReady, &realPendingFlush, &Backing);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setCodeSharingEnabled(true);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EJitCoreId::setCurrentForTest(1);
+  Peer.bind(state_.get());
+  Peer.setMode(EJitCompileMode::Async);
+  Peer.setCodeSharingEnabled(true);
+  ASSERT_EQ(Peer.init(), EJitSharedTaskPool::InitResult::AttachedReady);
+  Backing.peer = &Peer;
+
+  StatsPublishPauseCtx Pause;
+  Owner.setCodePoolStatsPublishHook(&pauseStatsPublishAfterOdd, &Pause);
+  std::atomic<int> WriterResult{-1};
+  std::thread Writer([&] {
+    EJitCoreId::setCurrentForTest(0);
+    WriterResult.store(Owner.flushCodeBatch() ? 1 : 0,
+                       std::memory_order_release);
+  });
+
+  while (Pause.entered.load(std::memory_order_acquire) == 0)
+    std::this_thread::yield();
+  EJitCodePoolStatsOut During;
+  EXPECT_FALSE(Peer.readCodePoolStats(&During))
+      << "reader must reject the odd seqcount while writer is interrupted";
+  Pause.release.store(1, std::memory_order_release);
+  Writer.join();
+  ASSERT_EQ(WriterResult.load(std::memory_order_acquire), 1);
+
+  EJitCodePoolStatsOut After;
+  ASSERT_TRUE(Peer.readCodePoolStats(&After));
+  EXPECT_EQ(After.pendingExecBytes, 0u);
+}
+#endif
+#endif
 
 } // namespace


### PR DESCRIPTION
## Dependencies

- Depends on #181 (`193dcde16622653fc5c8fdad851b98ab250b785e`)
- Depends on #191 (`bd06bea2bc4d10931081bfd5ee159b68c11aac5d`)
- Does **not** depend on #189

This is intentionally a draft integration PR. Its dependency diff will shrink after #181 and #191 land. The accounting change itself is one commit on top of clean integration parent `1e070997c946a22886549c2ae34669304e675b5a`.

## Summary / 摘要

Adds accurate code-pool diagnostics for the combined MFS cold-pool and batched Tier-2 layout:

- `print_compiled` reports function/executable addresses and sizes in code-address order, including every hot/cold companion range.
- Reports per-entry bytes and unioned executable bytes without double-counting shared ranges.
- Separates near-hot, near-cold/MFS, far Tier-1, unknown, pending, and finalized accounting.
- Clarifies that pool `usedBytes` is bump usage (alignment, holes, abandoned tails included), while executable-union bytes represent actual recorded executable extents.
- Mirrors pending/finalized stats to peer cores through ABI v19 with a full-barrier seqcount.
- Coalesces expensive range-union refreshes to O(batch), with generation/worker fast-fail and acknowledged provider failures.

为 #181 的 MFS 冷区和 #191 的 Tier-2 批量布局补齐统一调测口径：按代码地址打印主函数及所有冷热 companion range，区分 pool bump 占用与真实 executable union，跨核读取使用 ABI v19 的一致快照，并避免逐函数全量统计造成性能劣化。

## Validation

- `EJITCodePoolTests`: 67/67 passed
- `EJITSharedTaskPoolTests`: 173/173 passed
- `git diff --check`: passed
- Accounting diff relative to the clean integration parent: 15 files

## Review note

Please review the final accounting commit independently from the two dependency commits. No #189 commit or local `3cb4b93` integration history is included.