### PR TITLE
[EJIT] Retain module dump API during lipo GC

### DIFF
--- a/ejit_test/lipo/lipo.py
+++ b/ejit_test/lipo/lipo.py
@@ -23,11 +23,12 @@ Override with --cxx / --ld for cross-compilation.
 The resulting ejit.o (~30-40 MB) can replace all individual LLVM .a files
 when linking EJIT test binaries.
 
-When the EJIT ASM diagnostic dump (ejit_dump_func / ejit_print_dumped) is
-enabled on SRE (EJIT_DUMP_ASM=ON under EJIT_TRIM_LLVM_BACKEND), the assembly
-emitter formats text into an in-memory raw_svector_ostream and therefore
-needs working buffer formatting (snprintf/vsnprintf). Link a libc that
-provides them; OR, if the SRE libc lacks them, add
+When the EJIT ASM diagnostic dump (ejit_dump_func / ejit_print_dumped /
+ejit_print_dumped_module) is enabled on SRE (EJIT_DUMP_ASM=ON under
+EJIT_TRIM_LLVM_BACKEND), the assembly emitter formats text into an in-memory
+raw_svector_ostream and therefore needs working buffer formatting
+(snprintf/vsnprintf). Link a libc that provides them; OR, if the SRE libc lacks
+them, add
 ejit_test/stubs/ejit_sre_format_stubs.o to the final SRE link/merge command
 alongside ejit.o — not both (strong-symbol conflict on snprintf/vsnprintf).
 The stub is intentionally NOT merged into ejit.o here so host builds keep
@@ -391,7 +392,8 @@ def doit_gc_merge(args):
         "ejit_taskpool_get_stats", "ejit_taskpool_print_stats", "ejit_taskpool_get_worker_core",
         "ejit_taskpool_print_compiled", "ejit_taskpool_trace_now",
         "ejit_taskpool_trace_wrapper", "ejit_dump_func", "ejit_print_dumped",
-        "ejit_dump_all", "ejit_print_mayconst_ranking",
+        "ejit_print_dumped_module", "ejit_dump_all",
+        "ejit_print_mayconst_ranking",
         # Inline-cache: ejit_register_icache_slot is called from
         # ejit_auto_register (AOT) when -ejit-inline-cache is on, not from the
         # runtime, so gc-merge's --gc-sections would discard it without this GC

--- a/ejit_test/lipo/test_lipo_gc_roots.py
+++ b/ejit_test/lipo/test_lipo_gc_roots.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Focused regression tests for lipo.py gc-merge API roots."""
+
+import contextlib
+import importlib.util
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+
+SCRIPT = Path(__file__).with_name("lipo.py")
+DUMP_APIS = (
+    "ejit_dump_func",
+    "ejit_print_dumped",
+    "ejit_print_dumped_module",
+)
+
+
+def find_tool(*names):
+    llvm_bin = Path(os.environ.get("LLVM_BIN", r"C:\Program Files\LLVM\bin"))
+    for name in names:
+        tool = shutil.which(name)
+        if tool:
+            return Path(tool)
+        candidate = llvm_bin / (name if name.endswith(".exe") else name + ".exe")
+        if candidate.is_file():
+            return candidate
+    raise RuntimeError("missing required tool: " + " or ".join(names))
+
+
+def run(command):
+    return subprocess.run(
+        [str(item) for item in command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def load_lipo():
+    spec = importlib.util.spec_from_file_location("ejit_lipo", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_archive(root, clang, ar, symbols, name):
+    source = root / f"{name}.c"
+    obj = root / f"{name}.o"
+    archive = root / f"{name}.a"
+    definitions = ["void ejit_init(void) {}"]
+    definitions.extend(f"void {symbol}(void) {{}}" for symbol in symbols)
+    definitions.append("void deliberately_unrooted(void) {}")
+    source.write_text("\n".join(definitions) + "\n", encoding="ascii")
+    run(
+        [
+            clang,
+            "--target=x86_64-unknown-linux-gnu",
+            "-c",
+            "-ffunction-sections",
+            source,
+            "-o",
+            obj,
+        ]
+    )
+    run([ar, "rcs", archive, obj])
+    return archive
+
+
+def gc_merge(lipo, root, archive, ar, nm, ld, name):
+    output = root / f"{name}_gc.a"
+    build_dir = root / "empty-build"
+    build_dir.mkdir(exist_ok=True)
+    original_run = lipo.sp.run
+
+    def routed_run(command, *args, **kwargs):
+        command = list(command)
+        if command[0] == "ar":
+            command[0] = str(ar)
+        elif command[0] == "nm":
+            command[0] = str(nm)
+        return original_run(command, *args, **kwargs)
+
+    lipo.sp.run = routed_run
+    try:
+        with contextlib.redirect_stdout(io.StringIO()) as output_log:
+            lipo.doit_gc_merge(
+                SimpleNamespace(
+                    input=str(archive),
+                    output=str(output),
+                    build_dir=str(build_dir),
+                    ld=str(ld),
+                )
+            )
+    finally:
+        lipo.sp.run = original_run
+    return output, output_log.getvalue()
+
+
+def defined_symbols(nm, archive):
+    output = run([nm, "-g", "--defined-only", archive]).stdout
+    return {line.split()[-1] for line in output.splitlines() if line.split()}
+
+
+def main():
+    clang = find_tool("clang")
+    ar = find_tool("llvm-ar", "ar")
+    nm = find_tool("llvm-nm", "nm")
+    ld = find_tool("ld.lld")
+    lipo = load_lipo()
+    with tempfile.TemporaryDirectory(prefix="ejit-lipo-roots-") as directory:
+        root = Path(directory)
+
+        complete = build_archive(root, clang, ar, DUMP_APIS, "complete")
+        input_symbols = defined_symbols(nm, complete)
+        if set(DUMP_APIS) - input_symbols:
+            raise AssertionError(f"input archive symbols missing: {sorted(input_symbols)}")
+        complete_gc, complete_log = gc_merge(
+            lipo, root, complete, ar, nm, ld, "complete"
+        )
+        complete_symbols = defined_symbols(nm, complete_gc)
+        missing = set(DUMP_APIS) - complete_symbols
+        if missing:
+            raise AssertionError(
+                f"dump API roots were discarded: {sorted(missing)}; "
+                f"defined={sorted(complete_symbols)}; log={complete_log!r}"
+            )
+        if "deliberately_unrooted" in complete_symbols:
+            raise AssertionError("gc-merge retained an unrooted control symbol")
+
+        minimal = build_archive(root, clang, ar, (), "minimal")
+        minimal_gc, _ = gc_merge(lipo, root, minimal, ar, nm, ld, "minimal")
+        minimal_symbols = defined_symbols(nm, minimal_gc)
+        if "ejit_init" not in minimal_symbols:
+            raise AssertionError("mandatory ejit_init root was discarded")
+        if set(DUMP_APIS) & minimal_symbols:
+            raise AssertionError("gc-merge fabricated missing optional symbols")
+
+    print("lipo GC-root regression: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary / 摘要

- retain `ejit_print_dumped_module` as an optional lipo GC root
- document the complete SRE dump API set
- add a real archive -> `gc-merge` regression covering all three callable dump APIs

- 将 `ejit_print_dumped_module` 加入 lipo 可选 GC root
- 补全 SRE dump API 说明
- 增加真实归档到 `gc-merge` 的回归，覆盖三个可直接调用的 dump API

## Root cause / 根因

`ejit_print_dumped_module` is called only by the application and has no reverse reference from the runtime/AOT objects. `lipo.py gc-merge` therefore discarded it under `--gc-sections`. The business image could still link through a stale or mismatched declaration, but the board call jumped to an unmapped address before the API's first logger line.

`ejit_print_dumped_module` 只由业务侧主动调用，runtime/AOT 对象没有反向引用；因此 `lipo.py gc-merge --gc-sections` 会裁掉该实现。板端调用会在进入 API 第一条日志之前跳到未映射地址。

## Validation / 验证

- `python -m py_compile` for lipo and the regression test
- real LLVM-toolchain GC-root regression: PASS
- verifies `ejit_dump_func`, `ejit_print_dumped`, and `ejit_print_dumped_module` survive
- verifies an unrooted control symbol is discarded
- verifies an archive without optional dump APIs still succeeds
- `git diff --check`: PASS
- LF, no BOM

Board integration must rebuild lipo/EJIT and relink the business image. Clang does not need rebuilding.

板端需要重新生成 lipo/EJIT 并重新链接业务镜像；无需重编 Clang。PR #209 demo 未修改。