### PR TITLE
[EJIT] Make may-const ranking samples exact

### DIFF
--- a/ejit_test/ejit_mayconst_ranking_accuracy_test.c
+++ b/ejit_test/ejit_mayconst_ranking_accuracy_test.c
@@ -1,0 +1,252 @@
+// Board flow after reset:
+//   core 6:  test_ejit_mayconst_accuracy
+//   core 16: test_ejit_mayconst_accuracy
+//   core 16: test_ejit_mayconst_accuracy_rank
+//
+// The owner remains alive between commands. No dump or manual code publish is
+// required. Build with branch audit, PGO, shared taskpool, and max-active=4.
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "llvm/ExecutionEngine/EJIT/EJitRuntime.h"
+
+extern void SRE_printf(const char *format, ...);
+extern uint32_t SRE_TaskDelay(uint32_t tick);
+extern void call_init_array_functions(void);
+extern uint8_t g_ucLocalCoreID;
+
+#define MC_WORKER_CORE 6u
+#define MC_PRODUCER_CORE 16u
+#define MC_ENTRY_COUNT 5u
+#define MC_SAMPLE_COUNT 64u
+#define MC_WAIT_ROUNDS 12000u
+#define MC_SHARED __attribute__((section(".mc_shared")))
+
+struct McAccuracyConfig {
+  ejit_may_const uint32_t multiplier;
+  ejit_may_const uint32_t bias;
+  ejit_may_const uint32_t mask;
+  uint32_t salt;
+};
+
+MC_SHARED ejit_period_arr(cell)
+struct McAccuracyConfig g_mc_accuracy_cfg[3];
+MC_SHARED volatile uint32_t g_mc_accuracy_initialized;
+MC_SHARED volatile uint32_t g_mc_accuracy_done;
+MC_SHARED volatile uint64_t g_mc_accuracy_sink;
+
+static bool g_mc_accuracy_ctors_done;
+
+#define MC_ENTRY_BODY(CELL, SEED, TAG)                                         \
+  do {                                                                         \
+    const struct McAccuracyConfig *_cfg = &g_mc_accuracy_cfg[(CELL)];          \
+    uint32_t _value = (SEED) ^ _cfg->salt ^ (TAG);                             \
+    _value = _value * _cfg->multiplier + _cfg->bias;                           \
+    if ((_value & _cfg->mask) == _cfg->bias)                                   \
+      _value ^= 0x9e3779b9u;                                                   \
+    return _value;                                                             \
+  } while (0)
+
+ejit_entry __attribute__((noinline)) uint32_t
+mc_accuracy_entry0(ejit_period_arr_ind(cell) uint8_t cell, uint32_t seed) {
+  MC_ENTRY_BODY(cell, seed, 0x101u);
+}
+ejit_entry __attribute__((noinline)) uint32_t
+mc_accuracy_entry1(ejit_period_arr_ind(cell) uint8_t cell, uint32_t seed) {
+  MC_ENTRY_BODY(cell, seed, 0x202u);
+}
+ejit_entry __attribute__((noinline)) uint32_t
+mc_accuracy_entry2(ejit_period_arr_ind(cell) uint8_t cell, uint32_t seed) {
+  MC_ENTRY_BODY(cell, seed, 0x303u);
+}
+ejit_entry __attribute__((noinline)) uint32_t
+mc_accuracy_entry3(ejit_period_arr_ind(cell) uint8_t cell, uint32_t seed) {
+  MC_ENTRY_BODY(cell, seed, 0x404u);
+}
+ejit_entry __attribute__((noinline)) uint32_t
+mc_accuracy_entry4(ejit_period_arr_ind(cell) uint8_t cell, uint32_t seed) {
+  MC_ENTRY_BODY(cell, seed, 0x505u);
+}
+
+static uint32_t mc_accuracy_call(uint32_t entry, uint8_t cell, uint32_t seed) {
+  switch (entry) {
+  case 0:
+    return mc_accuracy_entry0(cell, seed);
+  case 1:
+    return mc_accuracy_entry1(cell, seed);
+  case 2:
+    return mc_accuracy_entry2(cell, seed);
+  case 3:
+    return mc_accuracy_entry3(cell, seed);
+  default:
+    return mc_accuracy_entry4(cell, seed);
+  }
+}
+
+static uint32_t mc_accuracy_expected(uint32_t entry, uint8_t cell,
+                                     uint32_t seed) {
+  static const uint32_t tags[MC_ENTRY_COUNT] = {0x101u, 0x202u, 0x303u, 0x404u,
+                                                0x505u};
+  const struct McAccuracyConfig *cfg = &g_mc_accuracy_cfg[cell];
+  uint32_t value = seed ^ cfg->salt ^ tags[entry];
+  value = value * cfg->multiplier + cfg->bias;
+  if ((value & cfg->mask) == cfg->bias)
+    value ^= 0x9e3779b9u;
+  return value;
+}
+
+static void mc_accuracy_init_shared(void) {
+  if (__atomic_load_n(&g_mc_accuracy_initialized, __ATOMIC_ACQUIRE))
+    return;
+  for (uint32_t cell = 0; cell != 3; ++cell) {
+    g_mc_accuracy_cfg[cell].multiplier = 3u + cell * 2u;
+    g_mc_accuracy_cfg[cell].bias = 1u + cell;
+    g_mc_accuracy_cfg[cell].mask = 7u;
+    g_mc_accuracy_cfg[cell].salt = 0x13579bdu + cell * 0x10203u;
+  }
+  __atomic_store_n(&g_mc_accuracy_done, 0u, __ATOMIC_RELAXED);
+  __atomic_store_n(&g_mc_accuracy_sink, 0u, __ATOMIC_RELAXED);
+  __atomic_store_n(&g_mc_accuracy_initialized, 1u, __ATOMIC_RELEASE);
+}
+
+static ejit_status_t mc_accuracy_init(void) {
+  ejit_config_t cfg = {0};
+  cfg.compileMode = EJIT_COMPILE_ASYNC;
+  cfg.optLevel = EJIT_OPT_L2;
+  cfg.enableLogger = true;
+  cfg.forceStaticRegistry = true;
+  return ejit_init_pgo(&cfg);
+}
+
+static bool mc_accuracy_stats(ejit_taskpool_stats_t *stats) {
+  *stats = (ejit_taskpool_stats_t){0};
+  return ejit_taskpool_get_stats(stats) == EJIT_OK;
+}
+
+static bool mc_accuracy_wait_delta(uint64_t baseline, uint64_t delta,
+                                   const char *phase) {
+  for (uint32_t round = 0; round != MC_WAIT_ROUNDS; ++round) {
+    ejit_taskpool_stats_t stats;
+    if (!mc_accuracy_stats(&stats) || stats.compileFailed ||
+        stats.publishFailed)
+      return false;
+    if (stats.asyncCompiles >= baseline + delta &&
+        ejit_taskpool_pending_count() == 0)
+      return true;
+    if ((round % 1000u) == 0)
+      SRE_printf("[MC-ACCURACY] waiting %s compiles=%llu/%llu pending=%u\n",
+                 phase, (unsigned long long)(stats.asyncCompiles - baseline),
+                 (unsigned long long)delta, ejit_taskpool_pending_count());
+    (void)SRE_TaskDelay(10u);
+  }
+  SRE_printf("[MC-ACCURACY] FAIL timeout phase=%s\n", phase);
+  ejit_taskpool_print_stats();
+  return false;
+}
+
+static int mc_accuracy_run_five_entries(void) {
+  ejit_taskpool_stats_t initial;
+  if (!mc_accuracy_stats(&initial))
+    return -10;
+
+  // Four entries may profile immediately. The fifth repeatedly follows AOT
+  // until a slot is released, proving max-active handoff without a stall.
+  for (uint32_t round = 0; round != MC_WAIT_ROUNDS; ++round) {
+    for (uint32_t entry = 0; entry != MC_ENTRY_COUNT; ++entry) {
+      const uint32_t seed = 0x10000u + round * 17u + entry;
+      const uint32_t got = mc_accuracy_call(entry, 0, seed);
+      if (got != mc_accuracy_expected(entry, 0, seed))
+        return -11;
+      __atomic_fetch_xor(&g_mc_accuracy_sink, got, __ATOMIC_RELAXED);
+    }
+    ejit_taskpool_stats_t stats;
+    if (!mc_accuracy_stats(&stats) || stats.compileFailed ||
+        stats.publishFailed)
+      return -12;
+    if (stats.asyncCompiles >= initial.asyncCompiles + MC_ENTRY_COUNT * 2u &&
+        ejit_taskpool_pending_count() == 0)
+      return 0;
+    (void)SRE_TaskDelay(1u);
+  }
+  return -13;
+}
+
+static int mc_accuracy_run_serial_version(uint8_t cell) {
+  ejit_taskpool_stats_t initial;
+  if (!mc_accuracy_stats(&initial))
+    return -20;
+
+  uint32_t seed = 0x20000u + cell;
+  if (mc_accuracy_call(0, cell, seed) != mc_accuracy_expected(0, cell, seed))
+    return -21;
+  if (!mc_accuracy_wait_delta(initial.asyncCompiles, 1u, "serial Tier-1"))
+    return -22;
+
+  for (uint32_t sample = 0; sample != MC_SAMPLE_COUNT; ++sample) {
+    seed = 0x30000u + cell * 0x1000u + sample;
+    if (mc_accuracy_call(0, cell, seed) != mc_accuracy_expected(0, cell, seed))
+      return -23;
+  }
+  if (!mc_accuracy_wait_delta(initial.asyncCompiles, 2u, "serial Tier-2"))
+    return -24;
+  return 0;
+}
+
+int test_ejit_mayconst_accuracy(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  const uint32_t core = (uint32_t)g_ucLocalCoreID;
+  if (!g_mc_accuracy_ctors_done) {
+    call_init_array_functions();
+    g_mc_accuracy_ctors_done = true;
+  }
+  if (core == MC_WORKER_CORE)
+    mc_accuracy_init_shared();
+  else if (!__atomic_load_n(&g_mc_accuracy_initialized, __ATOMIC_ACQUIRE))
+    return -1;
+
+  if (mc_accuracy_init() != EJIT_OK)
+    return -2;
+  if (ejit_taskpool_get_worker_core() != MC_WORKER_CORE)
+    return -3;
+  if (core == MC_WORKER_CORE) {
+    SRE_printf("[MC-ACCURACY] worker ready; run on core %u\n",
+               MC_PRODUCER_CORE);
+    return 0;
+  }
+  if (core != MC_PRODUCER_CORE)
+    return -4;
+
+  for (uint32_t cell = 0; cell != 3; ++cell)
+    if (ejit_activate("cell", cell) != EJIT_OK)
+      return -5;
+  int result = mc_accuracy_run_five_entries();
+  if (result != 0)
+    return result;
+  for (uint8_t cell = 1; cell != 3; ++cell) {
+    result = mc_accuracy_run_serial_version(cell);
+    if (result != 0)
+      return result;
+  }
+
+  __atomic_store_n(&g_mc_accuracy_done, 1u, __ATOMIC_RELEASE);
+  SRE_printf("[MC-ACCURACY] PASS; run test_ejit_mayconst_accuracy_rank on "
+             "core %u\n",
+             MC_PRODUCER_CORE);
+  return 0;
+}
+
+int test_ejit_mayconst_accuracy_rank(uint8_t a, uint8_t b, uint8_t c,
+                                     uint8_t d) {
+  (void)a;
+  (void)b;
+  (void)c;
+  (void)d;
+  if (!__atomic_load_n(&g_mc_accuracy_done, __ATOMIC_ACQUIRE))
+    return -1;
+  ejit_print_mayconst_ranking();
+  return 0;
+}

--- a/jit_design_doc/EJIT_BRANCH_PROFILE_AUDIT.md
+++ b/jit_design_doc/EJIT_BRANCH_PROFILE_AUDIT.md
@@ -34,18 +34,22 @@ the shared light-optimization prefix so Tier-1 and Tier-2 keep matching CFG
 hashes. Those temporary increments and their global are removed immediately
 after `PGOInstrumentationUse`; they never reach stable Baseline/PGOUse code.
 
-After the normal 64-entry sampling window, the compile driver snapshots the
-site counters before replacing T0. `ejit_init()` publishes ordinary Baseline
-code; `ejit_init_pgo()` continues to the normal PGOUse code. Thus audit-only
-mode samples runtime behavior without applying profile-guided optimization to
-the stable JIT version. The INFO line reports the current version plus the
+The 64-entry window counts only calls that actually dispatch an executable
+Tier-1 pointer. A peer that cannot execute the shared pointer, a null pointer,
+execute-permission preparation failure, or any other AOT fallback does not
+consume the quota. The 64th real dispatch still executes Tier-1 and atomically
+freezes the timestamp and entry count; later calls use AOT while Tier-2 waits or
+compiles. The compile driver therefore snapshots the site counters without
+including queue, worker-throttle, or Tier-2 compile delay in `sample_cycles`.
+`ejit_init()` publishes ordinary Baseline code; `ejit_init_pgo()` continues to
+normal PGOUse code. The INFO line reports the current version plus the
 unique-cache-key aggregate for that entry:
 
 ```text
 [EJIT] mayconst-audit entry=FuncA key=0x1234 tier=2 versions=30 \
   mayconst=42/3/0 removed=42 direct=39 pipeline=3 runtime_hits=99872 \
   hit_sites=17 removed_runtime_hits=95000 removed_hit_sites=16 \
-  sampled_entries=67 sample_cycles=1900000 avg_removed=40 \
+  sampled_entries=64 sample_cycles=1900000 avg_removed=40 \
   weighted_permille=952 min=36 max=42
 ```
 
@@ -102,10 +106,14 @@ million platform timestamp units:
 
 ```text
 [EJIT] mayconst-ranking entries=2 sort=benefit_per_mcycle_desc
-[EJIT] rank=1 entry=FuncA versions=30 benefit_per_mcycle=71225.850 \
-  removed_per_entry=20882.518 removed_runtime_hits=8582715 \
-  sampled_entries=411 sample_cycles=120500000 avg_active_sites=17.000 \
-  hit_sites=510 runtime_hits=10000000 avg_removed=40 total_removed=1200 \
+[EJIT] rank=1 entry=FuncA versions=6 benefit_per_mcycle=71225.850 \
+  entry_benefit_density=1187.097 density_valid=1 hot_code_bytes=23040 \
+  size_source=fn size_valid_versions=6/6 hot_icache_lines=360 \
+  fingerprinted_lines=360 cross_version_matching_lines=90 \
+  partial_jit_candidate_lines=75 partial_jit_candidate_ratio=20.8% \
+  removed_per_entry=20882.518 removed_runtime_hits=8018887 \
+  sampled_entries=384 sample_cycles=112583000 avg_active_sites=17.000 \
+  hit_sites=102 runtime_hits=9000000 avg_removed=40 total_removed=240 \
   min=36 max=42
 ```
 
@@ -116,9 +124,19 @@ floating point. The primary score is
 `removed_runtime_hits * 1,000,000 / sample_cycles`. The equivalent decomposition
 is `(removed_runtime_hits / sampled_entries) *
 (sampled_entries / sample_cycles)`: work removed per entry multiplied by entry
-frequency. Recording the actual entries and elapsed ticks makes samples
-comparable even though the asynchronous Tier-2 snapshot normally occurs after
-the nominal 64-hit trigger rather than at exactly 64 completed calls.
+frequency. With the default threshold, six completed versions therefore report
+`sampled_entries=384`. Queueing and compilation after the threshold cannot
+change either that count or the frozen interval.
+
+`hot_code_bytes` and `hot_icache_lines` use the finalized entry symbol's exact
+`fnPtr + fnSize`, not the containing JITLink allocation. The byte range is read
+only after publication and only when it lies completely inside the finalized
+executable allocation; a zero/missing/out-of-range size is reported as
+`size_source=unknown` or `mixed`, with `density_valid=0`. In that case density
+and all aggregate line-fingerprint metrics are omitted rather than estimated
+from a partial version set or allocation bytes.
+`entry_benefit_density` divides `benefit_per_mcycle` by the sum of per-version
+`ceil(fnSize / 64)` I-cache lines.
 
 `avg_active_sites` is `hit_sites / versions` and remains an explanatory metric;
 three decimal places are printed using integer fixed-point arithmetic.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitBranchProfile.h
@@ -57,6 +57,8 @@ struct EJitMayConstBenefitSample {
   uint64_t sampleCycles = 0;
   /// Finalized executable bytes published for this JIT version.
   uint64_t publishedHotCodeBytes = 0;
+  /// True only when publishedHotCodeBytes came from a validated fnPtr/fnSize.
+  bool publishedHotCodeSizeValid = false;
   /// Fingerprints of non-zero 64-byte executable lines. Used only by the
   /// diagnostic cross-version Partial JIT audit.
   std::vector<uint64_t> publishedHotLineFingerprints;
@@ -81,6 +83,8 @@ struct EJitMayConstBenefitSummary {
   uint64_t sampledEntries = 0;
   uint64_t sampleCycles = 0;
   uint64_t publishedHotCodeBytes = 0;
+  uint64_t validPublishedHotCodeVersions = 0;
+  bool entryBenefitDensityValid = false;
   /// Sum of per-version ceil(publishedHotCodeBytes / 64).
   uint64_t publishedHotICacheLines = 0;
   /// Non-zero executable lines included in the cross-version audit.
@@ -116,6 +120,14 @@ summarizeMayConstBenefits(ArrayRef<EJitMayConstBenefitSample> Samples);
 /// Fingerprint non-zero 64-byte executable lines for the Partial JIT audit.
 std::vector<uint64_t>
 fingerprintPublishedHotICacheLines(ArrayRef<uint8_t> CodeBytes);
+
+/// Validate that fnPtr/fnSize names a complete function body inside its
+/// finalized executable allocation. Out is empty on failure and no bytes are
+/// read, which keeps RW/NX, missing-size, and neighboring allocations out of
+/// the ranking audit.
+bool getPublishedFunctionBytes(const void *FnPtr, uint64_t FnSize,
+                               uintptr_t AllocationStart,
+                               uint64_t AllocationSize, ArrayRef<uint8_t> &Out);
 
 } // namespace ejit
 } // namespace llvm

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitCompileDriver.h
@@ -207,8 +207,10 @@ private:
     EJitCompileRequest request{};
     std::string entry;
     uint64_t cacheKey = 0;
-    uintptr_t codeStart = 0;
-    uint64_t codeSize = 0;
+    uintptr_t fnPtr = 0;
+    uint64_t fnSize = 0;
+    uintptr_t allocationStart = 0;
+    uint64_t allocationSize = 0;
   };
   /// Batch mode may link several Tier-2 versions before publishing them. Keep
   /// their readable ranges private until the matching publish callback says

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOptimizer.h
@@ -105,7 +105,9 @@ public:
   /// Attach the finalized executable footprint to a completed specialization
   /// sample. Returns false when the sample is unavailable or audit is off.
   bool recordMayConstPublishedCode(StringRef Entry, uint64_t CacheKey,
-                                   const void *CodeStart, uint64_t CodeBytes);
+                                   const void *FnPtr, uint64_t FnSize,
+                                   uintptr_t AllocationStart,
+                                   uint64_t AllocationSize);
 
 private:
   /// Replace ejit_period_arr_ind parameters with their runtime constants.

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -128,6 +128,8 @@ struct SpecializationContext {
   /// Platform timestamp distance from Tier-1 counter capture to the Tier-2
   /// snapshot. SRE uses cycle counter ticks; hosts use steady-clock ns.
   uint64_t mayConstSampleCycles = 0;
+  /// Root Tier-1 dispatches admitted into this frozen sampling window.
+  uint64_t mayConstSampledEntries = 0;
   /// True when profile data is collected for diagnostics only. The optimizer
   /// restores weights for reporting but must publish ordinary Baseline code.
   bool profileAuditOnly = false;
@@ -182,7 +184,9 @@ public:
 
   /// Attach finalized executable bytes to a completed may_const sample.
   bool recordMayConstPublishedCode(const std::string &Entry, uint64_t CacheKey,
-                                   const void *CodeStart, uint64_t CodeBytes);
+                                   const void *FnPtr, uint64_t FnSize,
+                                   uintptr_t AllocationStart,
+                                   uint64_t AllocationSize);
 
   /// Register a user-defined external symbol (function or global) that the
   /// JIT can resolve when compiling bitcode modules. Required for bare-metal

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedPlatform.h
@@ -113,7 +113,9 @@ constexpr uint32_t kEJitSharedAbiMagic = 0x456A5370u; // "EjSp"
 /// recorded (print_compiled reports fn_size=0, overhead=codeSize).
 /// v19: the owner-published pool mirror carries the 16 cell + public near-hot
 /// pool details and pool ids are stable across separate managers.
-constexpr uint32_t kEJitSharedAbiVersion = 19u;
+/// v20: Tier-1 sampling end/count are frozen in the shared slot and carried by
+/// the Tier-2 request, excluding queue and compile delay from ranking cycles.
+constexpr uint32_t kEJitSharedAbiVersion = 20u;
 
 /// Sentinel "no core" id. Out of any plausible core-id range.
 constexpr uint32_t kEJitInvalidCoreId = 0xFFFFFFFFu;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPool.h
@@ -413,6 +413,8 @@ public:
   /// Owner-private diagnostic callback. It runs only on the owner worker and
   /// may access owner-local optimizer state.
   using MayConstRankingCallback = bool (*)(void *ctx);
+  /// Platform timestamp source used on the core closing a Tier-1 window.
+  using TraceNowCallback = uint64_t (*)(void *ctx);
 #ifdef EJIT_SRE_TASKPOOL_TESTING
   using TestHookFn = void (*)(void *ctx);
 #endif
@@ -519,6 +521,10 @@ public:
   void setMayConstRankingCallback(MayConstRankingCallback fn, void *ctx) {
     mayConstRankingFn_ = fn;
     mayConstRankingCtx_ = ctx;
+  }
+  void setTraceNowCallback(TraceNowCallback fn, void *ctx) {
+    traceNowFn_ = fn;
+    traceNowCtx_ = ctx;
   }
   void setReleaser(ReleaseCallback fn, void *ctx) {
     const bool had = (releaseFn_ != nullptr);
@@ -753,10 +759,10 @@ public:
   void setMode(EJitCompileMode mode) { configuredMode_ = mode; }
 
   /// PGO (§6): enable the online-PGO Tier-2 auto-trigger on the shared
-  /// taskpool.  When enabled, every cache hit atomically increments the
-  /// slot's hitCount; the hit that crosses \p threshold arms a one-shot
-  /// Tier-2 (PGOUse) lazy recompile via enqueue. \p threshold 0 disables
-  /// the trigger (hits are still counted).
+  /// taskpool. Only a dispatch that returns an executable Tier-1 pointer
+  /// consumes the sampling quota. The threshold dispatch freezes the sample
+  /// end/count and arms Tier-2; later calls use AOT until Tier-2 publishes.
+  /// \p threshold 0 disables the trigger (legal hits are still counted).
   void setPgoEnabled(
       bool enable, uint32_t threshold,
       uint32_t maxConcurrentProfiles = EJIT_SRE_PGO_MAX_CONCURRENT_PROFILES) {
@@ -1188,11 +1194,6 @@ private:
     uint32_t bucketIndex = 0;
     bool hasReadToken = false;
     bool readyButNotShareable = false;
-    /// The instrumented Tier-1 has collected its configured number of root
-    /// samples and Tier-2 is queued/compiling. Keep the Tier-1 allocation and
-    /// counters alive for profile synthesis, but route calls back to AOT until
-    /// Tier-2 publication replaces the slot.
-    bool pgoSamplingComplete = false;
     /// EJIT_SRE_TASKPOOL_NO_RECLAIM only: a validated seqlock hit that holds NO
     /// read token. classifyHit() treats it as a CacheHit; bucketIndex is the
     /// out-of-range sentinel (kEJitSharedCacheBuckets) so the wrapper's
@@ -1264,7 +1265,11 @@ private:
   /// Submit Tier-2 from an identity/version-validated slot while its bucket
   /// read lock is held. This preserves the exact slot snapshot without
   /// enlarging the 16-byte CompileOrGetResult hot-path return value.
-  void enqueueTier2FromSlot(const EJitSharedCacheSlot &slot);
+  void enqueueTier2FromSlot(const EJitSharedCacheSlot &slot, uint64_t sampleEnd,
+                            uint32_t sampleEntries);
+  /// Count one dispatch only after a legal Tier-1 pointer is ready to return.
+  /// False means sampling was already complete and this call must use AOT.
+  bool accountTier1Dispatch(const SharedLookup &hit);
   /// Cold non-owner first-touch execute-permission preparation for a matched
   /// slot, with the bucket read lock HELD on entry (this function releases it).
   /// Snapshots the slot, drops the lock for the per-core platform seal, then
@@ -1447,6 +1452,8 @@ private:
   void *codePoolStatsCtx_ = nullptr;
   MayConstRankingCallback mayConstRankingFn_ = nullptr;
   void *mayConstRankingCtx_ = nullptr;
+  TraceNowCallback traceNowFn_ = nullptr;
+  void *traceNowCtx_ = nullptr;
   CodeReadyCallback codeReadyFn_ = nullptr;
   CodeBatchFlushCallback codeBatchFlushFn_ = nullptr;
   void *codeBatchCtx_ = nullptr;

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSharedTaskPoolState.h
@@ -253,6 +253,10 @@ struct EJitSharedCacheSlot {
   /// compile driver via ORC lookup and kept driver-private — they do not
   /// need to live in the shared slot.
   EJitAtomicU64 hitCount;
+  /// Sampling window frozen by the threshold-winning real Tier-1 dispatch.
+  /// The end and entry count are published before hitCount reaches threshold.
+  EJitAtomicU64 pgoSampleEnd;
+  EJitAtomicU32 pgoSampleEntries;
   /// PGO (§7.1): current compile tier of the published code.  0 = Baseline /
   /// not yet published, 1 = Instrumented (Tier-1), 2 = PGOUse (Tier-2).
   /// Used to suppress the Tier-2 auto-trigger on slots that are already

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitSreQueue.h
@@ -63,6 +63,10 @@ struct EJitCompileRequest {
   uint32_t numDims;
   EJitDimPair dims[4];
   uint32_t versions[4];
+  /// Frozen at the final real Tier-1 dispatch. Tier-2 must use these values
+  /// instead of measuring after queue/worker delay. pgoSampleEntries == 0
+  /// means this timestamp is unavailable; the timestamp itself may be zero.
+  uint64_t pgoSampleEnd;
   uintptr_t fallbackPtr;
   // Shared-taskpool owner generation captured at enqueue time. A worker drops a
   // request whose generation no longer equals the shared state's generation
@@ -70,6 +74,7 @@ struct EJitCompileRequest {
   // cache. Unused (left 0) by the non-shared taskpool. Endianness: a plain
   // fixed-width scalar accessed by value, never byte-parsed.
   uint32_t generation;
+  uint32_t pgoSampleEntries;
   // Optional shallow pointee snapshot for ejit_bound_ptr. It is stored inline
   // so an async request owns every byte it needs after the caller returns.
   // boundSize == 0 means no bound pointer. No raw caller pointer crosses the
@@ -79,13 +84,12 @@ struct EJitCompileRequest {
   alignas(uintptr_t) uint8_t boundData[EJIT_BOUND_PTR_MAX_BYTES];
 };
 
-// Size is stable per pointer width: on a 64-bit target the trailing uint32_t
-// generation forces 4 bytes of tail padding (alignof == 8) -> 72; on a 32-bit
-// target everything is 4-aligned with no padding -> 64.
+// Size is stable per pointer width. The 64-bit layout retains 8-byte alignment;
+// the 32-bit layout is 4-byte aligned.
 static_assert(sizeof(EJitCompileRequest) ==
-                  (sizeof(uintptr_t) == 8 ? 80u + EJIT_BOUND_PTR_MAX_BYTES
-                                          : 72u + EJIT_BOUND_PTR_MAX_BYTES),
-              "EJitCompileRequest size must stay stable (incl. generation)");
+                  (sizeof(uintptr_t) == 8 ? 88u + EJIT_BOUND_PTR_MAX_BYTES
+                                          : 84u + EJIT_BOUND_PTR_MAX_BYTES),
+              "EJitCompileRequest size must stay stable (incl. PGO sample)");
 static_assert(alignof(EJitCompileRequest) <= 8,
               "EJitCompileRequest alignment must stay <= 8 bytes");
 static_assert(sizeof(uintptr_t) == 4 || sizeof(uintptr_t) == 8,

--- a/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitBranchProfile.cpp
@@ -34,8 +34,7 @@ uint64_t saturatingAdd(uint64_t L, uint64_t R) {
   return R > Max - L ? Max : L + R;
 }
 
-uint64_t scaledRatio(uint64_t Numerator, uint64_t Denominator,
-                     uint64_t Scale) {
+uint64_t scaledRatio(uint64_t Numerator, uint64_t Denominator, uint64_t Scale) {
   if (Denominator == 0)
     return 0;
   APInt Wide(129, Numerator);
@@ -66,8 +65,8 @@ uint64_t scaledRatioWithProductDenominator(uint64_t Numerator,
 
 } // namespace
 
-std::vector<uint64_t> llvm::ejit::fingerprintPublishedHotICacheLines(
-    ArrayRef<uint8_t> CodeBytes) {
+std::vector<uint64_t>
+llvm::ejit::fingerprintPublishedHotICacheLines(ArrayRef<uint8_t> CodeBytes) {
   std::vector<uint64_t> Fingerprints;
   Fingerprints.reserve(CodeBytes.size() / EJitICacheLineBytes +
                        (CodeBytes.size() % EJitICacheLineBytes != 0));
@@ -85,6 +84,24 @@ std::vector<uint64_t> llvm::ejit::fingerprintPublishedHotICacheLines(
     Fingerprints.push_back(Fingerprint);
   }
   return Fingerprints;
+}
+
+bool llvm::ejit::getPublishedFunctionBytes(const void *FnPtr, uint64_t FnSize,
+                                           uintptr_t AllocationStart,
+                                           uint64_t AllocationSize,
+                                           ArrayRef<uint8_t> &Out) {
+  Out = {};
+  const uintptr_t FnStart = reinterpret_cast<uintptr_t>(FnPtr);
+  if (FnStart == 0 || FnSize == 0 || AllocationStart == 0 ||
+      AllocationSize == 0 || FnSize > std::numeric_limits<size_t>::max() ||
+      FnStart < AllocationStart)
+    return false;
+  const uint64_t Offset = FnStart - AllocationStart;
+  if (Offset > AllocationSize || FnSize > AllocationSize - Offset)
+    return false;
+  Out = ArrayRef<uint8_t>(static_cast<const uint8_t *>(FnPtr),
+                          static_cast<size_t>(FnSize));
+  return true;
 }
 
 EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
@@ -107,7 +124,8 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
         Summary.specializedMayConstLoads, Sample.specializedMayConstLoads);
     Summary.finalMayConstLoads =
         saturatingAdd(Summary.finalMayConstLoads, Sample.finalMayConstLoads);
-    Summary.runtimeHits = saturatingAdd(Summary.runtimeHits, Sample.runtimeHits);
+    Summary.runtimeHits =
+        saturatingAdd(Summary.runtimeHits, Sample.runtimeHits);
     Summary.hitSites = saturatingAdd(Summary.hitSites, Sample.hitSites);
     Summary.removedRuntimeHits =
         saturatingAdd(Summary.removedRuntimeHits, Sample.removedRuntimeHits);
@@ -117,13 +135,16 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
         saturatingAdd(Summary.sampledEntries, Sample.sampledEntries);
     Summary.sampleCycles =
         saturatingAdd(Summary.sampleCycles, Sample.sampleCycles);
-    Summary.publishedHotCodeBytes = saturatingAdd(
-        Summary.publishedHotCodeBytes, Sample.publishedHotCodeBytes);
+    Summary.publishedHotCodeBytes = saturatingAdd(Summary.publishedHotCodeBytes,
+                                                  Sample.publishedHotCodeBytes);
+    Summary.validPublishedHotCodeVersions =
+        saturatingAdd(Summary.validPublishedHotCodeVersions,
+                      Sample.publishedHotCodeSizeValid ? 1 : 0);
     const uint64_t VersionICacheLines =
         Sample.publishedHotCodeBytes / EJitICacheLineBytes +
         (Sample.publishedHotCodeBytes % EJitICacheLineBytes != 0);
-    Summary.publishedHotICacheLines = saturatingAdd(
-        Summary.publishedHotICacheLines, VersionICacheLines);
+    Summary.publishedHotICacheLines =
+        saturatingAdd(Summary.publishedHotICacheLines, VersionICacheLines);
     DenseSet<uint64_t> SeenInVersion;
     for (uint64_t Fingerprint : Sample.publishedHotLineFingerprints) {
       Summary.fingerprintedHotICacheLines =
@@ -159,23 +180,32 @@ EJitMayConstBenefitSummary llvm::ejit::summarizeMayConstBenefits(
       scaledRatio(Summary.hitSites, Summary.versions, 1000);
   Summary.removedHitsPerEntryPermille =
       scaledRatio(Summary.removedRuntimeHits, Summary.sampledEntries, 1000);
-  Summary.benefitPerMillionCyclesMilli = scaledRatio(
-      Summary.removedRuntimeHits, Summary.sampleCycles, 1000000000);
-  Summary.entryBenefitDensityMilli = scaledRatioWithProductDenominator(
-      Summary.removedRuntimeHits, Summary.sampleCycles,
-      Summary.publishedHotICacheLines, 1000000000);
-  for (const auto &Entry : Fingerprints) {
-    const FingerprintCounts &Counts = Entry.second;
-    if (Counts.versions < 2)
-      continue;
-    Summary.crossVersionMatchingICacheLines = saturatingAdd(
-        Summary.crossVersionMatchingICacheLines, Counts.occurrences);
-    Summary.partialJitCandidateICacheLines = saturatingAdd(
-        Summary.partialJitCandidateICacheLines, Counts.occurrences - 1);
+  Summary.benefitPerMillionCyclesMilli =
+      scaledRatio(Summary.removedRuntimeHits, Summary.sampleCycles, 1000000000);
+  Summary.entryBenefitDensityValid =
+      Summary.validPublishedHotCodeVersions == Summary.versions;
+  if (Summary.entryBenefitDensityValid) {
+    Summary.entryBenefitDensityMilli = scaledRatioWithProductDenominator(
+        Summary.removedRuntimeHits, Summary.sampleCycles,
+        Summary.publishedHotICacheLines, 1000000000);
+    for (const auto &Entry : Fingerprints) {
+      const FingerprintCounts &Counts = Entry.second;
+      if (Counts.versions < 2)
+        continue;
+      Summary.crossVersionMatchingICacheLines = saturatingAdd(
+          Summary.crossVersionMatchingICacheLines, Counts.occurrences);
+      Summary.partialJitCandidateICacheLines = saturatingAdd(
+          Summary.partialJitCandidateICacheLines, Counts.occurrences - 1);
+    }
+    Summary.partialJitCandidatePermille =
+        scaledRatio(Summary.partialJitCandidateICacheLines,
+                    Summary.publishedHotICacheLines, 1000);
+  } else {
+    // A partial version set cannot support an honest cross-version code
+    // comparison. Keep size_valid_versions as the explanation, but suppress
+    // all aggregate fingerprint claims alongside density.
+    Summary.fingerprintedHotICacheLines = 0;
   }
-  Summary.partialJitCandidatePermille =
-      scaledRatio(Summary.partialJitCandidateICacheLines,
-                  Summary.publishedHotICacheLines, 1000);
   if (Summary.inputMayConstLoads != 0)
     Summary.weightedRemovedPermille =
         Summary.totalRemoved * 1000 /

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCodePool.cpp
@@ -795,12 +795,10 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
       Out.fnPtr = const_cast<void *>(Ptr);
       Out.codeStart = Found->start;
       Out.codeSize = Found->size;
-      // Recover the entry function's real size for print_compiled waste
-      // diagnostics. The published fnPtr is the entry symbol's address; match
-      // it against the recorded defined symbols. Prefer an exact address match
-      // (the entry itself); otherwise fall back to the symbol whose body
-      // contains A (SAddr <= A < SAddr + size). 0 if no symbol metadata was
-      // recorded (then overhead defaults to the whole codeSize).
+      // Recover the entry function's real size for diagnostics. A size is
+      // exact only when the published fnPtr equals a defined symbol's start;
+      // a pointer into a symbol still resolves its executable allocation, but
+      // must report an unknown fnSize rather than hashing past the body tail.
       Out.fnSize = 0;
       for (uint32_t S = 0; S < Found->symCount; ++S) {
         uintptr_t SAddr = Found->syms[S].addr;
@@ -808,12 +806,6 @@ bool EJitCodePoolManager::findRange(const void *Ptr,
           Out.fnSize = Found->syms[S].size;
           break; // exact entry match
         }
-        // Containing-symbol fallback (e.g. fnPtr points into the middle of a
-        // symbol body rather than at its start). A real "contains" test needs
-        // both bounds; without it a non-containing preceding symbol could win.
-        if (SAddr <= A &&
-            A - SAddr < Found->syms[S].size) // SAddr <= A < SAddr + size
-          Out.fnSize = Found->syms[S].size;
       }
       Out.poolBase = B;
       Out.poolSize = static_cast<uint64_t>(P.size);

--- a/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitCompileDriver.cpp
@@ -64,6 +64,8 @@ bool sameAuditRequest(const EJitCompileRequest &L,
                       const EJitCompileRequest &R) {
   if (L.funcIndex != R.funcIndex || L.numDims != R.numDims ||
       L.fallbackPtr != R.fallbackPtr || L.generation != R.generation ||
+      L.pgoSampleEnd != R.pgoSampleEnd ||
+      L.pgoSampleEntries != R.pgoSampleEntries ||
       L.boundArgIndex != R.boundArgIndex || L.boundSize != R.boundSize ||
       L.boundSize > EJIT_BOUND_PTR_MAX_BYTES)
     return false;
@@ -93,6 +95,8 @@ void taskpoolPublishThunk(void *ctx, const EJitCompileRequest &req,
   static_cast<EJitCompileDriver *>(ctx)->notifyTaskpoolPublished(req,
                                                                  published);
 }
+
+uint64_t taskpoolTraceNowThunk(void *) { return ejit_taskpool_trace_now(); }
 
 #ifdef EJIT_SRE_SHARED_TASKPOOL
 [[maybe_unused]] bool sharedPrepareCodeThunk(void * /*ctx*/,
@@ -317,6 +321,7 @@ EJitCompileDriver::EJitCompileDriver(const Config &config,
   sharedPool_.setCompiler(&taskpoolCompileThunk, this);
   sharedPool_.setPublishCallback(&taskpoolPublishThunk, this);
   sharedPool_.setMayConstRankingCallback(&sharedMayConstRankingThunk, this);
+  sharedPool_.setTraceNowCallback(&taskpoolTraceNowThunk, this);
   sharedPool_.setWorkerHooks(&EJitCompileDriver::sharedWorkerStart,
                              &EJitCompileDriver::sharedWorkerStop, this);
   // Inject the platform yield so the worker never busy-spins while waiting for
@@ -622,10 +627,14 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
       auto mayConstIt = tier1MayConst_.find(cacheKey);
       if (mayConstIt != tier1MayConst_.end()) {
         ctx.mayConstLoadSites = mayConstIt->second.sites;
-        const uint64_t SampleEnd = ejit_taskpool_trace_now();
+        const uint64_t SampleEnd = request && request->pgoSampleEntries != 0
+                                       ? request->pgoSampleEnd
+                                       : ejit_taskpool_trace_now();
         if (mayConstIt->second.sampleStart != 0)
           ctx.mayConstSampleCycles =
               SampleEnd - mayConstIt->second.sampleStart;
+        if (request)
+          ctx.mayConstSampledEntries = request->pgoSampleEntries;
         const auto *Counters = reinterpret_cast<const EJitAtomicU64 *>(
             mayConstIt->second.counterBase);
         if (Counters) {
@@ -910,12 +919,11 @@ void *EJitCompileDriver::compileCold(uint64_t cacheKey, uint32_t tier,
       jitEngine_->findCodeRange(funcPtr, CodeInfo)) {
     if (request) {
       pendingMayConstCodeAudits_.push_back(
-          {*request, funcName, cacheKey, CodeInfo.codeStart,
-           CodeInfo.codeSize});
+          {*request, funcName, cacheKey, reinterpret_cast<uintptr_t>(funcPtr),
+           CodeInfo.fnSize, CodeInfo.codeStart, CodeInfo.codeSize});
     } else {
       (void)jitEngine_->recordMayConstPublishedCode(
-          funcName, cacheKey,
-          reinterpret_cast<const void *>(CodeInfo.codeStart),
+          funcName, cacheKey, funcPtr, CodeInfo.fnSize, CodeInfo.codeStart,
           CodeInfo.codeSize);
     }
   }
@@ -1016,8 +1024,8 @@ void EJitCompileDriver::notifyTaskpoolPublished(const EJitCompileRequest &req,
     if (published && jitEngine_)
       (void)jitEngine_->recordMayConstPublishedCode(
           CodeAudit->entry, CodeAudit->cacheKey,
-          reinterpret_cast<const void *>(CodeAudit->codeStart),
-          CodeAudit->codeSize);
+          reinterpret_cast<const void *>(CodeAudit->fnPtr), CodeAudit->fnSize,
+          CodeAudit->allocationStart, CodeAudit->allocationSize);
     pendingMayConstCodeAudits_.erase(CodeAudit);
   }
 

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOptimizer.cpp
@@ -317,7 +317,9 @@ void EJitOptimizer::runPipeline(Module &M, const SpecializationContext &ctx) {
         ZeroEdges += Summary.zeroCountEdges;
         if (Summary.isRoot) {
           RootEntries = Summary.entryCount;
-          AuditSampledEntries = Summary.entryCount;
+          AuditSampledEntries = ctx.mayConstSampledEntries != 0
+                                    ? ctx.mayConstSampledEntries
+                                    : Summary.entryCount;
         }
         EJIT_DIAG_DEBUG(
             "branch-audit-fn entry=%s fn=%s root=%u entries=%llu insts=%llu "
@@ -549,16 +551,16 @@ void EJitOptimizer::recordMayConstBenefit(
 }
 #endif
 
-bool EJitOptimizer::recordMayConstPublishedCode(StringRef Entry,
-                                                uint64_t CacheKey,
-                                                const void *CodeStart,
-                                                uint64_t CodeBytes) {
+bool EJitOptimizer::recordMayConstPublishedCode(
+    StringRef Entry, uint64_t CacheKey, const void *FnPtr, uint64_t FnSize,
+    uintptr_t AllocationStart, uint64_t AllocationSize) {
 #if defined(EJIT_SRE_PGO_BRANCH_AUDIT) && defined(EJIT_DIAG_ENABLE)
-  const auto *Bytes = static_cast<const uint8_t *>(CodeStart);
+  ArrayRef<uint8_t> FunctionBytes;
+  const bool SizeValid = getPublishedFunctionBytes(
+      FnPtr, FnSize, AllocationStart, AllocationSize, FunctionBytes);
   std::vector<uint64_t> Fingerprints;
-  if (Bytes && CodeBytes <= std::numeric_limits<size_t>::max())
-    Fingerprints = fingerprintPublishedHotICacheLines(
-        ArrayRef<uint8_t>(Bytes, static_cast<size_t>(CodeBytes)));
+  if (SizeValid)
+    Fingerprints = fingerprintPublishedHotICacheLines(FunctionBytes);
 
   uint32_t Expected = 0;
   while (!mayConstBenefitLock_.compareExchange(Expected, 1))
@@ -573,7 +575,8 @@ bool EJitOptimizer::recordMayConstPublishedCode(StringRef Entry,
     mayConstBenefitLock_.storeRelease(0);
     return false;
   }
-  VersionIt->second.publishedHotCodeBytes = CodeBytes;
+  VersionIt->second.publishedHotCodeBytes = SizeValid ? FnSize : 0;
+  VersionIt->second.publishedHotCodeSizeValid = SizeValid;
   VersionIt->second.publishedHotLineFingerprints.assign(Fingerprints.begin(),
                                                         Fingerprints.end());
   mayConstBenefitLock_.storeRelease(0);
@@ -581,8 +584,10 @@ bool EJitOptimizer::recordMayConstPublishedCode(StringRef Entry,
 #else
   (void)Entry;
   (void)CacheKey;
-  (void)CodeStart;
-  (void)CodeBytes;
+  (void)FnPtr;
+  (void)FnSize;
+  (void)AllocationStart;
+  (void)AllocationSize;
   return false;
 #endif
 }
@@ -646,7 +651,8 @@ bool EJitOptimizer::printMayConstRanking() const {
         Row.summary.partialJitCandidatePermille;
     EJIT_DIAG_RAW(
         "rank=%u entry=%s versions=%llu benefit_per_mcycle=%llu.%03llu "
-        "entry_benefit_density=%llu.%03llu hot_code_bytes=%llu "
+        "entry_benefit_density=%llu.%03llu density_valid=%u "
+        "hot_code_bytes=%llu size_source=%s size_valid_versions=%llu/%llu "
         "hot_icache_lines=%llu fingerprinted_lines=%llu "
         "cross_version_matching_lines=%llu partial_jit_candidate_lines=%llu "
         "partial_jit_candidate_ratio=%llu.%01llu%% "
@@ -660,7 +666,15 @@ bool EJitOptimizer::printMayConstRanking() const {
         static_cast<unsigned long long>(Benefit % 1000),
         static_cast<unsigned long long>(Density / 1000),
         static_cast<unsigned long long>(Density % 1000),
+        Row.summary.entryBenefitDensityValid ? 1u : 0u,
         static_cast<unsigned long long>(Row.summary.publishedHotCodeBytes),
+        Row.summary.validPublishedHotCodeVersions == Row.summary.versions
+            ? "fn"
+            : (Row.summary.validPublishedHotCodeVersions == 0 ? "unknown"
+                                                              : "mixed"),
+        static_cast<unsigned long long>(
+            Row.summary.validPublishedHotCodeVersions),
+        static_cast<unsigned long long>(Row.summary.versions),
         static_cast<unsigned long long>(Row.summary.publishedHotICacheLines),
         static_cast<unsigned long long>(
             Row.summary.fingerprintedHotICacheLines),

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -1358,12 +1358,12 @@ bool EJitOrcEngine::printMayConstRanking() const {
   return P->optimizer && P->optimizer->printMayConstRanking();
 }
 
-bool EJitOrcEngine::recordMayConstPublishedCode(const std::string &Entry,
-                                                uint64_t CacheKey,
-                                                const void *CodeStart,
-                                                uint64_t CodeBytes) {
-  return P->optimizer && P->optimizer->recordMayConstPublishedCode(
-                             Entry, CacheKey, CodeStart, CodeBytes);
+bool EJitOrcEngine::recordMayConstPublishedCode(
+    const std::string &Entry, uint64_t CacheKey, const void *FnPtr,
+    uint64_t FnSize, uintptr_t AllocationStart, uint64_t AllocationSize) {
+  return P->optimizer &&
+         P->optimizer->recordMayConstPublishedCode(
+             Entry, CacheKey, FnPtr, FnSize, AllocationStart, AllocationSize);
 }
 
 void EJitOrcEngine::addUserSymbol(const std::string &name, void *addr) {

--- a/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitSharedTaskPool.cpp
@@ -1398,79 +1398,6 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   SharedLookup R;
   EJitSharedCacheSlot &Slot = B.slots[slotIndex];
 
-  // PGO (§6): every identity-matched hit increments the slot's hitCount.
-  // The hit that crosses tier2Threshold_ arms a one-shot Tier-2 recompile.
-  // We count all identity hits — even those rejected for shareability —
-  // because the function IS being called; the PGO counter is a hotness
-  // proxy, not an execution-completed count.
-  // A slot already at Tier-2 (PGOUse) is never re-armed — Tier-2 code does
-  // not need another Tier-2 compile (§4 repeat-trigger).
-  if (state_->pgoEnabled.loadAcquire()) {
-    uint8_t slotTier = Slot.tier.loadRelaxed();
-    if (slotTier < kEJitTierPgoUse) {
-      uint32_t threshold = state_->tier2Threshold.loadAcquire();
-      uint64_t sampleIndex = 0;
-      if (slotTier == kEJitTierInstrumented && threshold) {
-        // Cap Tier-1 execution at the requested number of root samples. A
-        // plain fetchAdd lets peer cores overshoot, and continuing to dispatch
-        // Tier-1 while a large Tier-2 waits/compiles keeps every instrumented
-        // function in that module doing atomic counter updates for no benefit.
-        uint64_t observed = Slot.hitCount.loadRelaxed();
-        while (observed < threshold &&
-               !Slot.hitCount.compareExchange(observed, observed + 1)) {
-        }
-        if (observed >= threshold) {
-          // Retry the enqueue on every saturated lookup if a previous attempt
-          // lost to queue pressure. dedupMark makes the normal pending case a
-          // cheap no-op. The slot and Tier-1 code remain intact because Tier-2
-          // profile synthesis still reads their counter storage.
-          enqueueTier2FromSlot(Slot);
-#ifndef EJIT_SRE_TASKPOOL_NO_RECLAIM
-          bucketReadRelease(B);
-#endif
-          R.pgoSamplingComplete = true;
-          return R;
-        }
-        sampleIndex = observed + 1;
-      } else {
-        sampleIndex = Slot.hitCount.fetchAdd(1) + 1;
-      }
-      uint32_t admissionSlot = kEJitSharedMaxConcurrentProfiles;
-      if (slotTier == kEJitTierInstrumented && threshold) {
-        const uint32_t encoded = Slot.funcIndex + 1;
-        for (uint32_t i = 0; i < kEJitSharedMaxConcurrentProfiles; ++i) {
-          if (state_->pgoActiveFunctions[i].loadAcquire() == encoded) {
-            admissionSlot = i;
-            break;
-          }
-        }
-      }
-      if (admissionSlot != kEJitSharedMaxConcurrentProfiles) {
-        uint32_t quarter = static_cast<uint32_t>(
-            std::min<uint64_t>(4, (sampleIndex * 4) / threshold));
-        uint32_t oldQuarter =
-            state_->pgoProgressQuarters[admissionSlot].loadRelaxed();
-        while (quarter > oldQuarter &&
-               !state_->pgoProgressQuarters[admissionSlot].compareExchange(
-                   oldQuarter, quarter)) {
-        }
-        if (quarter > oldQuarter)
-          EJIT_DIAG("PGO profile progress func=%u: %llu/%u", Slot.funcIndex,
-                    static_cast<unsigned long long>(sampleIndex), threshold);
-      }
-      // >= (not ==): if the enqueue fails (queue full / already pending),
-      // the next hit can still arm — a transient failure is not fatal (§7).
-      if (threshold && sampleIndex >= threshold) {
-        enqueueTier2FromSlot(Slot);
-        if (slotTier == kEJitTierInstrumented && sampleIndex == threshold)
-          EJIT_DIAG("PGO sampling complete func=%u: %llu/%u; routing AOT "
-                    "until Tier-2 publish",
-                    Slot.funcIndex,
-                    static_cast<unsigned long long>(sampleIndex), threshold);
-      }
-    }
-  }
-
   // fnPtr cross-core gate (§11 prerequisites): a non-owner core may read the
   // pointer only when code sharing is platform-validated (same VA, sealed,
   // I/D-cache coherent). Otherwise CLEAN-REJECT — never hand back a pointer
@@ -1540,7 +1467,85 @@ EJitSharedTaskPool::resolveMatchedSlot(EJitSharedCacheBucket &B,
   return peerPrepareSlot(B, bucket, slotIndex);
 }
 
-void EJitSharedTaskPool::enqueueTier2FromSlot(const EJitSharedCacheSlot &Slot) {
+bool EJitSharedTaskPool::accountTier1Dispatch(const SharedLookup &Hit) {
+  if (!state_->pgoEnabled.loadAcquire() || !Hit.fnPtr || !Hit.slot)
+    return true;
+
+  EJitSharedCacheSlot &Slot = *Hit.slot;
+  const uint8_t SlotTier = Slot.tier.loadRelaxed();
+  if (SlotTier >= kEJitTierPgoUse)
+    return true;
+
+  const uint32_t Threshold = state_->tier2Threshold.loadAcquire();
+  if (SlotTier != kEJitTierInstrumented || Threshold == 0) {
+    const uint64_t SampleIndex = Slot.hitCount.fetchAdd(1) + 1;
+    if (Threshold && SampleIndex >= Threshold)
+      enqueueTier2FromSlot(Slot, 0, 0);
+    return true;
+  }
+
+  // The final sampler temporarily owns hitCount while publishing the frozen
+  // end/count. Concurrent callers route to AOT instead of spinning on a shared
+  // cache line; the winner still returns Tier-1 for the final real sample.
+  constexpr uint64_t kSamplingFreezeInProgress = ~uint64_t{0};
+  uint64_t Observed = Slot.hitCount.loadAcquire();
+  uint64_t SampleIndex = 0;
+  for (;;) {
+    if (Observed == kSamplingFreezeInProgress) {
+      return false;
+    }
+    if (Observed >= Threshold) {
+      enqueueTier2FromSlot(Slot, Slot.pgoSampleEnd.loadAcquire(),
+                           Slot.pgoSampleEntries.loadAcquire());
+      return false;
+    }
+    const uint64_t Next = Observed + 1;
+    if (Next == Threshold) {
+      if (!Slot.hitCount.compareExchange(Observed, kSamplingFreezeInProgress))
+        continue;
+      const uint64_t SampleEnd = traceNowFn_ ? traceNowFn_(traceNowCtx_) : 0;
+      Slot.pgoSampleEnd.storeRelease(SampleEnd);
+      Slot.pgoSampleEntries.storeRelease(Threshold);
+      Slot.hitCount.storeRelease(Threshold);
+      SampleIndex = Threshold;
+      break;
+    }
+    if (Slot.hitCount.compareExchange(Observed, Next)) {
+      SampleIndex = Next;
+      break;
+    }
+  }
+
+  const uint32_t Encoded = Slot.funcIndex + 1;
+  for (uint32_t I = 0; I < kEJitSharedMaxConcurrentProfiles; ++I) {
+    if (state_->pgoActiveFunctions[I].loadAcquire() != Encoded)
+      continue;
+    const uint32_t Quarter = static_cast<uint32_t>(
+        std::min<uint64_t>(4, (SampleIndex * 4) / Threshold));
+    uint32_t OldQuarter = state_->pgoProgressQuarters[I].loadRelaxed();
+    while (
+        Quarter > OldQuarter &&
+        !state_->pgoProgressQuarters[I].compareExchange(OldQuarter, Quarter)) {
+    }
+    if (Quarter > OldQuarter)
+      EJIT_DIAG("PGO profile progress func=%u: %llu/%u", Slot.funcIndex,
+                static_cast<unsigned long long>(SampleIndex), Threshold);
+    break;
+  }
+
+  if (SampleIndex == Threshold) {
+    enqueueTier2FromSlot(Slot, Slot.pgoSampleEnd.loadAcquire(), Threshold);
+    EJIT_DIAG("PGO sampling complete func=%u: %llu/%u; routing AOT after "
+              "this Tier-1 dispatch until Tier-2 publish",
+              Slot.funcIndex, static_cast<unsigned long long>(SampleIndex),
+              Threshold);
+  }
+  return true;
+}
+
+void EJitSharedTaskPool::enqueueTier2FromSlot(const EJitSharedCacheSlot &Slot,
+                                              uint64_t SampleEnd,
+                                              uint32_t SampleEntries) {
   if (state_->mode.loadAcquire() !=
       static_cast<uint32_t>(EJitCompileMode::Async))
     return;
@@ -1549,6 +1554,8 @@ void EJitSharedTaskPool::enqueueTier2FromSlot(const EJitSharedCacheSlot &Slot) {
   T2.funcIndex = encodeReqTier(Slot.funcIndex, kEJitTierPgoUse);
   T2.numDims = Slot.numDims;
   T2.generation = Slot.generation;
+  T2.pgoSampleEnd = SampleEnd;
+  T2.pgoSampleEntries = SampleEntries;
   for (uint32_t i = 0; i < Slot.numDims && i < 4; ++i) {
     T2.dims[i] = Slot.dims[i];
     T2.versions[i] = Slot.versions[i];
@@ -2302,6 +2309,8 @@ EJitSharedTaskPool::cacheStageBatchRequest(const EJitCompileRequest &req) {
   Target->poolSize = 0;
   Target->poolId = 0;
   Target->executableCoreMask.storeRelease(0);
+  Target->pgoSampleEnd.storeRelaxed(0);
+  Target->pgoSampleEntries.storeRelaxed(0);
   Target->fnPtr.storeRelease(0);
   Target->state.storeRelease(
       static_cast<uint32_t>(EJitSharedSlotState::Pending));
@@ -2372,6 +2381,8 @@ EJitSharedTaskPool::cacheStagePending(const EJitCompileRequest &req,
   Target->poolSize = 0;
   Target->poolId = 0;
   Target->executableCoreMask.storeRelease(0);
+  Target->pgoSampleEnd.storeRelaxed(0);
+  Target->pgoSampleEntries.storeRelaxed(0);
   Target->fnPtr.storeRelease(reinterpret_cast<uintptr_t>(fnPtr));
   Target->state.storeRelease(
       static_cast<uint32_t>(EJitSharedSlotState::Pending));
@@ -2541,6 +2552,8 @@ EJitSharedTaskPool::cachePublish(const EJitCompileRequest &req, void *fnPtr,
   // resolveMatchedSlot can suppress the Tier-2 trigger on already-Tier-2
   // slots (§4 repeat-trigger).  Under the write lock + before state=Ready.
   target->hitCount.storeRelaxed(0);
+  target->pgoSampleEnd.storeRelaxed(0);
+  target->pgoSampleEntries.storeRelaxed(0);
   target->tier.storeRelaxed(static_cast<uint8_t>(tier));
   target->postPublishSeen.storeRelaxed(0);
   const uint32_t OwnerCore = state_->ownerCoreId.loadAcquire();
@@ -2771,6 +2784,8 @@ void initSharedStorage(EJitSharedTaskPoolState *st, uint32_t mode,
       // PGO (§6): clear hitCount + tier so a re-init never leaks stale
       // hotness state or tier-tracking from a prior generation.
       Slot.hitCount.storeRelaxed(0);
+      Slot.pgoSampleEnd.storeRelaxed(0);
+      Slot.pgoSampleEntries.storeRelaxed(0);
       Slot.tier.storeRelaxed(0);
       Slot.postPublishSeen.storeRelaxed(0);
     }
@@ -3042,6 +3057,12 @@ __attribute__((always_inline)) EJitSharedTaskPool::CompileOrGetResult
 EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   CompileOrGetResult R;
   if (Hit.hasReadToken && Hit.fnPtr) {
+    if (!accountTier1Dispatch(Hit)) {
+      bucketReadRelease(state_->buckets[Hit.bucketIndex]);
+      R.status = EJitCompileOrGetStatus::AlreadyPending;
+      R.fastPathTerminal = true;
+      return R;
+    }
     if (Hit.slot)
       markPostPublishSeen(*Hit.slot);
     EJIT_STAT_INC(state_->counters.cacheHits);
@@ -3057,6 +3078,11 @@ EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
   // bucketIndex is the out-of-range sentinel, so the wrapper's releaseRead()
   // cleanly no-ops. Safe because published code is never freed in this build.
   if (Hit.noTokenHit && Hit.fnPtr) {
+    if (!accountTier1Dispatch(Hit)) {
+      R.status = EJitCompileOrGetStatus::AlreadyPending;
+      R.fastPathTerminal = true;
+      return R;
+    }
     if (Hit.slot)
       markPostPublishSeen(*Hit.slot);
     EJIT_STAT_INC(state_->counters.cacheHits);
@@ -3073,14 +3099,6 @@ EJitSharedTaskPool::classifyHit(const SharedLookup &Hit) {
     // pointer; fall back cleanly WITHOUT re-enqueuing (avoids recompile churn).
     R.status = EJitCompileOrGetStatus::OffMode;
     R.readyButNotShareable = true;
-    R.fastPathTerminal = true;
-    return R;
-  }
-  if (Hit.pgoSamplingComplete) {
-    // Tier-1 has enough data. Do not enter compileOrGet() again: Tier-2 already
-    // owns the per-function dedup claim, and the wrapper should execute its AOT
-    // fallback until the final code is published.
-    R.status = EJitCompileOrGetStatus::AlreadyPending;
     R.fastPathTerminal = true;
     return R;
   }
@@ -4062,10 +4080,9 @@ bool EJitSharedTaskPool::readCodePoolStats(EJitCodePoolStatsOut *out) const {
 void EJitSharedTaskPool::runCompile(const EJitCompileRequest &req,
                                     bool hasBatchRequestMarker) {
   // PGO (§4.9): the aarch64 exclusive-monitor workaround is a property of the
-  // Tier-2 publish, not a caller flag. A Tier-2 (PGOUse) request always follows
-  // an arming hit whose hitCount.fetchAdd primed the monitor on this bucket, so
-  // derive pgoClearExclusive from the request's encoded tier here in the
-  // worker.
+  // Tier-2 publish, not a caller flag. A Tier-2 (PGOUse) request follows a
+  // threshold-winning hitCount RMW on this bucket, so derive
+  // pgoClearExclusive from the request's encoded tier here in the worker.
   const uint32_t tier = decodeReqTier(req.funcIndex);
   const uint32_t realFuncIndex = stripReqTier(req.funcIndex);
   const bool pgoClearExclusive = tier == kEJitTierPgoUse;

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitBranchProfileTest.cpp
@@ -131,20 +131,31 @@ TEST(EJitBranchProfile, BenefitScalingRoundsToNearestFixedPoint) {
   EXPECT_EQ(Summary.removedHitsPerEntryPermille, 667u);
 }
 
+TEST(EJitBranchProfile, SixVersionsReportExactFrozenEntryTotal) {
+  std::vector<EJitMayConstBenefitSample> Samples(6);
+  for (EJitMayConstBenefitSample &Sample : Samples)
+    Sample.sampledEntries = 64;
+  EXPECT_EQ(summarizeMayConstBenefits(Samples).sampledEntries, 384u);
+}
+
 TEST(EJitBranchProfile, ComputesBenefitDensityFromPerVersionCacheLines) {
   EJitMayConstBenefitSample First;
   First.removedRuntimeHits = 200;
   First.sampleCycles = 500;
   First.publishedHotCodeBytes = 65;
+  First.publishedHotCodeSizeValid = true;
   EJitMayConstBenefitSample Second;
   Second.removedRuntimeHits = 100;
   Second.sampleCycles = 500;
   Second.publishedHotCodeBytes = 64;
+  Second.publishedHotCodeSizeValid = true;
 
   EJitMayConstBenefitSummary Summary =
       summarizeMayConstBenefits({First, Second});
   EXPECT_EQ(Summary.publishedHotCodeBytes, 129u);
   EXPECT_EQ(Summary.publishedHotICacheLines, 3u);
+  EXPECT_EQ(Summary.validPublishedHotCodeVersions, 2u);
+  EXPECT_TRUE(Summary.entryBenefitDensityValid);
   EXPECT_EQ(Summary.benefitPerMillionCyclesMilli, 300000000u);
   EXPECT_EQ(Summary.entryBenefitDensityMilli, 100000000u);
 }
@@ -156,17 +167,21 @@ TEST(EJitBranchProfile, ZeroCodeFootprintHasZeroBenefitDensity) {
   EJitMayConstBenefitSummary Summary = summarizeMayConstBenefits({Sample});
   EXPECT_EQ(Summary.publishedHotICacheLines, 0u);
   EXPECT_EQ(Summary.entryBenefitDensityMilli, 0u);
+  EXPECT_FALSE(Summary.entryBenefitDensityValid);
 }
 
 TEST(EJitBranchProfile, AuditsCrossVersionPartialJitCandidates) {
   EJitMayConstBenefitSample First;
   First.publishedHotCodeBytes = 5 * 64;
+  First.publishedHotCodeSizeValid = true;
   First.publishedHotLineFingerprints = {1, 2, 3, 9, 9};
   EJitMayConstBenefitSample Second;
   Second.publishedHotCodeBytes = 3 * 64;
+  Second.publishedHotCodeSizeValid = true;
   Second.publishedHotLineFingerprints = {2, 3, 4};
   EJitMayConstBenefitSample Third;
   Third.publishedHotCodeBytes = 2 * 64;
+  Third.publishedHotCodeSizeValid = true;
   Third.publishedHotLineFingerprints = {2, 5};
 
   EJitMayConstBenefitSummary Summary =
@@ -183,11 +198,63 @@ TEST(EJitBranchProfile, FingerprintsPublishedCodeLinesAndSkipsZeroPadding) {
   std::fill(Code.begin() + 128, Code.begin() + 192, 0x5a);
   std::fill(Code.begin() + 192, Code.end(), 0x5a);
 
-  std::vector<uint64_t> Fingerprints =
-      fingerprintPublishedHotICacheLines(Code);
+  std::vector<uint64_t> Fingerprints = fingerprintPublishedHotICacheLines(Code);
   ASSERT_EQ(Fingerprints.size(), 3u);
   EXPECT_EQ(Fingerprints[0], Fingerprints[1]);
   EXPECT_NE(Fingerprints[0], Fingerprints[2]);
+}
+
+TEST(EJitBranchProfile, PublishedFunctionBytesUseExactSymbolExtent) {
+  std::vector<uint8_t> Allocation(256, 0x7a);
+  ArrayRef<uint8_t> FunctionBytes;
+  ASSERT_TRUE(
+      getPublishedFunctionBytes(Allocation.data() + 64, 65,
+                                reinterpret_cast<uintptr_t>(Allocation.data()),
+                                Allocation.size(), FunctionBytes));
+  EXPECT_EQ(FunctionBytes.data(), Allocation.data() + 64);
+  EXPECT_EQ(FunctionBytes.size(), 65u);
+  EXPECT_EQ(fingerprintPublishedHotICacheLines(FunctionBytes).size(), 2u);
+}
+
+TEST(EJitBranchProfile, PublishedFunctionBytesRejectUnknownOrOutOfRangeSize) {
+  std::vector<uint8_t> Allocation(128, 0x5a);
+  ArrayRef<uint8_t> FunctionBytes;
+  EXPECT_FALSE(getPublishedFunctionBytes(
+      Allocation.data(), 0, reinterpret_cast<uintptr_t>(Allocation.data()),
+      Allocation.size(), FunctionBytes));
+  EXPECT_TRUE(FunctionBytes.empty());
+  EXPECT_FALSE(
+      getPublishedFunctionBytes(Allocation.data() + 96, 64,
+                                reinterpret_cast<uintptr_t>(Allocation.data()),
+                                Allocation.size(), FunctionBytes));
+  EXPECT_TRUE(FunctionBytes.empty());
+  EXPECT_FALSE(getPublishedFunctionBytes(
+      reinterpret_cast<const void *>(
+          reinterpret_cast<uintptr_t>(Allocation.data()) - 1),
+      1, reinterpret_cast<uintptr_t>(Allocation.data()), Allocation.size(),
+      FunctionBytes));
+}
+
+TEST(EJitBranchProfile, UnknownFunctionSizeInvalidatesEntryDensity) {
+  EJitMayConstBenefitSample Known;
+  Known.removedRuntimeHits = 100;
+  Known.sampleCycles = 100;
+  Known.publishedHotCodeBytes = 64;
+  Known.publishedHotCodeSizeValid = true;
+  Known.publishedHotLineFingerprints = {0x1234};
+  EJitMayConstBenefitSample Unknown = Known;
+  Unknown.publishedHotCodeBytes = 0;
+  Unknown.publishedHotCodeSizeValid = false;
+
+  EJitMayConstBenefitSummary Summary =
+      summarizeMayConstBenefits({Known, Unknown});
+  EXPECT_EQ(Summary.validPublishedHotCodeVersions, 1u);
+  EXPECT_FALSE(Summary.entryBenefitDensityValid);
+  EXPECT_EQ(Summary.entryBenefitDensityMilli, 0u);
+  EXPECT_EQ(Summary.fingerprintedHotICacheLines, 0u);
+  EXPECT_EQ(Summary.crossVersionMatchingICacheLines, 0u);
+  EXPECT_EQ(Summary.partialJitCandidateICacheLines, 0u);
+  EXPECT_EQ(Summary.benefitPerMillionCyclesMilli, 1000000000u);
 }
 
 } // namespace

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitCodePoolMemoryManagerTest.cpp
@@ -703,6 +703,30 @@ TEST(EJitCodePoolMemMgr4K, FinalizedRangeCarriesEntryFnSize) {
   cantFail(MM.deallocate(std::move(FA)));
 }
 
+// A pointer inside a symbol is enough to recover its executable allocation,
+// but not an exact function body beginning at that pointer.
+TEST(EJitCodePoolMemMgr4K, InteriorPointerHasUnknownFnSize) {
+  MockSre4K M;
+  EJitCodePoolManager Pool(
+      fourKMemMgrOpts(), [&M](size_t N) { return M.rawAlloc(N); },
+      [&M](void *V) { return M.seal(V); },
+      [&M](void *B, size_t S) { return M.split(B, S); });
+  EJitCodePoolMemoryManager MM(Pool, kFourKiB);
+
+  auto G = makeCodeGraphWithDefinedSymbol(64, 0x1000);
+  auto IFA = cantFail(MM.allocate(nullptr, *G));
+  auto *EntryAddr = static_cast<uint8_t *>(firstBlockAddr(*G));
+  auto FA = cantFail(IFA->finalize());
+
+  EJitCompiledCodeInfo Info{};
+  ASSERT_TRUE(Pool.findRange(EntryAddr + 1, Info));
+  EXPECT_EQ(Info.fnPtr, EntryAddr + 1);
+  EXPECT_EQ(Info.fnSize, 0u);
+  EXPECT_GT(Info.codeSize, 0u);
+
+  cantFail(MM.deallocate(std::move(FA)));
+}
+
 // A graph with no defined symbol records no symbol metadata: fnSize is 0
 // (print_compiled then reports fn_size=0, overhead=codeSize). This guards the
 // "no symbol metadata" fallback path so a symbolless graph never mis-reports

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitSharedTaskPoolTest.cpp
@@ -1787,6 +1787,7 @@ TEST_F(SharedTaskPoolTest, PeerPrepareFailureCleanlyFallsBack) {
   EJitSharedTaskPool owner;
   owner.setPrepareCodeCallback(&mockPrepareCode, &prepare);
   bringUpOwner(owner, /*codeSharing=*/true);
+  owner.setPgoEnabled(true, 1);
 
   EJitCoreId::setCurrentForTest(0);
   ASSERT_EQ(owner.compileOrGet(23, nullptr, 0, codeFor(23)).status,
@@ -1801,6 +1802,10 @@ TEST_F(SharedTaskPoolTest, PeerPrepareFailureCleanlyFallsBack) {
   EXPECT_FALSE(peerHit.hasReadToken);
   EXPECT_TRUE(peerHit.readyButNotShareable);
   EXPECT_EQ(state_->counters.executePrepareFailed.loadAcquire(), 1u);
+  EJitSharedCacheSlot *Slot = findReadySlot(23);
+  ASSERT_NE(Slot, nullptr);
+  EXPECT_EQ(Slot->hitCount.loadAcquire(), 0u)
+      << "a peer that falls back before execution must not consume T1 quota";
 }
 
 //===----------------------------------------------------------------------===//
@@ -2209,6 +2214,32 @@ TEST_F(SharedTaskPoolTest, CodeSharingOffRejectsPeerWithoutReenqueue) {
   peer.getDiagnostics(after);
   EXPECT_EQ(after.queueDepth, before.queueDepth); // NOT re-enqueued
   EXPECT_EQ(after.pendingCount, before.pendingCount);
+}
+
+TEST_F(SharedTaskPoolTest, UnshareablePeerDoesNotConsumeTier1Sample) {
+  EJitSharedTaskPool Owner;
+  Owner.setPgoEnabled(true, 1);
+  bringUpOwner(Owner, /*codeSharing=*/false);
+  EJitCoreId::setCurrentForTest(0);
+  ASSERT_EQ(Owner.compileOrGet(60, nullptr, 0, codeFor(60)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+
+  EJitSharedTaskPool Peer;
+  Peer.bind(state_.get());
+  EJitCoreId::setCurrentForTest(7);
+  auto Fallback = Peer.compileOrGet(60, nullptr, 0, codeFor(60));
+  EXPECT_TRUE(Fallback.readyButNotShareable);
+  EJitSharedCacheSlot *Slot = findReadySlot(60);
+  ASSERT_NE(Slot, nullptr);
+  EXPECT_EQ(Slot->hitCount.loadAcquire(), 0u);
+
+  EJitCoreId::setCurrentForTest(0);
+  auto OwnerHit = Owner.compileOrGet(60, nullptr, 0, codeFor(60));
+  EXPECT_EQ(OwnerHit.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(Slot->hitCount.loadAcquire(), 1u);
+  if (OwnerHit.hasReadToken)
+    Owner.releaseRead(OwnerHit.bucketIndex);
 }
 #endif
 
@@ -3091,7 +3122,8 @@ TEST_F(SharedTaskPoolTest, FourKAbiVersionAndRangeFieldSemantics) {
   // peer for sealing or enable_rw.
   // v19 adds fixed near-hot pool
   // diagnostics and stable semantic pool ids.
-  EXPECT_EQ(kEJitSharedAbiVersion, 19u);
+  // v20 freezes the exact Tier-1 sample end/count in shared state.
+  EXPECT_EQ(kEJitSharedAbiVersion, 20u);
   EXPECT_TRUE(std::is_standard_layout<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(std::is_trivially_destructible<EJitSharedPoolSplit>::value);
   EXPECT_TRUE(
@@ -6155,6 +6187,8 @@ struct PgoRecorder {
   std::vector<uint32_t> t2Func; // stripped funcIndex per Tier-2 compile
   std::vector<uint32_t> t2Gen;  // generation per Tier-2 compile
   std::vector<uint32_t> t2Ver0; // versions[0] per Tier-2 compile
+  std::vector<uint64_t> t2SampleEnd;
+  std::vector<uint32_t> t2SampleEntries;
 };
 bool mockCompileRecordPgo(void *ctx, const EJitCompileRequest &req,
                           void **outFn) {
@@ -6164,12 +6198,16 @@ bool mockCompileRecordPgo(void *ctx, const EJitCompileRequest &req,
     r->t2Func.push_back(stripReqTier(req.funcIndex));
     r->t2Gen.push_back(req.generation);
     r->t2Ver0.push_back(req.numDims ? req.versions[0] : 0u);
+    r->t2SampleEnd.push_back(req.pgoSampleEnd);
+    r->t2SampleEntries.push_back(req.pgoSampleEntries);
   } else {
     ++r->tier1;
   }
   *outFn = codeFor(req.funcIndex);
   return true;
 }
+
+uint64_t controlledPgoClock(void *Ctx) { return *static_cast<uint64_t *>(Ctx); }
 
 // Fails only the Tier-2 (PGOUse) compile; Tier-1/Baseline succeed. Lets a test
 // drive the compile-failure dedup-rollback path.
@@ -6368,6 +6406,73 @@ TEST_F(SharedTaskPoolTest, PeerCrossesThresholdOwnerConsumes) {
   EXPECT_FALSE(owner.pollOne()); // queue empty
 }
 
+TEST_F(SharedTaskPoolTest, FinalRealTier1DispatchFreezesSamplingWindow) {
+  EJitSharedTaskPool Owner;
+  PgoRecorder Recorder;
+  uint64_t Clock = 111;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockCompileRecordPgo, &Recorder);
+  Owner.setTraceNowCallback(&controlledPgoClock, &Clock);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setCodeSharingEnabled(true);
+  Owner.setPgoEnabled(true, 3);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  ASSERT_EQ(Owner.compileOrGet(5, nullptr, 0, codeFor(5)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+
+  for (uint32_t I = 1; I <= 3; ++I) {
+    auto Result = Owner.compileOrGet(5, nullptr, 0, codeFor(5));
+    EXPECT_EQ(Result.status, EJitCompileOrGetStatus::CacheHit) << I;
+    if (Result.hasReadToken)
+      Owner.releaseRead(Result.bucketIndex);
+  }
+  EJitSharedCacheSlot *Slot = findReadySlot(5);
+  ASSERT_NE(Slot, nullptr);
+  EXPECT_EQ(Slot->hitCount.loadAcquire(), 3u);
+  EXPECT_EQ(Slot->pgoSampleEnd.loadAcquire(), 111u);
+  EXPECT_EQ(Slot->pgoSampleEntries.loadAcquire(), 3u);
+
+  Clock = 999999;
+  for (uint32_t I = 0; I != 1000; ++I) {
+    auto Fallback = Owner.compileOrGet(5, nullptr, 0, codeFor(5));
+    EXPECT_EQ(Fallback.status, EJitCompileOrGetStatus::AlreadyPending);
+    EXPECT_EQ(Fallback.fnPtr, codeFor(5));
+  }
+  EXPECT_EQ(Slot->hitCount.loadAcquire(), 3u);
+  ASSERT_TRUE(Owner.pollOne());
+  ASSERT_EQ(Recorder.t2SampleEnd.size(), 1u);
+  EXPECT_EQ(Recorder.t2SampleEnd[0], 111u);
+  EXPECT_EQ(Recorder.t2SampleEntries[0], 3u);
+
+  auto Tier2 = Owner.compileOrGet(5, nullptr, 0, codeFor(5));
+  EXPECT_EQ(Tier2.status, EJitCompileOrGetStatus::CacheHit);
+  if (Tier2.hasReadToken)
+    Owner.releaseRead(Tier2.bucketIndex);
+}
+
+TEST_F(SharedTaskPoolTest, NullTier1PointerDoesNotConsumeSamplingQuota) {
+  EJitSharedTaskPool Owner;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockCompile, nullptr);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setPgoEnabled(true, 1);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+  ASSERT_EQ(Owner.compileOrGet(5, nullptr, 0, codeFor(5)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+  EJitSharedCacheSlot *Slot = findReadySlot(5);
+  ASSERT_NE(Slot, nullptr);
+  Slot->fnPtr.storeRelease(0);
+
+  auto Result = Owner.compileOrGet(5, nullptr, 0, codeFor(5));
+  EXPECT_NE(Result.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(Slot->hitCount.loadAcquire(), 0u);
+  EXPECT_EQ(Slot->pgoSampleEnd.loadAcquire(), 0u);
+}
+
 // (2) Two peers cross the threshold on the SAME identity; shared dedup admits
 // exactly one Tier-2 request and the owner compiles it once. No permanent
 // pending remains.
@@ -6484,6 +6589,61 @@ TEST_F(SharedTaskPoolTest, ConcurrentPeersCapTier1AtConfiguredSampleCount) {
   EJitCoreId::setCurrentForTest(0);
   ASSERT_TRUE(owner.pollOne());
   EXPECT_EQ(rec.tier2, 1);
+}
+
+TEST_F(SharedTaskPoolTest, FiveFunctionsHandoffAcrossFourProfileSlots) {
+  constexpr uint32_t FirstFunc = 40;
+  constexpr uint32_t Threshold = 64;
+  EJitSharedTaskPool Owner;
+  PgoRecorder Recorder;
+  uint64_t Clock = 1000;
+  EJitCoreId::setCurrentForTest(0);
+  Owner.bind(state_.get());
+  Owner.setCompiler(&mockCompileRecordPgo, &Recorder);
+  Owner.setTraceNowCallback(&controlledPgoClock, &Clock);
+  Owner.setMode(EJitCompileMode::Async);
+  Owner.setPgoEnabled(true, Threshold, 4);
+  ASSERT_EQ(Owner.init(), EJitSharedTaskPool::InitResult::BecameOwner);
+
+  for (uint32_t Func = FirstFunc; Func != FirstFunc + 4; ++Func)
+    ASSERT_EQ(Owner.compileOrGet(Func, nullptr, 0, codeFor(Func)).status,
+              EJitCompileOrGetStatus::EnqueuedPending);
+  EXPECT_EQ(
+      Owner.compileOrGet(FirstFunc + 4, nullptr, 0, codeFor(FirstFunc + 4))
+          .status,
+      EJitCompileOrGetStatus::PgoAdmissionDeferred);
+  for (uint32_t I = 0; I != 4; ++I)
+    ASSERT_TRUE(Owner.pollOne());
+
+  for (uint32_t Func = FirstFunc; Func != FirstFunc + 4; ++Func) {
+    for (uint32_t I = 0; I != Threshold; ++I) {
+      auto Hit = Owner.compileOrGet(Func, nullptr, 0, codeFor(Func));
+      ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+      if (Hit.hasReadToken)
+        Owner.releaseRead(Hit.bucketIndex);
+    }
+  }
+  for (uint32_t I = 0; I != 4; ++I)
+    ASSERT_TRUE(Owner.pollOne());
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 0u);
+
+  const uint32_t LastFunc = FirstFunc + 4;
+  ASSERT_EQ(Owner.compileOrGet(LastFunc, nullptr, 0, codeFor(LastFunc)).status,
+            EJitCompileOrGetStatus::EnqueuedPending);
+  ASSERT_TRUE(Owner.pollOne());
+  for (uint32_t I = 0; I != Threshold; ++I) {
+    auto Hit = Owner.compileOrGet(LastFunc, nullptr, 0, codeFor(LastFunc));
+    ASSERT_EQ(Hit.status, EJitCompileOrGetStatus::CacheHit);
+    if (Hit.hasReadToken)
+      Owner.releaseRead(Hit.bucketIndex);
+  }
+  ASSERT_TRUE(Owner.pollOne());
+
+  ASSERT_EQ(Recorder.t2SampleEntries.size(), 5u);
+  for (uint32_t Entries : Recorder.t2SampleEntries)
+    EXPECT_EQ(Entries, Threshold);
+  EXPECT_EQ(state_->pgoActiveFunctionCount.loadAcquire(), 0u);
+  EXPECT_EQ(Owner.pendingCount(), 0u);
 }
 
 #ifdef EJIT_SRE_TASKPOOL_NO_RECLAIM
@@ -6617,8 +6777,15 @@ TEST_F(SharedTaskPoolTest, SameFuncSameNumDimsBucketCollisionUsesExactSlot) {
 // rolled back so a later hit (after space frees) can retrigger and succeed.
 TEST_F(SharedTaskPoolTest, Tier2QueueFullRollsBackDedup) {
   EJitSharedTaskPool pool;
-  bringUpOwner(pool);
+  PgoRecorder Recorder;
+  uint64_t Clock = 777;
   EJitCoreId::setCurrentForTest(0);
+  pool.bind(state_.get());
+  pool.setCompiler(&mockCompileRecordPgo, &Recorder);
+  pool.setTraceNowCallback(&controlledPgoClock, &Clock);
+  pool.setMode(EJitCompileMode::Async);
+  pool.setPgoEnabled(true, 1);
+  ASSERT_EQ(pool.init(), EJitSharedTaskPool::InitResult::BecameOwner);
   pool.setInstanceEnabled(1, 4, true);
   EJitDimPair d0[1] = {dim(1, 4)};
 
@@ -6627,8 +6794,8 @@ TEST_F(SharedTaskPoolTest, Tier2QueueFullRollsBackDedup) {
             EJitCompileOrGetStatus::EnqueuedPending);
   ASSERT_TRUE(pool.pollOne());
 
-  // Fill the shared queue with ordinary undrained requests until full, then
-  // enable PGO so staged admission does not intentionally defer the fillers.
+  // Fill with ordinary requests without consuming the target's PGO admission.
+  pool.setPgoEnabled(false, 0);
   bool full = false;
   uint32_t f = 100;
   for (; f < 100 + kEJitSharedQueueSlots + 8; ++f) {
@@ -6646,6 +6813,10 @@ TEST_F(SharedTaskPoolTest, Tier2QueueFullRollsBackDedup) {
   ASSERT_EQ(state_->inFlight[5].loadRelaxed(), 0u);
   auto hit = pool.compileOrGet(5, d0, 1, codeFor(5));
   EXPECT_EQ(hit.status, EJitCompileOrGetStatus::CacheHit);
+  EJitSharedCacheSlot *Target = findReadySlot(5);
+  ASSERT_NE(Target, nullptr);
+  EXPECT_EQ(Target->pgoSampleEnd.loadAcquire(), 777u);
+  EXPECT_EQ(Target->pgoSampleEntries.loadAcquire(), 1u);
   EXPECT_EQ(state_->inFlight[5].loadRelaxed(), 0u)
       << "queue-full Tier-2 must roll back its in-flight claim";
   if (hit.hasReadToken)
@@ -6655,9 +6826,11 @@ TEST_F(SharedTaskPoolTest, Tier2QueueFullRollsBackDedup) {
   // slot is not evicted by a full recompile storm before we retry).
   (void)pool.pollBudget(8);
 
-  // Now the target can retrigger and successfully enqueue its Tier-2.
+  // Retry queues Tier-2 with the same frozen window but routes this call AOT.
+  Clock = 999999;
   auto hit2 = pool.compileOrGet(5, d0, 1, codeFor(5));
-  EXPECT_EQ(hit2.status, EJitCompileOrGetStatus::CacheHit);
+  EXPECT_EQ(hit2.status, EJitCompileOrGetStatus::AlreadyPending);
+  EXPECT_EQ(hit2.fnPtr, codeFor(5));
   EXPECT_NE(state_->inFlight[5].loadRelaxed(), 0u)
       << "retry after space frees must claim the in-flight bit";
   if (hit2.hasReadToken)
@@ -6670,6 +6843,9 @@ TEST_F(SharedTaskPoolTest, Tier2QueueFullRollsBackDedup) {
   EJitSharedCacheSlot *s = findReadySlot(5);
   ASSERT_NE(s, nullptr);
   EXPECT_EQ(s->tier.loadRelaxed(), static_cast<uint8_t>(kEJitTierPgoUse));
+  ASSERT_EQ(Recorder.t2SampleEnd.size(), 1u);
+  EXPECT_EQ(Recorder.t2SampleEnd[0], 777u);
+  EXPECT_EQ(Recorder.t2SampleEntries[0], 1u);
 }
 
 // (6) The encoded Tier-2 funcIndex must leave NO in-flight bit after success,

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitTaskPoolTest.cpp
@@ -128,8 +128,8 @@ TEST(EJitTaskPoolLayout, RequestIsFlatPod) {
   // The fixed request owns its optional bound-pointer bytes inline. See the
   // cross-pointer-width layout assertion in EJitSreQueue.h.
   EXPECT_EQ(sizeof(EJitCompileRequest), sizeof(uintptr_t) == 8
-                                            ? 80u + EJIT_BOUND_PTR_MAX_BYTES
-                                            : 72u + EJIT_BOUND_PTR_MAX_BYTES);
+                                            ? 88u + EJIT_BOUND_PTR_MAX_BYTES
+                                            : 84u + EJIT_BOUND_PTR_MAX_BYTES);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

- Count exactly 64 dispatches that actually return an executable Tier-1 pointer. Null pointers, unshareable peer hits, execute-preparation failures, and other AOT fallbacks no longer consume the sampling quota.
- The 64th real Tier-1 dispatch freezes both the sample end timestamp and entry count and still executes Tier-1. Later calls use AOT while Tier-2 is queued or compiling, so queueing, worker delay, and Tier-2 compilation are excluded from `sample_cycles`.
- Carry the frozen sampling window through Tier-2 requests and queue-full retries. Shared taskpool ABI is bumped from v19 to v20; owner, all producer cores, the EJIT library, and business binaries must be rebuilt together.
- Base ranking code-size and cache-line fingerprints on PR #206's finalized `fnPtr + fnSize`. Missing, zero, interior, or out-of-allocation sizes are conservatively marked invalid; density and aggregate fingerprints are omitted for incomplete version sets.
- Add a self-contained board demo with core 6 as the PGO worker, core 16 as producer, five entries with max-active=4, serial multi-cell versions, bounded waits, and a separate ranking command. It requires neither `dump_all` nor manual publish.

## 中文说明

- 只统计真正返回并执行可执行 Tier-1 指针的 64 次调用；空指针、跨核不可共享、执行权限准备失败以及其它 AOT 回退均不消耗采样次数。
- 第 64 次真实 Tier-1 调用会冻结采样结束时间和 entry 数量，并仍然执行 Tier-1；从第 65 次开始，在 Tier-2 排队或编译期间回退 AOT，因此 `sample_cycles` 不再包含队列等待、worker delay 和 Tier-2 编译时间。
- 冻结后的采样窗口随 Tier-2 请求及 queue-full 重试传递。共享 taskpool ABI 从 v19 升至 v20，owner、所有 producer 核、EJIT 库和业务包必须统一重编。
- 排行榜使用 PR #206 提供的最终 `fnPtr + fnSize` 计算精确函数体大小和 cache-line fingerprint。大小缺失、为零、指向符号中间或越过 allocation 时保守标记 invalid；版本集合不完整时不计算 density 和聚合 fingerprint。
- 新增自包含板端单 `.c` 用例：core 6 启动 PGO worker，core 16 触发五个 entry（max-active=4）并串行提交同函数多 cell 版本，另有独立排行榜命令；等待均有界，不依赖 `dump_all` 或手动 publish。

## Validation

- `EJITSharedTaskPoolTests`: 166/166 passed after rebasing onto current `ejit_dev_spec4`, with PGO + DIAG + batched publish + 4K seal + shared pointers and PR #201's 17-pool layout.
- `EJITCodePoolTests`: 71/71 passed, including exact-entry/interior-pointer size coverage and fixed near-pool coverage.
- `EJITBranchProfileTests`: 12/12 passed.
- `EJITTaskPoolTests`: 89/89 passed.
- Batched-publish OFF `EJitSharedTaskPool.cpp` compile passed.
- PGO/DIAG affected TUs compiled successfully.
- Demo host C syntax check passed; `aarch64_be-none-elf` freestanding object compile passed with only expected EJIT/SRE undefined symbols and no libc dependency.
- Changed-line clang-format, `git diff --check`, LF-only, and UTF-8/no-BOM checks passed.

## Remaining validation

The self-contained demo has not yet been run on the physical SRE board. Board validation must use a uniformly rebuilt ABI-v20 EJIT library and business image on every owner/producer core.