### PR TITLE
[EJIT] Place entry definitions first in the extracted bitcode

### DIFF
--- a/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
+++ b/llvm/lib/Transforms/EmbeddedJIT/EJitRegisterBitcode.cpp
@@ -799,6 +799,43 @@ static std::string extractAndSerialize(Module &M,
     F.setLinkage(GlobalValue::InternalLinkage);
   }
 
+  // Move the entry definitions to the head of the function list, keeping their
+  // relative order. This is about the ALIGNMENT of the specialized entry, not
+  // about ordering for its own sake:
+  //
+  //   * The JIT TargetMachine leaves function-sections off, so codegen emits
+  //     every function into one .text in module order, and AArch64 emits no
+  //     inter-function padding — a function that is not first starts at an
+  //     arbitrary 4-byte offset.
+  //   * EJitCodePoolManager::allocateCode floors each allocation's alignment at
+  //     Options::minCodeAlign (64B, raised to the seal page size under
+  //     immediate 4K sealing), so only the FIRST function of .text inherits it.
+  //
+  // A specialization compiles exactly one entry and the JIT deletes the other
+  // entries' bodies (isolateSpecializationEntry), so whichever entry is being
+  // compiled ends up first in .text and starts on a cache-line (or page)
+  // boundary rather than straddling one. Purely a layout change: function order
+  // within a module carries no semantics.
+  {
+    SmallVector<Function *, 4> EntryDefs;
+    for (Function &F : Extracted->functions())
+      if (!F.isDeclaration() &&
+          hasMDStringEntry(F.getMetadata(MD_EJIT_METADATA), TAG_EJIT_ENTRY))
+        EntryDefs.push_back(&F);
+
+    auto &FnList = Extracted->getFunctionList();
+    auto InsertPt = FnList.begin();
+    for (Function *F : EntryDefs) {
+      // splice() asserts when the insertion point is the node being moved, and
+      // an entry already in place needs no move — just step past it. EntryDefs
+      // is in list order, so InsertPt is never at end() here.
+      if (&*InsertPt == F) {
+        ++InsertPt;
+        continue;
+      }
+      FnList.splice(InsertPt, FnList, F->getIterator());
+    }
+  }
 
   logEJitGlobalMeta("extract-after-extern", *Extracted);
 

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-entry-first-in-bitcode.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-entry-first-in-bitcode.ll
@@ -1,0 +1,50 @@
+; RUN: rm -rf %t-dump && mkdir -p %t-dump
+; RUN: opt -passes=ejit-register-bitcode -ejit-dump-bitcode-dir=%t-dump -S <%s >/dev/null
+; RUN: opt -S %t-dump/*.bc | FileCheck --check-prefix=EXTRACTED %s
+;
+; The extracted bitcode must list every ejit_entry definition BEFORE any other
+; definition, keeping the entries in their original relative order.
+;
+; Why: the JIT TargetMachine leaves function-sections off, so codegen emits all
+; functions into one .text in module order with no inter-function padding on
+; AArch64, while EJitCodePoolManager::allocateCode floors each allocation's
+; alignment at minCodeAlign (64B, or the seal page size under 4K sealing). Only
+; the first function of .text inherits that alignment. A specialization compiles
+; one entry and the JIT deletes the other entries' bodies, so putting the
+; entries first makes the compiled entry start on a cache-line boundary instead
+; of at an arbitrary 4-byte offset.
+;
+; Note the source order below: a helper is defined first, and the two entries
+; are interleaved with a second helper.
+
+define i32 @helper_add(i32 %a, i32 %b) {
+  %sum = add i32 %a, %b
+  ret i32 %sum
+}
+
+define i32 @entry_first(i32 %x) !ejit.metadata !2 {
+  %a = call i32 @helper_add(i32 %x, i32 1)
+  ret i32 %a
+}
+
+define i32 @helper_mul(i32 %a, i32 %b) {
+  %prod = mul i32 %a, %b
+  ret i32 %prod
+}
+
+define i32 @entry_second(i32 %x) !ejit.metadata !3 {
+  %b = call i32 @helper_mul(i32 %x, i32 2)
+  ret i32 %b
+}
+
+; The leading CHECK-NOT spans from the start of the file to the entry_first
+; match: no helper may be defined ahead of the first entry. Then both entries
+; appear in their original relative order, with the helpers after them.
+; EXTRACTED-NOT:  define{{.*}}@helper_
+; EXTRACTED:      define{{.*}} i32 @entry_first(
+; EXTRACTED:      define{{.*}} i32 @entry_second(
+; EXTRACTED:      define internal i32 @helper_
+
+!0 = !{!"ejit_entry"}
+!2 = !{!0}
+!3 = !{!0}

--- a/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/ejit-externalize-helpers.ll
@@ -248,12 +248,9 @@ attributes #1 = { inlinehint }
 ; EXT side: the extracted bitcode. Big helpers are declarations (the static
 ; one renamed to its registration key); small helpers stay as internal
 ; definitions; entries keep their bodies; hint_big is gone (inlined).
-; EXT: declare i32 @ejit_static._stdin_.{{0x[0-9a-f]+}}.st_helper_big(i32)
-; EXT: define internal i32 @st_helper_small(i32 %x)
-; EXT: declare i32 @ext_helper_big(i32)
-; EXT: define internal i32 @ext_helper_small(i32 %x)
-; EXT: declare i32 @boundary_helper(i32)
-; EXT: define internal i32 @kept_15inst(i32 %x)
+; The entries come first (extractAndSerialize moves every ejit_entry definition
+; to the head of the function list so the compiled entry starts at the aligned
+; base of .text); the helpers follow in their original relative order.
 ; EXT: define i32 @entry(i32 %idx) {{.*}} {
 ; EXT: tail call i32 @ejit_static._stdin_.{{0x[0-9a-f]+}}.st_helper_big(i32 %v)
 ; EXT: tail call i32 @st_helper_small(i32 %r1)
@@ -262,6 +259,12 @@ attributes #1 = { inlinehint }
 ; EXT: tail call i32 @boundary_helper(i32 {{.*}})
 ; EXT: tail call i32 @kept_15inst(i32 {{.*}})
 ; EXT: define internal i32 @entry_big(i32 %idx) #[[ENTRY_ATTR:[0-9]+]] {{.*}} {
+; EXT: declare i32 @ejit_static._stdin_.{{0x[0-9a-f]+}}.st_helper_big(i32)
+; EXT: define internal i32 @st_helper_small(i32 %x)
+; EXT: declare i32 @ext_helper_big(i32)
+; EXT: define internal i32 @ext_helper_small(i32 %x)
+; EXT: declare i32 @boundary_helper(i32)
+; EXT: define internal i32 @kept_15inst(i32 %x)
 ; EXT: attributes #[[ENTRY_ATTR]] = { {{.*}}"ejit.wrapper_symbol"="ejit_static._stdin_.{{0x[0-9a-f]+}}.entry_big"{{.*}} }
 ; EXT-NOT: @st_helper_big
 ; EXT-NOT: @hint_big

--- a/llvm/test/Transforms/EmbeddedJIT/internalize-non-entry-definitions.ll
+++ b/llvm/test/Transforms/EmbeddedJIT/internalize-non-entry-definitions.ll
@@ -41,16 +41,18 @@ define void @ejit_entry_ext() !ejit.metadata !3 {
   ret void
 }
 
+; Entry functions come first (extractAndSerialize moves every ejit_entry
+; definition to the head of the function list) and must keep their original
+; linkage (not internal).
+; EXTRACTED: define{{.*}} i32 @ejit_entry_calc(
+; EXTRACTED-NOT: define internal {{.*}}@ejit_entry_calc
+; EXTRACTED: define{{.*}} void @ejit_entry_ext(
+; EXTRACTED-NOT: define internal {{.*}}@ejit_entry_ext
+
 ; Check that helpers become internal in the extracted bitcode.
 ; EXTRACTED: define internal i32 @helper_add(
 ; EXTRACTED: define internal i32 @helper_mul(
-
-; Entry functions must keep their original linkage (not internal).
-; EXTRACTED: define{{.*}} i32 @ejit_entry_calc(
-; EXTRACTED-NOT: define internal {{.*}}@ejit_entry_calc
 ; EXTRACTED: declare{{.*}} void @external_lib_func()
-; EXTRACTED: define{{.*}} void @ejit_entry_ext(
-; EXTRACTED-NOT: define internal {{.*}}@ejit_entry_ext
 
 !0 = !{!"ejit_entry"}
 !1 = !{!0}


### PR DESCRIPTION
As pointed out in [197](https://github.com/dongjianqiang2/llvm-project/issues/197) to reduce near code-pool waste, this moves the `ejit_entry` definitions to the head of the extracted module's function list, keeping their relative order. 

A compile specializes exactly one entry and the JIT deletes the other entries' bodies (`isolateSpecializationEntry`), so putting the entries first means whichever one is being compiled ends up first in `.text` and starts on a cache-line (or page) boundary. Emulating that deletion for `entry_2` of a four-entry test TU, the entry moves from `.text+0x60` to `.text+0x0`.

Function order within a module carries no semantics, so this is purely a layout change.

New test `ejit-entry-first-in-bitcode.ll` covers the multi-entry case with helpers interleaved in source order. Two existing tests were also updated. 

Assisted-by: Claude Opus 5