### PR TITLE
[EJIT] Select backend CodeGenOptLevel from Config::optLevel

### DIFF
--- a/ejit_test/ejit_opt_level_test.c
+++ b/ejit_test/ejit_opt_level_test.c
@@ -1,16 +1,14 @@
 /**
  * EJIT 优化等级测试 — L1 / L2 / L3
  *
- * NOTE: the L1/L2/L3 optimizer tiers have been collapsed into a single fixed
- * pipeline. optLevel is still accepted (ABI compatibility) but no longer selects
- * a pipeline — every level runs the full specialization and must produce the
- * same correct result. This test therefore verifies that JIT compilation
- * succeeds and the result is correct for whichever level is passed.
+ * optLevel selects both the post-specialization IR simplification pipeline and
+ * the corresponding LLVM machine-code optimization level. This test verifies
+ * that JIT compilation succeeds and preserves the result at every level.
  *
  * 每个等级独立进程 (EJitRegistrationStore 只能 consume 一次)。
  *
  * 用法:
- *   ./ejit_opt_level L1|L2|L3   # all run the same collapsed pipeline
+ *   ./ejit_opt_level L1|L2|L3
  *
  * 编译:
  *   build/bin/clang -O2 -c ejit_test/ejit_opt_level_test.c -o /tmp/opt_level.o

--- a/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
+++ b/llvm/include/llvm/ExecutionEngine/EJIT/EJitOrcEngine.h
@@ -14,6 +14,7 @@
 #include "llvm/ExecutionEngine/EJIT/EJitBoundPtr.h"
 #include "llvm/ExecutionEngine/EJIT/EJitOptions.h"
 #include "llvm/ExecutionEngine/EJIT/EJitProfileMerge.h"
+#include "llvm/Support/CodeGen.h"
 #ifdef EJIT_SRE_PGO_BRANCH_AUDIT
 #include "llvm/ExecutionEngine/EJIT/EJitBranchProfile.h"
 #endif
@@ -49,6 +50,24 @@ struct EJitVpFunctionInfo; // defined in EJitOptimizer.h (value-profile capture)
 enum class CompileTier : uint8_t;
 
 namespace detail {
+/// Map the public EJIT optimization level to the backend machine-code
+/// optimization level. Keep this alongside the engine interface so focused
+/// tests can lock the contract without constructing an LLJIT instance.
+constexpr CodeGenOptLevel
+codeGenOptLevelFor(OptimizationLevel Level) {
+  switch (Level) {
+  case OptimizationLevel::L1:
+    return CodeGenOptLevel::Less;
+  case OptimizationLevel::L2:
+    return CodeGenOptLevel::Default;
+  case OptimizationLevel::L3:
+    return CodeGenOptLevel::Aggressive;
+  }
+  // parseConfig() rejects out-of-range C values, so this is reachable only
+  // from a hand-built C++ Config holding an invalid enum representation.
+  return CodeGenOptLevel::Default;
+}
+
 /// Render one function definition without the rest of its specialization
 /// module. Exposed for focused dump-path testing; callers should use the
 /// ejit_dump_* APIs.

--- a/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitOrcEngine.cpp
@@ -728,6 +728,13 @@ EJitOrcEngine::Create(const Config &config, PeriodArrayRegistry &periodReg,
     return JTMBOrErr.takeError();
   }
 
+  // Match machine-code optimization to the IR optimization tier. Previously
+  // Config::optLevel selected the O1/O2/O3 function-simplification pipeline,
+  // but JITTargetMachineBuilder stayed at CodeGenOptLevel::Default for every
+  // tier. In particular, L3 never enabled the AArch64 backend's aggressive
+  // scheduling and late machine optimizations.
+  JTMBOrErr->setCodeGenOptLevel(detail::codeGenOptLevelFor(config.optLevel));
+
   // Use Small code model so data accesses use ADRP+LDR (2 insns/global, ±4GB
   // PC-relative) instead of movz/movk absolute (5 insns/global). The JIT slab
   // is ~1.5-2.2GB from .text (within ADRP's ±4GB range), confirmed by

--- a/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
+++ b/llvm/lib/ExecutionEngine/EJIT/EJitRuntime.cpp
@@ -323,7 +323,23 @@ static void parseConfig(const ejit_config_t *src, Config &dst) {
   dst.compileMode = (src->compileMode == EJIT_COMPILE_ASYNC)
                         ? CompileMode::Async
                         : CompileMode::Sync;
-  dst.optLevel = static_cast<OptimizationLevel>(src->optLevel);
+  // Only adopt a level the enum actually defines. optLevel now selects the
+  // backend CodeGenOptLevel as well as the IR pipeline, so an out-of-range
+  // value would otherwise reach two separate switches and depend on both
+  // agreeing on a fallback. A zero-initialised ejit_config_t is the common
+  // case here and keeps the L2 default.
+  switch (src->optLevel) {
+  case EJIT_OPT_L1:
+  case EJIT_OPT_L2:
+  case EJIT_OPT_L3:
+    dst.optLevel = static_cast<OptimizationLevel>(src->optLevel);
+    break;
+  default:
+    EJIT_DIAG("config: optLevel=%d out of range, keeping L%d",
+              static_cast<int>(src->optLevel),
+              static_cast<int>(dst.optLevel));
+    break;
+  }
   if (src->maxCodeMemory > 0)
     dst.maxCodeMemory = src->maxCodeMemory;
   if (src->maxDataMemory > 0)

--- a/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEngineHeaderTest.cpp
+++ b/llvm/unittests/ExecutionEngine/EJIT/EJitOrcEngineHeaderTest.cpp
@@ -11,3 +11,20 @@
 
 static_assert(llvm::ejit::kEJitMaxBoundPointers == 8u,
               "EJitOrcEngine must include the bound-pointer limit header");
+
+static_assert(llvm::ejit::detail::codeGenOptLevelFor(
+                  llvm::ejit::OptimizationLevel::L1) ==
+                  llvm::CodeGenOptLevel::Less,
+              "EJIT L1 must select less backend optimization");
+static_assert(llvm::ejit::detail::codeGenOptLevelFor(
+                  llvm::ejit::OptimizationLevel::L2) ==
+                  llvm::CodeGenOptLevel::Default,
+              "EJIT L2 must select default backend optimization");
+static_assert(llvm::ejit::detail::codeGenOptLevelFor(
+                  llvm::ejit::OptimizationLevel::L3) ==
+                  llvm::CodeGenOptLevel::Aggressive,
+              "EJIT L3 must select aggressive backend optimization");
+static_assert(llvm::ejit::detail::codeGenOptLevelFor(
+                  static_cast<llvm::ejit::OptimizationLevel>(0)) ==
+                  llvm::CodeGenOptLevel::Default,
+              "invalid internal levels must use the safe backend default");


### PR DESCRIPTION
`optLevel` selected the `L1/L2/L3` IR simplification pipeline but the `JITTargetMachineBuilder` stayed at `CodeGenOptLevel::Default` for every tier, so `L3` never reached the AArch64 backend's aggressive machine passes.

Also validate `optLevel` in `parseConfig`: it now feeds two separate switches, and an out-of-range C value should not depend on both agreeing on a fallback.