### PR TITLE
[EJIT] Carry entry fnSize through finalize→sharedslot→print_compiled (ABI v18)

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodePool.h
@@ -250,7 +250,9 @@ public:
   /// batch by flushPendingRanges().
   bool recordPendingRange(const void *Base, size_t Size,
                           const EJitWritableRange *Writables = nullptr,
-                          uint32_t WritableCount = 0);
+                          uint32_t WritableCount = 0,
+                          const EJitFnSymEntry *Syms = nullptr,
+                          uint32_t SymCount = 0);
   void notePendingAllocation();
   Error flushPendingRanges();
   size_t pendingRangeCount() const;
@@ -277,9 +279,19 @@ public:
   /// A null/zero writable set (WritableCount == 0) records the executable range
   /// with no writable data and returns true. A benign no-op (Base null / Size
   /// 0) also returns true.
+  ///
+  /// \p Syms / \p SymCount give the defined symbols (address,size) of this
+  /// executable range, captured from the JITLink graph at finalize. Purely
+  /// diagnostic: findRange() matches the published fnPtr against them to
+  /// recover fnSize for print_compiled waste reporting. An over-bound set is
+  /// truncated (not rejected) since fnSize is diagnostic, not a safety
+  /// invariant. Null/zero records the range with no symbol metadata (findRange
+  /// then reports fnSize=0).
   bool recordFinalizedRange(const void *Base, size_t Size,
                             const EJitWritableRange *Writables = nullptr,
-                            uint32_t WritableCount = 0);
+                            uint32_t WritableCount = 0,
+                            const EJitFnSymEntry *Syms = nullptr,
+                            uint32_t SymCount = 0);
 
   /// Resolve a function pointer to the finalized executable allocation and pool
   /// that contain it, filling \p Out (codeStart/codeSize from the recorded
@@ -330,6 +342,14 @@ private:
     /// rejected at record time).
     uint32_t writableCount = 0;
     EJitWritableRange writables[kEJitMaxWritableRanges] = {};
+    /// Defined symbols (address,size) inside [start, start+size), captured at
+    /// finalize from the JITLink graph. Diagnostic only (never a peer-prepare
+    /// invariant): findRange() matches the published fnPtr address against
+    /// these to recover the entry's real size (fnSize). Over-bound sets are
+    /// truncated, not rejected, since fnSize is a diagnostic quantity. Owner-
+    /// private: only the matched fnSize crosses into the shared cache slot.
+    uint32_t symCount = 0;
+    EJitFnSymEntry syms[kEJitMaxSymsPerRange] = {};
   };
   std::vector<FinalizedRange> FinalizedRanges_;
   std::vector<FinalizedRange> PendingRanges_;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCodeRange.h
@@ -61,6 +61,31 @@ struct EJitWritableRange {
   uint64_t size = 0;
 };
 
+/// Maximum number of defined symbols (address,size) carried with one finalized
+/// executable range, used to recover the entry function's real size for waste
+/// diagnostics (print_compiled fn_size/overhead). A finalized allocation's
+/// executable segment usually holds a single defined symbol (the entry, since
+/// isolateSpecializationEntry turns the TU's other ejit_entry definitions into
+/// declarations); the small fixed bound leaves head room for the rare graph
+/// with several linked-in symbol bodies. Unlike writableRanges this is purely
+/// diagnostic (never a safety/peer-prepare invariant), so an over-bound set is
+/// truncated rather than rejected. Owner-private bookkeeping only — never
+/// serialized into the shared cache slot; only fnSize (the matched entry's
+/// size) crosses the ABI boundary.
+constexpr uint32_t kEJitMaxSymsPerRange = 8u;
+
+/// One defined symbol of a finalized executable range (owner-private,
+/// diagnostic only): the entry function's real size is recovered by matching
+/// the published fnPtr address against these recorded (addr,size) pairs at
+/// findRange() time. Every field is a fixed-width scalar accessed by value
+/// (endian-safe on aarch64_be).
+struct EJitFnSymEntry {
+  /// Address of a defined symbol inside the executable segment.
+  uintptr_t addr = 0;
+  /// Size in bytes of that symbol. 0 => unused entry.
+  uint64_t size = 0;
+};
+
 /// Real executable extent of one finalized compilation. Every field is a
 /// fixed-width scalar accessed by value (endian-safe on aarch64_be).
 struct EJitCompiledCodeInfo {
@@ -71,6 +96,13 @@ struct EJitCompiledCodeInfo {
   uintptr_t codeStart = 0;
   /// Size in bytes of that executable allocation. 0 => no range metadata.
   uint64_t codeSize = 0;
+  /// Real size in bytes of the entry function symbol (the published fnPtr),
+  /// recovered from the finalized graph's defined symbols. Smaller than
+  /// codeSize (which covers the whole allocation incl. padding/rodata/other
+  /// linked symbol bodies). 0 => no symbol metadata: print_compiled then
+  /// reports fn_size=0 and overhead=codeSize (cannot split). Carried into the
+  /// shared cache slot (ABI v18) so every core's print_compiled sees it.
+  uint64_t fnSize = 0;
   /// Base of the 2MiB-aligned code pool that contains the allocation (the
   /// split_2m_to_4k granularity on the target).
   uintptr_t poolBase = 0;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -105,7 +105,13 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// diagnostic mirror publishes aggregate plus placement-specific statistics.
 /// v17: cache slots can remain Pending while compact code waits for an explicit
 /// owner-worker batch publish request.
-constexpr uint32_t kEJitSharedAbiVersion = 17u;
+/// v18: each cache slot carries fnSize (the entry function's real size in
+/// bytes, recovered from the finalized graph's defined symbols) so every core's
+/// print_compiled can report per-function fn_size and waste overhead
+/// (codeSize - fnSize) without owner-private lookups. Purely diagnostic; a peer
+/// core never uses it for sealing or enable_rw. 0 means no symbol metadata was
+/// recorded (print_compiled reports fn_size=0, overhead=codeSize).
+constexpr uint32_t kEJitSharedAbiVersion = 18u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -204,6 +204,17 @@ struct EJitSharedCacheSlot {
   /// consistently. 0 codeSize => no range metadata (peer cleanly falls back).
   uintptr_t codeStart;    ///< start of the RX-sealed executable allocation
   uint64_t codeSize;      ///< size in bytes of that allocation (0 = none)
+  /// Real size in bytes of the entry function symbol (the published fnPtr),
+  /// recovered by findRange() from the finalized graph's defined symbols and
+  /// carried here so every core's print_compiled can report fn_size/overhead
+  /// (v18). Smaller than codeSize (which covers the whole allocation incl.
+  /// padding/rodata/other symbol bodies). 0 => no symbol metadata was
+  /// recorded: print_compiled then reports fn_size=0 and overhead=codeSize.
+  /// Plain scalar, written under the bucket write lock BEFORE state=Ready is
+  /// released (same write-seq as codeSize), so an acquiring reader sees it
+  /// consistently. Cleared at every slot-zeroing path (publish-empty,
+  /// stage-pending, drop-pending, re-init generation flip).
+  uint64_t fnSize;
   uintptr_t poolBase;     ///< 2MiB pool base (split_2m_to_4k granule)
   uint64_t poolSize;      ///< usable pool size
   uint32_t poolId;   ///< stable pool index within its near/far manager

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -526,7 +526,9 @@ Error EJitCodePoolManager::restoreRxRange(const void *Start, size_t Size) {
 
 bool EJitCodePoolManager::recordPendingRange(const void *Base, size_t Size,
                                              const EJitWritableRange *Writables,
-                                             uint32_t WritableCount) {
+                                             uint32_t WritableCount,
+                                             const EJitFnSymEntry *Syms,
+                                             uint32_t SymCount) {
   if (!Opts_.batchedPageSeal || !Base || Size == 0)
     return true;
   if (WritableCount > kEJitMaxWritableRanges ||
@@ -556,6 +558,15 @@ bool EJitCodePoolManager::recordPendingRange(const void *Base, size_t Size,
   Rec.writableCount = WritableCount;
   for (uint32_t I = 0; I < WritableCount; ++I)
     Rec.writables[I] = Writables[I];
+  // Diagnostic-only symbol metadata (truncated, not rejected) — see
+  // recordFinalizedRange for the rationale.
+  if (Syms && SymCount > 0) {
+    uint32_t N = SymCount > kEJitMaxSymsPerRange ? kEJitMaxSymsPerRange
+                                                 : SymCount;
+    Rec.symCount = N;
+    for (uint32_t I = 0; I < N; ++I)
+      Rec.syms[I] = Syms[I];
+  }
   PendingRanges_.push_back(Rec);
   return true;
 }
@@ -656,7 +667,7 @@ bool EJitCodePoolManager::contains(const void *Ptr) const {
 
 bool EJitCodePoolManager::recordFinalizedRange(
     const void *Base, size_t Size, const EJitWritableRange *Writables,
-    uint32_t WritableCount) {
+    uint32_t WritableCount, const EJitFnSymEntry *Syms, uint32_t SymCount) {
   if (!Base || Size == 0) {
     EJIT_DIAG_DEBUG("recordFinalizedRange skip: base=%p size=%zu", Base, Size);
     return true; // benign no-op (no executable extent to record).
@@ -732,6 +743,18 @@ bool EJitCodePoolManager::recordFinalizedRange(
   Rec.writableCount = WritableCount;
   for (uint32_t I = 0; I < WritableCount; ++I)
     Rec.writables[I] = Writables[I];
+  // Defined symbols (address,size) are diagnostic-only: an over-bound set is
+  // truncated, not rejected (fnSize is a waste-diagnostic quantity, never a
+  // peer-prepare/safety invariant like the writable set above). A non-zero
+  // count with a null array is treated as zero (no symbol metadata) rather than
+  // a hard reject — findRange then reports fnSize=0 (clean fallback).
+  if (Syms && SymCount > 0) {
+    uint32_t N = SymCount > kEJitMaxSymsPerRange ? kEJitMaxSymsPerRange
+                                                 : SymCount;
+    Rec.symCount = N;
+    for (uint32_t I = 0; I < N; ++I)
+      Rec.syms[I] = Syms[I];
+  }
   FinalizedRanges_.push_back(Rec);
   EJIT_DIAG_DEBUG(
       "recordFinalizedRange OK: base=%p size=%zu writable=%u total=%zu", Base,
@@ -770,6 +793,26 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
       Out.fnPtr = const_cast<void *>(Ptr);
       Out.codeStart = Found->start;
       Out.codeSize = Found->size;
+      // Recover the entry function's real size for print_compiled waste
+      // diagnostics. The published fnPtr is the entry symbol's address; match
+      // it against the recorded defined symbols. Prefer an exact address match
+      // (the entry itself); otherwise fall back to the symbol whose body
+      // contains A (SAddr <= A < SAddr + size). 0 if no symbol metadata was
+      // recorded (then overhead defaults to the whole codeSize).
+      Out.fnSize = 0;
+      for (uint32_t S = 0; S < Found->symCount; ++S) {
+        uintptr_t SAddr = Found->syms[S].addr;
+        if (SAddr == A) {
+          Out.fnSize = Found->syms[S].size;
+          break; // exact entry match
+        }
+        // Containing-symbol fallback (e.g. fnPtr points into the middle of a
+        // symbol body rather than at its start). A real "contains" test needs
+        // both bounds; without it a non-containing preceding symbol could win.
+        if (SAddr <= A &&
+            A - SAddr < Found->syms[S].size) // SAddr <= A < SAddr + size
+          Out.fnSize = Found->syms[S].size;
+      }
       Out.poolBase = B;
       Out.poolSize = static_cast<uint64_t>(P.size);
       Out.poolId = static_cast<uint32_t>(I);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePoolMemoryManager.cpp
@@ -96,7 +96,30 @@ public:
           // malformed writable set rather than truncating it; that must fail
           // finalize (no callable pointer) so a peer is never handed code whose
           // counter pages it cannot fully prepare. Restore W^X and report.
+          // Pre-collect this graph's defined symbols (address,size) once: the
+          // entry symbol's real size (fnSize) is recovered by findRange() from
+          // these, matched against the published fnPtr. Collected before G is
+          // marked finalized (below). isolateSpecializationEntry guarantees the
+          // TU's ejit_entry has the sole defined body, so the executable
+          // segment normally holds exactly one defined symbol (the entry).
           for (const ExecSegRange &R : ExecRanges) {
+            EJitFnSymEntry Syms[kEJitMaxSymsPerRange];
+            uint32_t SymCount = 0;
+            if (G) {
+              const uintptr_t SegStart = R.Addr;
+              const uintptr_t SegEnd = R.Addr + R.Size;
+              for (auto *Sym : G->defined_symbols()) {
+                uintptr_t SAddr = Sym->getAddress().getValue();
+                if (SAddr < SegStart || SAddr >= SegEnd)
+                  continue;
+                if (SymCount < kEJitMaxSymsPerRange) {
+                  Syms[SymCount] = {SAddr,
+                                   static_cast<uint64_t>(Sym->getSize())};
+                  ++SymCount;
+                }
+                // over-bound: truncate (fnSize is diagnostic, not safety)
+              }
+            }
             const bool Recorded =
                 Pool->usesBatchedPageSeal()
                     ? Pool->recordPendingRange(
@@ -104,13 +127,15 @@ public:
                           static_cast<size_t>(R.Size),
                           WritableRanges.empty() ? nullptr
                                                  : WritableRanges.data(),
-                          static_cast<uint32_t>(WritableRanges.size()))
+                          static_cast<uint32_t>(WritableRanges.size()),
+                          SymCount ? Syms : nullptr, SymCount)
                     : Pool->recordFinalizedRange(
                           reinterpret_cast<void *>(R.Addr),
                           static_cast<size_t>(R.Size),
                           WritableRanges.empty() ? nullptr
                                                  : WritableRanges.data(),
-                          static_cast<uint32_t>(WritableRanges.size()));
+                          static_cast<uint32_t>(WritableRanges.size()),
+                          SymCount ? Syms : nullptr, SymCount);
             if (!Recorded) {
               EJIT_DIAG(
                   "finalize FAIL: recordFinalizedRange rejected addr=0x%llx"

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -28,6 +28,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitVpCollector.h"
 #endif
 #ifndef EJIT_FREESTANDING
+#include <algorithm>
 #include <chrono>
 #endif
 // ejit_print_version() falls back to std::printf when not routing through the
@@ -37,6 +38,7 @@
 #endif
 #include <cstddef>
 #include <type_traits>
+#include <vector>
 
 using namespace llvm;
 using namespace llvm::ejit;
@@ -1756,22 +1758,50 @@ void ejit_taskpool_print_compiled() {
     uint32_t byTier[3];
     uint32_t byPool[3];
     uint32_t finalPostPublishSeen;
-  } count = {{0}, {0}, {0}, 0};
+    /// Per-slot code-extent samples for the sizes summary line. Collected in
+    /// the count pass, sorted by codeStart within each pool, then tallied:
+    /// fn_total = ΣfnSize, alloc_total = ΣcodeSize, pad_total = Σ(codeSize -
+    /// fnSize), and 16B_VIOLATIONS counts same-pool adjacent allocations whose
+    /// gap < 16 (the compact-layout precondition; compact graphs should be 0,
+    /// a non-zero value flags that task-1 16B alignment has not taken effect).
+    /// The gap uses codeStart (the allocation start), NOT fnPtr (the entry
+    /// symbol address, which may sit at a non-zero offset inside the
+    /// allocation) so the inter-allocation stride is measured correctly.
+    struct Sample {
+      uintptr_t codeStart;
+      uint64_t codeSize;
+      uint64_t fnSize;
+      uint32_t poolKind;
+    };
+    std::vector<Sample> samples;
+  } count = {{0}, {0}, {0}, 0, {}};
+  // Pre-reserve the upper bound (every slot Ready) so the count-pass callback
+  // never allocates while holding a per-bucket read lock (forEachCompiled
+  // calls cb between bucketTryRead/bucketReadRelease with no try/catch).
+  count.samples.reserve(kEJitSharedCacheBuckets * kEJitSharedCacheSlots);
   EJitSharedTaskPool::ForEachCompiledStats st = sp->forEachCompiled(
       [](const EJitSharedCacheSlot &slot, void *cbCtx) {
+        CountCtx *C = static_cast<CountCtx *>(cbCtx);
         // Valid numDims is 0..kEJitSharedMaxDims; clamp a corrupt slot's
         // value so the tally cannot index past byDims.
         uint32_t n = slot.numDims < kEJitSharedMaxDims ? slot.numDims
                                                        : kEJitSharedMaxDims;
-        ++static_cast<CountCtx *>(cbCtx)->byDims[n];
+        ++C->byDims[n];
         uint8_t tier = slot.tier.loadRelaxed();
         if (tier <= kEJitTierPgoUse)
-          ++static_cast<CountCtx *>(cbCtx)->byTier[tier];
+          ++C->byTier[tier];
         if (slot.poolKind <= static_cast<uint32_t>(EJitCodePoolKind::Far))
-          ++static_cast<CountCtx *>(cbCtx)->byPool[slot.poolKind];
+          ++C->byPool[slot.poolKind];
         if (tier != kEJitTierInstrumented &&
             slot.postPublishSeen.loadRelaxed() != 0)
-          ++static_cast<CountCtx *>(cbCtx)->finalPostPublishSeen;
+          ++C->finalPostPublishSeen;
+        // Collect a sizes sample for the summary line. A shared_alloc slot
+        // (codeStart 0 / codeSize 0) carries no real allocation and is skipped
+        // so its zero extent cannot dilute the tallies.
+        uintptr_t cs0 = slot.codeStart;
+        uint64_t cs = slot.codeSize;
+        if (cs0 != 0 && cs != 0)
+          C->samples.push_back({cs0, cs, slot.fnSize, slot.poolKind});
       },
       &count);
   // Summary line first (fixed line count, so no throttle): total, cache
@@ -1802,6 +1832,49 @@ void ejit_taskpool_print_compiled() {
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Near)],
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Far)],
                 count.byPool[static_cast<uint32_t>(EJitCodePoolKind::Unknown)]);
+  // Sizes summary: total function bytes vs total allocation bytes, plus a
+  // compact-precondition check. Sorted by fnPtr within each pool, adjacent
+  // same-pool allocations whose gap < 16 count as a 16B_VIOLATION (the
+  // compact layout's stride requirement; a compact graph should be 0, a
+  // non-zero value flags that task-1 16B alignment has not taken effect).
+  // 0 fnSize (no symbol metadata) contributes its full codeSize to padding so
+  // the totals still reconcile. Fixed line count, no throttle (matches the
+  // entries/tiers/pools summary style above).
+  uint64_t fnTotal = 0, allocTotal = 0, padTotal = 0;
+  uint32_t violations = 0;
+  if (!count.samples.empty()) {
+    std::sort(count.samples.begin(), count.samples.end(),
+              [](const CountCtx::Sample &A, const CountCtx::Sample &B) {
+                if (A.poolKind != B.poolKind)
+                  return A.poolKind < B.poolKind;
+                return A.codeStart < B.codeStart;
+              });
+    for (size_t I = 0; I < count.samples.size(); ++I) {
+      const auto &S = count.samples[I];
+      fnTotal += S.fnSize;
+      allocTotal += S.codeSize;
+      padTotal += (S.fnSize <= S.codeSize) ? (S.codeSize - S.fnSize) : 0;
+      // Gap to the next same-pool sample: an executable pointer never resolves
+      // to a stale range (v1 append-only), so a later address in the same pool
+      // is a distinct later allocation; their gap is the inter-allocation
+      // stride the compact layout caps at 16. Measure on codeStart (the
+      // allocation start), not fnPtr (entry offset may be non-zero).
+      if (I + 1 < count.samples.size()) {
+        const auto &N = count.samples[I + 1];
+        if (N.poolKind == S.poolKind && N.codeStart > S.codeStart) {
+          uint64_t Gap = N.codeStart - S.codeStart;
+          uint64_t Used = S.codeSize;
+          if (Gap > Used && (Gap - Used) < 16)
+            ++violations;
+        }
+      }
+    }
+  }
+  EJIT_DIAG_RAW("compiled sizes: fn_total=%llu alloc_total=%llu pad_total=%llu "
+                "16B_VIOLATIONS=%u",
+                static_cast<unsigned long long>(fnTotal),
+                static_cast<unsigned long long>(allocTotal),
+                static_cast<unsigned long long>(padTotal), violations);
 #ifdef EJIT_STATS_ENABLE
   constexpr bool ReuseTrackingEnabled = true;
   const uint32_t FinalVersions = count.byTier[kEJitTierBaseline] +
@@ -1877,20 +1950,34 @@ void ejit_taskpool_print_compiled() {
             p = end - 1;
           *p = '\0';
           EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
-                        "post_publish_seen=%s ver=[%s] size=%llu "
+                        "post_publish_seen=%s ver=[%s] code_size=%llu "
+                        "fn_size=%llu overhead=%llu "
                         "pool=%s pool_id=%u "
                         "gen=%u",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(), Tier,
                         slot.numDims, dims, fn, PostPublishSeen, ver,
                         static_cast<unsigned long long>(slot.codeSize),
+                        static_cast<unsigned long long>(slot.fnSize),
+                        static_cast<unsigned long long>(
+                            slot.fnSize <= slot.codeSize
+                                ? slot.codeSize - slot.fnSize
+                                : 0),
                         PoolKind, slot.poolId, slot.generation);
         } else {
           EJIT_DIAG_RAW("funcIdx=%u name=%s tier=%s numDims=%u dims=[%s] fn=%p "
+                        "code_size=%llu fn_size=%llu overhead=%llu "
                         "pool=%s post_publish_seen=%s",
                         slot.funcIndex,
                         name.empty() ? "<unknown>" : name.c_str(), Tier,
-                        slot.numDims, dims, fn, PoolKind, PostPublishSeen);
+                        slot.numDims, dims, fn,
+                        static_cast<unsigned long long>(slot.codeSize),
+                        static_cast<unsigned long long>(slot.fnSize),
+                        static_cast<unsigned long long>(
+                            slot.fnSize <= slot.codeSize
+                                ? slot.codeSize - slot.fnSize
+                                : 0),
+                        PoolKind, PostPublishSeen);
         }
         ejitDiagPrintThrottle();
       },

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -2297,6 +2297,7 @@ EJitSharedTaskPool::cacheStageBatchRequest(const EJitCompileRequest &req) {
   }
   Target->codeStart = 0;
   Target->codeSize = 0;
+  Target->fnSize = 0;
   Target->poolBase = 0;
   Target->poolSize = 0;
   Target->poolId = 0;
@@ -2366,6 +2367,7 @@ EJitSharedTaskPool::cacheStagePending(const EJitCompileRequest &req,
   }
   Target->codeStart = 0;
   Target->codeSize = 0;
+  Target->fnSize = 0;
   Target->poolBase = 0;
   Target->poolSize = 0;
   Target->poolId = 0;
@@ -2403,6 +2405,7 @@ void EJitSharedTaskPool::cacheDropPending(const EJitCompileRequest &req,
     Slot.executableCoreMask.storeRelease(0);
     Slot.codeStart = 0;
     Slot.codeSize = 0;
+    Slot.fnSize = 0;
     Slot.poolBase = 0;
     Slot.poolSize = 0;
     Slot.poolId = 0;
@@ -2496,6 +2499,7 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   if (info && info->codeSize != 0) {
     target->codeStart = info->codeStart;
     target->codeSize = info->codeSize;
+    target->fnSize = info->fnSize;
     target->poolBase = info->poolBase;
     target->poolSize = info->poolSize;
     target->poolId = info->poolId;
@@ -2520,6 +2524,7 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   } else {
     target->codeStart = 0;
     target->codeSize = 0;
+    target->fnSize = 0;
     target->poolBase = 0;
     target->poolSize = 0;
     target->poolId = 0;
@@ -2742,6 +2747,7 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
       // earlier generation can never be read back after a re-init.
       Slot.codeStart = 0;
       Slot.codeSize = 0;
+      Slot.fnSize = 0;
       Slot.poolBase = 0;
       Slot.poolSize = 0;
       Slot.poolId = 0;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -114,6 +114,24 @@ void *firstBlockAddr(LinkGraph &G) {
   return B->getAddress().toPtr<void *>();
 }
 
+// A code graph with one DEFINED symbol of the given size at the block's start
+// (offset 0). fnSize capture at finalize iterates G->defined_symbols(), so a
+// graph with no defined symbol yields fnSize=0 (the "no symbol metadata"
+// fallback); this helper builds the symbol-bearing variant used to assert the
+// entry's real size is recovered.
+std::unique_ptr<LinkGraph> makeCodeGraphWithDefinedSymbol(size_t Size,
+                                                          uint64_t VAddr) {
+  auto G = makeCodeGraph(Size, VAddr);
+  // blocks() yields Block* (BlockSet iterators); dereference to a Block& for
+  // addDefinedSymbol, which attaches a named defined symbol of |Size| at the
+  // block's start (offset 0).
+  Block &B = **G->blocks().begin();
+  G->addDefinedSymbol(B, orc::ExecutorAddrDiff(0), "entry",
+                      orc::ExecutorAddrDiff(Size), Linkage::Strong,
+                      Scope::Default, true, false);
+  return G;
+}
+
 } // namespace
 
 // JIT code memory is allocated out of the pool (not mmap), and the resolved
@@ -644,6 +662,60 @@ TEST(EJitCodePoolMemMgr4K, FinalizedRangeCarriesWritableDataExtent) {
   uintptr_t WPE =
       pageUp(Info.writableRanges[0].addr + Info.writableRanges[0].size);
   EXPECT_TRUE(WPE <= CodePS || CodePE <= WPS); // no shared 4K page
+
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// The finalized executable range carries the entry function's real size
+// (fnSize), recovered from the JITLink graph's defined symbols by matching
+// the published fnPtr address. fnSize < codeSize (the allocation covers the
+// whole executable extent incl. padding).
+TEST(EJitCodePoolMemMgr4K, FinalizedRangeCarriesEntryFnSize) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  constexpr size_t FnSize = 64;
+  auto G = makeCodeGraphWithDefinedSymbol(FnSize, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *EntryAddr = firstBlockAddr(*G);
+  auto FA = cantFail(IFA->finalize());
+
+  EJitCompiledCodeInfo Info{};
+  ASSERT_TRUE(Pool.findRange(EntryAddr, Info));
+  EXPECT_EQ(Info.fnPtr, EntryAddr);
+  EXPECT_EQ(Info.fnSize, static_cast<uint64_t>(FnSize));
+  // codeSize covers the whole executable allocation (page-rounded): it is at
+  // least the function size, so overhead = codeSize - fnSize >= 0.
+  EXPECT_GE(Info.codeSize, Info.fnSize);
+
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// A graph with no defined symbol records no symbol metadata: fnSize is 0
+// (print_compiled then reports fn_size=0, overhead=codeSize). This guards the
+// "no symbol metadata" fallback path so a symbolless graph never mis-reports
+// a stale fnSize.
+TEST(EJitCodePoolMemMgr4K, FinalizedRangeFnSizeZeroWithoutDefinedSymbol) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeCodeGraph(64, 0x1000); // no defined symbol
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *CodeAddr = firstBlockAddr(*G);
+  auto FA = cantFail(IFA->finalize());
+
+  EJitCompiledCodeInfo Info{};
+  ASSERT_TRUE(Pool.findRange(CodeAddr, Info));
+  EXPECT_EQ(Info.fnSize, 0u);
+  EXPECT_GT(Info.codeSize, 0u);
 
   cantFail(MM.deallocate(std::move(FA)));
 }
@@ -1274,5 +1346,39 @@ TEST(EJitCodePoolMemMgr4K, FarPoolTier1ProfdFoldsProfcStaysWritable) {
             PageOf(ProfcAddr));
   EXPECT_NE(PageOf(reinterpret_cast<void *>(Info.writableRanges[0].addr)),
             PageOf(TextAddr));
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
+// In batched-seal mode, fnSize capture flows through the pending path
+// (recordPendingRange → flushPendingRanges → findRange), not the immediate
+// recordFinalizedRange path. A pending range is NOT resolvable by findRange
+// until flush; fnSize must survive the pending→finalized copy so it is still
+// recoverable after flush.
+TEST(EJitCodePoolMemMgrBatch, FnSizeSurvivesPendingFlush) {
+  MockSre4K M;
+  auto O = fourKMemMgrOpts();
+  O.minCodeAlign = 16;
+  O.batchedPageSeal = true;
+  EJitCodePoolManager Pool(
+      O, [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  constexpr size_t FnSize = 64;
+  auto G = makeCodeGraphWithDefinedSymbol(FnSize, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  void *EntryAddr = firstBlockAddr(*G);
+  auto FA = cantFail(IFA->finalize());
+
+  // Pending: not resolvable yet, so fnSize is not yet recoverable.
+  EJitCompiledCodeInfo Info{};
+  EXPECT_FALSE(Pool.findRange(EntryAddr, Info));
+
+  cantFail(Pool.flushPendingRanges());
+  ASSERT_TRUE(Pool.findRange(EntryAddr, Info));
+  EXPECT_EQ(Info.fnPtr, EntryAddr);
+  EXPECT_EQ(Info.fnSize, static_cast<uint64_t>(FnSize));
+
   cantFail(MM.deallocate(std::move(FA)));
 }

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -179,6 +179,7 @@ struct RangeCtx {
   uint64_t poolSize = 0x200000ull; // 2 MiB
   uintptr_t codeStart = 0x40000000ull;
   uint64_t codeSize = 64;
+  uint64_t fnSize = 0; // entry function's real size (v18); 0 => no metadata.
   uint32_t poolId = 0;
   EJitCodePoolKind poolKind = EJitCodePoolKind::Near;
   bool provide = true;
@@ -199,6 +200,7 @@ bool mockCodeRange(void *ctx, const void *fnPtr, EJitCompiledCodeInfo *out) {
   out->fnPtr = const_cast<void *>(fnPtr);
   out->codeStart = r->codeStart;
   out->codeSize = r->codeSize;
+  out->fnSize = r->fnSize;
   out->poolBase = r->poolBase;
   out->poolSize = r->poolSize;
   out->poolId = r->poolId;
@@ -1645,6 +1647,47 @@ TEST_F(SharedTaskPoolTest, ForEachCompiledReportsVisitedAndSkipped) {
 }
 
 //===----------------------------------------------------------------------===//
+// The shared cache slot carries fnSize (the entry function's real size, ABI
+// v18) so every core's print_compiled can report fn_size/overhead without an
+// owner-private lookup. The code-range provider fills info.fnSize at publish
+// time; it must land in the slot under the bucket write lock (before
+// state=Ready) and be readable back through forEachCompiled.
+//===----------------------------------------------------------------------===//
+TEST_F(SharedTaskPoolTest, PublishedSlotCarriesFnSize) {
+  EJitSharedTaskPool owner;
+  FourKLog fourK;
+  RangeCtx range;
+  range.codeSize = 128;
+  range.fnSize = 56; // entry real size < allocation extent
+  bringUpOwner4K(owner, fourK, range);
+  publish(owner, 42);
+
+  EJitSharedCacheSlot *slot = findReadySlot(42);
+  ASSERT_NE(slot, nullptr);
+  EXPECT_EQ(slot->codeSize, 128u);
+  EXPECT_EQ(slot->fnSize, 56u);
+
+  // A walk callback reads fnSize back without an owner-private lookup.
+  struct Ctx {
+    uint64_t fnSize;
+    uint64_t codeSize;
+    uint32_t seen;
+  } ctx{0, 0, 0};
+  auto cb = [](const EJitSharedCacheSlot &s, void *c) {
+    auto *cc = static_cast<Ctx *>(c);
+    if (s.funcIndex == 42) {
+      cc->fnSize = s.fnSize;
+      cc->codeSize = s.codeSize;
+      ++cc->seen;
+    }
+  };
+  owner.forEachCompiled(cb, &ctx);
+  EXPECT_EQ(ctx.seen, 1u);
+  EXPECT_EQ(ctx.fnSize, 56u);
+  EXPECT_EQ(ctx.codeSize, 128u);
+}
+
+//===----------------------------------------------------------------------===//
 // 11/ Cross-core fnPtr sharing gate.
 //===----------------------------------------------------------------------===//
 TEST_F(SharedTaskPoolTest, CrossCoreFnPtrSharingGate) {
@@ -3043,7 +3086,10 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // requests; v14 adds the owned bound-pointer snapshot, and v15 adds
   // per-version post-publish reuse tracking; v16 adds near/far placement.
   // v17 adds explicit batch publish state.
-  EXPECT_EQ(kEJitSharedAbiVersion, 17u);
+  // v18 adds per-slot fnSize (entry function's real size) for print_compiled
+  // waste diagnostics (fn_size/overhead); purely diagnostic, never used by a
+  // peer for sealing or enable_rw.
+  EXPECT_EQ(kEJitSharedAbiVersion, 18u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(


### PR DESCRIPTION
## Issue #197 任务 5：在 `print_compiled` 中显示每个函数的真实大小（fnSize，ABI v18）

> 基线 `ejit_dev_spec4` @ `7716fde7`，独立于 task 2/PR #203（两者互不依赖）。
> 跨核 ABI 改动，按 issue 正文要求"单独成 PR、最后落"。

### 做了什么

打通跨 5 层通路把入口函数真实大小（fnSize）带到 `print_compiled`：

1. **捕获**（`EJitCodePoolMemoryManager.cpp` finalize）：在 G 标记 finalized 前，从 `G->defined_symbols()` 为每个 `ExecSegRange` 收集落在段内的符号 (addr,size)，存进 owner-private 的 `FinalizedRange::syms[]`（新增 `EJitFnSymEntry` + `kEJitMaxSymsPerRange=8`）。
2. **盖章**（`EJitCodePool.cpp` findRange）：按发布的 fnPtr 精确匹配符号地址，写 `EJitCompiledCodeInfo::fnSize`；无精确匹配则取 body 包含该指针的符号；无符号→0（overhead 回退为整个 codeSize）。
3. **共享槽**（`EJitSharedTaskPoolState.h` + `EJitSharedPlatform.h`）：`EJitSharedCacheSlot::fnSize`（ABI **17→18**），写序同 `codeSize`（桶写锁窗口内、`state=Ready` 前），5 处清零点同步（publish-empty / stage-pending ×2 / drop-pending / re-init 翻转）。纯诊断，peer 不用于 sealing/enable_rw。
4. **打印**（`EJitRuntime.cpp` print_compiled）：
   - VERBOSE 现有 `size=` → 改名 `code_size=`（与 INFO 统一）；
   - INFO 条目行新增 `code_size=` `fn_size=` `overhead=`(=codeSize−fnSize)；
   - 新增 INFO 汇总行 `compiled sizes: fn_total= alloc_total= pad_total= 16B_VIOLATIONS=`（相邻同池分配 gap<16 计数，gap 用 `codeStart` 非 `fnPtr` 避免入口偏移致误；samples 预 reserve 防 read-lock 内 bad_alloc）。

### 规格（已与用户对齐）
- fn_size 跨核可见（ABI 18，非 owner 核 print_compiled 也能看到）；
- size 命名统一为 `code_size=`（与新增 `fn_size=` 对称）；
- 核心 size 信息上 INFO，关键性差一层（ver/pool_id/gen）留 VERBOSE；
- `16B_VIOLATIONS` 入 INFO 汇总（任务1 未落时 >0 正暴露问题）；
- 跟随现有 `EJIT_DIAG_ENABLE` + `gEJitDiagLevel` 门控，关掉零遍历零开销。

### 验证
- 构建：`ninja -C build_release_x86 LLVMEJIT` + 三套 gtest 目标全绿。
- gtest：EJITCodePoolTests **65** + EJITSharedTaskPoolTests **157** + EJITTests **141** 全绿，无回归；含 4 个新测试：
  - `FinalizedRangeCarriesEntryFnSize`（带 defined symbol 的图 → fnSize 正确）；
  - `FinalizedRangeFnSizeZeroWithoutDefinedSymbol`（无符号 → fnSize=0 回退）；
  - `PublishedSlotCarriesFnSize`（publish → forEachCompiled 读回 slot.fnSize）；
  - `FnSizeSurvivesPendingFlush`（batched: pending→flush→findRange 携带）；
  - 守卫 `FourKAbiVersionAndRangeFieldSemantics` 17→18。
- AOT lit：`EmbeddedJIT/` 50 个里 45 pass / 4 expectedly-failed / 1 fail（`ejit-externalize-helpers.ll`，该 pass 名在 upstream 不存在，是预存失败，与改动无关）。
- code-review 子代理检视通过：写序、5 处清零、finalize 捕获、ABI 全部确认正确；修了 gap 公式、fallback 语义、reserve 三处。

### 文件（10）
`EJitCodeRange.h` `EJitCodePool.h` `EJitSharedPlatform.h` `EJitSharedTaskPoolState.h` `EJitCodePool.cpp` `EJitCodePoolMemoryManager.cpp` `EJitRuntime.cpp` `EJitSharedTaskPool.cpp` + 2 测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
