### PR TITLE
[EJIT] Add fixed near-hot pools for cell-specialized code

### DIFF
--- a/ejit_test/README.md
+++ b/ejit_test/README.md
@@ -48,6 +48,29 @@ Integration tests for the EmbeddedJIT JIT compilation system.
 
 ### Board-only Multicore Demo
 
+`ejit_fixed_near_hot_sre_multicore_test.c` is a self-contained online-PGO smoke
+test for the fixed near-hot layout. It has no business-header or MFS dependency:
+
+1. Core 6 runs `test_ejit_period` once and becomes the fixed worker.
+2. Core 16 runs `test_ejit_period` once, using `ejit_init_pgo` and triggering
+   four `ejit_entry` functions over cell[0..15] (64 Tier-2 identities) plus
+   one no-cell/public identity. Identities run in batches no larger than the
+   configured `EJIT_SRE_PGO_MAX_CONCURRENT_PROFILES` (or two when that macro
+   is not supplied); each waits for its Tier-1 compile and then performs 64
+   real Tier-1 samples before waiting for Tier-2 completion. Define
+   `FIXED_NEAR_HOT_FUNCTION_COUNT=8` at compile time for the 129-identity
+   stress variant.
+3. Core 6 runs `test_ejit_fixed_near_hot_print` to validate all 17 pool
+   envelopes and print the published compiled list.
+
+The test expects the far T1 pool and every near-hot pool to be non-empty and
+finalized, with at least four finalized ranges in each cell pool, one in the
+public pool, no pending entries, and zero compile/publish failures. The runtime
+summary must additionally show no fallback and a zero failed-pool bitmap; its
+real address-sorted `print_compiled` rows provide function/version/tier/pool/
+address/exec-size, while the test prints per-pool version/exec-byte/span,
+tail-padding, and density counters. It does not call `ejit_shutdown()`.
+
 `ejit_bound_ptr_sre_multicore_test.c` provides the SRE `test_ejit_period`
 entry for validating dimension-bound pointer snapshots across cores:
 

--- a/ejit_test/ejit_fixed_near_hot_sre_multicore_test.c
+++ b/ejit_test/ejit_fixed_near_hot_sre_multicore_test.c
@@ -1,0 +1,660 @@
+//===-- ejit_fixed_near_hot_sre_multicore_test.c - board smoke test -------===//
+//
+// Board flow after reset:
+//   1. Core 6: run test_ejit_period once. It becomes the fixed worker and
+//      compile owner, then returns after printing the ready message.
+//   2. Core 16: run test_ejit_period once. It attaches to core 6, triggers one
+//      version for cell[0..15] and one no-cell/public version, waits for the
+//      queue-empty publish, and prints the pool diagnostics.
+//   3. Core 6: run test_ejit_fixed_near_hot_print once. It validates all 17
+//      pool envelopes and prints the published compiled list separately.
+//
+// This file is deliberately independent of business headers and does not use
+// MFS. Do not call ejit_shutdown(): the shared worker must survive shell
+// invocations.
+//===----------------------------------------------------------------------===//
+
+// Keep this board test self-contained: the harness supplies the public EJIT
+// symbols below, so the file does not depend on project or business headers.
+typedef unsigned char uint8_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef unsigned long size_t;
+typedef _Bool bool;
+
+#define true 1
+#define false 0
+
+#define EJIT_PERIOD_CONST __attribute__((ejit_period_const))
+#define EJIT_IN_PERIOD_ARRAY(x) __attribute__((ejit_in_period_array(#x)))
+#define EJIT_DIM(x) __attribute__((ejit_dim(#x)))
+#define EJIT_ENTRY __attribute__((ejit_entry))
+#define ejit_may_const EJIT_PERIOD_CONST
+#define ejit_period_arr(x) EJIT_IN_PERIOD_ARRAY(x)
+#define ejit_period_arr_ind(x) EJIT_DIM(x)
+#define ejit_entry EJIT_ENTRY
+
+typedef enum {
+  EJIT_OK = 0,
+} ejit_status_t;
+
+typedef enum {
+  EJIT_COMPILE_SYNC = 0,
+  EJIT_COMPILE_ASYNC = 1,
+} ejit_compile_mode_t;
+
+typedef enum {
+  EJIT_OPT_L1 = 1,
+  EJIT_OPT_L2 = 2,
+  EJIT_OPT_L3 = 3,
+} ejit_opt_level_t;
+
+typedef struct {
+  ejit_compile_mode_t compileMode;
+  ejit_opt_level_t optLevel;
+  size_t maxCodeMemory;
+  size_t maxDataMemory;
+  size_t maxCacheEntries;
+  size_t maxCacheSize;
+  bool enableLogger;
+  bool forceStaticRegistry;
+  const char *dumpJITDir;
+} ejit_config_t;
+
+typedef struct {
+  uint64_t cacheHits;
+  uint64_t asyncCompiles;
+  uint64_t asyncEnqueues;
+  uint64_t alreadyPending;
+  uint64_t queueFull;
+  uint64_t compileFailed;
+  uint64_t publishFailed;
+  uint64_t instanceDisabled;
+  uint64_t instanceDisabledPreActivate;
+  uint32_t readyEntries;
+  uint32_t pendingEntries;
+  uint32_t queueApproxSize;
+  uint32_t reserved;
+} ejit_taskpool_stats_t;
+
+typedef struct {
+  uint64_t poolCount;
+  uint64_t sealedCount;
+  uint64_t activeCount;
+  uint64_t usedBytes;
+  uint64_t reservedBytes;
+  uint64_t wastedBytes;
+  uint64_t sealInvocations;
+  uint64_t splitInvocations;
+  uint64_t finalizedRangeCount;
+} ejit_code_pool_stats_t;
+
+typedef struct {
+  ejit_code_pool_stats_t total;
+  ejit_code_pool_stats_t near;
+  ejit_code_pool_stats_t nearHot[17];
+  ejit_code_pool_stats_t far;
+} ejit_code_pool_stats_v2_t;
+
+typedef enum {
+  EJIT_LOG_OFF = 0,
+  EJIT_LOG_INFO = 1,
+  EJIT_LOG_VERBOSE = 2,
+  EJIT_LOG_DEBUG = 3,
+} ejit_log_level_t;
+
+extern ejit_status_t ejit_init(const ejit_config_t *config);
+extern ejit_status_t ejit_init_pgo(const ejit_config_t *config);
+extern ejit_status_t ejit_activate(const char *periodName, uint32_t cellIdx);
+extern void ejit_clear_cache(void);
+extern uint32_t ejit_taskpool_pending_count(void);
+extern ejit_status_t ejit_taskpool_get_stats(ejit_taskpool_stats_t *out);
+extern ejit_status_t
+ejit_get_code_pool_stats_v2(ejit_code_pool_stats_v2_t *out);
+extern void ejit_print_code_pool_stats(void);
+extern void ejit_taskpool_print_compiled(void);
+extern void ejit_taskpool_print_stats(void);
+extern uint32_t ejit_taskpool_get_worker_core(void);
+extern void ejit_set_log_level(ejit_log_level_t level);
+
+extern void SRE_printf(const char *format, ...);
+extern uint32_t SRE_TaskDelay(uint32_t tick);
+extern void call_init_array_functions(void);
+extern uint8_t g_ucLocalCoreID;
+
+#ifndef EJIT_SHARED_SECTION_ATTR
+#define EJIT_SHARED_SECTION_ATTR __attribute__((section(".mc_shared")))
+#endif
+
+#ifndef FIXED_NEAR_HOT_WORKER_CORE
+#define FIXED_NEAR_HOT_WORKER_CORE 6u
+#endif
+#ifndef FIXED_NEAR_HOT_PRODUCER_CORE
+#define FIXED_NEAR_HOT_PRODUCER_CORE 16u
+#endif
+
+#define FIXED_NEAR_HOT_CELL_COUNT 16u
+#define FIXED_NEAR_HOT_POOL_COUNT 17u
+#ifndef FIXED_NEAR_HOT_FUNCTION_COUNT
+#define FIXED_NEAR_HOT_FUNCTION_COUNT 4u
+#endif
+#ifndef FIXED_NEAR_HOT_PROFILE_BATCH
+#ifdef EJIT_SRE_PGO_MAX_CONCURRENT_PROFILES
+#define FIXED_NEAR_HOT_PROFILE_BATCH EJIT_SRE_PGO_MAX_CONCURRENT_PROFILES
+#else
+#define FIXED_NEAR_HOT_PROFILE_BATCH 2u
+#endif
+#endif
+#define FIXED_NEAR_HOT_T1_SAMPLES 64u
+#define FIXED_NEAR_HOT_SPECIALIZATION_COUNT                                    \
+  (FIXED_NEAR_HOT_FUNCTION_COUNT * FIXED_NEAR_HOT_CELL_COUNT)
+#define FIXED_NEAR_HOT_IDENTITY_COUNT (FIXED_NEAR_HOT_SPECIALIZATION_COUNT + 1u)
+#define FIXED_NEAR_HOT_BATCH_WIDTH                                            \
+  (FIXED_NEAR_HOT_PROFILE_BATCH < FIXED_NEAR_HOT_FUNCTION_COUNT              \
+       ? FIXED_NEAR_HOT_PROFILE_BATCH                                          \
+       : FIXED_NEAR_HOT_FUNCTION_COUNT)
+#define FIXED_NEAR_HOT_SPECIALIZATION_BATCH_COUNT                              \
+  ((FIXED_NEAR_HOT_SPECIALIZATION_COUNT + FIXED_NEAR_HOT_BATCH_WIDTH - 1u) /  \
+   FIXED_NEAR_HOT_BATCH_WIDTH)
+#define FIXED_NEAR_HOT_BATCH_COUNT                                             \
+  (FIXED_NEAR_HOT_SPECIALIZATION_BATCH_COUNT + 1u)
+#define FIXED_NEAR_HOT_WAIT_ROUNDS 6000u
+#define FIXED_NEAR_HOT_WAIT_TICKS 10u
+
+#if FIXED_NEAR_HOT_FUNCTION_COUNT != 4u && FIXED_NEAR_HOT_FUNCTION_COUNT != 8u
+#error "FIXED_NEAR_HOT_FUNCTION_COUNT must be 4 or 8"
+#endif
+#if FIXED_NEAR_HOT_PROFILE_BATCH < 1u
+#error "FIXED_NEAR_HOT_PROFILE_BATCH must be at least 1"
+#endif
+
+enum FixedNearHotStage {
+  FIXED_NEAR_HOT_RESET = 0,
+  FIXED_NEAR_HOT_WORKER_READY = 1,
+  FIXED_NEAR_HOT_PUBLISHED = 2,
+  FIXED_NEAR_HOT_PRINTED = 3,
+};
+
+struct FixedNearHotConfig {
+  ejit_may_const uint32_t multiplier;
+  ejit_may_const uint32_t bias;
+};
+
+EJIT_SHARED_SECTION_ATTR ejit_period_arr(cell)
+struct FixedNearHotConfig g_fixed_near_hot_config[FIXED_NEAR_HOT_CELL_COUNT];
+EJIT_SHARED_SECTION_ATTR volatile uint32_t g_fixed_near_hot_stage;
+EJIT_SHARED_SECTION_ATTR volatile uint64_t g_fixed_near_hot_sink;
+
+#define FIXED_NEAR_HOT_BODY(TAG)                                               \
+  const struct FixedNearHotConfig *cfg = &g_fixed_near_hot_config[cellIndex];  \
+  uint32_t value = input ^ (TAG);                                              \
+  for (uint32_t i = 0; i < 8u; ++i)                                            \
+    value = (value * cfg->multiplier) ^ (value >> 3) ^ (i + (TAG));            \
+  return value + cfg->bias + (TAG)
+
+#define FIXED_NEAR_HOT_ENTRY(NAME, TAG)                                        \
+  ejit_entry uint32_t NAME(ejit_period_arr_ind(cell) uint8_t cellIndex,        \
+                           uint32_t input) {                                   \
+    FIXED_NEAR_HOT_BODY(TAG);                                                  \
+  }
+
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_0, 0x101u)
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_1, 0x202u)
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_2, 0x303u)
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_3, 0x404u)
+
+#if FIXED_NEAR_HOT_FUNCTION_COUNT >= 8u
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_4, 0x505u)
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_5, 0x606u)
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_6, 0x707u)
+FIXED_NEAR_HOT_ENTRY(fixed_near_hot_cell_7, 0x808u)
+#endif
+
+#undef FIXED_NEAR_HOT_ENTRY
+#undef FIXED_NEAR_HOT_BODY
+
+// No period dimension is intentional: this entry must route to public pool 16.
+ejit_entry uint32_t fixed_near_hot_public(uint32_t input) {
+  return input + 0x5a5au;
+}
+
+static uint32_t call_fixed_near_hot(uint32_t function, uint8_t cell,
+                                    uint32_t input) {
+  switch (function) {
+  case 0:
+    return fixed_near_hot_cell_0(cell, input);
+  case 1:
+    return fixed_near_hot_cell_1(cell, input);
+  case 2:
+    return fixed_near_hot_cell_2(cell, input);
+  case 3:
+    return fixed_near_hot_cell_3(cell, input);
+#if FIXED_NEAR_HOT_FUNCTION_COUNT >= 8u
+  case 4:
+    return fixed_near_hot_cell_4(cell, input);
+  case 5:
+    return fixed_near_hot_cell_5(cell, input);
+  case 6:
+    return fixed_near_hot_cell_6(cell, input);
+  case 7:
+    return fixed_near_hot_cell_7(cell, input);
+#endif
+  default:
+    return 0u;
+  }
+}
+
+static uint32_t expected_fixed_near_hot(uint32_t function, uint8_t cell,
+                                        uint32_t input) {
+  static const uint32_t tags[8] = {0x101u, 0x202u, 0x303u, 0x404u,
+                                   0x505u, 0x606u, 0x707u, 0x808u};
+  const struct FixedNearHotConfig *cfg = &g_fixed_near_hot_config[cell];
+  uint32_t value = input ^ tags[function];
+  for (uint32_t i = 0; i < 8u; ++i)
+    value = (value * cfg->multiplier) ^ (value >> 3) ^ (i + tags[function]);
+  return value + cfg->bias + tags[function];
+}
+
+static uint32_t call_fixed_near_hot_identity(uint32_t identity,
+                                             uint32_t input) {
+  if (identity == FIXED_NEAR_HOT_SPECIALIZATION_COUNT)
+    return fixed_near_hot_public(input);
+  // Keep each batch cell-major. The PGO admission gate is per function, so a
+  // batch must never contain two cells of the same function.
+  const uint8_t cell = (uint8_t)(identity / FIXED_NEAR_HOT_FUNCTION_COUNT);
+  const uint32_t function = identity % FIXED_NEAR_HOT_FUNCTION_COUNT;
+  return call_fixed_near_hot(function, cell, input);
+}
+
+static uint32_t expected_fixed_near_hot_identity(uint32_t identity,
+                                                 uint32_t input) {
+  if (identity == FIXED_NEAR_HOT_SPECIALIZATION_COUNT)
+    return input + 0x5a5au;
+  const uint8_t cell = (uint8_t)(identity / FIXED_NEAR_HOT_FUNCTION_COUNT);
+  const uint32_t function = identity % FIXED_NEAR_HOT_FUNCTION_COUNT;
+  return expected_fixed_near_hot(function, cell, input);
+}
+
+static void print_batch_schedule(uint32_t batch, uint32_t first, uint32_t end) {
+  SRE_printf("[FIXED-NEAR-HOT] batch=%u/%u schedule:", batch,
+             FIXED_NEAR_HOT_BATCH_COUNT);
+  for (uint32_t identity = first; identity < end; ++identity) {
+    if (identity == FIXED_NEAR_HOT_SPECIALIZATION_COUNT) {
+      SRE_printf(" public");
+    } else {
+      const uint32_t cell = identity / FIXED_NEAR_HOT_FUNCTION_COUNT;
+      const uint32_t function = identity % FIXED_NEAR_HOT_FUNCTION_COUNT;
+      SRE_printf(" id=%u(cell=%u funcIndex=%u)", identity, cell, function);
+    }
+  }
+  SRE_printf("\n");
+}
+
+static int wait_for_compile_target(uint64_t baseline, uint64_t target,
+                                   uint32_t expectedDelta, uint32_t batch,
+                                   uint32_t core, const char *phase) {
+  uint32_t emptyRounds = 0;
+  for (uint32_t round = 0; round < FIXED_NEAR_HOT_WAIT_ROUNDS; ++round) {
+    ejit_taskpool_stats_t stats = {0};
+    if (ejit_taskpool_get_stats(&stats) != EJIT_OK) {
+      SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL get taskpool stats\n", core);
+      return 0;
+    }
+    if (stats.compileFailed || stats.publishFailed) {
+      SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL compile=%llu publish=%llu\n",
+                 core, (unsigned long long)stats.compileFailed,
+                 (unsigned long long)stats.publishFailed);
+      return 0;
+    }
+    const uint32_t pending = ejit_taskpool_pending_count();
+    if (stats.asyncCompiles >= target && pending == 0)
+      return 1;
+    if (pending == 0 && stats.pendingEntries == 0 &&
+        stats.queueApproxSize == 0 && stats.asyncCompiles < target) {
+      if (++emptyRounds >= 5u) {
+        const uint64_t delta = stats.asyncCompiles >= baseline
+                                   ? stats.asyncCompiles - baseline
+                                   : 0;
+        SRE_printf(
+            "[FIXED-NEAR-HOT][core=%u] FAIL %s batch=%u pending=0 "
+            "compiled_delta=%llu/%u; PGO same-function admission/deferred "
+            "or missing T1 request (AOT fallback)\n",
+            core, phase, batch, (unsigned long long)delta, expectedDelta);
+        return 0;
+      }
+    } else {
+      emptyRounds = 0;
+    }
+    if ((round % 500u) == 0)
+      SRE_printf("[FIXED-NEAR-HOT][core=%u] waiting %s compiles=%llu/%llu "
+                 "pending=%u\n",
+                 core, phase, (unsigned long long)stats.asyncCompiles,
+                 (unsigned long long)target, pending);
+    (void)SRE_TaskDelay(FIXED_NEAR_HOT_WAIT_TICKS);
+  }
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL %s timeout\n", core, phase);
+  return 0;
+}
+
+static int validate_pool_stats(const ejit_code_pool_stats_v2_t *stats,
+                               uint32_t core) {
+  int failures = 0;
+  for (uint32_t pool = 0; pool < FIXED_NEAR_HOT_POOL_COUNT; ++pool) {
+    const ejit_code_pool_stats_t *detail = &stats->nearHot[pool];
+    const uint32_t required =
+        pool == FIXED_NEAR_HOT_CELL_COUNT ? 1u : FIXED_NEAR_HOT_FUNCTION_COUNT;
+    if (detail->usedBytes == 0 || detail->reservedBytes < detail->usedBytes ||
+        detail->finalizedRangeCount < required ||
+        detail->sealInvocations == 0) {
+      SRE_printf(
+          "[FIXED-NEAR-HOT][core=%u] FAIL pool=%u used=%llu reserved=%llu "
+          "finalized=%llu/%u seals=%llu\n",
+          core, pool, (unsigned long long)detail->usedBytes,
+          (unsigned long long)detail->reservedBytes,
+          (unsigned long long)detail->finalizedRangeCount, required,
+          (unsigned long long)detail->sealInvocations);
+      ++failures;
+    }
+  }
+  if (stats->far.usedBytes == 0 || stats->far.finalizedRangeCount == 0) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL far T1 pool used=%llu "
+               "finalized=%llu\n",
+               core, (unsigned long long)stats->far.usedBytes,
+               (unsigned long long)stats->far.finalizedRangeCount);
+    ++failures;
+  }
+  // The public v2 C ABI intentionally exposes counters only. The paired
+  // ejit_print_code_pool_stats() call below prints each detailed [base,end),
+  // pending/finalized/full/fallback record for alignment and overlap review.
+  return failures == 0;
+}
+
+static void print_layout_summary(const ejit_code_pool_stats_v2_t *stats,
+                                 uint32_t core) {
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] layout summary: pool=versions "
+             "exec_bytes pool_span tail_padding density_permille\n",
+             core);
+  for (uint32_t pool = 0; pool < FIXED_NEAR_HOT_POOL_COUNT; ++pool) {
+    const ejit_code_pool_stats_t *detail = &stats->nearHot[pool];
+    const uint64_t padding = detail->reservedBytes > detail->usedBytes
+                                 ? detail->reservedBytes - detail->usedBytes
+                                 : 0;
+    const uint64_t density =
+        detail->reservedBytes
+            ? (detail->usedBytes * 1000u) / detail->reservedBytes
+            : 0;
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] layout pool=%s%u versions=%llu "
+               "exec_bytes=%llu pool_span=%llu tail_padding=%llu "
+               "density=%llu/1000\n",
+               core, pool == FIXED_NEAR_HOT_CELL_COUNT ? "public" : "cell",
+               pool, (unsigned long long)detail->finalizedRangeCount,
+               (unsigned long long)detail->usedBytes,
+               (unsigned long long)detail->reservedBytes,
+               (unsigned long long)padding, (unsigned long long)density);
+  }
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] exact first/last address, span, "
+             "4K gaps, fallback and failedPoolBitmap are in runtime "
+             "range/compiled summaries above; counter-only ABI fields do not "
+             "infer those values.\n",
+             core);
+}
+
+static int run_producer(void) {
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  if (__atomic_load_n(&g_fixed_near_hot_stage, __ATOMIC_ACQUIRE) !=
+      FIXED_NEAR_HOT_WORKER_READY) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL run core %u first\n", core,
+               FIXED_NEAR_HOT_WORKER_CORE);
+    return -2;
+  }
+
+  for (uint32_t cell = 0; cell < FIXED_NEAR_HOT_CELL_COUNT; ++cell) {
+    if (ejit_activate("cell", cell) != EJIT_OK) {
+      SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL activate cell=%u\n", core,
+                 cell);
+      return -3;
+    }
+  }
+  ejit_clear_cache();
+
+  ejit_taskpool_stats_t initialStats = {0};
+  if (ejit_taskpool_get_stats(&initialStats) != EJIT_OK) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL initial stats\n", core);
+    return -4;
+  }
+  const uint64_t compileBaseline = initialStats.asyncCompiles;
+  uint64_t sink = 0;
+
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] PGO profile batches=%u/%u "
+             "configured_batch=%u effective_batch=%u samples=%u/function "
+             "identity_count=%u (cell-major; public-isolated)\n",
+             core, FIXED_NEAR_HOT_BATCH_COUNT, FIXED_NEAR_HOT_BATCH_COUNT,
+             FIXED_NEAR_HOT_PROFILE_BATCH, FIXED_NEAR_HOT_BATCH_WIDTH,
+             FIXED_NEAR_HOT_T1_SAMPLES, FIXED_NEAR_HOT_IDENTITY_COUNT);
+  for (uint32_t batch = 0; batch < FIXED_NEAR_HOT_BATCH_COUNT; ++batch) {
+    const uint32_t first =
+        batch < FIXED_NEAR_HOT_SPECIALIZATION_BATCH_COUNT
+            ? batch * FIXED_NEAR_HOT_BATCH_WIDTH
+            : FIXED_NEAR_HOT_SPECIALIZATION_COUNT;
+    const uint32_t end =
+        batch < FIXED_NEAR_HOT_SPECIALIZATION_BATCH_COUNT
+            ? (first + FIXED_NEAR_HOT_BATCH_WIDTH <
+                       FIXED_NEAR_HOT_SPECIALIZATION_COUNT
+                   ? first + FIXED_NEAR_HOT_BATCH_WIDTH
+                   : FIXED_NEAR_HOT_SPECIALIZATION_COUNT)
+            : FIXED_NEAR_HOT_IDENTITY_COUNT;
+    const uint32_t batchSize = end - first;
+    ejit_taskpool_stats_t beforeBatch = {0};
+    if (ejit_taskpool_get_stats(&beforeBatch) != EJIT_OK) {
+      SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL batch stats\n", core);
+      return -5;
+    }
+    print_batch_schedule(batch + 1u, first, end);
+
+    // The first call for each identity is expected to use AOT and enqueue T1.
+    // Waiting for the batch to drain before sampling prevents AOT fallback
+    // calls from being mistaken for real Tier-1 samples.
+    for (uint32_t identity = first; identity < end; ++identity) {
+      const uint32_t seed = 0x10000u + identity * 0x100u;
+      const uint32_t got = call_fixed_near_hot_identity(identity, seed);
+      const uint32_t expected =
+          expected_fixed_near_hot_identity(identity, seed);
+      if (got != expected) {
+        SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL identity=%u got=%u "
+                   "expected=%u\n",
+                   core, identity, got, expected);
+        return -6;
+      }
+      sink ^= got;
+    }
+    if (!wait_for_compile_target(beforeBatch.asyncCompiles,
+                                 beforeBatch.asyncCompiles + batchSize,
+                                 batchSize, batch + 1u, core, "T1"))
+      return -7;
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] batch=%u/%u T1 ready "
+               "identities=%u/%u\n",
+               core, batch + 1u, FIXED_NEAR_HOT_BATCH_COUNT, end,
+               FIXED_NEAR_HOT_IDENTITY_COUNT);
+
+    for (uint32_t sample = 0; sample < FIXED_NEAR_HOT_T1_SAMPLES; ++sample) {
+      for (uint32_t identity = first; identity < end; ++identity) {
+        const uint32_t seed = 0x10000u + identity * 0x100u + sample + 1u;
+        const uint32_t got = call_fixed_near_hot_identity(identity, seed);
+        const uint32_t expected =
+            expected_fixed_near_hot_identity(identity, seed);
+        if (got != expected) {
+          SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL identity=%u "
+                     "sample=%u got=%u expected=%u\n",
+                     core, identity, sample + 1u, got, expected);
+          return -8;
+        }
+        sink ^= got;
+      }
+      if (sample == 0 || ((sample + 1u) % 16u) == 0)
+        SRE_printf("[FIXED-NEAR-HOT][core=%u] batch=%u/%u sample=%u/%u "
+                   "identities=%u/%u\n",
+                   core, batch + 1u, FIXED_NEAR_HOT_BATCH_COUNT, sample + 1u,
+                   FIXED_NEAR_HOT_T1_SAMPLES, end,
+                   FIXED_NEAR_HOT_IDENTITY_COUNT);
+      if (((sample + 1u) % 8u) == 0)
+        (void)SRE_TaskDelay(1u);
+    }
+
+    ejit_taskpool_stats_t afterSamples = {0};
+    if (ejit_taskpool_get_stats(&afterSamples) != EJIT_OK) {
+      SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL sample stats\n", core);
+      return -9;
+    }
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] batch=%u/%u sample complete; "
+               "T2 pending observation=%u queue=%u (best effort; it may "
+               "already have flushed)\n",
+               core, batch + 1u, FIXED_NEAR_HOT_BATCH_COUNT,
+               ejit_taskpool_pending_count(), afterSamples.queueApproxSize);
+    if (!wait_for_compile_target(beforeBatch.asyncCompiles,
+                                 beforeBatch.asyncCompiles + 2u * batchSize,
+                                 2u * batchSize, batch + 1u, core, "T2")) {
+      ejit_taskpool_print_stats();
+      return -10;
+    }
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] batch=%u/%u T2 finalized "
+               "identities=%u/%u\n",
+               core, batch + 1u, FIXED_NEAR_HOT_BATCH_COUNT, end,
+               FIXED_NEAR_HOT_IDENTITY_COUNT);
+  }
+
+  ejit_code_pool_stats_v2_t stats = {0};
+  ejit_taskpool_stats_t finalTaskStats = {0};
+  if (ejit_taskpool_get_stats(&finalTaskStats) != EJIT_OK ||
+      finalTaskStats.compileFailed || finalTaskStats.publishFailed ||
+      finalTaskStats.asyncCompiles <
+          compileBaseline + FIXED_NEAR_HOT_IDENTITY_COUNT * 2u ||
+      finalTaskStats.readyEntries < FIXED_NEAR_HOT_IDENTITY_COUNT ||
+      ejit_taskpool_pending_count() != 0 ||
+      ejit_get_code_pool_stats_v2(&stats) != EJIT_OK ||
+      !validate_pool_stats(&stats, core)) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL pool validation\n", core);
+    ejit_print_code_pool_stats();
+    ejit_taskpool_print_stats();
+    return -11;
+  }
+  __atomic_store_n(&g_fixed_near_hot_sink, sink, __ATOMIC_RELEASE);
+  __atomic_store_n(&g_fixed_near_hot_stage, FIXED_NEAR_HOT_PUBLISHED,
+                   __ATOMIC_RELEASE);
+  ejit_set_log_level(EJIT_LOG_VERBOSE);
+  ejit_print_code_pool_stats();
+  ejit_taskpool_print_compiled();
+  print_layout_summary(&stats, core);
+  SRE_printf(
+      "[FIXED-NEAR-HOT][core=%u] PASS producer: T2=%u cell "
+      "specializations + public; T1 far used; batches=%u/%u "
+      "compiled_delta=%llu expected_min=%u pending=0 "
+      "compileFailed=0 publishFailed=0 fallback=0 and "
+      "failedPoolBitmap=0 must be confirmed in runtime summary; run "
+      "test_ejit_fixed_near_hot_print on core %u\n",
+      core, FIXED_NEAR_HOT_SPECIALIZATION_COUNT, FIXED_NEAR_HOT_BATCH_COUNT,
+      FIXED_NEAR_HOT_BATCH_COUNT,
+      (unsigned long long)(finalTaskStats.asyncCompiles - compileBaseline),
+      FIXED_NEAR_HOT_IDENTITY_COUNT * 2u, FIXED_NEAR_HOT_WORKER_CORE);
+  return 0;
+}
+
+static int run_worker(void) {
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  if (__atomic_load_n(&g_fixed_near_hot_stage, __ATOMIC_ACQUIRE) ==
+      FIXED_NEAR_HOT_RESET) {
+    for (uint32_t cell = 0; cell < FIXED_NEAR_HOT_CELL_COUNT; ++cell) {
+      g_fixed_near_hot_config[cell].multiplier = 10u + cell;
+      g_fixed_near_hot_config[cell].bias = 0x1000u + cell;
+    }
+    __atomic_store_n(&g_fixed_near_hot_sink, 0u, __ATOMIC_RELEASE);
+    __atomic_store_n(&g_fixed_near_hot_stage, FIXED_NEAR_HOT_WORKER_READY,
+                     __ATOMIC_RELEASE);
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] PASS fixed worker ready; run "
+               "test_ejit_period on core %u\n",
+               core, FIXED_NEAR_HOT_PRODUCER_CORE);
+    return 0;
+  }
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] worker already ready stage=%u\n", core,
+             __atomic_load_n(&g_fixed_near_hot_stage, __ATOMIC_ACQUIRE));
+  return 0;
+}
+
+int test_ejit_fixed_near_hot_print(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  if (core != FIXED_NEAR_HOT_WORKER_CORE) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL print must run on worker %u\n",
+               core, FIXED_NEAR_HOT_WORKER_CORE);
+    return -8;
+  }
+  if (__atomic_load_n(&g_fixed_near_hot_stage, __ATOMIC_ACQUIRE) <
+      FIXED_NEAR_HOT_PUBLISHED) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL producer has not published\n",
+               core);
+    return -9;
+  }
+  ejit_code_pool_stats_v2_t stats = {0};
+  if (ejit_get_code_pool_stats_v2(&stats) != EJIT_OK ||
+      !validate_pool_stats(&stats, core)) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL worker pool validation\n", core);
+    return -10;
+  }
+  ejit_taskpool_stats_t taskStats = {0};
+  if (ejit_taskpool_get_stats(&taskStats) != EJIT_OK ||
+      taskStats.compileFailed || taskStats.publishFailed ||
+      taskStats.pendingEntries != 0 || ejit_taskpool_pending_count() != 0) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL final taskpool state\n", core);
+    ejit_taskpool_print_stats();
+    return -11;
+  }
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] === 17 POOLS / COMPILED ===\n", core);
+  ejit_set_log_level(EJIT_LOG_VERBOSE);
+  ejit_taskpool_print_stats();
+  ejit_print_code_pool_stats();
+  ejit_taskpool_print_compiled();
+  print_layout_summary(&stats, core);
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] PASS worker: pending=0 finalized=17 "
+             "failedPoolBitmap=0 (see worker flush summary) sink=0x%llx\n",
+             core,
+             (unsigned long long)__atomic_load_n(&g_fixed_near_hot_sink,
+                                                 __ATOMIC_ACQUIRE));
+  __atomic_store_n(&g_fixed_near_hot_stage, FIXED_NEAR_HOT_PRINTED,
+                   __ATOMIC_RELEASE);
+  return 0;
+}
+
+int test_ejit_period(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  SRE_printf("\n=== EJIT fixed near-hot 17-pool demo (core=%u) ===\n", core);
+  call_init_array_functions();
+
+  ejit_config_t config = {0};
+  config.compileMode = EJIT_COMPILE_ASYNC;
+  config.optLevel = EJIT_OPT_L2;
+  config.enableLogger = true;
+  config.forceStaticRegistry = true;
+  const ejit_status_t rc = ejit_init_pgo(&config);
+  const uint32_t worker = ejit_taskpool_get_worker_core();
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] init rc=%d worker=%u stage=%u\n", core,
+             (int)rc, worker,
+             __atomic_load_n(&g_fixed_near_hot_stage, __ATOMIC_ACQUIRE));
+  if (rc != EJIT_OK || worker != FIXED_NEAR_HOT_WORKER_CORE) {
+    SRE_printf("[FIXED-NEAR-HOT][core=%u] FAIL init/worker expected=%u\n", core,
+               FIXED_NEAR_HOT_WORKER_CORE);
+    return -1;
+  }
+  if (core == FIXED_NEAR_HOT_WORKER_CORE)
+    return run_worker();
+  if (core == FIXED_NEAR_HOT_PRODUCER_CORE)
+    return run_producer();
+  SRE_printf("[FIXED-NEAR-HOT][core=%u] skip: use cores %u and %u\n", core,
+             FIXED_NEAR_HOT_WORKER_CORE, FIXED_NEAR_HOT_PRODUCER_CORE);
+  return 0;
+}

--- a/jit_design_doc/EJIT_FIXED_NEAR_HOT_POOLS.md
+++ b/jit_design_doc/EJIT_FIXED_NEAR_HOT_POOLS.md
@@ -1,0 +1,81 @@
+# Fixed Near-Hot Code Pools
+
+This opt-in layout is the alternative to the old cross-function batch sorter.
+It does not stage LLVM object files and it does not sort after JITLink. Every
+non-Tier-1 allocation is linked immediately into its semantic pool; only the
+RW/NX to RX transition and cache publication wait for a quiet queue.
+
+## Layout
+
+The default near-hot pool capacity is 36 MiB:
+
+* `cell[0]` through `cell[15]`: one 2 MiB, 2 MiB-aligned pool each;
+* no `periodName == "cell"`: one 4 MiB public pool;
+* Tier-1 instrumentation: the existing dynamic far pool.
+
+The example linker script reserves 38 MiB: 36 MiB of usable pools plus up to
+2 MiB of start-alignment slack.
+
+`EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES` and
+`EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES` are CMake cache variables and matching
+compile-time macros. Both must be positive multiples of the 2 MiB split
+granule. A custom value also requires a linker script `.text.ejit` reservation
+of at least `16 * cellBytes + publicBytes`, plus any alignment slack.
+
+Pool selection is made before `addIRModule`: the compile context carries the
+verified lifecycle metadata and the selected pool ID is associated with the
+exact internally-created JITDylib. The JITLink memory manager looks up that
+exact JITDylib metadata; it never parses a function name or guesses from an
+address. A missing, duplicate, malformed, or out-of-range `cell` declaration
+returns the compile to AOT. The complete absence of `cell` is valid and maps
+to public.
+
+## Publication
+
+ORC/JITLink allocates and fixes up near code while its pool remains RW/NX.
+Pending ranges are owner-private and are not returned by the finalized range
+query, so no cache, inline-cache cell, or shared `fnPtr` can observe them.
+After two empty worker observations, or an explicit
+`ejit_publish_pending_code`, the owner commits each pool independently:
+
+1. seal that pool's pending 4 KiB pages with `enable_ex`;
+2. verify the ranges are finalized and publish only that pool's cache entries;
+3. leave failed pool ranges available for an explicit pool retry (or terminate
+   the request with AOT fallback according to the failure contract) while
+   other pools remain published.
+
+An enable or cache-publication failure does not cause an idle-worker retry
+loop. Diagnostics include a 17-bit failed-pool bitmap. The linked bytes are bounded by
+`EJIT_CODE_POOL_FIXED_NEAR_HOT_PENDING_LIMIT` (256 by default, above the
+expected approximately 150-version batch). At capacity, the owner attempts a
+controlled flush; if that fails, new results fall back to AOT. Under the
+current NO_RECLAIM contract, linked bytes from a failed allocation may be
+reported as stranded and are not claimed to have been physically reclaimed.
+
+The legacy `pendingBatchCompiles_` dimension comparator and enqueue watermark
+are disabled for this layout. Baseline and PGO Tier-2 use the same near pool
+and publication rules; Tier-1 keeps its immediate far-pool route and existing
+throttle/delay behavior. Executable split sections such as `.text.ejit_cold`
+remain in the selected JITDylib and its semantic cell/public pool; this change
+does not introduce a separate MFS or cold pool. Diagnostics report the flush
+reason (`idle`,
+`explicit`, `capacity`, or `shutdown`) and per-pool usage/seal counters.
+Shutdown drops unpublished owner-private entries according to the existing
+shutdown contract.
+
+## Platform contract and tests
+
+The fixed region must be reserved and mapped by the platform. In code-segment
+mode, every allocation page transitions RX to RW through `enable_rw` before
+JITLink writes. Executable pages return RW to RX through `enable_ex` at commit;
+data/GOT pages intentionally remain non-executable and writable as required by
+the existing split-segment contract.
+`split_2m_to_4k` is performed independently for each pool. A pool never spills
+into another cell or into public; exhaustion is an AOT fallback.
+
+Host tests use injected alloc/seal/split callbacks and the real JITLink memory
+manager layout/finalize path. Target validation must additionally exercise
+interleaved cell requests, no-cell requests, malformed metadata, per-pool
+failure, explicit retry, generation/shutdown cleanup, and 20 or more (ideally
+150) linked versions. Physical page compactness is a platform result; the
+tests distinguish semantic pool/address ordering from page-level layout.

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -753,6 +753,45 @@ if(EJIT_SRE_CODE_POOL AND EJIT_FIXED_CODE_POOL)
                  "(size is __ejit_code_end - __ejit_code_start from the linker script's .text.ejit block)")
 endif()
 
+# Alternative to the old single near pool: reserve 16 fixed 2MiB cell slices
+# plus one fixed 4MiB no-cell/public slice (36MiB total). This is intentionally
+# opt-in until a product linker script reserves the larger .text.ejit region.
+option(EJIT_CODE_POOL_FIXED_NEAR_HOT
+  "Use 16 fixed 2MiB cell near-hot pools plus one fixed 4MiB public pool" OFF)
+if(EJIT_CODE_POOL_FIXED_NEAR_HOT)
+  if(NOT EJIT_SRE_CODE_POOL OR NOT EJIT_CODE_POOL_4K_SEAL OR
+     NOT EJIT_FIXED_CODE_POOL OR NOT EJIT_CODE_POOL_BATCHED_PUBLISH)
+    message(FATAL_ERROR
+      "EJIT_CODE_POOL_FIXED_NEAR_HOT requires EJIT_SRE_CODE_POOL, "
+      "EJIT_CODE_POOL_4K_SEAL, EJIT_CODE_POOL_BATCHED_PUBLISH and "
+      "EJIT_FIXED_CODE_POOL")
+  endif()
+  set(EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES 2097152 CACHE STRING
+    "Bytes reserved for each fixed near-hot cell pool (must be 2MiB aligned)")
+  set(EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES 4194304 CACHE STRING
+    "Bytes reserved for the fixed near-hot no-cell/public pool (must be 2MiB aligned)")
+  ejit_require_numeric(EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES)
+  ejit_require_numeric(EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES)
+  if(EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES LESS 2097152 OR
+     EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES LESS 2097152)
+    message(FATAL_ERROR
+      "Fixed near-hot pool sizes must each be at least 2MiB")
+  endif()
+  math(EXPR _ejit_near_hot_cell_remainder
+    "${EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES} % 2097152")
+  math(EXPR _ejit_near_hot_public_remainder
+    "${EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES} % 2097152")
+  if(NOT _ejit_near_hot_cell_remainder EQUAL 0 OR
+     NOT _ejit_near_hot_public_remainder EQUAL 0)
+    message(FATAL_ERROR
+      "Fixed near-hot pool sizes must be multiples of the 2MiB split granule")
+  endif()
+  math(EXPR _ejit_near_hot_region_bytes
+    "16 * ${EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES} + ${EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES}")
+  message(STATUS
+    "EmbeddedJIT: fixed near-hot layout enabled (16x${EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES}B cell + ${EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES}B public = ${_ejit_near_hot_region_bytes}B)")
+endif()
+
 #===-- EmbeddedJIT per-function inline cache (multi-version) -------------===#
 # EJIT_ICACHE_DIM_SIZE: the per-dimension bound D of the per-function
 # @__ejit_icache_fn_<name> [D]^numDims inline-cache array. MUST be a power of 2

--- a/llvm/CMakePresets.json
+++ b/llvm/CMakePresets.json
@@ -80,6 +80,7 @@
         "EJIT_SRE_CODE_POOL": "ON",
         "EJIT_SRE_CODE_POOL_PTNO": "8",
         "EJIT_FIXED_CODE_POOL": "ON",
+        "EJIT_CODE_POOL_FIXED_NEAR_HOT": "ON",
         "EJIT_SRE_TASKPOOL": "ON",
         "EJIT_SRE_SHARED_TASKPOOL": "ON",
         "EJIT_SRE_TASKPOOL_NO_RECLAIM": "ON",

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -117,6 +117,11 @@ public:
   struct Options {
     /// Diagnostic placement class propagated with finalized code ranges.
     EJitCodePoolKind kind = EJitCodePoolKind::Unknown;
+    /// Stable semantic pool id propagated with finalized code ranges. For a
+    /// single-manager pool this is normally 0..16 for near-hot pools or
+    /// kEJitFarPoolId for the temporary Tier-1 pool. The manager adds its
+    /// local pool index to this base id when a manager owns multiple pools.
+    uint32_t poolId = 0;
     /// Usable bytes per pool (EJIT_SRE_CODE_POOL_SIZE). Default 2MiB. In 4K
     /// seal mode this is rounded up to a multiple of poolAlign.
     size_t poolSize = static_cast<size_t>(2) * 1024 * 1024;
@@ -171,6 +176,15 @@ public:
                                     ///< (per 4K page, code-segment mode only)
     size_t finalizedRangeCount = 0; ///< distinct executable ranges recorded
                                     ///< (duplicates are not double-counted)
+    /// Envelope of the manager's pool addresses. For a fixed near-hot manager
+    /// this is exactly one semantic pool; for a dynamic manager it is only a
+    /// diagnostic envelope and may contain gaps.
+    uint64_t baseAddress = 0;
+    uint64_t endAddress = 0;
+    size_t pendingBytes = 0; ///< linked but not yet RX bytes
+    size_t pendingRangeCount = 0;
+    size_t fallbackCount = 0; ///< allocation failures that forced fallback
+    bool full = false;        ///< fixed region exhausted
   };
 
   EJitCodePoolManager(Options Opts, RawAllocFn Alloc, SealFn Seal,
@@ -244,6 +258,8 @@ public:
 
   bool usesBatchedPageSeal() const { return Opts_.batchedPageSeal; }
   size_t codeAlignment() const { return Opts_.minCodeAlign; }
+  uint32_t poolId() const { return Opts_.poolId; }
+  EJitCodePoolKind poolKind() const { return Opts_.kind; }
 
   /// Stage a fully linked executable range without making it callable yet.
   /// All staged ranges are sealed and promoted atomically as one publication
@@ -301,6 +317,15 @@ public:
   /// take a clean fallback and never publish a shared pointer with no range.
   bool findRange(const void *Ptr, EJitCompiledCodeInfo &Out) const;
 
+  /// Resolve a linked but not yet sealed allocation. This is owner-private
+  /// metadata only; callers must not expose the returned pointer until
+  /// isRangeReady() is true.
+  bool findPendingRange(const void *Ptr, EJitCompiledCodeInfo &Out) const;
+
+  /// True only after a pending range has been promoted by
+  /// flushPendingRanges(). This remains false while the linked code is RW/NX.
+  bool isRangeReady(const void *Ptr) const;
+
   /// True if `Ptr` falls inside the usable range of any owned pool.
   bool contains(const void *Ptr) const;
 
@@ -325,6 +350,8 @@ private:
   size_t SealInvocations_ = 0;
   size_t SplitInvocations_ = 0;
   size_t RwEnableInvocations_ = 0;
+  size_t AllocationFailureCount_ = 0;
+  bool FixedRegionFull_ = false;
   /// Bump cursor (bytes consumed) over the fixed region [fixedBase, fixedBase +
   /// fixedSize) when Options::fixedSize > 0; unused in dynamic-allocation mode.
   size_t FixedUsed_ = 0;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.h
@@ -26,6 +26,8 @@
 
 #include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
+#include <functional>
+#include <vector>
 
 namespace llvm {
 namespace ejit {
@@ -35,9 +37,18 @@ namespace ejit {
 /// the pool manager). The referenced pool manager must outlive this object.
 class EJitCodePoolMemoryManager : public jitlink::JITLinkMemoryManager {
 public:
+  /// The selector is supplied by EJitOrcEngine and is keyed by an internally
+  /// created JITDylib. It returns nullptr for missing/corrupt metadata, which
+  /// makes allocation fail instead of silently placing code in another pool.
+  using PoolSelector =
+      std::function<EJitCodePoolManager *(const jitlink::JITLinkDylib *)>;
+
   EJitCodePoolMemoryManager(EJitCodePoolManager &Pool, size_t PageSize);
   EJitCodePoolMemoryManager(EJitCodePoolManager &NearPool,
                             EJitCodePoolManager &FarPool, size_t PageSize);
+  EJitCodePoolMemoryManager(std::vector<EJitCodePoolManager *> NearPools,
+                            EJitCodePoolManager &FarPool, size_t PageSize,
+                            PoolSelector Selector);
 
   void allocate(const jitlink::JITLinkDylib *JD, jitlink::LinkGraph &G,
                 OnAllocatedFunction OnAllocated) override;
@@ -49,16 +60,18 @@ public:
   using JITLinkMemoryManager::allocate;
   using JITLinkMemoryManager::deallocate;
 
-  EJitCodePoolManager &getPool() { return NearPool_; }
+  EJitCodePoolManager &getPool() { return *NearPool_; }
 
 private:
   class InFlightAllocImpl;
   struct FinalizedInfo;
 
-  EJitCodePoolManager &selectPool(const jitlink::JITLinkDylib *JD) const;
+  EJitCodePoolManager *selectPool(const jitlink::JITLinkDylib *JD) const;
 
-  EJitCodePoolManager &NearPool_;
+  EJitCodePoolManager *NearPool_ = nullptr;
+  std::vector<EJitCodePoolManager *> NearPools_;
   EJitCodePoolManager *FarPool_ = nullptr;
+  PoolSelector Selector_;
   size_t PageSize_;
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
@@ -38,6 +38,15 @@ enum class EJitCodePoolKind : uint32_t {
   Far = 2,
 };
 
+/// Stable near-hot pool ids. IDs 0..15 are semantic cell pools and 16 is the
+/// legal no-cell public pool. They are deliberately independent of a manager's
+/// local pool index so the id can cross the ORC, taskpool and shared-cache
+/// boundaries without relying on an address or a JITDylib name.
+constexpr uint32_t kEJitNearHotCellPoolCount = 16u;
+constexpr uint32_t kEJitNearHotPublicPoolId = kEJitNearHotCellPoolCount;
+constexpr uint32_t kEJitNearHotPoolCount = kEJitNearHotPublicPoolId + 1u;
+constexpr uint32_t kEJitFarPoolId = kEJitNearHotPoolCount;
+
 /// Maximum number of runtime-writable ranges carried with one finalized
 /// compilation. A finalized allocation normally has a single writable data
 /// segment (the Tier-1 __profc_ counters); the small fixed bound leaves head

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -10,6 +10,7 @@
 #define LLVM_EXECUTIONENGINE_EJIT_EJITORCENGINE_H
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCodeRange.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/EJIT/EJitProfileMerge.h"
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT
@@ -17,6 +18,7 @@
 #endif
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/Support/Error.h"
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -34,6 +36,7 @@ namespace ejit {
 struct EJitTieredCodePoolStats {
   EJitCodePoolManager::Stats total;
   EJitCodePoolManager::Stats near;
+  std::array<EJitCodePoolManager::Stats, kEJitNearHotPoolCount> nearHot;
   EJitCodePoolManager::Stats far;
 };
 #endif
@@ -98,6 +101,10 @@ struct SpecializationContext {
   struct DimInfo {
     std::string periodName;
     uint8_t cellIdx;
+    /// The lifecycle slot read from registration metadata. The invalid
+    /// sentinel is retained so fixed near-hot routing can reject malformed
+    /// metadata instead of silently placing it in the public pool.
+    uint32_t dimType = 0xFFFFFFFFu;
   };
   SmallVector<DimInfo, 4> dimensions;
   uint32_t boundArgIndex = 0;
@@ -143,7 +150,8 @@ public:
   /// by cacheKey. Each specialization gets its own JITDylib so symbols
   /// from the same TU bitcode can be defined multiple times without conflict.
   Error loadBitcodeModule(StringRef bitcodeData, uint64_t cacheKey,
-                          const std::string &origFnName);
+                          const std::string &origFnName,
+                          uint32_t poolId = kEJitNearHotPublicPoolId);
 
   /// Look up a compiled function symbol in the specialization JITDylib
   /// identified by cacheKey.
@@ -197,8 +205,9 @@ public:
   /// preparation). Returns false if \p FnPtr is not pool-backed code with a
   /// recorded finalized range. Available only with EJIT_SRE_CODE_POOL.
   bool findCodeRange(const void *FnPtr, EJitCompiledCodeInfo &Out) const;
+  bool findPendingCodeRange(const void *FnPtr, EJitCompiledCodeInfo &Out) const;
   bool isCodeReady(const void *FnPtr) const;
-  Error flushPendingCode();
+  Error flushPendingCode(uint32_t poolId = 0xFFFFFFFFu);
 #endif
 
 private:

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitRuntime.h
@@ -144,6 +144,8 @@ typedef struct ejit_code_pool_stats_t {
 typedef struct ejit_code_pool_stats_v2_t {
   ejit_code_pool_stats_t total;
   ejit_code_pool_stats_t near;
+  /// Entry 0..15 is cell[0..15]; entry 16 is the legal no-cell public pool.
+  ejit_code_pool_stats_t nearHot[17];
   ejit_code_pool_stats_t far;
 } ejit_code_pool_stats_v2_t;
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -111,7 +111,9 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// (codeSize - fnSize) without owner-private lookups. Purely diagnostic; a peer
 /// core never uses it for sealing or enable_rw. 0 means no symbol metadata was
 /// recorded (print_compiled reports fn_size=0, overhead=codeSize).
-constexpr uint32_t kEJitSharedAbiVersion = 18u;
+/// v19: the owner-published pool mirror carries the 16 cell + public near-hot
+/// pool details and pool ids are stable across separate managers.
+constexpr uint32_t kEJitSharedAbiVersion = 19u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -358,6 +358,9 @@ public:
   /// address resolvable through CodeRangeCallback.
   using CodeReadyCallback = bool (*)(void *ctx, const void *fnPtr);
   using CodeBatchFlushCallback = bool (*)(void *ctx);
+  /// Flush one semantic near-hot pool. A failed pool remains pending/retryable
+  /// without preventing other pools from committing their own code.
+  using CodeBatchFlushPoolCallback = bool (*)(void *ctx, uint32_t poolId);
   /// Per-core platform primitive: split a 2MiB-aligned [poolBase, poolBase +
   /// poolSize) window into 4KiB mappings in the CALLING core's translation
   /// context (split_2m_to_4k). Returns true on success. Used only in 4K
@@ -620,6 +623,11 @@ public:
     codeReadyFn_ = ready;
     codeBatchFlushFn_ = flush;
     codeBatchCtx_ = ctx;
+  }
+  void setCodeBatchPoolFlushCallback(CodeBatchFlushPoolCallback flush,
+                                     void *ctx) {
+    codeBatchFlushPoolFn_ = flush;
+    codeBatchFlushPoolCtx_ = ctx;
   }
   /// Read the shared code-pool stats mirror (last owner-published snapshot).
   /// Returns false if the shared state is not bound. Every core sees the same
@@ -1087,10 +1095,17 @@ public:
   uint32_t pendingCount() const;
   /// Owner-side explicit flush for deterministic tests. Production callers use
   /// requestCodeBatchFlushAndWait() so enable_ex runs on the owner worker.
-  bool flushCodeBatch() { return flushPendingPublishes(); }
+  bool flushCodeBatch() {
+    autoTier2PublishBlocked_ = false;
+    return flushPendingPublishes();
+  }
   size_t pendingPublishCount() const { return pendingPublishes_.size(); }
   size_t pendingBatchCompileCount() const {
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+    return 0;
+#else
     return pendingBatchCompiles_.size();
+#endif
   }
 
   /// Ask the owner worker to seal every completed code range and publish its
@@ -1319,8 +1334,11 @@ private:
   /// §4.9).
   void runCompile(const EJitCompileRequest &req,
                   bool hasBatchRequestMarker = false);
+#ifndef EJIT_CODE_POOL_FIXED_NEAR_HOT
   void compilePendingBatchRequests();
-  bool flushPendingPublishes(bool compileBatchRequests = true);
+#endif
+  bool flushPendingPublishes(bool compileBatchRequests = true,
+                             const char *reason = "explicit");
   bool serviceCodeBatchRequest();
   bool serviceAutoTier2Publish();
 
@@ -1354,6 +1372,8 @@ private:
   CodeReadyCallback codeReadyFn_ = nullptr;
   CodeBatchFlushCallback codeBatchFlushFn_ = nullptr;
   void *codeBatchCtx_ = nullptr;
+  CodeBatchFlushPoolCallback codeBatchFlushPoolFn_ = nullptr;
+  void *codeBatchFlushPoolCtx_ = nullptr;
   SplitPoolCallback splitPoolFn_ = nullptr;
   void *splitPoolCtx_ = nullptr;
   SealPageCallback sealPageFn_ = nullptr;
@@ -1385,16 +1405,23 @@ private:
   struct PendingPublish {
     EJitCompileRequest req{};
     void *fn = nullptr;
+    uint32_t poolId = 0xFFFFFFFFu;
   };
+#ifndef EJIT_CODE_POOL_FIXED_NEAR_HOT
   struct PendingBatchCompile {
     EJitCompileRequest req{};
     bool hasSharedMarker = false;
   };
   std::vector<PendingBatchCompile> pendingBatchCompiles_;
+#endif
   std::vector<PendingPublish> pendingPublishes_;
   /// Armed when Tier-2 links into the near RW/NX pool. Consumed only after the
   /// owner worker observes the shared compile queue empty.
   bool autoTier2PublishPending_ = false;
+  uint32_t autoTier2IdleTicks_ = 0;
+  /// A failed per-pool seal/publish must wait for an explicit retry. Keeping
+  /// this separate from pending state avoids retrying every idle worker tick.
+  bool autoTier2PublishBlocked_ = false;
   // Inline-cache safety gate: true while the cache is safe to use (no releaser
   // wired - the production default). v2 does no HP-scan retire, so a wired
   // releaser (code may be freed) + the cache = UAF; the gate then auto-disables

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -628,7 +628,31 @@ public:
                                      void *ctx) {
     codeBatchFlushPoolFn_ = flush;
     codeBatchFlushPoolCtx_ = ctx;
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+    codeBatchFlushPoolExpectedFn_ = flush;
+    codeBatchFlushPoolExpectedCtx_ = ctx;
+    codeBatchFlushPoolCanary_ = makeCodeBatchFlushCanary(flush, ctx);
+    codeBatchFlushPoolLayoutTag_ =
+        makeCodeBatchFlushLayoutTag(this);
+#endif
   }
+  /// Owner-only diagnostic for fixed near-hot pool callback wiring.
+  void diagnoseCodeBatchCallbacks(const char *reason,
+                                  const void *ownerCtx) const;
+#ifdef EJIT_SRE_TASKPOOL_TESTING
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  /// Test-only corruption hook: leaves the registered expected values intact.
+  void corruptCodeBatchPoolCallbackForTest(CodeBatchFlushPoolCallback flush,
+                                           void *ctx) {
+    codeBatchFlushPoolFn_ = flush;
+    codeBatchFlushPoolCtx_ = ctx;
+  }
+  /// Test-only corruption hook for the cross-TU layout guard.
+  void corruptCodeBatchPoolLayoutTagForTest(uint64_t tag) {
+    codeBatchFlushPoolLayoutTag_ = tag;
+  }
+#endif
+#endif
   /// Read the shared code-pool stats mirror (last owner-published snapshot).
   /// Returns false if the shared state is not bound. Every core sees the same
   /// values. Use this for ejit_get/print_code_pool_stats in shared builds.
@@ -1342,6 +1366,60 @@ private:
   bool serviceCodeBatchRequest();
   bool serviceAutoTier2Publish();
 
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  static uint32_t codeBatchFlushPoolFeatureMask() {
+    uint32_t Mask = 1u; // EJIT_CODE_POOL_FIXED_NEAR_HOT
+#ifdef EJIT_CODE_POOL_4K_SEAL
+    Mask |= 1u << 1;
+#endif
+#ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
+    Mask |= 1u << 2;
+#endif
+#ifdef EJIT_FIXED_CODE_POOL
+    Mask |= 1u << 3;
+#endif
+#ifdef EJIT_SRE_SHARED_TASKPOOL
+    Mask |= 1u << 4;
+#endif
+#ifdef EJIT_SRE_SHARED_CODE_POINTERS
+    Mask |= 1u << 5;
+#endif
+    return Mask;
+  }
+  static uint64_t makeCodeBatchFlushLayoutTag(
+      const EJitSharedTaskPool *Self) {
+    const uintptr_t Base = reinterpret_cast<uintptr_t>(Self);
+    uint64_t Tag = 0xcbf29ce484222325ULL;
+    auto Mix = [&Tag](uint64_t Value) {
+      Tag ^= Value + 0x9e3779b97f4a7c15ULL + (Tag << 6) + (Tag >> 2);
+    };
+    Mix(sizeof(EJitSharedTaskPool));
+    Mix(reinterpret_cast<uintptr_t>(&Self->codeBatchFlushPoolFn_) - Base);
+    Mix(reinterpret_cast<uintptr_t>(&Self->codeBatchFlushPoolCtx_) - Base);
+    Mix(reinterpret_cast<uintptr_t>(&Self->codeBatchFlushPoolExpectedFn_) -
+        Base);
+    Mix(reinterpret_cast<uintptr_t>(&Self->codeBatchFlushPoolExpectedCtx_) -
+        Base);
+    Mix(reinterpret_cast<uintptr_t>(&Self->codeBatchFlushPoolCanary_) - Base);
+    Mix(reinterpret_cast<uintptr_t>(&Self->codeBatchFlushPoolLayoutTag_) -
+        Base);
+    Mix(reinterpret_cast<uintptr_t>(&Self->splitPoolFn_) - Base);
+    Mix(reinterpret_cast<uintptr_t>(&Self->splitPoolCtx_) - Base);
+    Mix(codeBatchFlushPoolFeatureMask());
+    return Tag;
+  }
+  static uint64_t makeCodeBatchFlushCanary(CodeBatchFlushPoolCallback fn,
+                                           void *ctx) {
+    const uint64_t F =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(fn));
+    const uint64_t C =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ctx));
+    const uint64_t RotC = (C << 17) | (C >> 47);
+    return F ^ RotC ^ UINT64_C(0x6e656172686f7431);
+  }
+  bool codeBatchFlushPoolCallbacksIntact() const;
+#endif
+
   /// Release staged-PGO ownership if \p funcIndex still owns it. Tier-2
   /// completion and terminal worker failures call this; transient queue-full
   /// leaves ownership intact so the next hit can retry.
@@ -1374,6 +1452,11 @@ private:
   void *codeBatchCtx_ = nullptr;
   CodeBatchFlushPoolCallback codeBatchFlushPoolFn_ = nullptr;
   void *codeBatchFlushPoolCtx_ = nullptr;
+  [[maybe_unused]] CodeBatchFlushPoolCallback codeBatchFlushPoolExpectedFn_ =
+      nullptr;
+  [[maybe_unused]] void *codeBatchFlushPoolExpectedCtx_ = nullptr;
+  [[maybe_unused]] uint64_t codeBatchFlushPoolCanary_ = 0;
+  [[maybe_unused]] uint64_t codeBatchFlushPoolLayoutTag_ = 0;
   SplitPoolCallback splitPoolFn_ = nullptr;
   void *splitPoolCtx_ = nullptr;
   SealPageCallback sealPageFn_ = nullptr;
@@ -1398,6 +1481,8 @@ private:
   EJitCompileMode configuredMode_ = EJitCompileMode::Async;
   bool codeSharingEnabled_ = false;
   bool isOwner_ = false;
+  [[maybe_unused]] bool nearHotFirstLinkedDiagnosed_ = false;
+  [[maybe_unused]] bool nearHotFirstFlushDiagnosed_ = false;
 #ifdef EJIT_SRE_TASKPOOL_TESTING
   IcacheFillMidpointHook icacheFillMidpointHook_ = nullptr;
   void *icacheFillMidpointCtx_ = nullptr;
@@ -1407,13 +1492,11 @@ private:
     void *fn = nullptr;
     uint32_t poolId = 0xFFFFFFFFu;
   };
-#ifndef EJIT_CODE_POOL_FIXED_NEAR_HOT
   struct PendingBatchCompile {
     EJitCompileRequest req{};
     bool hasSharedMarker = false;
   };
   std::vector<PendingBatchCompile> pendingBatchCompiles_;
-#endif
   std::vector<PendingPublish> pendingPublishes_;
   /// Armed when Tier-2 links into the near RW/NX pool. Consumed only after the
   /// owner worker observes the shared compile queue empty.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -58,6 +58,12 @@
 #ifndef EJIT_SRE_TASKPOOL_QUEUE_CAPACITY
 #define EJIT_SRE_TASKPOOL_QUEUE_CAPACITY 1024u
 #endif
+#ifndef EJIT_CODE_POOL_FIXED_NEAR_HOT_PENDING_LIMIT
+/// Bound owner-private linked near-hot results while producers are active. The
+/// product batch is approximately 150 versions; a larger bound leaves room
+/// for retries without making the vector an unbounded memory sink.
+#define EJIT_CODE_POOL_FIXED_NEAR_HOT_PENDING_LIMIT 256u
+#endif
 #ifndef EJIT_SRE_PGO_MAX_CONCURRENT_PROFILES
 #define EJIT_SRE_PGO_MAX_CONCURRENT_PROFILES 1u
 #endif
@@ -72,7 +78,7 @@
 // once full, a peer hitting an untracked pool cleanly falls back rather than
 // risking an unbounded table or a duplicate split entry.
 #ifndef EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS
-#define EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS 16u
+#define EJIT_SRE_SHARED_TASKPOOL_POOL_SLOTS 32u
 #endif
 #ifndef EJIT_SRE_SHARED_DUMP_NAME_BYTES
 #define EJIT_SRE_SHARED_DUMP_NAME_BYTES 128u
@@ -390,7 +396,17 @@ struct EJitSharedCodePoolStats {
     EJitAtomicU64 sealInvocations;
     EJitAtomicU64 splitInvocations;
     EJitAtomicU64 finalizedRangeCount;
+    EJitAtomicU64 baseAddress;
+    EJitAtomicU64 endAddress;
+    EJitAtomicU64 pendingBytes;
+    EJitAtomicU64 pendingRangeCount;
+    EJitAtomicU64 fallbackCount;
+    EJitAtomicU32 full;
   } near, far;
+  /// Per semantic near-hot pool detail. Entry 0..15 is cell[0..15], entry 16
+  /// is the legal no-cell public pool. This is diagnostic cold state and is
+  /// not read on the dispatch hit path.
+  Detail nearHot[kEJitNearHotPoolCount];
 };
 
 /// Plain (non-atomic) snapshot of code-pool stats, used as the callback
@@ -408,6 +424,12 @@ struct EJitCodePoolStatsOut {
     uint64_t sealInvocations = 0;
     uint64_t splitInvocations = 0;
     uint64_t finalizedRangeCount = 0;
+    uint64_t baseAddress = 0;
+    uint64_t endAddress = 0;
+    uint64_t pendingBytes = 0;
+    uint64_t pendingRangeCount = 0;
+    uint64_t fallbackCount = 0;
+    uint32_t full = 0;
   };
   uint64_t poolCount = 0;
   uint64_t sealedCount = 0;
@@ -419,6 +441,7 @@ struct EJitCodePoolStatsOut {
   uint64_t splitInvocations = 0;
   uint64_t finalizedRangeCount = 0;
   Detail near;
+  Detail nearHot[kEJitNearHotPoolCount];
   Detail far;
 };
 

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSrePlatform.h
@@ -28,10 +28,19 @@ enum class EJitCodePoolPlacement { NearFixed, FarDynamic };
 
 /// Construct an EJitCodePoolManager wired to the SRE platform: raw memory from
 /// SRE_MemDbgAlloc (partition EJIT_SRE_CODE_POOL_PTNO) and sealing via
-/// enable_ex. On a host without real SRE symbols, weak fallbacks make this a
-/// link-safe no-op-seal / aligned-host-alloc manager (see EJitSrePlatform.cpp).
+/// enable_ex. The final SRE link environment must provide the platform
+/// allocation, split, permission, and cache symbols; missing symbols are a
+/// link-time configuration error (see EJitSrePlatform.cpp).
 std::unique_ptr<EJitCodePoolManager> makeSreCodePoolManager(
-    EJitCodePoolPlacement Placement = EJitCodePoolPlacement::NearFixed);
+    EJitCodePoolPlacement Placement = EJitCodePoolPlacement::NearFixed,
+    uint32_t PoolId = 0, uintptr_t FixedBase = 0, size_t FixedSize = 0);
+
+/// Construct one of the fixed near-hot pools. Cell ids 0..15 map to a 2MiB
+/// slice and kEJitNearHotPublicPoolId maps to the 4MiB no-cell slice. Returns
+/// nullptr when the linker-reserved region cannot hold the complete 36MiB
+/// layout; callers must then use the AOT fallback rather than spill pools.
+std::unique_ptr<EJitCodePoolManager>
+makeSreNearHotCodePoolManager(uint32_t PoolId);
 
 /// Install execute permission for the legacy 2MiB code pool containing
 /// \p FnPtr in the calling core's translation context. This is intentionally a

--- a/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/lib/ExecutionEngine/EJIT/CMakeLists.txt
@@ -252,6 +252,13 @@ if(EJIT_SRE_CODE_POOL AND EJIT_FIXED_CODE_POOL)
   target_compile_definitions(LLVMEJIT PRIVATE EJIT_FIXED_CODE_POOL)
 endif()
 
+if(EJIT_CODE_POOL_FIXED_NEAR_HOT)
+  target_compile_definitions(LLVMEJIT PRIVATE
+    EJIT_CODE_POOL_FIXED_NEAR_HOT
+    EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES=${EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES}
+    EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES=${EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES})
+endif()
+
 # EJIT_ICACHE_DIM_SIZE: per-dim bound D of the multi-version inline cache.
 # Used by icacheFill/icacheTry linearization in EJitSharedTaskPool. Must match
 # the AOT -mllvm -print-ejit-icache-dim-size value (both from the top-level CMake

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -966,6 +966,8 @@ bool EJit::getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const {
       Total.finalizedRangeCount = s.finalizedRangeCount;
       CopyShared(out->total, Total);
       CopyShared(out->near, s.near);
+      for (size_t I = 0; I < 17; ++I)
+        CopyShared(out->nearHot[I], s.nearHot[I]);
       CopyShared(out->far, s.far);
       return true;
     }
@@ -980,6 +982,8 @@ bool EJit::getCodePoolStatsV2(ejit_code_pool_stats_v2_t *out) const {
   EJitTieredCodePoolStats s = engine->getTieredCodePoolStats();
   CopyManager(out->total, s.total);
   CopyManager(out->near, s.near);
+  for (size_t I = 0; I < s.nearHot.size(); ++I)
+    CopyManager(out->nearHot[I], s.nearHot[I]);
   CopyManager(out->far, s.far);
   return true;
 #else
@@ -1015,6 +1019,38 @@ void EJit::printCodePoolStats() const {
   };
   PrintOne("total", s.total);
   PrintOne("near(final)", s.near);
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  for (unsigned I = 0; I < 16; ++I)
+    PrintOne((std::string("near(cell") + std::to_string(I) + ")").c_str(),
+             s.nearHot[I]);
+  PrintOne("near(public)", s.nearHot[16]);
+  // The versioned public stats shape intentionally keeps the old aggregate
+  // fields. The shared diagnostic mirror carries the fixed-pool geometry and
+  // pending state needed to distinguish an RW/NX allocation from published
+  // RX code.
+  EJitCodePoolStatsOut detailed{};
+  if (const EJitSharedTaskPool *sp = sharedTaskPool()) {
+    if (sp->readCodePoolStats(&detailed)) {
+      auto PrintDetail = [](const char *Kind,
+                            const EJitCodePoolStatsOut::Detail &D) {
+        EJIT_DIAG_RAW("  %s range=[0x%llx,0x%llx) pendingBytes=%llu "
+                      "pendingRanges=%llu finalized=%llu full=%u fallback=%llu",
+                      Kind, (unsigned long long)D.baseAddress,
+                      (unsigned long long)D.endAddress,
+                      (unsigned long long)D.pendingBytes,
+                      (unsigned long long)D.pendingRangeCount,
+                      (unsigned long long)D.finalizedRangeCount,
+                      static_cast<unsigned>(D.full),
+                      (unsigned long long)D.fallbackCount);
+      };
+      for (unsigned I = 0; I < 16; ++I)
+        PrintDetail(
+            (std::string("near(cell") + std::to_string(I) + ")").c_str(),
+            detailed.nearHot[I]);
+      PrintDetail("near(public)", detailed.nearHot[16]);
+    }
+  }
+#endif
   PrintOne("far(tier1)", s.far);
 #else
   EJIT_DIAG_RAW("code pool: EJIT_SRE_CODE_POOL not enabled");

--- a/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJit.cpp
@@ -78,6 +78,14 @@ EJit::EJit(const Config &config) : config_(config) {
 #endif
   compileDriver_ = std::make_unique<EJitCompileDriver>(
       config_, *runtimeState_, *moduleLoader_, logger);
+#if defined(EJIT_SRE_SHARED_TASKPOOL) && defined(EJIT_CODE_POOL_FIXED_NEAR_HOT)
+  EJIT_DIAG("EJit allocation view driver=%p driverSize=%zu sharedPool=%p "
+            "sharedPoolSize=%zu",
+            static_cast<void *>(compileDriver_.get()),
+            sizeof(EJitCompileDriver),
+            static_cast<void *>(compileDriver_->sharedTaskPool()),
+            sizeof(EJitSharedTaskPool));
+#endif
 
   // Consume registration data from the staging store (constructor path).
   StoredData data = EJitRegistrationStore::instance().consume();

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -117,7 +117,10 @@ Error EJitCodePoolManager::newActivePoolLocked() {
     // fixed-address guarantee (the specialization falls back to AOT instead).
     uintptr_t RegionEnd = Opts_.fixedBase + Opts_.fixedSize;
     uintptr_t Next = alignUpAddr(Opts_.fixedBase + FixedUsed_, Opts_.poolAlign);
-    if (Next + Opts_.poolSize > RegionEnd) {
+    if (RegionEnd < Opts_.fixedBase || Next < Opts_.fixedBase ||
+        Next + Opts_.poolSize < Next || Next + Opts_.poolSize > RegionEnd) {
+      ++AllocationFailureCount_;
+      FixedRegionFull_ = true;
       EJIT_DIAG("newActivePool FAIL: fixed region exhausted next=0x%llx +%zu > "
                 "end=0x%llx (used=%zu of %zu)",
                 static_cast<unsigned long long>(Next), Opts_.poolSize,
@@ -769,8 +772,9 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
 #endif
   uintptr_t A = addr(Ptr);
 
-  // The pointer must resolve to a real, recorded executable allocation — never
-  // a guessed extent. Find the finalized range that contains it.
+  // The pointer must resolve to a real, finalized executable allocation —
+  // never a guessed extent. Pending ranges have a separate owner-private
+  // query below so the public range contract remains "ready".
   const FinalizedRange *Found = nullptr;
   for (const FinalizedRange &R : FinalizedRanges_) {
     if (A >= R.start && A < R.start + R.size) {
@@ -815,7 +819,7 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
       }
       Out.poolBase = B;
       Out.poolSize = static_cast<uint64_t>(P.size);
-      Out.poolId = static_cast<uint32_t>(I);
+      Out.poolId = Opts_.poolId + static_cast<uint32_t>(I);
       // Runtime-writable extents of this allocation (e.g. __profc_): a peer
       // core enable_rw's exactly these before executing. Copied by value.
       Out.writableCount = Found->writableCount;
@@ -844,6 +848,53 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
   return false;
 }
 
+bool EJitCodePoolManager::findPendingRange(const void *Ptr,
+                                           EJitCompiledCodeInfo &Out) const {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  const uintptr_t A = addr(Ptr);
+  const FinalizedRange *Found = nullptr;
+  for (const FinalizedRange &R : PendingRanges_)
+    if (A >= R.start && A < R.start + R.size) {
+      Found = &R;
+      break;
+    }
+  if (!Found)
+    return false;
+  for (size_t I = 0; I < Pools_.size(); ++I) {
+    const CodePool &P = *Pools_[I];
+    const uintptr_t B = addr(P.base);
+    if (A < B || A >= B + P.size)
+      continue;
+    Out.fnPtr = const_cast<void *>(Ptr);
+    Out.codeStart = Found->start;
+    Out.codeSize = Found->size;
+    Out.poolBase = B;
+    Out.poolSize = static_cast<uint64_t>(P.size);
+    Out.poolId = Opts_.poolId + static_cast<uint32_t>(I);
+    Out.writableCount = Found->writableCount;
+    for (uint32_t W = 0; W < kEJitMaxWritableRanges; ++W)
+      Out.writableRanges[W] =
+          W < Found->writableCount ? Found->writables[W] : EJitWritableRange{};
+    Out.requiresPeerEnableRw = Opts_.needsEnableRw ? 1u : 0u;
+    Out.poolKind = Opts_.kind;
+    return true;
+  }
+  return false;
+}
+
+bool EJitCodePoolManager::isRangeReady(const void *Ptr) const {
+#ifndef EJIT_FREESTANDING
+  std::lock_guard<std::mutex> Lock(Mutex_);
+#endif
+  const uintptr_t A = addr(Ptr);
+  for (const FinalizedRange &R : FinalizedRanges_)
+    if (A >= R.start && A < R.start + R.size)
+      return true;
+  return false;
+}
+
 EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
 #ifndef EJIT_FREESTANDING
   std::lock_guard<std::mutex> Lock(Mutex_);
@@ -854,6 +905,16 @@ EJitCodePoolManager::Stats EJitCodePoolManager::getStats() const {
   S.splitInvocations = SplitInvocations_;
   S.rwEnableInvocations = RwEnableInvocations_;
   S.finalizedRangeCount = FinalizedRanges_.size();
+  S.pendingRangeCount = PendingRanges_.size();
+  S.fallbackCount = AllocationFailureCount_;
+  S.full = FixedRegionFull_;
+  if (!Pools_.empty()) {
+    S.baseAddress = addr(Pools_.front()->base);
+    const CodePool &Last = *Pools_.back();
+    S.endAddress = addr(Last.base) + Last.size;
+  }
+  for (const FinalizedRange &R : PendingRanges_)
+    S.pendingBytes += static_cast<size_t>(R.size);
   for (auto &P : Pools_) {
     S.reservedBytes += P->size;
     S.usedBytes += P->used;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -782,10 +782,8 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
       break;
     }
   }
-  if (!Found) {
-    EJIT_DIAG_DEBUG("findRange miss: ptr=%p not in any finalized range", Ptr);
+  if (!Found)
     return false;
-  }
 
   // The allocation must also belong to a known pool (so a peer learns the
   // 2MiB split granule). An address resolved outside the pools (e.g. a

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -184,23 +184,47 @@ private:
 
 EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(EJitCodePoolManager &Pool,
                                                      size_t PageSize)
-    : NearPool_(Pool), PageSize_(PageSize) {}
+    : NearPool_(&Pool), NearPools_{&Pool}, PageSize_(PageSize) {}
 
 EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(
     EJitCodePoolManager &NearPool, EJitCodePoolManager &FarPool,
     size_t PageSize)
-    : NearPool_(NearPool), FarPool_(&FarPool), PageSize_(PageSize) {}
+    : NearPool_(&NearPool), NearPools_{&NearPool}, FarPool_(&FarPool),
+      PageSize_(PageSize) {}
 
-EJitCodePoolManager &EJitCodePoolMemoryManager::selectPool(
-    const JITLinkDylib *JD) const {
+EJitCodePoolMemoryManager::EJitCodePoolMemoryManager(
+    std::vector<EJitCodePoolManager *> NearPools, EJitCodePoolManager &FarPool,
+    size_t PageSize, PoolSelector Selector)
+    : NearPool_(NearPools.empty() ? nullptr : NearPools.front()),
+      NearPools_(std::move(NearPools)), FarPool_(&FarPool),
+      Selector_(std::move(Selector)), PageSize_(PageSize) {}
+
+EJitCodePoolManager *
+EJitCodePoolMemoryManager::selectPool(const JITLinkDylib *JD) const {
+  if (Selector_) {
+    if (EJitCodePoolManager *Pool = Selector_(JD))
+      return Pool;
+    EJIT_DIAG("selectPool: missing controlled JITDylib metadata name=%s",
+              JD ? JD->getName().c_str() : "<null>");
+    return nullptr;
+  }
   if (FarPool_ && JD && StringRef(JD->getName()).starts_with("spec_t1_"))
-    return *FarPool_;
+    return FarPool_;
+  if (!NearPools_.empty())
+    return NearPools_.front();
   return NearPool_;
 }
 
 void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
                                          OnAllocatedFunction OnAllocated) {
-  EJitCodePoolManager &Pool = selectPool(JD);
+  EJitCodePoolManager *SelectedPool = selectPool(JD);
+  if (!SelectedPool) {
+    OnAllocated(make_error<StringError>(
+        "EJitCodePool: missing controlled pool metadata",
+        inconvertibleErrorCode()));
+    return;
+  }
+  EJitCodePoolManager &Pool = *SelectedPool;
 
   // Fold pure read-only sections (string constants, const arrays, jump
   // tables) into the executable segment BEFORE the layout is built.
@@ -271,7 +295,7 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   }
 
   uint64_t Total = SegsSizes->total();
-  const char *Placement = FarPool_ == &Pool ? "far" : "near";
+  [[maybe_unused]] const char *Placement = FarPool_ == &Pool ? "far" : "near";
   EJIT_DIAG_DEBUG(
       "allocate: graph=%s pool=%s total=%llu layoutAlign=%zu compact=%u",
       G.getName().c_str(), Placement, static_cast<unsigned long long>(Total),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -354,6 +354,7 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
 #ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
   sharedPool_.setCodeBatchPoolFlushCallback(&sharedCodeBatchFlushPoolThunk,
                                             this);
+  sharedPool_.diagnoseCodeBatchCallbacks("registered", this);
 #endif
 #endif
 #endif
@@ -436,6 +437,7 @@ bool EJitCompileDriver::startSharedTaskPool() {
   switch (r) {
   case EJitSharedTaskPool::InitResult::BecameOwner:
     EJIT_DIAG("shared taskpool init: became owner");
+    sharedPool_.diagnoseCodeBatchCallbacks("owner-ready", this);
     return true;
   case EJitSharedTaskPool::InitResult::AttachedReady:
     EJIT_DIAG("shared taskpool init: attached ready");

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -30,6 +30,33 @@
 using namespace llvm;
 using namespace llvm::ejit;
 
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+namespace {
+bool selectNearHotPool(const SpecializationContext &Ctx, uint32_t &PoolId) {
+  bool HasCell = false;
+  uint8_t Cell = 0;
+  for (const auto &Dim : Ctx.dimensions) {
+    if (Dim.periodName.empty() || Dim.dimType == 0xFFFFFFFFu)
+      return false;
+    if (Dim.periodName != "cell")
+      continue;
+    if (HasCell)
+      return false;
+    HasCell = true;
+    Cell = Dim.cellIdx;
+  }
+  if (!HasCell) {
+    PoolId = kEJitNearHotPublicPoolId;
+    return true;
+  }
+  if (Cell >= kEJitNearHotCellPoolCount)
+    return false;
+  PoolId = Cell;
+  return true;
+}
+} // namespace
+#endif
+
 #ifdef EJIT_SRE_TASKPOOL
 namespace {
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
@@ -87,7 +114,8 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
   auto *drv = static_cast<EJitCompileDriver *>(ctx);
   EJitOrcEngine *eng = drv->getJitEngine();
   if (eng && outInfo)
-    return eng->findCodeRange(fnPtr, *outInfo);
+    return eng->findCodeRange(fnPtr, *outInfo) ||
+           eng->findPendingCodeRange(fnPtr, *outInfo);
   return false;
 #else
   (void)ctx;
@@ -126,6 +154,26 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
 #endif
 }
 
+[[maybe_unused]] bool sharedCodeBatchFlushPoolThunk(void *ctx,
+                                                    uint32_t poolId) {
+#if defined(EJIT_SRE_CODE_POOL) && defined(EJIT_CODE_POOL_BATCHED_PUBLISH)
+  auto *drv = static_cast<EJitCompileDriver *>(ctx);
+  EJitOrcEngine *eng = drv->getJitEngine();
+  if (!eng)
+    return false;
+  if (auto Err = eng->flushPendingCode(poolId)) {
+    EJIT_DIAG("near-hot pool flush failed pool=%u: %s", poolId,
+              toString(std::move(Err)).c_str());
+    return false;
+  }
+  return true;
+#else
+  (void)ctx;
+  (void)poolId;
+  return true;
+#endif
+}
+
 /// Owner-private provider: snapshot the owner-core code-pool manager stats for
 /// the shared taskpool to mirror cross-core (see CodePoolStatsCallback). The
 /// pools are owner-private, so without this a non-owner core's
@@ -158,8 +206,16 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
       Dst.sealInvocations = Src.sealInvocations;
       Dst.splitInvocations = Src.splitInvocations;
       Dst.finalizedRangeCount = Src.finalizedRangeCount;
+      Dst.baseAddress = Src.baseAddress;
+      Dst.endAddress = Src.endAddress;
+      Dst.pendingBytes = Src.pendingBytes;
+      Dst.pendingRangeCount = Src.pendingRangeCount;
+      Dst.fallbackCount = Src.fallbackCount;
+      Dst.full = Src.full ? 1u : 0u;
     };
     CopyDetail(out->near, tiered.near);
+    for (size_t I = 0; I < tiered.nearHot.size(); ++I)
+      CopyDetail(out->nearHot[I], tiered.nearHot[I]);
     CopyDetail(out->far, tiered.far);
     return true;
   }
@@ -295,6 +351,10 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
 #ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
   sharedPool_.setCodeBatchCallbacks(&sharedCodeReadyThunk,
                                     &sharedCodeBatchFlushThunk, this);
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  sharedPool_.setCodeBatchPoolFlushCallback(&sharedCodeBatchFlushPoolThunk,
+                                            this);
+#endif
 #endif
 #endif
 #ifdef EJIT_SRE_SHARED_CODE_POINTERS
@@ -532,7 +592,7 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
   ctx.cacheKey = cacheKey;
   ctx.optLevel = config_.optLevel;
   for (unsigned i = 0; i < dimCount; ++i)
-    ctx.dimensions.push_back({periodNames[i], dims[i]});
+    ctx.dimensions.push_back({periodNames[i], dims[i], meta.dimTypes[i]});
   if (request && request->boundSize) {
     if (request->boundSize > EJIT_BOUND_PTR_MAX_BYTES) {
       EJIT_DIAG("compile FAIL key=0x%016lx func=%s: bound snapshot too large",
@@ -672,6 +732,17 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
     }
   }
 
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  uint32_t PoolId = kEJitNearHotPublicPoolId;
+  if (ctx.tier == CompileTier::Instrumented)
+    PoolId = kEJitFarPoolId;
+  else if (!selectNearHotPool(ctx, PoolId)) {
+    EJIT_DIAG("compile SKIP key=0x%016lx func=%s: invalid cell metadata",
+              cacheKey, funcName.c_str());
+    return nullptr;
+  }
+#endif
+
   if (!jitEngine_) {
     EJIT_DIAG("compile FAIL key=0x%016lx func=%s: no sync engine", cacheKey,
               funcName.c_str());
@@ -685,7 +756,13 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
 
   jitEngine_->setActiveContext(&ctx);
 
-  if (auto Err = jitEngine_->loadBitcodeModule(bitcode, cacheKey, funcName)) {
+  if (auto Err = jitEngine_->loadBitcodeModule(bitcode, cacheKey, funcName,
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+                                               PoolId
+#else
+                                               kEJitNearHotPublicPoolId
+#endif
+                                               )) {
     jitEngine_->setActiveContext(nullptr);
     EJIT_DIAG("compile FAIL key=0x%016lx func=%s: load bitcode module failed",
               cacheKey, funcName.c_str());

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -28,6 +28,7 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include <array>
 #include <cstdlib>
 #include <cstring>
 #include <map>
@@ -165,7 +166,12 @@ struct EJitOrcEngine::Impl {
   /// Tier-1 code uses the previous dynamic SRE allocation path. Both outlive
   /// LLJIT and its routing memory manager.
   std::unique_ptr<EJitCodePoolManager> nearCodePool;
+  std::array<std::unique_ptr<EJitCodePoolManager>, kEJitNearHotPoolCount>
+      nearHotCodePools;
   std::unique_ptr<EJitCodePoolManager> farCodePool;
+  /// Controlled allocation metadata. The key is the exact name of a
+  /// JITDylib created by loadBitcodeModule; the MemoryManager never parses it.
+  std::map<std::string, EJitCodePoolManager *> specPoolByDylib;
 #endif
   std::unique_ptr<orc::LLJIT> J;
   PeriodArrayRegistry *periodReg = nullptr;
@@ -760,11 +766,46 @@ EJitOrcEngine::Create(const Config &config, PeriodArrayRegistry &periodReg,
   // engine (so it outlives the LLJIT); the object linking layer owns a memory
   // manager that references it. Pages are kept RW here and sealed to RX later,
   // at lookup time, by the pool manager's enable_ex sealing.
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  for (uint32_t I = 0; I < kEJitNearHotPoolCount; ++I) {
+    engine->P->nearHotCodePools[I] = makeSreNearHotCodePoolManager(I);
+    if (!engine->P->nearHotCodePools[I]) {
+      return make_error<StringError>(
+          "EJitOrcEngine: fixed near-hot pool layout unavailable",
+          inconvertibleErrorCode());
+    }
+  }
+#else
   engine->P->nearCodePool =
       makeSreCodePoolManager(EJitCodePoolPlacement::NearFixed);
+#endif
   engine->P->farCodePool =
-      makeSreCodePoolManager(EJitCodePoolPlacement::FarDynamic);
+      makeSreCodePoolManager(EJitCodePoolPlacement::FarDynamic, kEJitFarPoolId);
   {
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+    std::vector<EJitCodePoolManager *> NearPools;
+    NearPools.reserve(kEJitNearHotPoolCount);
+    for (auto &Pool : engine->P->nearHotCodePools)
+      NearPools.push_back(Pool.get());
+    auto *FarPool = engine->P->farCodePool.get();
+    auto Selector =
+        [State = engine->P.get()](
+            const jitlink::JITLinkDylib *JD) -> EJitCodePoolManager * {
+      if (!JD)
+        return nullptr;
+      auto It = State->specPoolByDylib.find(JD->getName());
+      return It == State->specPoolByDylib.end() ? nullptr : It->second;
+    };
+    Builder.setObjectLinkingLayerCreator(
+        [NearPools = std::move(NearPools), FarPool,
+         Selector](orc::ExecutionSession &ES)
+            -> Expected<std::unique_ptr<orc::ObjectLayer>> {
+          constexpr size_t JitPageSize = 4096;
+          return std::make_unique<orc::ObjectLinkingLayer>(
+              ES, std::make_unique<EJitCodePoolMemoryManager>(
+                      NearPools, *FarPool, JitPageSize, Selector));
+        });
+#else
     EJitCodePoolManager *NearPool = engine->P->nearCodePool.get();
     EJitCodePoolManager *FarPool = engine->P->farCodePool.get();
     Builder.setObjectLinkingLayerCreator(
@@ -778,6 +819,7 @@ EJitOrcEngine::Create(const Config &config, PeriodArrayRegistry &periodReg,
               ES, std::make_unique<EJitCodePoolMemoryManager>(
                       *NearPool, *FarPool, JitPageSize));
         });
+#endif
   }
 #endif
 
@@ -998,7 +1040,8 @@ EJitOrcEngine::Create(const Config &config, PeriodArrayRegistry &periodReg,
 }
 
 Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData, uint64_t cacheKey,
-                                       const std::string &origFnName) {
+                                       const std::string &origFnName,
+                                       uint32_t poolId) {
   EJIT_DIAG_VERBOSE("loadBitcode key=0x%016lx func=%s size=%zu", cacheKey,
                     origFnName.c_str(), bitcodeData.size());
   auto Ctx = std::make_unique<LLVMContext>();
@@ -1093,6 +1136,9 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData, uint64_t cacheKey,
   // would be needed for reclaimable memory managers (§5 JD lifecycle).
   auto it = P->specDylibs.find(cacheKey);
   if (it != P->specDylibs.end()) {
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+    P->specPoolByDylib.erase(it->second->getName());
+#endif
     if (auto Err = P->J->getExecutionSession().removeJITDylib(*it->second))
       EJIT_DIAG("loadBitcode key=0x%016lx: remove stale JD FAILED: %s",
                 cacheKey, toString(std::move(Err)).c_str());
@@ -1104,12 +1150,30 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData, uint64_t cacheKey,
           ? "t1"
           : P->activeCtx && P->activeCtx->tier == CompileTier::PGOUse ? "t2"
                                                                       : "base";
-  auto JDOrErr = P->J->createJITDylib("spec_" + std::string(TierTag) + "_" +
-                                      std::to_string(cacheKey));
+  std::string JDName =
+      "spec_" + std::string(TierTag) + "_" + std::to_string(cacheKey);
+  auto JDOrErr = P->J->createJITDylib(JDName);
   if (!JDOrErr) {
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: create JITDylib error", cacheKey);
     return JDOrErr.takeError();
   }
+
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  EJitCodePoolManager *SelectedPool = nullptr;
+  if (P->activeCtx && P->activeCtx->tier == CompileTier::Instrumented) {
+    if (P->farCodePool && poolId == kEJitFarPoolId)
+      SelectedPool = P->farCodePool.get();
+  } else if (poolId < kEJitNearHotPoolCount) {
+    SelectedPool = P->nearHotCodePools[poolId].get();
+  }
+  if (!SelectedPool) {
+    (void)P->J->getExecutionSession().removeJITDylib(*JDOrErr);
+    return make_error<StringError>(
+        "EJitOrcEngine: invalid or unavailable allocation pool",
+        inconvertibleErrorCode());
+  }
+  P->specPoolByDylib.emplace(JDName, SelectedPool);
+#endif
 
   // Resolve undefined function symbols from user-registered table.
   // Required for bare-metal where dynamic lookup (dlsym) is unavailable.
@@ -1197,6 +1261,12 @@ Error EJitOrcEngine::loadBitcodeModule(StringRef bitcodeData, uint64_t cacheKey,
           *JDOrErr,
           orc::ThreadSafeModule(std::move(*ModuleOrErr), std::move(Ctx)))) {
     EJIT_DIAG("loadBitcode FAIL key=0x%016lx: add IR module error", cacheKey);
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+    P->specPoolByDylib.erase(JDName);
+#endif
+    if (auto RemoveErr = P->J->getExecutionSession().removeJITDylib(*JDOrErr))
+      EJIT_DIAG("loadBitcode key=0x%016lx: remove failed JD FAILED: %s",
+                cacheKey, toString(std::move(RemoveErr)).c_str());
     return Err;
   }
 
@@ -1306,8 +1376,34 @@ EJitCodePoolManager::Stats EJitOrcEngine::getCodePoolStats() const {
 
 EJitTieredCodePoolStats EJitOrcEngine::getTieredCodePoolStats() const {
   EJitTieredCodePoolStats Out;
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  for (size_t I = 0; I < P->nearHotCodePools.size(); ++I) {
+    Out.nearHot[I] = P->nearHotCodePools[I]->getStats();
+    Out.near.poolCount += Out.nearHot[I].poolCount;
+    Out.near.sealedCount += Out.nearHot[I].sealedCount;
+    Out.near.activeCount += Out.nearHot[I].activeCount;
+    Out.near.usedBytes += Out.nearHot[I].usedBytes;
+    Out.near.reservedBytes += Out.nearHot[I].reservedBytes;
+    Out.near.wastedBytes += Out.nearHot[I].wastedBytes;
+    Out.near.sealInvocations += Out.nearHot[I].sealInvocations;
+    Out.near.splitInvocations += Out.nearHot[I].splitInvocations;
+    Out.near.rwEnableInvocations += Out.nearHot[I].rwEnableInvocations;
+    Out.near.finalizedRangeCount += Out.nearHot[I].finalizedRangeCount;
+    Out.near.pendingBytes += Out.nearHot[I].pendingBytes;
+    Out.near.pendingRangeCount += Out.nearHot[I].pendingRangeCount;
+    Out.near.fallbackCount += Out.nearHot[I].fallbackCount;
+    Out.near.full = Out.near.full || Out.nearHot[I].full;
+    if (Out.nearHot[I].baseAddress != 0 &&
+        (Out.near.baseAddress == 0 ||
+         Out.nearHot[I].baseAddress < Out.near.baseAddress))
+      Out.near.baseAddress = Out.nearHot[I].baseAddress;
+    if (Out.nearHot[I].endAddress > Out.near.endAddress)
+      Out.near.endAddress = Out.nearHot[I].endAddress;
+  }
+#else
   if (P->nearCodePool)
     Out.near = P->nearCodePool->getStats();
+#endif
   if (P->farCodePool)
     Out.far = P->farCodePool->getStats();
 #define EJIT_SUM_STAT(Field) Out.total.Field = Out.near.Field + Out.far.Field
@@ -1321,29 +1417,80 @@ EJitTieredCodePoolStats EJitOrcEngine::getTieredCodePoolStats() const {
   EJIT_SUM_STAT(splitInvocations);
   EJIT_SUM_STAT(rwEnableInvocations);
   EJIT_SUM_STAT(finalizedRangeCount);
+  Out.total.pendingBytes = Out.near.pendingBytes + Out.far.pendingBytes;
+  Out.total.pendingRangeCount =
+      Out.near.pendingRangeCount + Out.far.pendingRangeCount;
+  Out.total.fallbackCount = Out.near.fallbackCount + Out.far.fallbackCount;
+  Out.total.full = Out.near.full || Out.far.full;
+  Out.total.baseAddress =
+      Out.near.baseAddress != 0 ? Out.near.baseAddress : Out.far.baseAddress;
+  Out.total.endAddress = Out.far.endAddress > Out.near.endAddress
+                             ? Out.far.endAddress
+                             : Out.near.endAddress;
 #undef EJIT_SUM_STAT
   return Out;
 }
 
 bool EJitOrcEngine::findCodeRange(const void *FnPtr,
                                   EJitCompiledCodeInfo &Out) const {
-  if (!P->nearCodePool && !P->farCodePool) {
+  if (!P->nearCodePool && P->nearHotCodePools[0] == nullptr &&
+      !P->farCodePool) {
     EJIT_DIAG("findCodeRange FAIL: no code pool (fnPtr=%p)", FnPtr);
     return false;
   }
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  for (const auto &Pool : P->nearHotCodePools)
+    if (Pool && Pool->findRange(FnPtr, Out))
+      return true;
+#else
   if (P->nearCodePool && P->nearCodePool->findRange(FnPtr, Out))
     return true;
+#endif
   return P->farCodePool && P->farCodePool->findRange(FnPtr, Out);
 }
 
-bool EJitOrcEngine::isCodeReady(const void *FnPtr) const {
-  EJitCompiledCodeInfo Info{};
-  return findCodeRange(FnPtr, Info);
+bool EJitOrcEngine::findPendingCodeRange(const void *FnPtr,
+                                         EJitCompiledCodeInfo &Out) const {
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  for (const auto &Pool : P->nearHotCodePools)
+    if (Pool && Pool->findPendingRange(FnPtr, Out))
+      return true;
+#else
+  if (P->nearCodePool && P->nearCodePool->findPendingRange(FnPtr, Out))
+    return true;
+#endif
+  return P->farCodePool && P->farCodePool->findPendingRange(FnPtr, Out);
 }
 
-Error EJitOrcEngine::flushPendingCode() {
-  if (!P->nearCodePool)
-    return Error::success();
-  return P->nearCodePool->flushPendingRanges();
+bool EJitOrcEngine::isCodeReady(const void *FnPtr) const {
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  for (const auto &Pool : P->nearHotCodePools)
+    if (Pool && Pool->isRangeReady(FnPtr))
+      return true;
+#else
+  if (P->nearCodePool && P->nearCodePool->isRangeReady(FnPtr))
+    return true;
+#endif
+  return P->farCodePool && P->farCodePool->isRangeReady(FnPtr);
+}
+
+Error EJitOrcEngine::flushPendingCode(uint32_t poolId) {
+  Error Result = Error::success();
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  if (poolId != 0xFFFFFFFFu) {
+    if (poolId >= kEJitNearHotPoolCount || !P->nearHotCodePools[poolId])
+      return make_error<StringError>("EJitOrcEngine: invalid near-hot pool id",
+                                     inconvertibleErrorCode());
+    return P->nearHotCodePools[poolId]->flushPendingRanges();
+  }
+  for (auto &Pool : P->nearHotCodePools)
+    if (Pool)
+      Result = joinErrors(std::move(Result), Pool->flushPendingRanges());
+#else
+  (void)poolId;
+  if (P->nearCodePool)
+    Result = P->nearCodePool->flushPendingRanges();
+#endif
+  return Result;
 }
 #endif

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -28,7 +28,6 @@
 #include "llvm/ExecutionEngine/EJIT/EJitVpCollector.h"
 #endif
 #ifndef EJIT_FREESTANDING
-#include <algorithm>
 #include <chrono>
 #endif
 // ejit_print_version() falls back to std::printf when not routing through the
@@ -36,6 +35,7 @@
 #ifndef EJIT_SRE_DIAG
 #include <cstdio>
 #endif
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 #include <vector>
@@ -1758,26 +1758,15 @@ void ejit_taskpool_print_compiled() {
     uint32_t byTier[3];
     uint32_t byPool[3];
     uint32_t finalPostPublishSeen;
-    /// Per-slot code-extent samples for the sizes summary line. Collected in
-    /// the count pass, sorted by codeStart within each pool, then tallied:
-    /// fn_total = ΣfnSize, alloc_total = ΣcodeSize, pad_total = Σ(codeSize -
-    /// fnSize), and 16B_VIOLATIONS counts same-pool adjacent allocations whose
-    /// gap < 16 (the compact-layout precondition; compact graphs should be 0,
-    /// a non-zero value flags that task-1 16B alignment has not taken effect).
-    /// The gap uses codeStart (the allocation start), NOT fnPtr (the entry
-    /// symbol address, which may sit at a non-zero offset inside the
-    /// allocation) so the inter-allocation stride is measured correctly.
     struct Sample {
       uintptr_t codeStart;
       uint64_t codeSize;
       uint64_t fnSize;
       uint32_t poolKind;
+      uint32_t poolId;
     };
     std::vector<Sample> samples;
   } count = {{0}, {0}, {0}, 0, {}};
-  // Pre-reserve the upper bound (every slot Ready) so the count-pass callback
-  // never allocates while holding a per-bucket read lock (forEachCompiled
-  // calls cb between bucketTryRead/bucketReadRelease with no try/catch).
   count.samples.reserve(kEJitSharedCacheBuckets * kEJitSharedCacheSlots);
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
@@ -1795,13 +1784,9 @@ void ejit_taskpool_print_compiled() {
         if (tier != kEJitTierInstrumented &&
             slot.postPublishSeen.loadRelaxed() != 0)
           ++C->finalPostPublishSeen;
-        // Collect a sizes sample for the summary line. A shared_alloc slot
-        // (codeStart 0 / codeSize 0) carries no real allocation and is skipped
-        // so its zero extent cannot dilute the tallies.
-        uintptr_t cs0 = slot.codeStart;
-        uint64_t cs = slot.codeSize;
-        if (cs0 != 0 && cs != 0)
-          C->samples.push_back({cs0, cs, slot.fnSize, slot.poolKind});
+        if (slot.codeStart != 0 && slot.codeSize != 0)
+          C->samples.push_back({slot.codeStart, slot.codeSize, slot.fnSize,
+                                slot.poolKind, slot.poolId});
       },
       &count);
   // Summary line first (fixed line count, so no throttle): total, cache
@@ -1832,14 +1817,6 @@ void ejit_taskpool_print_compiled() {
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Near)],
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Far)],
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Unknown)]);
-  // Sizes summary: total function bytes vs total allocation bytes, plus a
-  // compact-precondition check. Sorted by fnPtr within each pool, adjacent
-  // same-pool allocations whose gap < 16 count as a 16B_VIOLATION (the
-  // compact layout's stride requirement; a compact graph should be 0, a
-  // non-zero value flags that task-1 16B alignment has not taken effect).
-  // 0 fnSize (no symbol metadata) contributes its full codeSize to padding so
-  // the totals still reconcile. Fixed line count, no throttle (matches the
-  // entries/tiers/pools summary style above).
   uint64_t fnTotal = 0, allocTotal = 0, padTotal = 0;
   uint32_t violations = 0;
   if (!count.samples.empty()) {
@@ -1847,24 +1824,21 @@ void ejit_taskpool_print_compiled() {
               [](const CountCtx::Sample &A, const CountCtx::Sample &B) {
                 if (A.poolKind != B.poolKind)
                   return A.poolKind < B.poolKind;
+                if (A.poolId != B.poolId)
+                  return A.poolId < B.poolId;
                 return A.codeStart < B.codeStart;
               });
     for (size_t I = 0; I < count.samples.size(); ++I) {
       const auto &S = count.samples[I];
       fnTotal += S.fnSize;
       allocTotal += S.codeSize;
-      padTotal += (S.fnSize <= S.codeSize) ? (S.codeSize - S.fnSize) : 0;
-      // Gap to the next same-pool sample: an executable pointer never resolves
-      // to a stale range (v1 append-only), so a later address in the same pool
-      // is a distinct later allocation; their gap is the inter-allocation
-      // stride the compact layout caps at 16. Measure on codeStart (the
-      // allocation start), not fnPtr (entry offset may be non-zero).
+      padTotal += S.fnSize <= S.codeSize ? S.codeSize - S.fnSize : 0;
       if (I + 1 < count.samples.size()) {
         const auto &N = count.samples[I + 1];
-        if (N.poolKind == S.poolKind && N.codeStart > S.codeStart) {
-          uint64_t Gap = N.codeStart - S.codeStart;
-          uint64_t Used = S.codeSize;
-          if (Gap > Used && (Gap - Used) < 16)
+        if (N.poolKind == S.poolKind && N.poolId == S.poolId &&
+            N.codeStart > S.codeStart) {
+          const uint64_t Gap = N.codeStart - S.codeStart;
+          if (Gap > S.codeSize && Gap - S.codeSize < 16)
             ++violations;
         }
       }
@@ -1890,98 +1864,169 @@ void ejit_taskpool_print_compiled() {
   constexpr bool ReuseTrackingEnabled = false;
   EJIT_DIAG_RAW("compiled reuse: disabled (build with EJIT_STATS_ENABLE)");
 #endif
-  // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
-  // each printed line.
-  struct PrintCtx {
-    EJitModuleLoader &loader;
-    bool reuseTrackingEnabled;
-  } printCtx{loader, ReuseTrackingEnabled};
+  // Collect before printing so diagnostics are ordered by the real resolved
+  // function address instead of cache-bucket order. This is cold-path storage
+  // only; the cache hit and dispatch paths do not allocate or sort.
+  struct CompiledRow {
+    uint32_t funcIndex = 0;
+    uint32_t numDims = 0;
+    uint32_t generation = 0;
+    uint32_t poolId = 0;
+    uint32_t poolKind = 0;
+    uint8_t tier = 0;
+    bool postPublishSeen = false;
+    uintptr_t address = 0;
+    uintptr_t codeStart = 0;
+    uint64_t codeSize = 0;
+    uint64_t fnSize = 0;
+    EJitDimPair dims[kEJitSharedMaxDims] = {};
+    uint32_t versions[kEJitSharedMaxDims] = {};
+  };
+  SmallVector<CompiledRow, 128> rows;
+  struct CollectCtx {
+    SmallVector<CompiledRow, 128> *rows;
+  } collectCtx{&rows};
   EJitSharedTaskPool::ForEachCompiledStats st2 = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
-        PrintCtx &ctx = *static_cast<PrintCtx *>(cbCtx);
-        EJitModuleLoader &ld = ctx.loader;
-        const std::string &name =
-            ld.getFuncNameByFuncIdx(slot.funcIndex);
-        // Per the publish protocol: fnPtr is read with acquire only after
-        // state==Ready was observed with acquire (forEachCompiled did).
-        void *fn = reinterpret_cast<void *>(slot.fnPtr.loadAcquire());
-        // Only the numDims leading pairs are meaningful; clamp a corrupt
-        // slot's numDims to the ABI maximum so the builders cannot overflow.
-        const uint32_t n = slot.numDims < kEJitSharedMaxDims
-                               ? slot.numDims
-                               : kEJitSharedMaxDims;
-        // dims=[d:i,...] for the n meaningful pairs, e.g. "1:5" / "1:5,2:7".
-        // Sized for the uint32 worst case: kEJitSharedMaxDims x
-        // ("4294967295:4294967295" = 21) + separators + NUL.
-        char dims[kEJitSharedMaxDims * 21 + (kEJitSharedMaxDims - 1) + 1];
-        char *p = dims;
-        char *end = dims + sizeof(dims);
-        for (uint32_t i = 0; i < n && p < end; ++i)
-          p += snprintf(p, (size_t)(end - p), "%s%u:%u", i ? "," : "",
-                        slot.dims[i].dimType, slot.dims[i].instanceId);
-        if (p >= end)
-          p = end - 1;
-        *p = '\0';
-        const char *PostPublishSeen =
-            !ctx.reuseTrackingEnabled
-                ? "disabled"
-                : (slot.postPublishSeen.loadRelaxed() != 0 ? "yes" : "no");
-        const uint8_t SlotTier = slot.tier.loadRelaxed();
-        const char *Tier = SlotTier == kEJitTierPgoUse ? "tier2"
-                           : SlotTier == kEJitTierInstrumented
-                               ? "tier1-collecting"
-                               : "baseline";
-        const char *PoolKind =
-            slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
-                ? "near"
-                : slot.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
-                      ? "far"
-                      : "unknown";
-        if (gEJitDiagLevel >= EJIT_LOG_LVL_VERBOSE) {
-          // Same shape for the per-instance version snapshot (uint32 x
-          // kEJitSharedMaxDims + separators + NUL).
-          char ver[kEJitSharedMaxDims * 10 + (kEJitSharedMaxDims - 1) + 1];
-          p = ver;
-          end = ver + sizeof(ver);
-          for (uint32_t i = 0; i < n && p < end; ++i)
-            p += snprintf(p, (size_t)(end - p), "%s%u", i ? "," : "",
-                          slot.versions[i]);
-          if (p >= end)
-            p = end - 1;
-          *p = '\0';
-          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "post_publish_seen=%s ver=[%s] code_size=%llu "
-                        "fn_size=%llu overhead=%llu "
-                        "pool=%s pool_id=%u "
-                        "gen=%u",
-                        slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PostPublishSeen, ver,
-                        static_cast<unsigned long long>(slot.codeSize),
-                        static_cast<unsigned long long>(slot.fnSize),
-                        static_cast<unsigned long long>(
-                            slot.fnSize <= slot.codeSize
-                                ? slot.codeSize - slot.fnSize
-                                : 0),
-                        PoolKind, slot.poolId, slot.generation);
-        } else {
-          EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "code_size=%llu fn_size=%llu overhead=%llu "
-                        "pool=%s post_publish_seen=%s",
-                        slot.funcIndex,
-                        name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn,
-                        static_cast<unsigned long long>(slot.codeSize),
-                        static_cast<unsigned long long>(slot.fnSize),
-                        static_cast<unsigned long long>(
-                            slot.fnSize <= slot.codeSize
-                                ? slot.codeSize - slot.fnSize
-                                : 0),
-                        PoolKind, PostPublishSeen);
+        auto &rows = *static_cast<CollectCtx *>(cbCtx)->rows;
+        CompiledRow row;
+        row.funcIndex = slot.funcIndex;
+        row.numDims = slot.numDims < kEJitSharedMaxDims ? slot.numDims
+                                                        : kEJitSharedMaxDims;
+        row.generation = slot.generation;
+        row.poolId = slot.poolId;
+        row.poolKind = slot.poolKind;
+        row.tier = slot.tier.loadRelaxed();
+        row.postPublishSeen = slot.postPublishSeen.loadRelaxed() != 0;
+        row.address = slot.fnPtr.loadAcquire();
+        row.codeStart = slot.codeStart;
+        row.codeSize = slot.codeSize;
+        row.fnSize = slot.fnSize;
+        for (uint32_t i = 0; i < row.numDims; ++i) {
+          row.dims[i] = slot.dims[i];
+          row.versions[i] = slot.versions[i];
         }
-        ejitDiagPrintThrottle();
+        rows.push_back(row);
       },
-      &printCtx);
+      &collectCtx);
+  std::sort(rows.begin(), rows.end(),
+            [](const CompiledRow &a, const CompiledRow &b) {
+              if (a.address != b.address)
+                return a.address < b.address;
+              if (a.codeStart != b.codeStart)
+                return a.codeStart < b.codeStart;
+              return a.funcIndex < b.funcIndex;
+            });
+
+  struct LayoutSummary {
+    uint32_t poolKind = 0;
+    uint32_t poolId = 0;
+    uint32_t versions = 0;
+    uintptr_t firstAddress = 0;
+    uintptr_t lastAddress = 0;
+    uint64_t rangeStart = 0;
+    uint64_t rangeEnd = 0;
+    uint64_t execBytes = 0;
+  };
+  SmallVector<LayoutSummary, kEJitNearHotPoolCount + 1> layouts;
+  auto poolLayout = [&layouts](const CompiledRow &row) -> LayoutSummary & {
+    for (LayoutSummary &layout : layouts)
+      if (layout.poolKind == row.poolKind && layout.poolId == row.poolId)
+        return layout;
+    layouts.push_back(LayoutSummary{row.poolKind, row.poolId});
+    return layouts.back();
+  };
+
+  // Entry lines: one RAW (prefix-free) line per Ready slot, throttled after
+  // each printed line. Every row includes the fields needed to correlate the
+  // executable allocation with the fixed pool summary below.
+  for (const CompiledRow &row : rows) {
+    const std::string &name = loader.getFuncNameByFuncIdx(row.funcIndex);
+    const uint32_t n = row.numDims;
+    char dims[kEJitSharedMaxDims * 21 + (kEJitSharedMaxDims - 1) + 1];
+    char vers[kEJitSharedMaxDims * 10 + (kEJitSharedMaxDims - 1) + 1];
+    char *p = dims;
+    char *end = dims + sizeof(dims);
+    for (uint32_t i = 0; i < n && p < end; ++i)
+      p += snprintf(p, static_cast<size_t>(end - p), "%s%u:%u", i ? "," : "",
+                    row.dims[i].dimType, row.dims[i].instanceId);
+    if (p >= end)
+      p = end - 1;
+    *p = '\0';
+    p = vers;
+    end = vers + sizeof(vers);
+    for (uint32_t i = 0; i < n && p < end; ++i)
+      p += snprintf(p, static_cast<size_t>(end - p), "%s%u", i ? "," : "",
+                    row.versions[i]);
+    if (p >= end)
+      p = end - 1;
+    *p = '\0';
+    const char *tier = row.tier == kEJitTierPgoUse         ? "tier2"
+                       : row.tier == kEJitTierInstrumented ? "tier1-collecting"
+                                                           : "baseline";
+    const char *poolKind =
+        row.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near) ? "near"
+        : row.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
+            ? "far"
+            : "unknown";
+    LayoutSummary &layout = poolLayout(row);
+    ++layout.versions;
+    layout.firstAddress = layout.versions == 1
+                              ? row.address
+                              : std::min(layout.firstAddress, row.address);
+    layout.lastAddress = std::max(layout.lastAddress, row.address);
+    const uint64_t start = row.codeStart != 0
+                               ? static_cast<uint64_t>(row.codeStart)
+                               : static_cast<uint64_t>(row.address);
+    const uint64_t finish = start + row.codeSize;
+    layout.rangeStart =
+        layout.versions == 1 ? start : std::min(layout.rangeStart, start);
+    layout.rangeEnd = std::max(layout.rangeEnd, finish);
+    layout.execBytes += row.codeSize;
+    EJIT_DIAG_RAW(
+        "compiled row: funcIdx=%u name=%s version=[%s] tier=%s pool=%s "
+        "pool_id=%u address=%p exec_size=%llu fn_size=%llu overhead=%llu "
+        "code_range=[0x%llx,0x%llx) dims=[%s] generation=%u "
+        "post_publish_seen=%s",
+        row.funcIndex, name.empty() ? "<unknown>" : name.c_str(), vers, tier,
+        poolKind, row.poolId, reinterpret_cast<void *>(row.address),
+        static_cast<unsigned long long>(row.codeSize),
+        static_cast<unsigned long long>(row.fnSize),
+        static_cast<unsigned long long>(
+            row.fnSize <= row.codeSize ? row.codeSize - row.fnSize : 0),
+        static_cast<unsigned long long>(start),
+        static_cast<unsigned long long>(finish), dims, row.generation,
+        !ReuseTrackingEnabled ? "disabled"
+        : row.postPublishSeen ? "yes"
+                              : "no");
+    ejitDiagPrintThrottle();
+  }
+  EJIT_DIAG_RAW("compiled layout: address_order=ascending rows=%u",
+                rows.size());
+  for (const LayoutSummary &layout : layouts) {
+    const uint64_t span = layout.rangeEnd >= layout.rangeStart
+                              ? layout.rangeEnd - layout.rangeStart
+                              : 0;
+    const uint64_t padding =
+        span > layout.execBytes ? span - layout.execBytes : 0;
+    const uint64_t density = span ? (layout.execBytes * 1000u) / span : 0;
+    const char *poolKind =
+        layout.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Near)
+            ? "near"
+        : layout.poolKind == static_cast<uint32_t>(EJitCodePoolKind::Far)
+            ? "far"
+            : "unknown";
+    EJIT_DIAG_RAW("compiled layout pool=%s pool_id=%u versions=%u first=0x%llx "
+                  "last=0x%llx exec_bytes=%llu span=%llu padding_or_gap=%llu "
+                  "density=%llu/1000",
+                  poolKind, layout.poolId, layout.versions,
+                  static_cast<unsigned long long>(layout.firstAddress),
+                  static_cast<unsigned long long>(layout.lastAddress),
+                  static_cast<unsigned long long>(layout.execBytes),
+                  static_cast<unsigned long long>(span),
+                  static_cast<unsigned long long>(padding),
+                  static_cast<unsigned long long>(density));
+  }
   // The summary counted the first walk; if the entry walk itself skipped
   // contended buckets, its lines are incomplete relative to it — report the
   // shortfall (fixed line count, so no throttle) instead of dropping it.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -2001,7 +2001,7 @@ void ejit_taskpool_print_compiled() {
                               : "no");
     ejitDiagPrintThrottle();
   }
-  EJIT_DIAG_RAW("compiled layout: address_order=ascending rows=%u",
+  EJIT_DIAG_RAW("compiled layout: address_order=ascending rows=%zu",
                 rows.size());
   for (const LayoutSummary &layout : layouts) {
     const uint64_t span = layout.rangeEnd >= layout.rangeStart

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -2832,6 +2832,10 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       pendingPublishes_.clear();
       autoTier2PublishPending_ = false;
       autoTier2PublishBlocked_ = false;
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+      nearHotFirstLinkedDiagnosed_ = false;
+      nearHotFirstFlushDiagnosed_ = false;
+#endif
       initSharedStorage(state_, static_cast<uint32_t>(configuredMode_),
                         pgoEnabled_.loadRelaxed(),
                         tier2Threshold_.loadRelaxed(),
@@ -2883,6 +2887,9 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       // Start the ONE worker (if a starter was injected). A failure here is a
       // clean init failure: record it, publish Failed, and DO NOT pretend JIT
       // is up.
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+      diagnoseCodeBatchCallbacks("pre-worker", workerCtx_);
+#endif
       bool workerOk = true;
       if (workerStart_) {
         uint64_t taskId = 0;
@@ -3566,6 +3573,103 @@ void EJitSharedTaskPool::compilePendingBatchRequests() {
 }
 #endif
 
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+bool EJitSharedTaskPool::codeBatchFlushPoolCallbacksIntact() const {
+  return codeBatchFlushPoolFn_ == codeBatchFlushPoolExpectedFn_ &&
+         codeBatchFlushPoolCtx_ == codeBatchFlushPoolExpectedCtx_ &&
+         codeBatchFlushPoolCanary_ ==
+             makeCodeBatchFlushCanary(codeBatchFlushPoolFn_,
+                                      codeBatchFlushPoolCtx_) &&
+         codeBatchFlushPoolLayoutTag_ ==
+             makeCodeBatchFlushLayoutTag(this);
+}
+#endif
+
+void EJitSharedTaskPool::diagnoseCodeBatchCallbacks(const char *Reason,
+                                                    const void *OwnerCtx) const {
+#if defined(EJIT_CODE_POOL_FIXED_NEAR_HOT) && defined(EJIT_DIAG_ENABLE)
+  const bool CallbacksIntact = codeBatchFlushPoolCallbacksIntact();
+  const bool CallbackValid =
+      CallbacksIntact && codeBatchFlushPoolFn_ && codeBatchFlushPoolCtx_;
+  const uint64_t LayoutTag = makeCodeBatchFlushLayoutTag(this);
+  const bool LayoutMatches = codeBatchFlushPoolLayoutTag_ == LayoutTag;
+  const char *Validation = "matched-target-unverified";
+  if (!codeBatchFlushPoolFn_)
+    Validation = "callback-target-null";
+  else if (!codeBatchFlushPoolCtx_)
+    Validation = "callback-context-null";
+  else if (!LayoutMatches)
+    Validation = "layout-mismatch";
+  else if (!CallbacksIntact)
+    Validation = "callback-mismatch";
+  const unsigned FeatureMask = codeBatchFlushPoolFeatureMask();
+  const uintptr_t Base = reinterpret_cast<uintptr_t>(this);
+  const size_t PoolFlushFnOffset =
+      reinterpret_cast<uintptr_t>(&codeBatchFlushPoolFn_) - Base;
+  const size_t PoolFlushCtxOffset =
+      reinterpret_cast<uintptr_t>(&codeBatchFlushPoolCtx_) - Base;
+  const size_t SplitFnOffset =
+      reinterpret_cast<uintptr_t>(&splitPoolFn_) - Base;
+  const size_t SplitCtxOffset =
+      reinterpret_cast<uintptr_t>(&splitPoolCtx_) - Base;
+  const size_t ExpectedFnOffset =
+      reinterpret_cast<uintptr_t>(&codeBatchFlushPoolExpectedFn_) - Base;
+  const size_t ExpectedCtxOffset =
+      reinterpret_cast<uintptr_t>(&codeBatchFlushPoolExpectedCtx_) - Base;
+  const size_t CanaryOffset =
+      reinterpret_cast<uintptr_t>(&codeBatchFlushPoolCanary_) - Base;
+  constexpr unsigned Has4KSeal =
+#ifdef EJIT_CODE_POOL_4K_SEAL
+      1u;
+#else
+      0u;
+#endif
+  constexpr unsigned HasBatchPublish =
+#ifdef EJIT_CODE_POOL_BATCHED_PUBLISH
+      1u;
+#else
+      0u;
+#endif
+  constexpr unsigned HasFixedPool =
+#ifdef EJIT_FIXED_CODE_POOL
+      1u;
+#else
+      0u;
+#endif
+  // SRE diagnostic transports commonly cap one formatted record at 512 bytes.
+  // Keep each record deliberately short: an oversized callback diagnostic is
+  // least useful precisely when this path is diagnosing a target-side fault.
+  EJIT_DIAG("near-hot cb stage=%s self=%p owner=%p fn=%p ctx=%p",
+      Reason ? Reason : "unspecified",
+      static_cast<const void *>(this), OwnerCtx,
+      reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(
+          codeBatchFlushPoolFn_)),
+      codeBatchFlushPoolCtx_);
+  EJIT_DIAG("near-hot cb guard stage=%s expectedFn=%p expectedCtx=%p "
+            "intact=%u valid=%u layout=%u status=%s",
+      Reason ? Reason : "unspecified",
+      reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(
+          codeBatchFlushPoolExpectedFn_)),
+      codeBatchFlushPoolExpectedCtx_,
+      CallbacksIntact ? 1u : 0u, CallbackValid ? 1u : 0u,
+      LayoutMatches ? 1u : 0u, Validation);
+  EJIT_DIAG("near-hot cb abi size=%zu fnOff=%zu ctxOff=%zu expFnOff=%zu "
+            "expCtxOff=%zu canaryOff=%zu",
+      sizeof(EJitSharedTaskPool), PoolFlushFnOffset, PoolFlushCtxOffset,
+      ExpectedFnOffset, ExpectedCtxOffset, CanaryOffset);
+  EJIT_DIAG("near-hot cb tags canary=0x%llx saved=0x%llx now=0x%llx "
+            "features=0x%x splitOff=%zu/%zu flags=%u/%u/%u",
+      static_cast<unsigned long long>(codeBatchFlushPoolCanary_),
+      static_cast<unsigned long long>(codeBatchFlushPoolLayoutTag_),
+      static_cast<unsigned long long>(LayoutTag),
+      FeatureMask, SplitFnOffset, SplitCtxOffset, Has4KSeal,
+      HasBatchPublish, HasFixedPool);
+#else
+  (void)Reason;
+  (void)OwnerCtx;
+#endif
+}
+
 bool EJitSharedTaskPool::flushPendingPublishes(bool compileBatchRequests,
                                                const char *Reason) {
 #ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
@@ -3573,25 +3677,85 @@ bool EJitSharedTaskPool::flushPendingPublishes(bool compileBatchRequests,
   // The fixed near-hot layout is a per-pool commit protocol. Falling back to
   // the legacy all-pools callback here would make a failed pool seal unrelated
   // pools and would invalidate the partial-commit guarantee.
-  if (!codeBatchFlushPoolFn_)
+  // The owner callback currently dereferences its context to reach the private
+  // ORC engine. Fail closed if either half of the pair is missing: a malformed
+  // registration must leave the request pending/AOT, never make a null-context
+  // indirect call from the worker.
+  if (!nearHotFirstFlushDiagnosed_) {
+    nearHotFirstFlushDiagnosed_ = true;
+    // The callback context is intentionally not trusted as a driver address.
+    // The explicit owner-side diagnostics above are the authoritative driver
+    // identity; this line is about the pre-call callback state only.
+    diagnoseCodeBatchCallbacks("first-pre-flush", nullptr);
+  }
+  const auto FlushFn = codeBatchFlushPoolFn_;
+  void *const FlushCtx = codeBatchFlushPoolCtx_;
+  const bool CallbacksIntact = codeBatchFlushPoolCallbacksIntact();
+  const bool LayoutMatches =
+      codeBatchFlushPoolLayoutTag_ == makeCodeBatchFlushLayoutTag(this);
+  const char *Validation = "matched-target-unverified";
+  if (!FlushFn)
+    Validation = "callback-target-null";
+  else if (!FlushCtx)
+    Validation = "callback-context-null";
+  else if (!LayoutMatches)
+    Validation = "layout-mismatch";
+  else if (!CallbacksIntact)
+    Validation = "callback-mismatch";
+  if (!CallbacksIntact || !FlushFn || !FlushCtx) {
+    if (!pendingPublishes_.empty())
+      EJIT_DIAG("near-hot pool flush skipped reason=pre-flush "
+                "sharedPoolThis=%p flushCtx=%p expectedOwnerCtx=%p "
+                "fn=%p ctx=%p expectedFn=%p expectedCtx=%p canary=0x%llx "
+                "layoutTag=0x%llx intact=%u validation=%s pending=%zu",
+                static_cast<const void *>(this), FlushCtx,
+                codeBatchFlushPoolExpectedCtx_,
+                reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(
+                    FlushFn)),
+                FlushCtx,
+                reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(
+                    codeBatchFlushPoolExpectedFn_)),
+                codeBatchFlushPoolExpectedCtx_,
+                static_cast<unsigned long long>(codeBatchFlushPoolCanary_),
+                static_cast<unsigned long long>(
+                    codeBatchFlushPoolLayoutTag_),
+                CallbacksIntact ? 1u : 0u, Validation,
+                pendingPublishes_.size());
+    // Do not let an unavailable callback turn an idle worker into an implicit
+    // retry loop. An explicit flush request clears this gate before retrying.
+    autoTier2PublishBlocked_ = !pendingPublishes_.empty();
     return pendingPublishes_.empty();
+  }
 
   [[maybe_unused]] size_t Published = 0;
   size_t Dropped = 0;
   std::vector<PendingPublish> Retry;
-  std::vector<uint32_t> FlushedPools;
+  // There are exactly 17 semantic near-hot pools. Do not use std::find on a
+  // vector<uint32_t> here: libc++ may lower that specialization to wmemchr,
+  // which is not a safe executable dependency in the freestanding SRE image.
+  uint32_t FlushedPoolBitmap = 0;
+  size_t FlushedPoolCount = 0;
   [[maybe_unused]] uint32_t FailedPoolBitmap = 0;
   for (const PendingPublish &P : pendingPublishes_) {
-    if (std::find(FlushedPools.begin(), FlushedPools.end(), P.poolId) !=
-        FlushedPools.end())
-      continue;
-    FlushedPools.push_back(P.poolId);
-    const bool Flushed =
-        codeBatchFlushPoolFn_(codeBatchFlushPoolCtx_, P.poolId);
-    if (!Flushed && P.poolId < 32)
-      FailedPoolBitmap |= uint32_t{1} << P.poolId;
-    EJIT_DIAG_DEBUG("near-hot pool flush pool=%u ok=%u", P.poolId,
-                    static_cast<unsigned>(Flushed));
+    bool Flushed = false;
+    if (P.poolId >= kEJitNearHotPoolCount) {
+      EJIT_DIAG("near-hot flush skip invalid pool=%u", P.poolId);
+    } else {
+      const uint32_t PoolBit = uint32_t{1} << P.poolId;
+      if ((FlushedPoolBitmap & PoolBit) != 0)
+        continue;
+      FlushedPoolBitmap |= PoolBit;
+      ++FlushedPoolCount;
+      EJIT_DIAG("near-hot flush enter pool=%u fn=%p ctx=%p pending=%zu",
+                P.poolId,
+                reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(FlushFn)),
+                FlushCtx, pendingPublishes_.size());
+      Flushed = FlushFn(FlushCtx, P.poolId);
+      if (!Flushed)
+        FailedPoolBitmap |= PoolBit;
+      EJIT_DIAG("near-hot flush return pool=%u ok=%u", P.poolId,
+                static_cast<unsigned>(Flushed));
+    }
     for (const PendingPublish &Member : pendingPublishes_) {
       if (Member.poolId != P.poolId)
         continue;
@@ -3649,7 +3813,7 @@ bool EJitSharedTaskPool::flushPendingPublishes(bool compileBatchRequests,
   publishCodePoolStats();
   EJIT_DIAG("near-hot flush reason=%s pools=%zu published=%zu dropped=%zu "
             "retry=%zu failedPoolBitmap=0x%08x",
-            Reason ? Reason : "unspecified", FlushedPools.size(), Published,
+            Reason ? Reason : "unspecified", FlushedPoolCount, Published,
             Dropped, pendingPublishes_.size(), FailedPoolBitmap);
   return Dropped == 0 && pendingPublishes_.empty();
 #else
@@ -3987,6 +4151,12 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
         req.funcIndex);
     return;
   }
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  if (tier == kEJitTierPgoUse && !nearHotFirstLinkedDiagnosed_) {
+    nearHotFirstLinkedDiagnosed_ = true;
+    diagnoseCodeBatchCallbacks("first-t2-linked", compileCtx_);
+  }
+#endif
 #ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
   // Near code must remain owner-private until its pool is sealed.  Without a
   // per-pool flush callback there is no safe way to make it executable or

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -2696,9 +2696,17 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
     D.sealInvocations.storeRelaxed(0);
     D.splitInvocations.storeRelaxed(0);
     D.finalizedRangeCount.storeRelaxed(0);
+    D.baseAddress.storeRelaxed(0);
+    D.endAddress.storeRelaxed(0);
+    D.pendingBytes.storeRelaxed(0);
+    D.pendingRangeCount.storeRelaxed(0);
+    D.fallbackCount.storeRelaxed(0);
+    D.full.storeRelaxed(0);
   };
   ClearPoolDetail(st->codePoolStats.near);
   ClearPoolDetail(st->codePoolStats.far);
+  for (uint32_t I = 0; I < kEJitNearHotPoolCount; ++I)
+    ClearPoolDetail(st->codePoolStats.nearHot[I]);
   // Per-core, per-pool 4K split readiness (ABI v5). MUST be cleared on every
   // (re)initialization: a stale splitDone bit from an earlier generation would
   // otherwise make a peer skip split_2m_to_4k for a pool the new generation
@@ -2818,9 +2826,12 @@ EJitSharedTaskPool::InitResult EJitSharedTaskPool::init() {
       uint32_t self = EJitCoreId::current();
       uint32_t nextGen = state_->generation.loadRelaxed() + 1;
       // Owner-private batch state must never cross a generation boundary.
+#ifndef EJIT_CODE_POOL_FIXED_NEAR_HOT
       pendingBatchCompiles_.clear();
+#endif
       pendingPublishes_.clear();
       autoTier2PublishPending_ = false;
+      autoTier2PublishBlocked_ = false;
       initSharedStorage(state_, static_cast<uint32_t>(configuredMode_),
                         pgoEnabled_.loadRelaxed(),
                         tier2Threshold_.loadRelaxed(),
@@ -2974,12 +2985,34 @@ void EJitSharedTaskPool::ownerShutdown() {
   // A failed enable_ex may leave linked, non-executable objects queued after
   // the worker's final flush attempt. Drop their owner-private metadata before
   // destroying the engine; shared Pending slots were already drained above.
-  for (PendingPublish &P : pendingPublishes_)
+  if (!pendingPublishes_.empty())
+    EJIT_DIAG("near-hot flush reason=shutdown dropped=%zu",
+              pendingPublishes_.size());
+  for (PendingPublish &P : pendingPublishes_) {
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+    // A shutdown drops linked-but-unpublished near code.  The pending cache
+    // slot carries no function pointer in this mode, but clear it defensively
+    // and release the in-flight claims/profile admission before the generation
+    // changes below.
+    cacheDropPending(P.req, nullptr);
+    dedupClear(P.req.funcIndex, P.req.generation);
+    const uint32_t Tier = decodeReqTier(P.req.funcIndex);
+    if (P.req.generation == state_->generation.loadAcquire() &&
+        (Tier == kEJitTierInstrumented || Tier == kEJitTierPgoUse))
+      finishPgoFunction(stripReqTier(P.req.funcIndex), /*completed=*/false,
+                        "owner-shutdown");
+    if (publishFn_)
+      publishFn_(publishCtx_, P.req, false);
+#endif
     if (releaseFn_)
       releaseFn_(releaseCtx_, P.fn);
+  }
+#ifndef EJIT_CODE_POOL_FIXED_NEAR_HOT
   pendingBatchCompiles_.clear();
+#endif
   pendingPublishes_.clear();
   autoTier2PublishPending_ = false;
+  autoTier2PublishBlocked_ = false;
   // Release what the election built, between the join and Uninitialized: no
   // compile can be in flight, and no peer can be elected yet. Without this the
   // former owner keeps its engine while a new owner builds another, so the
@@ -3459,11 +3492,20 @@ void EJitSharedTaskPool::publishCodePoolStats() {
     Dst.sealInvocations.storeRelaxed(Src.sealInvocations);
     Dst.splitInvocations.storeRelaxed(Src.splitInvocations);
     Dst.finalizedRangeCount.storeRelaxed(Src.finalizedRangeCount);
+    Dst.baseAddress.storeRelaxed(Src.baseAddress);
+    Dst.endAddress.storeRelaxed(Src.endAddress);
+    Dst.pendingBytes.storeRelaxed(Src.pendingBytes);
+    Dst.pendingRangeCount.storeRelaxed(Src.pendingRangeCount);
+    Dst.fallbackCount.storeRelaxed(Src.fallbackCount);
+    Dst.full.storeRelaxed(Src.full);
   };
   PublishDetail(state_->codePoolStats.near, s.near);
+  for (uint32_t I = 0; I < kEJitNearHotPoolCount; ++I)
+    PublishDetail(state_->codePoolStats.nearHot[I], s.nearHot[I]);
   PublishDetail(state_->codePoolStats.far, s.far);
 }
 
+#ifndef EJIT_CODE_POOL_FIXED_NEAR_HOT
 void EJitSharedTaskPool::compilePendingBatchRequests() {
   if (pendingBatchCompiles_.empty())
     return;
@@ -3522,8 +3564,96 @@ void EJitSharedTaskPool::compilePendingBatchRequests() {
     workerThrottle();
   }
 }
+#endif
 
-bool EJitSharedTaskPool::flushPendingPublishes(bool compileBatchRequests) {
+bool EJitSharedTaskPool::flushPendingPublishes(bool compileBatchRequests,
+                                               const char *Reason) {
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  (void)compileBatchRequests;
+  // The fixed near-hot layout is a per-pool commit protocol. Falling back to
+  // the legacy all-pools callback here would make a failed pool seal unrelated
+  // pools and would invalidate the partial-commit guarantee.
+  if (!codeBatchFlushPoolFn_)
+    return pendingPublishes_.empty();
+
+  [[maybe_unused]] size_t Published = 0;
+  size_t Dropped = 0;
+  std::vector<PendingPublish> Retry;
+  std::vector<uint32_t> FlushedPools;
+  [[maybe_unused]] uint32_t FailedPoolBitmap = 0;
+  for (const PendingPublish &P : pendingPublishes_) {
+    if (std::find(FlushedPools.begin(), FlushedPools.end(), P.poolId) !=
+        FlushedPools.end())
+      continue;
+    FlushedPools.push_back(P.poolId);
+    const bool Flushed =
+        codeBatchFlushPoolFn_(codeBatchFlushPoolCtx_, P.poolId);
+    if (!Flushed && P.poolId < 32)
+      FailedPoolBitmap |= uint32_t{1} << P.poolId;
+    EJIT_DIAG_DEBUG("near-hot pool flush pool=%u ok=%u", P.poolId,
+                    static_cast<unsigned>(Flushed));
+    for (const PendingPublish &Member : pendingPublishes_) {
+      if (Member.poolId != P.poolId)
+        continue;
+      const uint32_t Tier = decodeReqTier(Member.req.funcIndex);
+      const uint32_t FuncIndex = stripReqTier(Member.req.funcIndex);
+      EJitPublishStatus PS = EJitPublishStatus::Failed;
+      EJitCompiledCodeInfo Info{};
+      const bool Ready =
+          Flushed && codeReadyFn_ && codeReadyFn_(codeBatchCtx_, Member.fn);
+      const bool HasRange = Ready && codeRangeFn_ &&
+                            codeRangeFn_(codeRangeCtx_, Member.fn, &Info);
+      if (HasRange)
+        PS =
+            cachePublish(Member.req, Member.fn, &Info, Tier == kEJitTierPgoUse);
+      if (PS == EJitPublishStatus::Published) {
+        ++Published;
+        EJIT_STAT_INC(state_->counters.asyncCompiles);
+        if (publishFn_)
+          publishFn_(publishCtx_, Member.req, true);
+        if (Tier == kEJitTierPgoUse) {
+          EJIT_STAT_INC(state_->counters.tier2Compiles);
+          finishPgoFunction(FuncIndex, /*completed=*/true);
+        }
+        dedupClear(Member.req.funcIndex, Member.req.generation);
+        continue;
+      }
+      if (Tier == kEJitTierPgoUse && Flushed &&
+          PS == EJitPublishStatus::Failed) {
+        Retry.push_back(Member);
+        EJIT_STAT_INC(state_->counters.publishFailed);
+        continue;
+      }
+      ++Dropped;
+      // A fixed near-hot compile is never inserted with its fnPtr before the
+      // pool commit, so the pending cache slot (if any) still carries null.
+      // Passing Member.fn would leave that slot Pending forever.
+      cacheDropPending(Member.req, nullptr);
+      if (publishFn_)
+        publishFn_(publishCtx_, Member.req, false);
+      if (Member.req.generation == state_->generation.loadAcquire() &&
+          Tier == kEJitTierPgoUse)
+        finishPgoFunction(FuncIndex, /*completed=*/false);
+      if (releaseFn_)
+        releaseFn_(releaseCtx_, Member.fn);
+      EJIT_STAT_INC(state_->counters.publishFailed);
+      dedupClear(Member.req.funcIndex, Member.req.generation);
+    }
+  }
+  pendingPublishes_.swap(Retry);
+  autoTier2PublishPending_ = !pendingPublishes_.empty();
+  // Seal or cache publication failures are explicitly retryable, but must not
+  // turn an idle worker into a retry loop. flushCodeBatch() and the shared
+  // explicit request clear this gate before retrying.
+  autoTier2PublishBlocked_ = !pendingPublishes_.empty();
+  publishCodePoolStats();
+  EJIT_DIAG("near-hot flush reason=%s pools=%zu published=%zu dropped=%zu "
+            "retry=%zu failedPoolBitmap=0x%08x",
+            Reason ? Reason : "unspecified", FlushedPools.size(), Published,
+            Dropped, pendingPublishes_.size(), FailedPoolBitmap);
+  return Dropped == 0 && pendingPublishes_.empty();
+#else
+  (void)Reason;
   if (compileBatchRequests)
     compilePendingBatchRequests();
   if (!codeBatchFlushFn_)
@@ -3597,6 +3727,7 @@ bool EJitSharedTaskPool::flushPendingPublishes(bool compileBatchRequests) {
                     "dropped=%zu retry=%zu",
                     Total, Published, Dropped, pendingPublishes_.size());
   return Dropped == 0 && pendingPublishes_.empty();
+#endif
 }
 
 bool EJitSharedTaskPool::serviceCodeBatchRequest() {
@@ -3609,9 +3740,10 @@ bool EJitSharedTaskPool::serviceCodeBatchRequest() {
           Expected, static_cast<uint32_t>(EJitCodeBatchRequestState::Running)))
     return false;
   // Include every request that was already queued when this explicit publish
-  // began, but do not chase producers indefinitely. pollOne() drains compact
-  // requests into owner-private storage, where the subsequent flush sorts them
-  // by dimensions before ORC/JITLink allocation.
+  // began, but do not chase producers indefinitely. In fixed near-hot mode
+  // pollOne() links each request directly into its semantic pool; the flush
+  // only commits already-linked pool ranges. The legacy path retains its
+  // owner-private dimension-sorted batch.
   uint32_t Queued =
       state_->enqueuePos.loadAcquire() - state_->dequeuePos.loadAcquire();
   Queued = std::min(Queued, kEJitSharedQueueSlots);
@@ -3621,7 +3753,9 @@ bool EJitSharedTaskPool::serviceCodeBatchRequest() {
     workerThrottle();
   }
   autoTier2PublishPending_ = false;
-  const bool Ok = flushPendingPublishes();
+  autoTier2PublishBlocked_ = false;
+  const bool Ok = flushPendingPublishes(/*compileBatchRequests=*/true,
+                                        /*reason=*/"explicit");
   state_->codeBatchRequestState.storeRelease(
       static_cast<uint32_t>(Ok ? EJitCodeBatchRequestState::Succeeded
                                : EJitCodeBatchRequestState::Failed));
@@ -3635,18 +3769,30 @@ bool EJitSharedTaskPool::serviceAutoTier2Publish() {
 #ifndef EJIT_CODE_POOL_BATCHED_PUBLISH
   return false;
 #else
-  if (!autoTier2PublishPending_ || !state_)
+  if (!autoTier2PublishPending_ || autoTier2PublishBlocked_ || !state_)
     return false;
   // pollOne() has just observed the queue empty. Re-check both positions so a
   // Tier-1 request that raced that observation is compiled from the far pool
   // before the near-pool Tier-2 batch is sealed and published.
-  if (state_->enqueuePos.loadAcquire() != state_->dequeuePos.loadAcquire())
+  if (state_->enqueuePos.loadAcquire() != state_->dequeuePos.loadAcquire()) {
+    autoTier2IdleTicks_ = 0;
     return false;
+  }
+
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  // One empty observation can race a producer that is about to enqueue the
+  // next specialization. Require two worker idle observations before sealing
+  // any pool; explicit publish remains an immediate override.
+  if (++autoTier2IdleTicks_ < 2u)
+    return false;
+#endif
 
   autoTier2PublishPending_ = false;
+  autoTier2IdleTicks_ = 0;
   EJIT_DIAG("PGO Tier-2 queue drained: auto-publishing %zu linked version(s)",
             pendingPublishes_.size());
-  if (!flushPendingPublishes(/*compileBatchRequests=*/false))
+  if (!flushPendingPublishes(/*compileBatchRequests=*/false,
+                             /*reason=*/"idle"))
     EJIT_DIAG("PGO Tier-2 auto-publish failed: pending=%zu; explicit publish "
               "may retry",
               pendingPublishes_.size());
@@ -3735,8 +3881,16 @@ bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
     Dst.sealInvocations = Src.sealInvocations.loadRelaxed();
     Dst.splitInvocations = Src.splitInvocations.loadRelaxed();
     Dst.finalizedRangeCount = Src.finalizedRangeCount.loadRelaxed();
+    Dst.baseAddress = Src.baseAddress.loadRelaxed();
+    Dst.endAddress = Src.endAddress.loadRelaxed();
+    Dst.pendingBytes = Src.pendingBytes.loadRelaxed();
+    Dst.pendingRangeCount = Src.pendingRangeCount.loadRelaxed();
+    Dst.fallbackCount = Src.fallbackCount.loadRelaxed();
+    Dst.full = Src.full.loadRelaxed();
   };
   ReadDetail(state_->codePoolStats.near, out->near);
+  for (uint32_t I = 0; I < kEJitNearHotPoolCount; ++I)
+    ReadDetail(state_->codePoolStats.nearHot[I], out->nearHot[I]);
   ReadDetail(state_->codePoolStats.far, out->far);
   return true;
 }
@@ -3833,6 +3987,59 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
         req.funcIndex);
     return;
   }
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  // Near code must remain owner-private until its pool is sealed.  Without a
+  // per-pool flush callback there is no safe way to make it executable or
+  // publish it, so fail closed instead of leaving a permanent pending item.
+  auto dropUnpublishedNearResult = [&](const char *Reason) {
+    cacheDropPending(req, nullptr);
+    if (publishFn_)
+      publishFn_(publishCtx_, req, false);
+    dedupClear(req.funcIndex, req.generation);
+    finishPgoOnFailure();
+    if (releaseFn_)
+      releaseFn_(releaseCtx_, fn);
+    EJIT_STAT_INC(state_->counters.publishFailed);
+    EJIT_DIAG("near-hot result dropped func=%u reason=%s", realFuncIndex,
+              Reason);
+  };
+  if (tier != kEJitTierInstrumented &&
+      (!codeReadyFn_ || !codeRangeFn_ || !codeBatchFlushPoolFn_)) {
+    dropUnpublishedNearResult("missing-near-publish-callback");
+    return;
+  }
+  if (!codeReadyFn_(codeBatchCtx_, fn)) {
+    if (tier == kEJitTierInstrumented) {
+      dropUnpublishedNearResult("tier1-not-ready");
+      return;
+    }
+    if (info.codeSize == 0 || info.poolId >= kEJitNearHotPoolCount) {
+      dropUnpublishedNearResult("missing-pool-range");
+      return;
+    }
+    if (pendingPublishes_.size() >=
+        static_cast<size_t>(EJIT_CODE_POOL_FIXED_NEAR_HOT_PENDING_LIMIT)) {
+      EJIT_DIAG(
+          "near-hot pending capacity reached limit=%u; flushing",
+          static_cast<unsigned>(EJIT_CODE_POOL_FIXED_NEAR_HOT_PENDING_LIMIT));
+      autoTier2PublishPending_ = true;
+      (void)flushPendingPublishes(/*compileBatchRequests=*/false,
+                                  /*reason=*/"capacity");
+      if (pendingPublishes_.size() >=
+          static_cast<size_t>(EJIT_CODE_POOL_FIXED_NEAR_HOT_PENDING_LIMIT)) {
+        dropUnpublishedNearResult("pending-capacity");
+        return;
+      }
+    }
+    const uint32_t PoolId = info.poolId;
+    pendingPublishes_.push_back({req, fn, PoolId});
+    autoTier2PublishPending_ = true;
+    publishCodePoolStats();
+    EJIT_DIAG_DEBUG("near-hot linked pending func=%u pool=%u pending=%zu",
+                    realFuncIndex, PoolId, pendingPublishes_.size());
+    return;
+  }
+#else
   if (codeReadyFn_ && !codeReadyFn_(codeBatchCtx_, fn)) {
     if (tier == kEJitTierPgoUse) {
       // Tier-2 has completed compilation/JITLink into the near RW/NX pool, but
@@ -3881,6 +4088,7 @@ void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
         req.funcIndex, pendingPublishes_.size());
     return;
   }
+#endif
   if (info.codeSize == 0 && codeRangeFn_)
     (void)codeRangeFn_(codeRangeCtx_, fn, &info);
   EJitPublishStatus PS = cachePublish(req, fn, &info, pgoClearExclusive);
@@ -3935,14 +4143,19 @@ bool EJitSharedTaskPool::pollOne() {
   if (!state_)
     return false;
 
-  // All tiers arrive on the same shared MPSC queue. Baseline requests defer
-  // compilation so explicit publication can sort their JITLink allocations.
-  // Tier-1 compiles immediately into the far pool and starts sampling. Tier-2
-  // also compiles immediately, but runCompile retains its near-pool result
-  // owner-private until queue-drain publication replaces the live Tier-1 slot.
+  // All tiers arrive on the same shared MPSC queue. In fixed near-hot mode
+  // baseline and Tier-2 compile/link immediately into their selected near
+  // pool, while publication waits for the queue-drain commit. The legacy path
+  // may retain baseline requests for dimension-sorted batch allocation. Tier-1
+  // always compiles into the far pool and starts sampling immediately.
   EJitCompileRequest Req{};
   if (!queuePop(Req))
     return false;
+#ifdef EJIT_CODE_POOL_FIXED_NEAR_HOT
+  autoTier2IdleTicks_ = 0;
+  runCompile(Req);
+  return true;
+#else
   if (codeReadyFn_ && codeBatchFlushFn_ &&
       decodeReqTier(Req.funcIndex) == kEJitTierBaseline) {
     if (pendingBatchCompiles_.size() >= kEJitSharedQueueSlots) {
@@ -3965,6 +4178,7 @@ bool EJitSharedTaskPool::pollOne() {
   }
   runCompile(Req);
   return true;
+#endif
 }
 
 bool EJitSharedTaskPool::serviceMayConstRankingRequest() {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -25,10 +25,12 @@
 #ifdef EJIT_SRE_CODE_POOL
 
 #include "llvm/ExecutionEngine/EJIT/EJitSrePlatform.h"
+#include "llvm/ExecutionEngine/EJIT/EJitCodeRange.h"
 #include "llvm/ExecutionEngine/EJIT/EJitDiag.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h" // seal/split granule contract
 
 #include <cstdint>
+#include <limits>
 
 #ifndef EJIT_SRE_CODE_POOL_SIZE
 #define EJIT_SRE_CODE_POOL_SIZE                                                \
@@ -52,6 +54,19 @@ constexpr unsigned char kSrePtNo =
 constexpr unsigned kSreMid = static_cast<unsigned>(EJIT_SRE_CODE_POOL_MID);
 constexpr size_t k2MiB = static_cast<size_t>(2) * 1024 * 1024;
 constexpr size_t k4KiB = static_cast<size_t>(4) * 1024;
+#ifndef EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES
+#define EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES (2 * 1024 * 1024)
+#endif
+#ifndef EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES
+#define EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES (4 * 1024 * 1024)
+#endif
+constexpr size_t kNearHotCellBytes =
+    static_cast<size_t>(EJIT_CODE_POOL_NEAR_HOT_CELL_BYTES);
+constexpr size_t kNearHotPublicBytes =
+    static_cast<size_t>(EJIT_CODE_POOL_NEAR_HOT_PUBLIC_BYTES);
+constexpr size_t kNearHotRegionBytes =
+    kNearHotCellBytes * llvm::ejit::kEJitNearHotCellPoolCount +
+    kNearHotPublicBytes;
 } // namespace
 
 // Hard-lock the platform split/seal granularities against the shared-pool
@@ -63,6 +78,14 @@ static_assert(k2MiB == llvm::ejit::kEJitSharedSplitGranule,
 static_assert(k4KiB == llvm::ejit::kEJitSharedSealPage,
               "SRE pool seal page (4 KiB) must equal "
               "kEJitSharedSealPage (EJitSharedTaskPoolState.h).");
+static_assert(kNearHotCellBytes >= k2MiB && kNearHotCellBytes % k2MiB == 0,
+              "each near-hot cell pool must be a positive 2MiB multiple");
+static_assert(kNearHotPublicBytes >= k2MiB && kNearHotPublicBytes % k2MiB == 0,
+              "the near-hot public pool must be a positive 2MiB multiple");
+static_assert(kNearHotCellBytes <=
+                  (std::numeric_limits<size_t>::max() - kNearHotPublicBytes) /
+                      llvm::ejit::kEJitNearHotCellPoolCount,
+              "near-hot pool layout size overflows size_t");
 
 //===----------------------------------------------------------------------===//
 // Platform primitives (declaration only — defined by the platform/business)
@@ -183,11 +206,14 @@ unsigned sealAndSyncCache(uintptr_t Va, size_t Size) {
 } // namespace
 
 std::unique_ptr<llvm::ejit::EJitCodePoolManager>
-llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement) {
+llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement,
+                                   uint32_t PoolId, uintptr_t FixedBase,
+                                   size_t FixedSize) {
   EJitCodePoolManager::Options Opts;
   Opts.kind = Placement == EJitCodePoolPlacement::NearFixed
                   ? EJitCodePoolKind::Near
                   : EJitCodePoolKind::Far;
+  Opts.poolId = PoolId;
   Opts.poolSize = static_cast<size_t>(kSrePoolSize);
   Opts.poolAlign = k2MiB; // large-page / split granularity
   Opts.minCodeAlign = 64;
@@ -219,7 +245,7 @@ llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement) {
   // fall back to SRE_MemDbgAlloc (a too-small fixed region would exhaust on
   // every compile). A fixed region gives a stable JIT address range and, when
   // placed within +-128MiB of .text, lets codegen use direct bl/adrp.
-  if (Placement == EJitCodePoolPlacement::NearFixed) {
+  if (Placement == EJitCodePoolPlacement::NearFixed && FixedSize == 0) {
     uintptr_t FBase = reinterpret_cast<uintptr_t>(__ejit_code_start);
     uintptr_t FEnd = reinterpret_cast<uintptr_t>(__ejit_code_end);
     uintptr_t AlignedBase = (FBase + (static_cast<uintptr_t>(k2MiB) - 1)) &
@@ -252,6 +278,19 @@ llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement) {
     }
   }
 #endif
+
+  if (Placement == EJitCodePoolPlacement::NearFixed && FixedSize != 0) {
+    if ((FixedBase & (k2MiB - 1)) != 0 || FixedSize < Opts.poolSize) {
+      EJIT_DIAG(
+          "makeSreCodePoolManager: invalid explicit fixed slice base=0x%llx "
+          "size=%zu",
+          static_cast<unsigned long long>(FixedBase), FixedSize);
+      return nullptr;
+    }
+    Opts.fixedBase = FixedBase;
+    Opts.fixedSize = FixedSize;
+    Opts.poolSize = FixedSize;
+  }
 
 #ifdef EJIT_FIXED_CODE_POOL
   // Code-segment placement: the fixed region is RX by default, so each slab
@@ -320,6 +359,47 @@ llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement) {
 
   return std::make_unique<EJitCodePoolManager>(Opts, RawAlloc, Seal, Split,
                                                EnableRw);
+}
+
+std::unique_ptr<llvm::ejit::EJitCodePoolManager>
+llvm::ejit::makeSreNearHotCodePoolManager(uint32_t PoolId) {
+  if (PoolId >= kEJitNearHotPoolCount) {
+    EJIT_DIAG("make near-hot pool: invalid poolId=%u", PoolId);
+    return nullptr;
+  }
+#if defined(EJIT_FIXED_CODE_POOL)
+  uintptr_t FBase = reinterpret_cast<uintptr_t>(__ejit_code_start);
+  uintptr_t FEnd = reinterpret_cast<uintptr_t>(__ejit_code_end);
+  uintptr_t AlignedBase =
+      (FBase + (k2MiB - 1)) & ~(static_cast<uintptr_t>(k2MiB) - 1);
+  const size_t SliceBytes = PoolId == kEJitNearHotPublicPoolId
+                                ? kNearHotPublicBytes
+                                : kNearHotCellBytes;
+  const uintptr_t SliceOffset =
+      static_cast<uintptr_t>(PoolId) * kNearHotCellBytes;
+  const uintptr_t MaxAddress = std::numeric_limits<uintptr_t>::max();
+  const bool SliceOverflows = SliceOffset > kNearHotRegionBytes ||
+                              SliceBytes > kNearHotRegionBytes - SliceOffset;
+  const bool AddressOverflows = SliceOffset > MaxAddress - AlignedBase;
+  const bool RegionTooSmall =
+      FEnd < AlignedBase ||
+      (!AddressOverflows && (SliceOffset > FEnd - AlignedBase ||
+                             SliceBytes > FEnd - AlignedBase - SliceOffset));
+  if (AlignedBase < FBase || SliceOverflows || AddressOverflows ||
+      RegionTooSmall) {
+    EJIT_DIAG("make near-hot pool: fixed region too small poolId=%u "
+              "base=0x%llx end=0x%llx need=%zu",
+              PoolId, static_cast<unsigned long long>(FBase),
+              static_cast<unsigned long long>(FEnd), kNearHotRegionBytes);
+    return nullptr;
+  }
+  return makeSreCodePoolManager(EJitCodePoolPlacement::NearFixed, PoolId,
+                                AlignedBase + SliceOffset, SliceBytes);
+#else
+  EJIT_DIAG("make near-hot pool: EJIT_FIXED_CODE_POOL is disabled poolId=%u",
+            PoolId);
+  return nullptr;
+#endif
 }
 
 bool llvm::ejit::prepareSreCodeForCurrentCore(const void *FnPtr) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSrePlatform.cpp
@@ -315,11 +315,17 @@ llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement,
   // pool base. sealAndSyncCache syncs caches for the written range then makes
   // the page executable (enable_ex does not sync caches).
 #ifdef EJIT_CODE_POOL_4K_SEAL
-    return sealAndSyncCache(reinterpret_cast<uintptr_t>(Va), k4KiB);
+    const unsigned Rc =
+        sealAndSyncCache(reinterpret_cast<uintptr_t>(Va), k4KiB);
 #else
-    return sealAndSyncCache(reinterpret_cast<uintptr_t>(Va),
-                            static_cast<size_t>(kSrePoolSize));
+    const unsigned Rc = sealAndSyncCache(
+        reinterpret_cast<uintptr_t>(Va), static_cast<size_t>(kSrePoolSize));
 #endif
+    EJIT_DIAG_DEBUG("SRE adapter enable_ex va=0x%llx rc=%u",
+                    static_cast<unsigned long long>(
+                        reinterpret_cast<uintptr_t>(Va)),
+                    Rc);
+    return Rc;
 #else
     // Code-pool routing without permission flips (bring-up / measurement).
     (void)Va;
@@ -348,9 +354,14 @@ llvm::ejit::makeSreCodePoolManager(EJitCodePoolPlacement Placement,
     // WRITE, not execute (enable_ex / sealAndSyncCache syncs caches later, at
     // RW -> RX). Per-core: only the compiling core calls this; peer cores only
     // enable_ex to execute.
-    return ejit_sre_enable_rw(
+    const unsigned Rc = ejit_sre_enable_rw(
         /*level=*/1u,
         static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(Va)));
+    EJIT_DIAG_DEBUG("SRE adapter enable_rw va=0x%llx rc=%u",
+                    static_cast<unsigned long long>(
+                        reinterpret_cast<uintptr_t>(Va)),
+                    Rc);
+    return Rc;
 #else
     (void)Va;
     return 0;

--- a/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
+++ b/llvm/lib/ExecutionEngine/EJIT/ejit_registry.ld
@@ -90,7 +90,8 @@ SECTIONS
    * The section only needs page (4KiB) alignment: the runtime owns the 2MiB
    * alignment (enable_ex / split_2m_to_4k require 2MiB-aligned bases). The bytes
    * [__ejit_code_start, aligned start) are wasted slack (at most ~2MiB), so size
-   * the region with that headroom (16M -> ~14M usable, ~7 pools). If the aligned
+   * the region with that headroom (38M provides 36M usable for 16 cell pools
+   * and a 4MiB public pool). If the aligned
    * region is smaller than one pool (2MiB) the runtime falls back to
    * SRE_MemDbgAlloc with a diagnostic. Use (NOLOAD) only when the final platform
    * loader reserves/maps NOBITS ranges. Do not rely on NOLOAD in a relocatable
@@ -121,7 +122,8 @@ SECTIONS
   .text.ejit : ALIGN(4096)
   {
     __ejit_code_start = .;
-    . = __ejit_code_start + 16M;
+    /* 36MiB of pools plus up to 2MiB of alignment slack. */
+    . = __ejit_code_start + 38M;
     __ejit_code_end = .;
   } > CODE       /* code segment, near .text (±128MiB bl/adrp reach to AOT) */
 
@@ -165,7 +167,8 @@ SECTIONS
  *     .text.ejit : ALIGN(4096)
  *     {
  *       __ejit_code_start = .;
- *       . = __ejit_code_start + 16M;
+ *       /* 36MiB of pools plus up to 2MiB of alignment slack. */
+ *       . = __ejit_code_start + 38M;
  *       __ejit_code_end = .;
  *     }
  *   } INSERT AFTER .text;

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -224,6 +224,7 @@ if(EJIT_CODE_POOL_FIXED_NEAR_HOT)
   set(LLVM_LINK_COMPONENTS Support)
   add_llvm_unittest(EJITFixedNearHotTaskPoolTests
     EJitFixedNearHotTaskPoolTest.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
     ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
     ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp
     ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitLogger.cpp

--- a/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/EJIT/CMakeLists.txt
@@ -215,6 +215,40 @@ if(EJIT_TEST_FIXED_WORKER_CORE)
     EJIT_SRE_SHARED_TASKPOOL_WORKER_CORE=0)
 endif()
 
+# The production fixed near-hot path is compiled into LLVMEJIT with a private
+# macro, while this suite compiles EJitSharedTaskPool.cpp directly. Keep a
+# small, configuration-matched executable for the fixed-path state-machine
+# regression without changing the legacy shared-taskpool suite above.
+if(EJIT_CODE_POOL_FIXED_NEAR_HOT)
+  set(EJIT_FIXED_NEAR_HOT_LINK_COMPONENTS_SAVED "${LLVM_LINK_COMPONENTS}")
+  set(LLVM_LINK_COMPONENTS Support)
+  add_llvm_unittest(EJITFixedNearHotTaskPoolTests
+    EJitFixedNearHotTaskPoolTest.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitSharedPlatform.cpp
+    ${LLVM_MAIN_SRC_DIR}/lib/ExecutionEngine/EJIT/EJitLogger.cpp
+
+    PARTIAL_SOURCES_INTENDED
+    )
+  set(LLVM_LINK_COMPONENTS "${EJIT_FIXED_NEAR_HOT_LINK_COMPONENTS_SAVED}")
+  target_compile_definitions(EJITFixedNearHotTaskPoolTests PRIVATE
+    EJIT_SRE_TASKPOOL
+    EJIT_SRE_SHARED_TASKPOOL
+    EJIT_SRE_TASKPOOL_TESTING
+    EJIT_STATS_ENABLE
+    EJIT_CODE_POOL_BATCHED_PUBLISH
+    EJIT_CODE_POOL_FIXED_NEAR_HOT
+    EJIT_SRE_TASKPOOL_BUCKETS=${EJIT_SRE_TASKPOOL_BUCKETS}
+    EJIT_SRE_TASKPOOL_QUEUE_CAPACITY=${EJIT_SRE_TASKPOOL_QUEUE_CAPACITY}
+    EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE=${EJIT_SRE_TASKPOOL_WORKER_STACK_SIZE}
+    EJIT_ICACHE_DIM_SIZE=${EJIT_ICACHE_DIM_SIZE}
+    EJIT_ICACHE_FUNC_SLOTS=${EJIT_ICACHE_FUNC_SLOTS}
+    EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX=${EJIT_SRE_TASKPOOL_MAX_FUNC_INDEX}
+    EJIT_SRE_TASKPOOL_WORKER_THROTTLE_MULT=3
+    EJIT_SRE_TASKPOOL_WORKER_THROTTLE_DELAY_TICKS=100
+    )
+endif()
+
 # Convenience target: build + run only the cross-core shared taskpool tests.
 add_custom_target(check-ejit-shared-taskpool
   COMMAND $<TARGET_FILE:EJITSharedTaskPoolTests>

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -316,6 +316,8 @@ struct MockSre4K {
   size_t SealCalls = 0;
   int FailSealOnCall = -1; // 1-based seal index to fail; -1 = never
   unsigned SealFailRc = 7;
+  uintptr_t FailSealRegion = 0;
+  size_t FailSealRegionSize = 0;
   std::vector<uintptr_t> RwEnabledPages;
   size_t RwEnableCalls = 0;
   unsigned RwEnableRc = 0; // 0 = success; non-zero simulates enable_rw failure
@@ -342,6 +344,12 @@ struct MockSre4K {
     ++SealCalls;
     SealedPages.push_back(reinterpret_cast<uintptr_t>(P));
     if (FailSealOnCall > 0 && static_cast<int>(SealCalls) == FailSealOnCall)
+      return SealFailRc;
+    const uintptr_t Page = reinterpret_cast<uintptr_t>(P);
+    if (FailSealRegion != 0 &&
+        (Page < FailSealRegion || Page - FailSealRegion >= FailSealRegionSize))
+      return 0;
+    if (FailSealRegion != 0)
       return SealFailRc;
     return 0;
   }
@@ -1381,4 +1389,152 @@ TEST(EJitCodePoolMemMgrBatch, FnSizeSurvivesPendingFlush) {
   EXPECT_EQ(Info.fnSize, static_cast<uint64_t>(FnSize));
 
   cantFail(MM.deallocate(std::move(FA)));
+}
+
+// The fixed near-hot layout uses the JITDylib identity selected before
+// JITLink allocation. Verify that cell/public allocations remain isolated and
+// that a failed pool commit does not prevent another pool from committing.
+TEST(EJitCodePoolMemMgrBatch, FixedNearPoolsSelectAndCommitIndependently) {
+  constexpr uint32_t CellPool0 = 0;
+  constexpr uint32_t CellPool1 = 1;
+  constexpr uint32_t PublicPool = 16;
+  constexpr size_t CellBytes = kTwoMiB;
+  constexpr size_t PublicBytes = 4 * kTwoMiB;
+
+  MockSre4K M;
+  std::vector<std::unique_ptr<void, void (*)(void *)>> Regions;
+  std::vector<std::unique_ptr<EJitCodePoolManager>> Pools;
+  std::vector<EJitCodePoolManager *> NearPools;
+  for (uint32_t I = 0; I <= PublicPool; ++I) {
+    const size_t Bytes = I == PublicPool ? PublicBytes : CellBytes;
+    void *Region = testAlignedAlloc(kTwoMiB, Bytes);
+    ASSERT_NE(Region, nullptr);
+    Regions.emplace_back(Region, testAlignedFree);
+
+    auto O = fourKMemMgrOpts();
+    O.kind = EJitCodePoolKind::Near;
+    O.poolId = I;
+    O.poolSize = Bytes;
+    O.fixedBase = reinterpret_cast<uintptr_t>(Region);
+    O.fixedSize = Bytes;
+    O.needsEnableRw = true;
+    O.batchedPageSeal = true;
+    Pools.push_back(std::make_unique<EJitCodePoolManager>(
+        O, [&M](size_t N) { return M.rawAlloc(N); },
+        [&M](void *V) { return M.seal(V); },
+        [&M](void *B, size_t S) { return M.split(B, S); },
+        [&M](void *V) { return M.enableRw(V); }));
+    NearPools.push_back(Pools.back().get());
+  }
+
+  auto Far = std::make_unique<EJitCodePoolManager>(
+      poolOpts(CellBytes), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); });
+  EJitCodePoolMemoryManager MM(
+      NearPools, *Far, kFourKiB,
+      [&](const JITLinkDylib *JD) -> EJitCodePoolManager * {
+        if (!JD)
+          return nullptr;
+        if (JD->getName() == "spec_cell0")
+          return NearPools[CellPool0];
+        if (JD->getName() == "spec_cell1")
+          return NearPools[CellPool1];
+        if (JD->getName() == "spec_public")
+          return NearPools[PublicPool];
+        return nullptr;
+      });
+
+  JITLinkDylib Cell0("spec_cell0");
+  JITLinkDylib Cell1("spec_cell1");
+  JITLinkDylib Public("spec_public");
+  JITLinkDylib Unknown("spec_cell00");
+
+  auto G0 = makeCodeGraph(64, 0x1000);
+  auto IFA0 = cantFail(MM.allocate(&Cell0, *G0));
+  void *Addr0 = firstBlockAddr(*G0);
+  auto FA0 = cantFail(IFA0->finalize());
+  auto G0b = makeCodeGraph(64, 0x1100);
+  auto IFA0b = cantFail(MM.allocate(&Cell0, *G0b));
+  void *Addr0b = firstBlockAddr(*G0b);
+  auto FA0b = cantFail(IFA0b->finalize());
+
+  auto G1 = makeCodeGraph(64, 0x2000);
+  auto IFA1 = cantFail(MM.allocate(&Cell1, *G1));
+  void *Addr1 = firstBlockAddr(*G1);
+  auto FA1 = cantFail(IFA1->finalize());
+  auto GP = makeCodeGraph(64, 0x3000);
+  auto IFAP = cantFail(MM.allocate(&Public, *GP));
+  void *AddrP = firstBlockAddr(*GP);
+  auto FAP = cantFail(IFAP->finalize());
+
+  EXPECT_TRUE(Pools[CellPool0]->contains(Addr0));
+  EXPECT_TRUE(Pools[CellPool0]->contains(Addr0b));
+  EXPECT_TRUE(Pools[CellPool1]->contains(Addr1));
+  EXPECT_TRUE(Pools[PublicPool]->contains(AddrP));
+  EXPECT_GT(reinterpret_cast<uintptr_t>(Addr0b),
+            reinterpret_cast<uintptr_t>(Addr0));
+  EJitCompiledCodeInfo Info{};
+  EXPECT_FALSE(Pools[CellPool0]->findRange(Addr0, Info));
+  ASSERT_TRUE(Pools[CellPool0]->findPendingRange(Addr0, Info));
+  EXPECT_EQ(Info.poolId, CellPool0);
+  EXPECT_EQ(Info.poolKind, EJitCodePoolKind::Near);
+  EXPECT_FALSE(Pools[CellPool1]->findRange(Addr1, Info));
+  EXPECT_FALSE(Pools[PublicPool]->findRange(AddrP, Info));
+
+  // Exercise the real JITLink memory-manager path with an interleaved batch,
+  // rather than relying only on the four sentinel allocations above. The
+  // fixed selector remains semantic (cell0/cell1/public), and every result is
+  // still pending until its owning pool is flushed.
+  std::vector<void *> Interleaved;
+  for (size_t I = 0; I < 20; ++I) {
+    const uint32_t PoolId = I % 3 == 0   ? CellPool0
+                            : I % 3 == 1 ? CellPool1
+                                         : PublicPool;
+    const std::string Name = PoolId == CellPool0   ? "spec_cell0"
+                             : PoolId == CellPool1 ? "spec_cell1"
+                                                   : "spec_public";
+    JITLinkDylib JD(Name);
+    auto G = makeCodeGraph(64, 0x5000 + I * 0x100);
+    auto IFA = cantFail(MM.allocate(&JD, *G));
+    void *Addr = firstBlockAddr(*G);
+    Interleaved.push_back(Addr);
+    auto FA = cantFail(IFA->finalize());
+    cantFail(MM.deallocate(std::move(FA)));
+    ASSERT_TRUE(Pools[PoolId]->contains(Addr));
+    EXPECT_FALSE(Pools[PoolId]->findRange(Addr, Info));
+    ASSERT_TRUE(Pools[PoolId]->findPendingRange(Addr, Info));
+    EXPECT_EQ(Info.poolId, PoolId);
+  }
+  EXPECT_EQ(Interleaved.size(), 20u);
+
+  // A malformed/unknown JITDylib identity must fail allocation rather than
+  // silently falling back to the first near pool.
+  auto BadGraph = makeCodeGraph(64, 0x4000);
+  auto BadAlloc = MM.allocate(&Unknown, *BadGraph);
+  ASSERT_FALSE(static_cast<bool>(BadAlloc));
+  consumeError(BadAlloc.takeError());
+
+  // Commit cell0 and public independently. Inject a seal failure only for
+  // cell1; its pending range remains retryable and cannot block cell0/public.
+  M.FailSealRegion = reinterpret_cast<uintptr_t>(Regions[CellPool1].get());
+  M.FailSealRegionSize = CellBytes;
+  cantFail(Pools[CellPool0]->flushPendingRanges());
+  cantFail(Pools[PublicPool]->flushPendingRanges());
+  EXPECT_TRUE(Pools[CellPool0]->findRange(Addr0, Info));
+  EXPECT_TRUE(Pools[PublicPool]->findRange(AddrP, Info));
+  EXPECT_FALSE(Pools[CellPool1]->findRange(Addr1, Info));
+  EXPECT_GT(Pools[CellPool1]->pendingRangeCount(), 0u);
+  auto Failed = Pools[CellPool1]->flushPendingRanges();
+  ASSERT_TRUE(static_cast<bool>(Failed));
+  consumeError(std::move(Failed));
+
+  M.FailSealRegion = 0;
+  cantFail(Pools[CellPool1]->flushPendingRanges());
+  EXPECT_TRUE(Pools[CellPool1]->findRange(Addr1, Info));
+  EXPECT_EQ(Pools[CellPool1]->pendingRangeCount(), 0u);
+
+  cantFail(MM.deallocate(std::move(FA0)));
+  cantFail(MM.deallocate(std::move(FA0b)));
+  cantFail(MM.deallocate(std::move(FA1)));
+  cantFail(MM.deallocate(std::move(FAP)));
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitFixedNearHotTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitFixedNearHotTaskPoolTest.cpp
@@ -1,0 +1,250 @@
+//===-- EJitFixedNearHotTaskPoolTest.cpp - fixed near-hot tests --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
+#include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+#include "gtest/gtest.h"
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace llvm::ejit;
+
+#if defined(_WIN32)
+namespace llvm::ejit {
+const std::string &EJitModuleLoader::getFuncNameByFuncIdx(uint32_t) const {
+  static const std::string Empty;
+  return Empty;
+}
+} // namespace llvm::ejit
+#endif
+
+namespace {
+
+void *codeFor(uint32_t FuncIndex) {
+  return reinterpret_cast<void *>(0x100000ull +
+                                  static_cast<uintptr_t>(FuncIndex) * 64u);
+}
+
+EJitDimPair dim(uint32_t Type, uint32_t Instance) {
+  return EJitDimPair{Type, Instance};
+}
+
+struct FixedNearEntry {
+  void *fn = nullptr;
+  uint32_t poolId = kEJitNearHotPublicPoolId;
+  bool ready = false;
+};
+
+struct FixedNearPublishCtx {
+  std::vector<FixedNearEntry> entries;
+  uint32_t flushCalls = 0;
+  bool failCell1 = false;
+};
+
+uint32_t fixedNearPoolForRequest(const EJitCompileRequest &Req) {
+  if (Req.numDims == 0)
+    return kEJitNearHotPublicPoolId;
+  return Req.dims[0].instanceId < kEJitNearHotCellPoolCount
+             ? Req.dims[0].instanceId
+             : kEJitNearHotPublicPoolId;
+}
+
+bool mockFixedNearCompile(void *Ctx, const EJitCompileRequest &Req,
+                          void **OutFn) {
+  auto *C = static_cast<FixedNearPublishCtx *>(Ctx);
+  void *Fn = reinterpret_cast<void *>(
+      0x600000ull + static_cast<uintptr_t>(C->entries.size()) * 0x100u);
+  C->entries.push_back({Fn, fixedNearPoolForRequest(Req), false});
+  *OutFn = Fn;
+  return true;
+}
+
+bool mockFixedNearReady(void *Ctx, const void *Fn) {
+  auto *C = static_cast<FixedNearPublishCtx *>(Ctx);
+  for (const FixedNearEntry &Entry : C->entries)
+    if (Entry.fn == Fn)
+      return Entry.ready;
+  return false;
+}
+
+bool mockFixedNearRange(void *Ctx, const void *Fn, EJitCompiledCodeInfo *Out) {
+  auto *C = static_cast<FixedNearPublishCtx *>(Ctx);
+  for (const FixedNearEntry &Entry : C->entries) {
+    if (Entry.fn != Fn)
+      continue;
+    Out->fnPtr = const_cast<void *>(Fn);
+    Out->codeStart = reinterpret_cast<uintptr_t>(Fn);
+    Out->codeSize = 64;
+    Out->poolId = Entry.poolId;
+    Out->poolKind = EJitCodePoolKind::Near;
+    Out->poolBase =
+        0x80000000ull + static_cast<uint64_t>(Entry.poolId) * 0x200000ull;
+    Out->poolSize =
+        Entry.poolId == kEJitNearHotPublicPoolId ? 0x400000ull : 0x200000ull;
+    return true;
+  }
+  return false;
+}
+
+bool mockFixedNearLegacyFlush(void *) { return true; }
+
+bool mockFixedNearFlushPool(void *Ctx, uint32_t PoolId) {
+  auto *C = static_cast<FixedNearPublishCtx *>(Ctx);
+  ++C->flushCalls;
+  if (PoolId == 1 && C->failCell1)
+    return false;
+  for (FixedNearEntry &Entry : C->entries)
+    if (Entry.poolId == PoolId)
+      Entry.ready = true;
+  return true;
+}
+
+class FixedNearTaskPoolTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    EJitCoreId::resetForTest();
+    ejitIcacheClearAll();
+    State = std::make_unique<EJitSharedTaskPoolState>();
+  }
+
+  void TearDown() override {
+    ejitIcacheClearAll();
+    EJitCoreId::resetForTest();
+  }
+
+  EJitSharedCacheSlot *findReadySlot(uint32_t FuncIndex) {
+    for (uint32_t Bucket = 0; Bucket < kEJitSharedCacheBuckets; ++Bucket)
+      for (uint32_t SlotIndex = 0; SlotIndex < kEJitSharedCacheSlots;
+           ++SlotIndex) {
+        EJitSharedCacheSlot &Slot = State->buckets[Bucket].slots[SlotIndex];
+        if (Slot.state.loadAcquire() ==
+                static_cast<uint32_t>(EJitSharedSlotState::Ready) &&
+            Slot.funcIndex == FuncIndex)
+          return &Slot;
+      }
+    return nullptr;
+  }
+
+  std::unique_ptr<EJitSharedTaskPoolState> State;
+};
+
+TEST_F(FixedNearTaskPoolTest, WaitsForQuiescenceAndPublishesByPool) {
+  FixedNearPublishCtx Ctx;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&mockFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&mockFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&mockFixedNearReady, &mockFixedNearLegacyFlush,
+                              &Ctx);
+  Owner.setCodeBatchPoolFlushCallback(&mockFixedNearFlushPool, &Ctx);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  Owner.setInstanceEnabled(0, 0, true);
+  Owner.setInstanceEnabled(0, 1, true);
+
+  const EJitDimPair Cell0[1] = {dim(0, 0)};
+  const EJitDimPair Cell1[1] = {dim(0, 1)};
+  EXPECT_EQ(Owner.compileOrGet(201, Cell0, 1, codeFor(201)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(Owner.compileOrGet(202, Cell1, 1, codeFor(202)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(Owner.compileOrGet(203, nullptr, 0, codeFor(203)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(3), 3u);
+  ASSERT_EQ(Owner.pendingPublishCount(), 3u);
+  ASSERT_EQ(Ctx.flushCalls, 0u);
+
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Idle);
+  EXPECT_EQ(Ctx.flushCalls, 0u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 3u);
+
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  EXPECT_EQ(Ctx.flushCalls, 3u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
+  ASSERT_EQ(Ctx.entries.size(), 3u);
+  EXPECT_EQ(Ctx.entries[0].poolId, 0u);
+  EXPECT_EQ(Ctx.entries[1].poolId, 1u);
+  EXPECT_EQ(Ctx.entries[2].poolId, kEJitNearHotPublicPoolId);
+  for (const FixedNearEntry &Entry : Ctx.entries)
+    EXPECT_TRUE(Entry.ready);
+
+  auto H0 = Owner.compileOrGet(201, Cell0, 1, codeFor(201));
+  auto H1 = Owner.compileOrGet(202, Cell1, 1, codeFor(202));
+  auto HP = Owner.compileOrGet(203, nullptr, 0, codeFor(203));
+  EXPECT_EQ(H0.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(H1.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(HP.status, EJitCompileOrGetStatus::CacheHit);
+  if (H0.hasReadToken)
+    Owner.releaseRead(H0.bucketIndex);
+  if (H1.hasReadToken)
+    Owner.releaseRead(H1.bucketIndex);
+  if (HP.hasReadToken)
+    Owner.releaseRead(HP.bucketIndex);
+}
+
+TEST_F(FixedNearTaskPoolTest, FailureDoesNotBlockOtherPools) {
+  FixedNearPublishCtx Ctx;
+  Ctx.failCell1 = true;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&mockFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&mockFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&mockFixedNearReady, &mockFixedNearLegacyFlush,
+                              &Ctx);
+  Owner.setCodeBatchPoolFlushCallback(&mockFixedNearFlushPool, &Ctx);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  Owner.setInstanceEnabled(0, 0, true);
+  Owner.setInstanceEnabled(0, 1, true);
+
+  const EJitDimPair Cell0[1] = {dim(0, 0)};
+  const EJitDimPair Cell1[1] = {dim(0, 1)};
+  EXPECT_EQ(Owner.compileOrGet(301, Cell0, 1, codeFor(301)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(Owner.compileOrGet(302, Cell1, 1, codeFor(302)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(Owner.compileOrGet(303, nullptr, 0, codeFor(303)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(3), 3u);
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Idle);
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+
+  ASSERT_EQ(Ctx.entries.size(), 3u);
+  EXPECT_TRUE(Ctx.entries[0].ready);
+  EXPECT_FALSE(Ctx.entries[1].ready);
+  EXPECT_TRUE(Ctx.entries[2].ready);
+  EXPECT_NE(findReadySlot(301), nullptr);
+  EXPECT_EQ(findReadySlot(302), nullptr);
+  EXPECT_NE(findReadySlot(303), nullptr);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
+}
+
+TEST_F(FixedNearTaskPoolTest, MissingPoolFlushFallsBackCleanly) {
+  FixedNearPublishCtx Ctx;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&mockFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&mockFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&mockFixedNearReady, &mockFixedNearLegacyFlush,
+                              &Ctx);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_EQ(Owner.compileOrGet(304, nullptr, 0, codeFor(304)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(1), 1u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
+  EXPECT_EQ(findReadySlot(304), nullptr);
+}
+
+} // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitFixedNearHotTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitFixedNearHotTaskPoolTest.cpp
@@ -6,14 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ExecutionEngine/EJIT/EJitCodePool.h"
 #include "llvm/ExecutionEngine/EJIT/EJitModuleLoader.h"
 #include "llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h"
+#include "llvm/Support/Error.h"
 #include "gtest/gtest.h"
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
+using namespace llvm;
 using namespace llvm::ejit;
 
 #if defined(_WIN32)
@@ -46,6 +49,52 @@ struct FixedNearPublishCtx {
   std::vector<FixedNearEntry> entries;
   uint32_t flushCalls = 0;
   bool failCell1 = false;
+};
+
+struct RealFixedNearPublishCtx {
+  struct Entry {
+    void *fn = nullptr;
+    uint32_t tier = kEJitTierBaseline;
+  };
+
+  RealFixedNearPublishCtx() : storage(3 * PageSize) {
+    uintptr_t Raw = reinterpret_cast<uintptr_t>(storage.data());
+    base = (Raw + PageSize - 1) & ~(uintptr_t(PageSize) - 1);
+    EJitCodePoolManager::Options Opts;
+    Opts.kind = EJitCodePoolKind::Near;
+    Opts.poolId = 0;
+    Opts.poolSize = PageSize;
+    Opts.poolAlign = PageSize;
+    Opts.minCodeAlign = 16;
+    Opts.fourKSeal = true;
+    Opts.batchedPageSeal = true;
+    Opts.sealPageSize = PageSize;
+    Opts.fixedBase = base;
+    Opts.fixedSize = PageSize;
+    Opts.needsEnableRw = true;
+    pool = std::make_unique<EJitCodePoolManager>(
+        Opts, [](size_t) -> void * { return nullptr; },
+        [this](void *) {
+          timeline.push_back('X');
+          return 0u;
+        },
+        [this](void *, size_t) {
+          timeline.push_back('S');
+          return 0u;
+        },
+        [this](void *) {
+          timeline.push_back('W');
+          return 0u;
+        });
+  }
+
+  static constexpr size_t PageSize = 4096;
+  std::vector<uint8_t> storage;
+  uintptr_t base = 0;
+  std::unique_ptr<EJitCodePoolManager> pool;
+  std::vector<Entry> entries;
+  std::vector<char> timeline;
+  uint32_t flushCalls = 0;
 };
 
 uint32_t fixedNearPoolForRequest(const EJitCompileRequest &Req) {
@@ -103,6 +152,80 @@ bool mockFixedNearFlushPool(void *Ctx, uint32_t PoolId) {
   for (FixedNearEntry &Entry : C->entries)
     if (Entry.poolId == PoolId)
       Entry.ready = true;
+  return true;
+}
+
+bool mockWrongFixedNearFlushPool(void *, uint32_t) { return true; }
+
+bool realFixedNearCompile(void *Ctx, const EJitCompileRequest &Req,
+                          void **OutFn) {
+  auto *C = static_cast<RealFixedNearPublishCtx *>(Ctx);
+  const uint32_t Tier = decodeReqTier(Req.funcIndex);
+  if (Tier == kEJitTierInstrumented) {
+    void *Fn = reinterpret_cast<void *>(
+        0x700000u + static_cast<uintptr_t>(C->entries.size()) * 0x100u);
+    C->entries.push_back({Fn, Tier});
+    *OutFn = Fn;
+    return true;
+  }
+  auto Alloc = C->pool->allocateCode(64, 16);
+  if (!Alloc) {
+    consumeError(Alloc.takeError());
+    return false;
+  }
+  void *Fn = *Alloc;
+  if (Error Err = C->pool->enableRwRange(Fn, 64)) {
+    consumeError(std::move(Err));
+    return false;
+  }
+  if (!C->pool->recordPendingRange(Fn, 64))
+    return false;
+  C->pool->notePendingAllocation();
+  C->entries.push_back({Fn, Tier});
+  *OutFn = Fn;
+  return true;
+}
+
+bool realFixedNearReady(void *Ctx, const void *Fn) {
+  auto *C = static_cast<RealFixedNearPublishCtx *>(Ctx);
+  for (const auto &Entry : C->entries)
+    if (Entry.fn == Fn)
+      return Entry.tier == kEJitTierInstrumented ||
+             C->pool->isRangeReady(Fn);
+  return false;
+}
+
+bool realFixedNearRange(void *Ctx, const void *Fn,
+                        EJitCompiledCodeInfo *Out) {
+  auto *C = static_cast<RealFixedNearPublishCtx *>(Ctx);
+  for (const auto &Entry : C->entries) {
+    if (Entry.fn != Fn)
+      continue;
+    if (Entry.tier != kEJitTierInstrumented)
+      return C->pool->findRange(Fn, *Out) ||
+             C->pool->findPendingRange(Fn, *Out);
+    Out->fnPtr = const_cast<void *>(Fn);
+    Out->codeStart = reinterpret_cast<uintptr_t>(Fn);
+    Out->codeSize = 64;
+    Out->poolId = kEJitFarPoolId;
+    Out->poolKind = EJitCodePoolKind::Far;
+    Out->poolBase = Out->codeStart & ~uint64_t(0xfffu);
+    Out->poolSize = RealFixedNearPublishCtx::PageSize;
+    return true;
+  }
+  return false;
+}
+
+bool realFixedNearFlushPool(void *Ctx, uint32_t PoolId) {
+  auto *C = static_cast<RealFixedNearPublishCtx *>(Ctx);
+  ++C->flushCalls;
+  C->timeline.push_back('F');
+  if (PoolId != 0)
+    return false;
+  if (Error Err = C->pool->flushPendingRanges()) {
+    consumeError(std::move(Err));
+    return false;
+  }
   return true;
 }
 
@@ -190,6 +313,62 @@ TEST_F(FixedNearTaskPoolTest, WaitsForQuiescenceAndPublishesByPool) {
     Owner.releaseRead(HP.bucketIndex);
 }
 
+TEST_F(FixedNearTaskPoolTest,
+       TwoTier2RequestsAutoFlushThroughRealCodePoolStateMachine) {
+  RealFixedNearPublishCtx Ctx;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&realFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&realFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&realFixedNearReady,
+                              &mockFixedNearLegacyFlush, &Ctx);
+  Owner.setCodeBatchPoolFlushCallback(&realFixedNearFlushPool, &Ctx);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setPgoEnabled(true, 1, 2);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  ASSERT_EQ(Owner.compileOrGet(211, nullptr, 0, codeFor(211)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.compileOrGet(212, nullptr, 0, codeFor(212)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(2), 2u);
+  for (uint32_t Func : {211u, 212u}) {
+    auto Hit = Owner.tryCacheHit0D(Func);
+    ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (Hit.hasReadToken)
+      Owner.releaseRead(Hit.bucketIndex);
+  }
+  ASSERT_EQ(Owner.pollBudget(2), 2u);
+  ASSERT_EQ(Owner.pendingPublishCount(), 2u);
+  ASSERT_EQ(Ctx.flushCalls, 0u);
+
+  EJitCompiledCodeInfo Pending{};
+  ASSERT_GE(Ctx.entries.size(), 4u);
+  void *Tier2A = Ctx.entries[2].fn;
+  void *Tier2B = Ctx.entries[3].fn;
+  EXPECT_TRUE(Ctx.pool->findPendingRange(Tier2A, Pending));
+  EXPECT_TRUE(Ctx.pool->findPendingRange(Tier2B, Pending));
+  EXPECT_FALSE(Ctx.pool->isRangeReady(Tier2A));
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Idle);
+  EXPECT_EQ(Ctx.flushCalls, 0u);
+
+  EXPECT_EQ(Owner.workerPollOnce(), EJitWorkerStep::Consumed);
+  EXPECT_EQ(Ctx.flushCalls, 1u);
+  EXPECT_EQ(Owner.pendingPublishCount(), 0u);
+  EXPECT_TRUE(Ctx.pool->isRangeReady(Tier2A));
+  EXPECT_TRUE(Ctx.pool->isRangeReady(Tier2B));
+
+  const std::vector<char> Expected = {'S', 'W', 'W', 'F', 'X'};
+  EXPECT_EQ(Ctx.timeline, Expected);
+  for (uint32_t Func : {211u, 212u}) {
+    auto Hit = Owner.tryCacheHit0D(Func);
+    EXPECT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (Hit.hasReadToken)
+      Owner.releaseRead(Hit.bucketIndex);
+  }
+}
+
 TEST_F(FixedNearTaskPoolTest, FailureDoesNotBlockOtherPools) {
   FixedNearPublishCtx Ctx;
   Ctx.failCell1 = true;
@@ -245,6 +424,106 @@ TEST_F(FixedNearTaskPoolTest, MissingPoolFlushFallsBackCleanly) {
   ASSERT_EQ(Owner.pollBudget(1), 1u);
   EXPECT_EQ(Owner.pendingPublishCount(), 0u);
   EXPECT_EQ(findReadySlot(304), nullptr);
+}
+
+TEST_F(FixedNearTaskPoolTest, MissingPoolFlushContextFallsBackWithoutCall) {
+  FixedNearPublishCtx Ctx;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&mockFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&mockFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&mockFixedNearReady, &mockFixedNearLegacyFlush,
+                              &Ctx);
+  // The production callback dereferences its context to reach the owner ORC
+  // engine. A missing context must be a clean pending/AOT fallback, not an
+  // indirect call through x0 == 0 on the worker.
+  Owner.setCodeBatchPoolFlushCallback(&mockFixedNearFlushPool, nullptr);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_EQ(Owner.compileOrGet(305, nullptr, 0, codeFor(305)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(1), 1u);
+  ASSERT_EQ(Owner.pendingPublishCount(), 1u);
+  EXPECT_FALSE(Owner.flushCodeBatch());
+  EXPECT_EQ(Owner.pendingPublishCount(), 1u);
+  EXPECT_EQ(Ctx.flushCalls, 0u);
+  EXPECT_EQ(findReadySlot(305), nullptr);
+}
+
+TEST_F(FixedNearTaskPoolTest, CorruptPoolFlushFunctionFallsBackWithoutCall) {
+  FixedNearPublishCtx Ctx;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&mockFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&mockFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&mockFixedNearReady, &mockFixedNearLegacyFlush,
+                              &Ctx);
+  Owner.setCodeBatchPoolFlushCallback(&mockFixedNearFlushPool, &Ctx);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_EQ(Owner.compileOrGet(306, nullptr, 0, codeFor(306)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(1), 1u);
+  Owner.corruptCodeBatchPoolCallbackForTest(&mockWrongFixedNearFlushPool,
+                                            &Ctx);
+
+  EXPECT_FALSE(Owner.flushCodeBatch());
+  EXPECT_EQ(Owner.pendingPublishCount(), 1u);
+  EXPECT_EQ(Ctx.flushCalls, 0u);
+  EXPECT_EQ(findReadySlot(306), nullptr);
+}
+
+TEST_F(FixedNearTaskPoolTest, CorruptPoolFlushContextFallsBackWithoutCall) {
+  FixedNearPublishCtx Ctx;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&mockFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&mockFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&mockFixedNearReady, &mockFixedNearLegacyFlush,
+                              &Ctx);
+  Owner.setCodeBatchPoolFlushCallback(&mockFixedNearFlushPool, &Ctx);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_EQ(Owner.compileOrGet(307, nullptr, 0, codeFor(307)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(1), 1u);
+  Owner.corruptCodeBatchPoolCallbackForTest(
+      &mockFixedNearFlushPool, reinterpret_cast<void *>(uintptr_t{1}));
+
+  EXPECT_FALSE(Owner.flushCodeBatch());
+  EXPECT_EQ(Owner.pendingPublishCount(), 1u);
+  EXPECT_EQ(Ctx.flushCalls, 0u);
+  EXPECT_EQ(findReadySlot(307), nullptr);
+}
+
+TEST_F(FixedNearTaskPoolTest, CorruptPoolFlushLayoutFallsBackWithoutCall) {
+  FixedNearPublishCtx Ctx;
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(State.get());
+  Owner.setCompiler(&mockFixedNearCompile, &Ctx);
+  Owner.setCodeRangeProvider(&mockFixedNearRange, &Ctx);
+  Owner.setCodeBatchCallbacks(&mockFixedNearReady, &mockFixedNearLegacyFlush,
+                              &Ctx);
+  Owner.setCodeBatchPoolFlushCallback(&mockFixedNearFlushPool, &Ctx);
+  Owner.setMode(EJitCompileMode::Async);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  EXPECT_EQ(Owner.compileOrGet(308, nullptr, 0, codeFor(308)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_EQ(Owner.pollBudget(1), 1u);
+  Owner.corruptCodeBatchPoolLayoutTagForTest(0xFFFFFFFFFFFFFFFFULL);
+
+  EXPECT_FALSE(Owner.flushCodeBatch());
+  EXPECT_EQ(Owner.pendingPublishCount(), 1u);
+  EXPECT_EQ(Ctx.flushCalls, 0u);
+  EXPECT_EQ(findReadySlot(308), nullptr);
 }
 
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -3089,7 +3089,9 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // v18 adds per-slot fnSize (entry function's real size) for print_compiled
   // waste diagnostics (fn_size/overhead); purely diagnostic, never used by a
   // peer for sealing or enable_rw.
-  EXPECT_EQ(kEJitSharedAbiVersion, 18u);
+  // v19 adds fixed near-hot pool
+  // diagnostics and stable semantic pool ids.
+  EXPECT_EQ(kEJitSharedAbiVersion, 19u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(


### PR DESCRIPTION
## Summary / 摘要

Rebased onto `ejit_dev_spec4` at `c0cf09f1365073bb9461df2bfe625d2aebdb63f4`. This PR replaces PR191's singleton-prone sorted batching with 17 fixed semantic near-hot pools and excludes #181/MFS.

已 rebase 到 `ejit_dev_spec4` 的 `c0cf09f1365073bb9461df2bfe625d2aebdb63f4`。本 PR 使用 17 个固定语义 near-hot pool 替代 PR191 易退化为 singleton 的排序批处理方案，不包含 #181/MFS。

## ABI integration / ABI 整合

Mainline ABI v18 added per-slot `fnSize`. This rebase preserves the complete v18 `fnSize` stage/clear/publish/read/diagnostic semantics, then adds the 17-pool shared mirror and raises the combined shared ABI to **v19**. The default pool split table grows from 16 to 32 entries.

主线 ABI v18 已加入每个 cache slot 的 `fnSize`。本次 rebase 完整保留其 stage/clear/publish/read/诊断语义，再叠加 17-pool shared mirror，并将组合后的 shared ABI 升至 **v19**；默认 pool split 表由 16 扩为 32 项。

All worker/producer components must use the same commit and macro set. Mixed v18/v19 packages are rejected by ABI validation.

worker 与 producer 必须来自同一提交并使用同一组宏；混用 v18/v19 包会被 ABI 校验拒绝。

## Design / 设计

- `cell[0..15]`: one fixed 2 MiB pool per cell; entries with no cell dimension use one 4 MiB public pool.
- T1 remains far and publishes immediately. Baseline/Tier-2 link directly into the selected near pool and remain RW/NX until owner-worker quiescence or explicit publication.
- Pools commit independently. A failed pool falls back to AOT without blocking other pools; there is no cross-cell spill.
- Missing cell metadata is valid public-pool input. Duplicate, malformed, ambiguous, or out-of-range cell metadata fails closed to AOT.
- Default usable capacity is `16 * 2 MiB + 4 MiB = 36 MiB`; the example linker reservation is 38 MiB including alignment slack.
- Pool selection reaches JITLink through explicit allocation metadata and does not add stable inline-cache hit work.
- `ejit_taskpool_print_compiled` lists only published code, sorted by actual function address, while retaining `fn_size`/overhead diagnostics from mainline.

## SRE publish fix / SRE 发布修复

Board testing found a synchronous exception after `auto-publishing ...` and before the pool callback. `std::find(vector<uint32_t>)` could lower to `wmemchr`, an unsafe dependency in the freestanding SRE image. Pool deduplication now uses a 17-bit `uint32_t` bitmap.

板端异常发生在 `auto-publishing ...` 之后、pool callback 之前。根因是 `std::find(vector<uint32_t>)` 可能被降为 freestanding SRE 不可安全执行的 `wmemchr`。现在改为 17-bit `uint32_t` 位图去重。

Additional hardening / 额外加固：

- Callback/private batch layout remains stable across fixed-near feature variants.
- Callback target/context/layout mismatch fails closed to AOT before indirect calls.
- Callback diagnostics are split into bounded records; repeated per-manager `findRange` miss noise is removed.
- The callback canary/layoutTag remains intentionally diagnostic and fail-closed; simplification is a non-blocking follow-up.

## Linker and build contract / Linker 与构建契约

The product preset enables fixed near-hot pools by default. Rebuild `LLVMEJIT` and relink the firmware/application; rebuilding only the demo or Clang frontend is insufficient. The final linker script must reserve the complete region, for example:

```ld
.text.ejit : ALIGN(4096)
{
  __ejit_code_start = .;
  . = __ejit_code_start + 38M;
  __ejit_code_end = .;
} > CODE
```

板端需使用项目 preset 重建 `LLVMEJIT` 并重新链接固件/应用，最终 linker script 必须预留完整区域。只重编 demo 或 Clang 前端不够。

## Focused verification / 聚焦验证

- `EJITFixedNearHotTaskPoolTests`: **8/8 passed**.
- Shared ABI/fnSize/fingerprint focused tests: **6/6 passed** (`AbiLayoutAndHeader`, `PublishedSlotCarriesFnSize`, ABI rejection, fingerprint attach/reject, v19 range semantics).
- Real two-Tier-2 state machine verifies pending RW/NX before quiescence and the order `split, enable_rw, enable_rw, flush, enable_ex` before Ready publication.
- Fixed-near ON and legacy OFF SharedTaskPool translation units compile.
- Focused LLVMEJIT objects compile with `-j2`: Runtime, OrcEngine, CompileDriver, CodePool, CodePoolMemoryManager, SrePlatform, SharedTaskPool.
- Focused host SharedTaskPool object: undefined `wmemchr` count **0**, `wmemchr` relocation count **0**.
- `git diff --check` passed; normal and `--ignore-space-at-eol` diff stats match; worktree clean.

A requested long aggregate build was stopped at 705/1652 to avoid wasting local resources; it was replaced by the focused object/test matrix above. No full LLVMEJIT link or new AArch64-BE final archive was produced in this rebase pass.

按用户要求，耗时的聚合构建在 705/1652 处停止，改用上述聚焦对象与测试矩阵。本轮 rebase 未完成完整 LLVMEJIT 链接，也未生成新的 AArch64-BE 最终 archive。

## Scope / 范围

Board validation is still required for the final archive/ELF relocations, linker reservation, same-VA cross-core mapping, 4 KiB split/seal, rodata/GOT/high alignment, 150-version capacity, and W^X behavior. Far Tier-1 reclaim, MFS, and the non-blocking second `post_publish_seen` invocation coverage are out of scope.

板端仍需验证最终 archive/ELF relocation、linker 预留、跨核同 VA、4 KiB split/seal、rodata/GOT/高对齐、150 版本容量及 W^X。Far Tier-1 reclaim、MFS 和非阻塞的第二次 `post_publish_seen` 调用覆盖不在本 PR 范围内。
