### PR TITLE
[EJIT] 只读段并入可执行段（4K-seal 全模式）— issue #197 task 2

### DIFF
--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -176,6 +176,28 @@ EJitCodePoolManager &EJitCodePoolMemoryManager::selectPool(
 void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
                                          OnAllocatedFunction OnAllocated) {
   EJitCodePoolManager &Pool = selectPool(JD);
+
+  // Fold pure read-only sections (string constants, const arrays, jump
+  // tables) into the executable segment BEFORE the layout is built: the
+  // compact 16B packing below requires every segment to be executable, so a
+  // single 37-byte .rodata would otherwise force the whole graph back to
+  // page-per-segment layout and burn a full 4KiB page. The constant bytes
+  // are never executed (the AOT path already embeds literal pools in .text),
+  // and sealing them RX together with the code only tightens W^X: in the
+  // page-based layout they sat on a slab that is enable_rw'd wholesale at
+  // allocate and from which only the exec ranges are sealed back, so the
+  // rodata page stayed writable in the fixed code segment. Writable sections
+  // keep their own pages (the peer enable_rw protocol and the no-RWX
+  // invariant rest on write/exec pages never sharing), and an alignment
+  // beyond the code alignment still falls back via the compact check below.
+  // Gated on batched seal mode — the only mode whose layout this serves.
+  if (Pool.usesBatchedPageSeal())
+    for (Section &Sec : G.sections())
+      if ((Sec.getMemProt() & orc::MemProt::Read) != orc::MemProt::None &&
+          (Sec.getMemProt() & (orc::MemProt::Write | orc::MemProt::Exec)) ==
+              orc::MemProt::None)
+        Sec.setMemProt(orc::MemProt::Read | orc::MemProt::Exec);
+
   BasicLayout BL(G);
 
   bool ExecOnly = true;

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -178,20 +178,42 @@ void EJitCodePoolMemoryManager::allocate(const JITLinkDylib *JD, LinkGraph &G,
   EJitCodePoolManager &Pool = selectPool(JD);
 
   // Fold pure read-only sections (string constants, const arrays, jump
-  // tables) into the executable segment BEFORE the layout is built: the
-  // compact 16B packing below requires every segment to be executable, so a
-  // single 37-byte .rodata would otherwise force the whole graph back to
-  // page-per-segment layout and burn a full 4KiB page. The constant bytes
-  // are never executed (the AOT path already embeds literal pools in .text),
-  // and sealing them RX together with the code only tightens W^X: in the
-  // page-based layout they sat on a slab that is enable_rw'd wholesale at
-  // allocate and from which only the exec ranges are sealed back, so the
-  // rodata page stayed writable in the fixed code segment. Writable sections
-  // keep their own pages (the peer enable_rw protocol and the no-RWX
-  // invariant rest on write/exec pages never sharing), and an alignment
-  // beyond the code alignment still falls back via the compact check below.
-  // Gated on batched seal mode — the only mode whose layout this serves.
-  if (Pool.usesBatchedPageSeal())
+  // tables) into the executable segment BEFORE the layout is built.
+  //
+  // Why fold: BasicLayout groups blocks by {MemProt, MemLifetime}. A pure
+  // read-only section (R--) and the code section (R+X) land in DIFFERENT
+  // segments, and whether the layout is the 16-byte compact one (batched
+  // mode) or the 4K-page one (immediate mode), the two segments each occupy
+  // their OWN 4KiB page(s) — a 37-byte .rodata costs a whole page and, in
+  // batched mode, also breaks the ExecOnly compact stride. Promoting the
+  // R-- section to R+X BEFORE BasicLayout merges it into the code segment,
+  // so text and rodata lay out contiguous within one segment and share a
+  // page. This wins in BOTH 4K seal sub-modes: batched (16-byte compact
+  // stride across allocations) and immediate (contiguous within the single
+  // allocation's page), and in both near and far pools.
+  //
+  // Why safe:
+  //  - The constant bytes are never executed (the AOT path already embeds
+  //    literal pools in .text), and even if executed they are on an RX page.
+  //  - Sealing them RX with the code tightens W^X: previously the rodata
+  //    page sat on a slab-wide enable_rw'd (RW) page and, being neither exec
+  //    nor write, was never sealed back — staying RW in the fixed code
+  //    segment. Folded, it seals RX with the code.
+  //  - Writable sections (e.g. Tier-1 __profc_ counters, R+W) are excluded
+  //    by the Write check, so the peer enable_rw protocol and the no-RWX
+  //    invariant (write/exec pages never share) are untouched. __profd_
+  //    (read-only) folding into the exec segment is fine: a peer reads it
+  //    from the RX page, same as it reads code.
+  //  - An over-aligned (e.g. alignas(32)) read-only block still triggers the
+  //    page-granular fallback: the merged segment's Alignment = max(block
+  //    alignments) exceeds codeAlignment(), so FitsCompactAlign=false (in
+  //    batched mode) / LayoutAlign stays PageSize_ (in immediate mode).
+  //
+  // Gated on usesPageSeal() (4K-seal, both sub-modes): the legacy 2MiB
+  // whole-pool seal flips an entire pool RX off a single pointer, which
+  // cannot carve out per-page W^X, so folding read-only data there would
+  // lose the W^X tightening and is not done.
+  if (Pool.usesPageSeal())
     for (Section &Sec : G.sections())
       if ((Sec.getMemProt() & orc::MemProt::Read) != orc::MemProt::None &&
           (Sec.getMemProt() & (orc::MemProt::Write | orc::MemProt::Exec)) ==

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -1120,3 +1120,56 @@ TEST(EJitCodePoolMemMgrBatch, HighAlignedReadOnlySectionKeepsPageLayout) {
   cantFail(MM.deallocate(std::move(FA)));
   cantFail(MM.deallocate(std::move(FA2)));
 }
+
+// Immediate 4K-seal mode (batchedPageSeal = false, fourKSeal = true): the
+// promotion must still fire, because it is gated on usesPageSeal(), not on
+// batched. Here the win is intra-allocation, not cross-allocation: a pure
+// read-only section would otherwise land in its own segment and own its own
+// 4KiB page (BasicLayout groups by {MemProt, MemLifetime}, so R-- and R+X
+// stay separate segments, each page-padded). Promoted to R+X, rodata merges
+// into the code segment, lays out contiguous with it, and the single 4K page
+// is sealed RX at finalize. This is the aarch64_be far-pool / Tier-1 shape
+// (online-PGO __profc_ counters are R+W and stay out of the gate).
+TEST(EJitCodePoolMemMgr4K, ReadOnlySectionFoldsIntoExecSegmentImmediate) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeTextAndRoDataGraph(0x1000, 0x2000, /*RodataAlign=*/16);
+  Section *Text = G->findSectionByName("__text");
+  Section *RoData = G->findSectionByName("__rodata");
+  ASSERT_NE(Text, nullptr);
+  ASSERT_NE(RoData, nullptr);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *TextAddr = blockAddrInSection(*G, *Text);
+  void *RoAddr = blockAddrInSection(*G, *RoData);
+  ASSERT_NE(TextAddr, nullptr);
+  ASSERT_NE(RoAddr, nullptr);
+
+  // Promoted, and the 37 bytes share the code's page (no page of its own).
+  EXPECT_EQ(RoData->getMemProt(), orc::MemProt::Read | orc::MemProt::Exec);
+  auto PageOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) &
+           ~static_cast<uintptr_t>(kFourKiB - 1);
+  };
+  EXPECT_EQ(PageOf(TextAddr), PageOf(RoAddr))
+      << "read-only content must not occupy a page of its own in immediate "
+         "mode either";
+  // Contiguous within the segment: rodata lands right after the 64-byte text
+  // block (16-byte aligned), so the two do not straddle a page boundary.
+  EXPECT_EQ(static_cast<uintptr_t>(reinterpret_cast<char *>(RoAddr) -
+                                   reinterpret_cast<char *>(TextAddr)),
+            static_cast<uintptr_t>(64))
+      << "text and rodata must be contiguous, not page-strided";
+
+  // Immediate mode seals the exec page at finalize (not deferred to flush).
+  EXPECT_EQ(M.SealCalls, 0u);
+  auto FA = cantFail(IFA->finalize());
+  EXPECT_EQ(M.SealCalls, 1u);
+  ASSERT_EQ(M.SealedPages.size(), 1u);
+  EXPECT_EQ(M.SealedPages[0], PageOf(TextAddr));
+  cantFail(MM.deallocate(std::move(FA)));
+}

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -397,6 +397,39 @@ void *blockAddrByExec(LinkGraph &G, bool WantExec) {
   return nullptr;
 }
 
+// A graph with one executable (__text, R+X) section and one pure read-only
+// (__rodata, R) section — the shape a function holding a string constant or a
+// const table links into. RodataAlign is the read-only block's alignment.
+std::unique_ptr<LinkGraph> makeTextAndRoDataGraph(uint64_t TextVAddr,
+                                                  uint64_t RoDataVAddr,
+                                                  unsigned RodataAlign) {
+  auto G = std::make_unique<LinkGraph>(
+      "g", std::make_shared<orc::SymbolStringPool>(),
+      Triple("x86_64-unknown-linux-gnu"), SubtargetFeatures(),
+      getGenericEdgeKindName);
+  auto &Text =
+      G->createSection("__text", orc::MemProt::Read | orc::MemProt::Exec);
+  G->createContentBlock(Text, ArrayRef<char>(CodeBytes, 64),
+                        orc::ExecutorAddr(TextVAddr), 16, 0);
+  auto &RoData = G->createSection("__rodata", orc::MemProt::Read);
+  // 37 bytes — the exact size of the .rodata.str1.1 section observed on the
+  // board forcing a whole-graph page fallback.
+  G->createContentBlock(RoData, ArrayRef<char>(CodeBytes, 37),
+                        orc::ExecutorAddr(RoDataVAddr), RodataAlign, 0);
+  return G;
+}
+
+// Returns the assigned address of the first block in the given section
+// (after allocate() has applied the layout). Section identity, not prot: the
+// read-only section is promoted to R+X during allocate, so a prot-based scan
+// can no longer tell it apart from the code.
+void *blockAddrInSection(LinkGraph &G, Section &S) {
+  for (Block *B : G.blocks())
+    if (&B->getSection() == &S)
+      return B->getAddress().toPtr<void *>();
+  return nullptr;
+}
+
 } // namespace
 
 // allocate() must not seal; finalize() seals exactly the covered 4K page(s);
@@ -974,4 +1007,116 @@ TEST(EJitCodePoolMemMgrBatch, PureCodeAllocationsSharePageUntilFlush) {
 
   cantFail(MM.deallocate(std::move(FA0)));
   cantFail(MM.deallocate(std::move(FA1)));
+}
+
+// A pure read-only section (string constant, const table, jump table) must
+// NOT cost a page-exclusive segment in batched-seal mode: allocate folds it
+// into the executable segment, so the graph keeps the compact 16B layout —
+// the 37 bytes of .rodata share the code's page instead of owning a 4KiB one
+// — and at flush they seal RX together with the code (tightening W^X over
+// the page-based layout, which left them on a slab-wide RW page).
+TEST(EJitCodePoolMemMgrBatch, ReadOnlySectionFoldsIntoExecSegment) {
+  MockSre4K M;
+  auto O = fourKMemMgrOpts();
+  O.minCodeAlign = 16;
+  O.batchedPageSeal = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeTextAndRoDataGraph(0x1000, 0x2000, /*RodataAlign=*/16);
+  Section *Text = G->findSectionByName("__text");
+  Section *RoData = G->findSectionByName("__rodata");
+  ASSERT_NE(Text, nullptr);
+  ASSERT_NE(RoData, nullptr);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  // Resolve by section identity, not block-iteration order: G.blocks() backs a
+  // DenseSet so its order is non-deterministic, and after promotion both
+  // sections are R+X so a prot-based scan cannot tell them apart either.
+  void *TextAddr = blockAddrInSection(*G, *Text);
+  void *RoAddr = blockAddrInSection(*G, *RoData);
+  ASSERT_NE(TextAddr, nullptr);
+  ASSERT_NE(RoAddr, nullptr);
+
+  // Folded into the executable segment: the section is promoted to R+X and
+  // the 37 bytes share the code's page.
+  EXPECT_EQ(RoData->getMemProt(),
+            orc::MemProt::Read | orc::MemProt::Exec);
+  auto PageOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) &
+           ~static_cast<uintptr_t>(kFourKiB - 1);
+  };
+  EXPECT_EQ(PageOf(TextAddr), PageOf(RoAddr))
+      << "read-only content must not occupy a page of its own";
+
+  // The compact stride survives the folded section: the next graph packs
+  // onto the same page (total 64+37 bytes, 16B-padded).
+  auto G2 = makeCodeGraph(64, 0x3000);
+  auto IFA2 = cantFail(MM.allocate(nullptr, *G2));
+  void *Addr2 = firstBlockAddr(*G2);
+  EXPECT_EQ(PageOf(Addr2), PageOf(TextAddr));
+
+  // Both allocations record pending ranges and seal as ONE page at flush.
+  EXPECT_EQ(M.SealCalls, 0u);
+  auto FA = cantFail(IFA->finalize());
+  auto FA2 = cantFail(IFA2->finalize());
+  EXPECT_EQ(Pool.pendingRangeCount(), 2u);
+  cantFail(Pool.flushPendingRanges());
+  EXPECT_EQ(M.SealCalls, 1u);
+
+  EJitCompiledCodeInfo Info{};
+  EXPECT_TRUE(Pool.findRange(TextAddr, Info));
+
+  cantFail(MM.deallocate(std::move(FA)));
+  cantFail(MM.deallocate(std::move(FA2)));
+}
+
+// A read-only block aligned BEYOND the code alignment (e.g. alignas(32))
+// keeps the page-granular fallback: the promotion still folds it into the
+// executable segment, but the merged segment's alignment then exceeds the
+// compact threshold, so the layout is page-per-segment again — the safety
+// valve that keeps over-aligned content out of 16B packing.
+TEST(EJitCodePoolMemMgrBatch, HighAlignedReadOnlySectionKeepsPageLayout) {
+  MockSre4K M;
+  auto O = fourKMemMgrOpts();
+  O.minCodeAlign = 16;
+  O.batchedPageSeal = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeTextAndRoDataGraph(0x1000, 0x2000, /*RodataAlign=*/32);
+  Section *Text = G->findSectionByName("__text");
+  Section *RoData = G->findSectionByName("__rodata");
+  ASSERT_NE(Text, nullptr);
+  ASSERT_NE(RoData, nullptr);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *TextAddr = blockAddrInSection(*G, *Text);
+  void *RoAddr = blockAddrInSection(*G, *RoData);
+  ASSERT_NE(TextAddr, nullptr);
+  ASSERT_NE(RoAddr, nullptr);
+
+  // Folded (promoted, same page as the code)…
+  EXPECT_EQ(RoData->getMemProt(), orc::MemProt::Read | orc::MemProt::Exec);
+  auto PageOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) &
+           ~static_cast<uintptr_t>(kFourKiB - 1);
+  };
+  EXPECT_EQ(PageOf(TextAddr), PageOf(RoAddr));
+
+  // …but the layout fell back to page granularity: a following allocation
+  // cannot share this page (a compact stride would land it ~112 bytes in).
+  auto G2 = makeCodeGraph(64, 0x3000);
+  auto IFA2 = cantFail(MM.allocate(nullptr, *G2));
+  void *Addr2 = firstBlockAddr(*G2);
+  EXPECT_NE(PageOf(Addr2), PageOf(TextAddr));
+
+  auto FA = cantFail(IFA->finalize());
+  auto FA2 = cantFail(IFA2->finalize());
+  cantFail(MM.deallocate(std::move(FA)));
+  cantFail(MM.deallocate(std::move(FA2)));
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -430,6 +430,31 @@ void *blockAddrInSection(LinkGraph &G, Section &S) {
   return nullptr;
 }
 
+// The Tier-1 online-PGO shape: one executable (__text, R+X), one read-only
+// data (__profd_, R), and one runtime-writable counter (__profc_, R+W) in
+// the same graph. The far pool serves spec_t1_* dylibs in immediate 4K-seal
+// mode; this is the layout the promotion widens to cover.
+std::unique_ptr<LinkGraph> makeTextProfdProfcGraph(uint64_t TextVAddr,
+                                                   uint64_t ProfdVAddr,
+                                                   uint64_t ProfcVAddr) {
+  auto G = std::make_unique<LinkGraph>(
+      "g", std::make_shared<orc::SymbolStringPool>(),
+      Triple("x86_64-unknown-linux-gnu"), SubtargetFeatures(),
+      getGenericEdgeKindName);
+  auto &Text =
+      G->createSection("__text", orc::MemProt::Read | orc::MemProt::Exec);
+  G->createContentBlock(Text, ArrayRef<char>(CodeBytes, 64),
+                        orc::ExecutorAddr(TextVAddr), 16, 0);
+  auto &Profd = G->createSection("__profd_", orc::MemProt::Read);
+  G->createContentBlock(Profd, ArrayRef<char>(CodeBytes, 37),
+                        orc::ExecutorAddr(ProfdVAddr), 16, 0);
+  auto &Profc =
+      G->createSection("__profc_", orc::MemProt::Read | orc::MemProt::Write);
+  G->createContentBlock(Profc, ArrayRef<char>(CodeBytes, 64),
+                        orc::ExecutorAddr(ProfcVAddr), 16, 0);
+  return G;
+}
+
 } // namespace
 
 // allocate() must not seal; finalize() seals exactly the covered 4K page(s);
@@ -1171,5 +1196,83 @@ TEST(EJitCodePoolMemMgr4K, ReadOnlySectionFoldsIntoExecSegmentImmediate) {
   EXPECT_EQ(M.SealCalls, 1u);
   ASSERT_EQ(M.SealedPages.size(), 1u);
   EXPECT_EQ(M.SealedPages[0], PageOf(TextAddr));
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// The Tier-1 online-PGO shape routed through selectPool's spec_t1_ branch:
+// text (R+X) + __profd_ (R, read-only) + __profc_ (R+W, runtime counter) in
+// one graph, allocated on the FAR pool in immediate 4K-seal mode. This is the
+// real surface the widened gate (usesPageSeal) exposes, and it asserts the
+// invariants the far-pool path must keep:
+//  - __profd_ is promoted to R+X and folds into the code page (it is
+//    read-only; a peer reads it from the RX page, same as code);
+//  - __profc_ (R+W) is NOT promoted (Write excluded) and keeps its own RW
+//    page, never sharing a 4K page with the executable extent (no RWX);
+//  - the recorded writable range covers ONLY __profc_ (never the exec
+//    extent), so a peer's enable_rw touches only the counter page.
+TEST(EJitCodePoolMemMgr4K, FarPoolTier1ProfdFoldsProfcStaysWritable) {
+  MockSre4K NearM, FarM;
+  auto NearOpts = fourKMemMgrOpts(); // fourKSeal=true, batched=false, near
+  NearOpts.kind = EJitCodePoolKind::Near;
+  auto FarOpts = fourKMemMgrOpts();
+  FarOpts.kind = EJitCodePoolKind::Far;
+  EJitCodePoolManager Near(
+      NearOpts, [&NearM](size_t N) { return NearM.rawAlloc(N); },
+      [&NearM](void *V) { return NearM.seal(V); },
+      [&NearM](void *B, size_t S) { return NearM.split(B, S); });
+  EJitCodePoolManager Far(
+      FarOpts, [&FarM](size_t N) { return FarM.rawAlloc(N); },
+      [&FarM](void *V) { return FarM.seal(V); },
+      [&FarM](void *B, size_t S) { return FarM.split(B, S); });
+  EJitCodePoolMemoryManager MM(Near, Far, kFourKiB);
+
+  JITLinkDylib Tier1("spec_t1_1");
+  auto G = makeTextProfdProfcGraph(0x1000, 0x2000, 0x3000);
+  Section *Text = G->findSectionByName("__text");
+  Section *Profd = G->findSectionByName("__profd_");
+  Section *Profc = G->findSectionByName("__profc_");
+  ASSERT_NE(Text, nullptr);
+  ASSERT_NE(Profd, nullptr);
+  ASSERT_NE(Profc, nullptr);
+  auto IFA = cantFail(MM.allocate(&Tier1, *G));
+  void *TextAddr = blockAddrInSection(*G, *Text);
+  void *ProfdAddr = blockAddrInSection(*G, *Profd);
+  void *ProfcAddr = blockAddrInSection(*G, *Profc);
+  ASSERT_NE(TextAddr, nullptr);
+  ASSERT_NE(ProfdAddr, nullptr);
+  ASSERT_NE(ProfcAddr, nullptr);
+
+  auto PageOf = [](void *P) {
+    return reinterpret_cast<uintptr_t>(P) &
+           ~static_cast<uintptr_t>(kFourKiB - 1);
+  };
+
+  // Routed to the far pool (selectPool's spec_t1_ branch).
+  EXPECT_TRUE(Far.contains(TextAddr));
+  EXPECT_FALSE(Near.contains(TextAddr));
+
+  // __profd_ (read-only) promoted to R+X and folded onto the code page.
+  EXPECT_EQ(Profd->getMemProt(), orc::MemProt::Read | orc::MemProt::Exec);
+  EXPECT_EQ(PageOf(TextAddr), PageOf(ProfdAddr))
+      << "__profd_ must fold into the code page, not own one";
+
+  // __profc_ (R+W) NOT promoted and never shares a page with the exec extent.
+  EXPECT_EQ(Profc->getMemProt(),
+            orc::MemProt::Read | orc::MemProt::Write);
+  EXPECT_NE(PageOf(ProfcAddr), PageOf(TextAddr))
+      << "__profc_ must keep its own RW page (no RWX)";
+
+  auto FA = cantFail(IFA->finalize());
+  EJitCompiledCodeInfo Info{};
+  ASSERT_TRUE(Far.findRange(TextAddr, Info));
+  EXPECT_EQ(Info.poolKind, EJitCodePoolKind::Far);
+  // Exactly one writable range, and it covers only __profc_ (never the exec
+  // extent that contains text + __profd_).
+  ASSERT_EQ(Info.writableCount, 1u);
+  EXPECT_EQ(Info.writableRanges[0].addr, PageOf(ProfcAddr));
+  EXPECT_EQ(PageOf(reinterpret_cast<void *>(Info.writableRanges[0].addr)),
+            PageOf(ProfcAddr));
+  EXPECT_NE(PageOf(reinterpret_cast<void *>(Info.writableRanges[0].addr)),
+            PageOf(TextAddr));
   cantFail(MM.deallocate(std::move(FA)));
 }


### PR DESCRIPTION
## issue #197 task 2 — 只读段并入可执行段（4K-seal 全模式）

> 本 PR 描述已随 commit `c98e5d9b`(gate 放宽)更新,与代码对齐;旧版(gate=`usesBatchedPageSeal()`、far pool 自动跳过)作废。

### 背景
issue #197 第 5 项诊断已上板实锤:一个 37 字节 `.rodata.str1.1` 字符串常量迫使整块页独占、56 字节代码 entry 换 4K 页。根因——`BasicLayout` 按 `{MemProt, MemLifetime}` 分段,纯只读段(R--)与代码段(R+X)落不同段,各占一页;batched 模式下还破坏 `ExecOnly` 紧凑步长。

### 改动
`EJitCodePoolMemoryManager::allocate()` 在构造 `BasicLayout` **之前**,当 `Pool.usesPageSeal()`(`fourKSeal`,near/far 都为真)为真时,遍历 `G.sections()`,把 MemProt 为**纯只读**(Read 且非 Write 且非 Exec)的段升格为 `Read|Exec`。升格后并入代码段、段内块连续、共享 4K 页。

**gate 从 `usesBatchedPageSeal()` 放宽到 `usesPageSeal()` 的依据**(实测):升格收益与 batched/即时无关,只与"是否升格"有关——batched=off 下不升格 Δ=-4096 分两页,升格 Δ=+64 同页相邻。覆盖 4K-seal 两子模式:
- **batched**(near fixed pool):16B 跨分配紧凑 + 单分配内连续;
- **即时**(far pool / Tier-1 在线 PGO):单分配内 text/rodata 同页,finalize 立即 `sealCodeRange` 封 RX。
- legacy 2MiB 整 pool 封(`fourKSeal=false`)**不覆盖**:单指针整 pool RX 无法 per-page W^X,升格会丢 W^X 收紧。

### P1 部署契约决策(已批准:接受全量)
本 PR 把 near/far 所有 `R--`(含 `__profd_` 及只读元数据)统一改 `R-X`,W^X 仍满足且消除了旧实现遗留的 RW rodata 页;但**可执行字节面扩大**(去 W 同时加 X),不只是"收紧 W^X"。经与平台/安全责任人确认,接受全量 `R--→R-X`:
- **威胁边界**:升格的只读字节(常量/只读元数据)位于 RX 页,永不执行(AOT 本嵌字面量池于 .text);即便被误执行也在 RX 页、无新增可写执行面;写段(`__profc_` R+W)被 Write 检查排除,不与 exec 共页(no-RNX 不变量不变),peer `enable_rw` 协议不动。
- **回滚**:gate 改回 `usesBatchedPageSeal()`(commit `ac1a1d60`)即可把范围缩回 near batched;或全删升格块回到旧行为。单一 `if` 块、可独立回退。

### 不变量复核(全绿,5 套件)
- `EJIT_SRE_PGO_BRANCH_AUDIT` 全是 `#ifdef ... && EJIT_DIAG_ENABLE` 诊断打印,不改布局,与升格互不干涉;
- `__profc_`(R+W)被 Write 检查排除不升格,peer `enable_rw` 协议不动;`__profd_`(R--)升格后 peer 从 RX 页读(同代码),安全;
- 对齐 >16B(如 `alignas(32)`)仍触发页粒度回退(合并段 Alignment 超 `codeAlignment()` → `FitsCompactAlign=false`);
- `recordFinalizedRange` 把 ExecRange+WritableRanges 一起记,peer 按 writable 集逐个 enable_rw,升格后 writable 集仍只含 `__profc_`。

### 测试(EJITCodePoolTests + EJITTests 等,全绿)
4 个新 gtest:
- `ReadOnlySectionFoldsIntoExecSegment`(batched):rodata 37B align16→升格、紧凑存活、同页、后续图同页打包、flush 封 1 页;
- `HighAlignedReadOnlySectionKeepsPageLayout`(batched):rodata align32→仍升格但退回页粒度(安全阀);
- `ReadOnlySectionFoldsIntoExecSegmentImmediate`(即时 4K):升格、同页、Δ=64、finalize `SealCalls==1`(封 101 字节合并段);
- `FarPoolTier1ProfdFoldsProfcStaysWritable`(far pool + `spec_t1_` + text/profd/profc 三段同图):断言 `__profd_`→RX 并入代码页、`__profc_` 保 RW 且不与 exec 共页、writable range 只覆盖 `__profc_`。

全 5 套件:CodePool 66 / EJIT 141 / TaskPool 89 / SharedTaskPool 156 / Tier1Writable 1。地址按 section 身份解析(`DenseSet` 序非确定)。

### 范围
本切片只做"并入"(issue 第 5 项的消除),不涉及 fnSize 观测/GlobalDCE/16B 对齐/entry-first 等其它切片,互不依赖可单独落地。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
